### PR TITLE
fix: Improve mobile game controls visibility in landscape and fix Safari fullscreen

### DIFF
--- a/labs/videogame/mobile.css
+++ b/labs/videogame/mobile.css
@@ -709,7 +709,7 @@ body.is-fullscreen .mobile-controls.fullscreen-mode:active {
 @media (pointer: coarse) {
     @media (orientation: landscape) {
         body.is-fullscreen .mobile-controls.fullscreen-mode .system-controls-container {
-            opacity: 0.4;
+            opacity: 0.7;
         }
 
         body.is-fullscreen .mobile-controls.fullscreen-mode .system-controls-container:active,
@@ -720,10 +720,13 @@ body.is-fullscreen .mobile-controls.fullscreen-mode:active {
         body.is-fullscreen .mobile-controls.fullscreen-mode .dpad-container,
         body.is-fullscreen .mobile-controls.fullscreen-mode .action-buttons,
         body.is-fullscreen .mobile-controls.fullscreen-mode .start-select-container {
-            opacity: 0.5;
+            opacity: 0.8;
             transition: opacity 0.3s ease;
         }
 
+        body.is-fullscreen .mobile-controls.fullscreen-mode .dpad-container:active,
+        body.is-fullscreen .mobile-controls.fullscreen-mode .action-buttons:active,
+        body.is-fullscreen .mobile-controls.fullscreen-mode .start-select-container:active,
         body.is-fullscreen .mobile-controls.fullscreen-mode:active .dpad-container,
         body.is-fullscreen .mobile-controls.fullscreen-mode:active .action-buttons,
         body.is-fullscreen .mobile-controls.fullscreen-mode:active .start-select-container {
@@ -733,7 +736,7 @@ body.is-fullscreen .mobile-controls.fullscreen-mode:active {
 
     @media (orientation: portrait) {
         body.is-fullscreen .mobile-controls.fullscreen-mode {
-            opacity: 0.4;
+            opacity: 0.7;
         }
 
         body.is-fullscreen .mobile-controls.fullscreen-mode:active {

--- a/labs/videogame/mobile.css
+++ b/labs/videogame/mobile.css
@@ -203,6 +203,7 @@
             right: 20px;
             pointer-events: auto;
             gap: 16px;
+            z-index: 100;
             bottom: calc(20px + env(safe-area-inset-bottom));
             right: calc(20px + env(safe-area-inset-right));
         }

--- a/labs/videogame/script.js
+++ b/labs/videogame/script.js
@@ -304,9 +304,25 @@ const App = {
         this.ui.screen.innerHTML = '';
         this.ui.screen.classList.remove('scanlines');
     },
+    isSafariMobile() {
+        const ua = navigator.userAgent || '';
+        const isIOS = /iPhone|iPad|iPod/.test(ua);
+        const isSafari = /Safari/.test(ua) && !/Chrome|CriOS|FxiOS/.test(ua);
+        return isIOS || (isSafari && 'ontouchstart' in window);
+    },
     toggleFullscreen() {
         const elem = this.ui.player;
         if (!elem) return;
+
+        // Safari mobile doesn't support fullscreen API reliably, use manual fallback
+        if (this.isSafariMobile()) {
+            if (!this.isManualFullscreen) {
+                this.enterManualFullscreen();
+            } else {
+                this.exitManualFullscreen();
+            }
+            return;
+        }
 
         if (!this.isFullscreenActive()) {
             const requested = this.requestFullscreenSafe(elem);


### PR DESCRIPTION
- Increase button opacity in landscape fullscreen mode from 0.4-0.5 to 0.7-0.8
- Add individual :active states for better touch responsiveness on controls
- Detect Safari mobile and use manual fullscreen fallback instead of native API
- Add isSafariMobile() helper to identify iOS and Safari touch devices

Fixes issues where:
1. Game control buttons were nearly invisible in landscape fullscreen mode
2. Fullscreen button didn't work on Safari mobile due to API limitations