### PR TITLE
Standardize lab headers

### DIFF
--- a/labs/aurora-flow/index.html
+++ b/labs/aurora-flow/index.html
@@ -9,7 +9,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Oxanium:wght@400;600;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=4">
+    <link rel="stylesheet" href="/labs/shared.css?v=5">
     <link rel="stylesheet" href="style.css">
 </head>
 
@@ -304,7 +304,7 @@
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
 
-    <script src="/labs/shared.js?v=5" defer></script>
+    <script src="/labs/shared.js?v=6" defer></script>
     <script src="script.js" defer></script>
 </body>
 

--- a/labs/calculator/index.html
+++ b/labs/calculator/index.html
@@ -7,7 +7,7 @@
     <title>Calculator - Labs</title>
     <meta name="description"
         content="Calculadora online com modos simples, científico e conversor de moedas em tempo real.">
-    <link rel="stylesheet" href="/labs/shared.css?v=4">
+    <link rel="stylesheet" href="/labs/shared.css?v=5">
     <link rel="stylesheet" href="style.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -178,7 +178,7 @@
 
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
-    <script src="/labs/shared.js?v=5" defer></script>
+    <script src="/labs/shared.js?v=6" defer></script>
     <script src="script.js" defer></script>
 </body>
 

--- a/labs/english-duo/index.html
+++ b/labs/english-duo/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Talk - Labs</title>
     <meta name="description" content="Aprenda idiomas de forma divertida e interativa com o Talk.">
-    <link rel="stylesheet" href="/labs/shared.css?v=4">
+    <link rel="stylesheet" href="/labs/shared.css?v=5">
     <link rel="stylesheet" href="style.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -307,7 +307,7 @@
 
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
-    <script src="/labs/shared.js?v=5" defer></script>
+    <script src="/labs/shared.js?v=6" defer></script>
     <script src="script.js" defer></script>
 </body>
 

--- a/labs/f1-racing/index.html
+++ b/labs/f1-racing/index.html
@@ -11,7 +11,7 @@
     <title>F1 Grand Prix — Racing Lab</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="stylesheet" href="/labs/shared.css?v=4">
+    <link rel="stylesheet" href="/labs/shared.css?v=5">
     <link rel="stylesheet" href="style.css?v=2">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Orbitron:wght@500;600;700;800;900&display=swap"
         rel="stylesheet">
@@ -251,7 +251,7 @@
         </section>
     </main>
 
-    <script src="/labs/shared.js?v=5" defer></script>
+    <script src="/labs/shared.js?v=6" defer></script>
     <script src="script.js?v=2" defer></script>
 </body>
 

--- a/labs/gravity/index.html
+++ b/labs/gravity/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Gravity - Diogo Paulino</title>
     <meta name="description" content="Simulação de física de partículas interativa.">
-    <link rel="stylesheet" href="/labs/shared.css?v=4">
+    <link rel="stylesheet" href="/labs/shared.css?v=5">
     <link rel="stylesheet" href="style.css">
 </head>
 
@@ -123,7 +123,7 @@
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
 
-    <script src="/labs/shared.js?v=5" defer></script>
+    <script src="/labs/shared.js?v=6" defer></script>
     <script src="script.js" defer></script>
 </body>
 

--- a/labs/image-editor/index.html
+++ b/labs/image-editor/index.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Image Editor - Labs</title>
-    <link rel="stylesheet" href="/labs/shared.css?v=4">
+    <link rel="stylesheet" href="/labs/shared.css?v=5">
     <link rel="stylesheet" href="style.css">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
 </head>
@@ -139,7 +139,7 @@
 
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
-    <script src="/labs/shared.js?v=5" defer></script>
+    <script src="/labs/shared.js?v=6" defer></script>
     <script src="script.js" defer></script>
 </body>
 

--- a/labs/image-optimizer/index.html
+++ b/labs/image-optimizer/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Image Optimizer - Labs</title>
     <meta name="description" content="Otimize e converta suas imagens para JPG, PNG ou WEBP diretamente no navegador.">
-    <link rel="stylesheet" href="/labs/shared.css?v=4">
+    <link rel="stylesheet" href="/labs/shared.css?v=5">
     <link rel="stylesheet" href="style.css">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
 </head>
@@ -66,7 +66,7 @@
 
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
-    <script src="/labs/shared.js?v=5" defer></script>
+    <script src="/labs/shared.js?v=6" defer></script>
     <script src="script.js" defer></script>
 </body>
 

--- a/labs/index.html
+++ b/labs/index.html
@@ -20,7 +20,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@100..900&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="/labs/shared.css?v=4">
+  <link rel="stylesheet" href="/labs/shared.css?v=5">
   <link rel="stylesheet" href="/labs/style.css">
   <script type="application/ld+json">
   {
@@ -448,7 +448,7 @@
   </div>
   <footer data-lab-footer data-home-href="/"></footer>
   </div>
-  <script src="/labs/shared.js?v=5"></script>
+  <script src="/labs/shared.js?v=6"></script>
   <script src="/labs/index.js"></script>
 </body>
 

--- a/labs/jungle-run/index.html
+++ b/labs/jungle-run/index.html
@@ -12,7 +12,7 @@
     <meta property="og:type" content="website">
     <meta property="og:image" content="https://diogopaulino.com.br/labs/jungle-run/og-jungle-run.jpg">
     <title>Jungle Run — Labs</title>
-    <link rel="stylesheet" href="/labs/shared.css?v=4">
+    <link rel="stylesheet" href="/labs/shared.css?v=5">
     <link rel="stylesheet" href="style.css?v=3">
     <script src="https://pixijs.download/v8.6.6/pixi.min.js" defer></script>
 </head>
@@ -195,7 +195,7 @@
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
 
-    <script src="/labs/shared.js?v=5" defer></script>
+    <script src="/labs/shared.js?v=6" defer></script>
     <script src="script.js?v=4" defer></script>
 </body>
 

--- a/labs/lander/index.html
+++ b/labs/lander/index.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Lander - Labs</title>
-    <link rel="stylesheet" href="/labs/shared.css?v=4">
+    <link rel="stylesheet" href="/labs/shared.css?v=5">
     <link rel="stylesheet" href="style.css?v=3">
     <!-- Courier Prime or VT323 for the retro feel -->
     <link href="https://fonts.googleapis.com/css2?family=VT323&display=swap" rel="stylesheet">
@@ -96,7 +96,7 @@
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
 
-    <script src="/labs/shared.js?v=5" defer></script>
+    <script src="/labs/shared.js?v=6" defer></script>
     <script src="script.js" defer></script>
 </body>
 

--- a/labs/minesweeper/index.html
+++ b/labs/minesweeper/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Campo Minado 95 - Labs</title>
     <meta name="description" content="Clássico jogo de Campo Minado estilo Windows 95.">
-    <link rel="stylesheet" href="/labs/shared.css?v=4">
+    <link rel="stylesheet" href="/labs/shared.css?v=5">
     <link rel="stylesheet" href="style.css">
 </head>
 
@@ -61,7 +61,7 @@
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
 
-    <script src="/labs/shared.js?v=5" defer></script>
+    <script src="/labs/shared.js?v=6" defer></script>
     <script src="script.js" defer></script>
 </body>
 

--- a/labs/paint/index.html
+++ b/labs/paint/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Paint Lab - Diogo Paulino</title>
     <meta name="description" content="Editor de imagens estilo Paint com ferramentas de desenho, formas e cores.">
-    <link rel="stylesheet" href="/labs/shared.css?v=4">
+    <link rel="stylesheet" href="/labs/shared.css?v=5">
     <link rel="stylesheet" href="style.css">
     <script src="https://unpkg.com/@phosphor-icons/web" defer></script>
 </head>
@@ -115,7 +115,7 @@
 
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
-    <script src="/labs/shared.js?v=5" defer></script>
+    <script src="/labs/shared.js?v=6" defer></script>
     <script src="script.js" defer></script>
 </body>
 

--- a/labs/piano/index.html
+++ b/labs/piano/index.html
@@ -8,7 +8,7 @@
   <meta name="mobile-web-app-capable" content="yes">
   <title>Piano - Diogo Paulino</title>
   <meta name="description" content="Piano minimalista com sons ultra realistas. 4 oitavas completas.">
-  <link rel="stylesheet" href="/labs/shared.css?v=4">
+  <link rel="stylesheet" href="/labs/shared.css?v=5">
   <link rel="stylesheet" href="style.css">
 </head>
 
@@ -71,7 +71,7 @@
     <footer data-lab-footer data-home-href="/"></footer>
   </div>
 
-  <script src="/labs/shared.js?v=5" defer></script>
+  <script src="/labs/shared.js?v=6" defer></script>
   <script src="script.js" defer></script>
 </body>
 

--- a/labs/pomodoro/index.html
+++ b/labs/pomodoro/index.html
@@ -8,7 +8,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;600&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=4">
+    <link rel="stylesheet" href="/labs/shared.css?v=5">
     <link rel="stylesheet" href="style.css?v=2">
 </head>
 
@@ -102,7 +102,7 @@
             </div>
         </div>
     </div>
-    <script src="/labs/shared.js?v=5" defer></script>
+    <script src="/labs/shared.js?v=6" defer></script>
     <script src="script.js" defer></script>
 </body>
 

--- a/labs/riff-rumble/index.html
+++ b/labs/riff-rumble/index.html
@@ -20,23 +20,25 @@
   <link
     href="https://fonts.googleapis.com/css2?family=Barlow+Condensed:ital,wght@0,600;0,700;0,800;0,900;1,800&family=Inter:wght@500;600;700;800&display=swap"
     rel="stylesheet">
+  <link rel="stylesheet" href="/labs/shared.css?v=5">
   <link rel="stylesheet" href="style.css">
+  <script src="/labs/shared.js?v=6" defer></script>
 </head>
 
 <body>
   <div class="noise" aria-hidden="true"></div>
 
-  <header class="topbar">
-    <a class="back-link" href="/labs/" aria-label="Voltar para Labs">
-      <span aria-hidden="true">←</span> LABS
-    </a>
-    <div class="brand" aria-label="Riff Rumble">
-      <span>RIFF</span><strong>RUMBLE</strong>
-    </div>
-    <div class="header-tools">
+  <header class="topbar" data-lab-header data-title="Riff Rumble" data-back-href="/labs/"
+    data-logo-heading-level="2">
+    <template data-slot="logo">
+      <div class="app-logo brand" aria-label="Riff Rumble">
+        <span>RIFF</span><strong>RUMBLE</strong>
+      </div>
+    </template>
+    <template data-slot="actions">
       <button class="icon-btn how-btn" id="how-to-play" type="button">? COMO JOGAR</button>
       <button class="icon-btn" id="sound-toggle" type="button" aria-label="Ativar ou desativar som">SOM: ON</button>
-    </div>
+    </template>
   </header>
 
   <main>
@@ -195,7 +197,7 @@
     </div>
   </div>
 
-  <script src="script.js"></script>
+  <script src="script.js" defer></script>
 </body>
 
 </html>

--- a/labs/riff-rumble/style.css
+++ b/labs/riff-rumble/style.css
@@ -14,8 +14,11 @@
 html { background: var(--ink); }
 body {
   margin: 0;
+  padding: 0;
   min-height: 100vh;
+  display: block;
   overflow-x: hidden;
+  align-items: initial;
   color: var(--cream);
   font-family: Inter, sans-serif;
   background:
@@ -33,6 +36,7 @@ button:focus-visible, a:focus-visible { outline: 3px solid var(--cyan); outline-
 }
 .topbar {
   height: 62px; padding: 0 clamp(16px, 4vw, 56px); position: fixed; z-index: 50; inset: 0 0 auto;
+  width: 100%; max-width: none; margin: 0;
   display: grid; grid-template-columns: 1fr auto 1fr; align-items: center;
   background: linear-gradient(180deg, rgba(7,5,11,.92), rgba(7,5,11,.32), transparent);
 }
@@ -42,7 +46,11 @@ button:focus-visible, a:focus-visible { outline: 3px solid var(--cyan); outline-
   border-radius: 999px; padding: 9px 13px; width: max-content; backdrop-filter: blur(8px);
 }
 .back-link span { color: var(--pink); margin-right: 4px; }
-.header-tools { justify-self:end; display:flex; gap:7px; }
+.topbar .header-actions { justify-self:end; display:flex; gap:7px; }
+.topbar .theme-switch-wrapper { flex: 0 0 auto; }
+.topbar .theme-toggle { width: 50px; height: 30px; background: rgba(7,5,11,.5); border-color: var(--line); }
+.topbar .theme-toggle-thumb { width: 22px; height: 22px; background: var(--pink); }
+[data-theme="dark"] .topbar .theme-toggle-thumb { transform: translateX(20px); background: var(--gold); }
 .icon-btn { cursor: pointer; }
 .how-btn { color:var(--gold); }
 .brand {
@@ -248,7 +256,7 @@ h1 span { color: var(--pink); }
 
 @media (max-width: 720px) {
   .topbar { height:54px; padding:0 12px; }
-  .header-tools { gap:4px; }
+  .topbar .header-actions { gap:4px; }
   .icon-btn { padding:8px 9px; font-size:9px; }
   #sound-toggle { font-size:0; }
   #sound-toggle::before { content:"♪"; font-size:13px; }

--- a/labs/shared.css
+++ b/labs/shared.css
@@ -73,7 +73,7 @@ body {
 }
 
 /* Header & Navigation */
-header {
+[data-lab-header] {
     width: 100%;
     display: grid;
     grid-template-columns: 1fr auto 1fr;
@@ -87,7 +87,7 @@ header {
     max-width: 1200px;
 }
 
-header .app-logo {
+[data-lab-header] .app-logo {
     grid-area: logo;
     display: flex;
     align-items: center;
@@ -100,8 +100,8 @@ header .app-logo {
     white-space: nowrap;
 }
 
-header .app-logo i,
-header .app-logo svg {
+[data-lab-header] .app-logo i,
+[data-lab-header] .app-logo svg {
     font-size: 1.5rem;
     color: var(--accent);
 }
@@ -155,7 +155,7 @@ header .app-logo svg {
     outline-offset: 3px;
 }
 
-header h1 {
+[data-lab-header] h1 {
     grid-area: logo;
     font-size: 2rem;
     font-weight: 700;
@@ -258,7 +258,7 @@ header h1 {
 }
 
 /* Footer */
-footer {
+[data-lab-footer] {
     width: 100%;
     max-width: 1200px;
     margin-top: 3rem;
@@ -273,14 +273,14 @@ footer {
     border-top: 1px solid var(--border-subtle);
 }
 
-footer a {
+[data-lab-footer] a {
     color: var(--accent);
     text-decoration: none;
     font-weight: 500;
     transition: color 0.3s ease;
 }
 
-footer a:hover {
+[data-lab-footer] a:hover {
     color: var(--accent-hover);
 }
 
@@ -290,14 +290,14 @@ footer a:hover {
         padding: 1rem;
     }
 
-    header {
+    [data-lab-header] {
         margin-bottom: 2rem;
         padding: 0;
         grid-template-columns: auto minmax(0, 1fr) auto;
         gap: 0.5rem;
     }
 
-    header .back-link {
+    [data-lab-header] .back-link {
         padding: 0.5rem;
         width: 36px;
         height: 36px;
@@ -305,11 +305,11 @@ footer a:hover {
         border-radius: 50%;
     }
 
-    header .back-link span {
+    [data-lab-header] .back-link span {
         display: none;
     }
 
-    header .app-logo {
+    [data-lab-header] .app-logo {
         justify-self: center;
         font-size: 1.1rem;
         max-width: 100%;
@@ -318,12 +318,12 @@ footer a:hover {
         text-overflow: ellipsis;
     }
 
-    header .theme-toggle,
-    header .header-actions {
+    [data-lab-header] .theme-toggle,
+    [data-lab-header] .header-actions {
         justify-self: end;
     }
 
-    footer {
+    [data-lab-footer] {
         margin-top: 2rem;
         padding: 1rem;
         font-size: 0.8rem;

--- a/labs/shared.js
+++ b/labs/shared.js
@@ -61,6 +61,7 @@
         const backLabel = header.getAttribute('data-back-label') || 'Labs';
         const title = header.getAttribute('data-title') || document.title || 'Labs';
         const subtitle = header.getAttribute('data-subtitle');
+        const logoHeadingLevel = header.getAttribute('data-logo-heading-level') || '1';
         const logoMarkup = extractSlotMarkup(header, 'logo');
         const actionsMarkup = extractSlotMarkup(header, 'actions');
         const renderedLogo = logoMarkup
@@ -86,7 +87,7 @@
         const logo = header.querySelector('.app-logo');
         if (logo && !logo.matches('h1, [role="heading"]')) {
             logo.setAttribute('role', 'heading');
-            logo.setAttribute('aria-level', '1');
+            logo.setAttribute('aria-level', logoHeadingLevel);
         }
 
         header.dataset.labReady = 'true';

--- a/labs/snake/index.html
+++ b/labs/snake/index.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Retro Snake - Labs</title>
-    <link rel="stylesheet" href="/labs/shared.css?v=4">
+    <link rel="stylesheet" href="/labs/shared.css?v=5">
     <link rel="stylesheet" href="style.css">
     <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
 </head>
@@ -84,7 +84,7 @@
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
 
-    <script src="/labs/shared.js?v=5" defer></script>
+    <script src="/labs/shared.js?v=6" defer></script>
     <script src="script.js" defer></script>
 </body>
 

--- a/labs/space-shooter/index.html
+++ b/labs/space-shooter/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Neon Invaders - Labs</title>
     <meta name="description" content="Jogo de tiro espacial estilo arcade com gráficos neon.">
-    <link rel="stylesheet" href="/labs/shared.css?v=4">
+    <link rel="stylesheet" href="/labs/shared.css?v=5">
     <link rel="stylesheet" href="style.css">
     <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
 </head>
@@ -45,7 +45,7 @@
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
 
-    <script src="/labs/shared.js?v=5" defer></script>
+    <script src="/labs/shared.js?v=6" defer></script>
     <script src="script.js" defer></script>
 </body>
 

--- a/labs/tetris/index.html
+++ b/labs/tetris/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Tetris 90s - Labs</title>
     <meta name="description" content="Jogue Tetris clássico estilo anos 90 no seu navegador.">
-    <link rel="stylesheet" href="/labs/shared.css?v=4">
+    <link rel="stylesheet" href="/labs/shared.css?v=5">
     <link rel="stylesheet" href="style.css">
 </head>
 
@@ -84,7 +84,7 @@
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
 
-    <script src="/labs/shared.js?v=5" defer></script>
+    <script src="/labs/shared.js?v=6" defer></script>
     <script src="script.js" defer></script>
 </body>
 

--- a/labs/videogame/index.html
+++ b/labs/videogame/index.html
@@ -9,13 +9,13 @@
 
 
 
-    <link rel="stylesheet" href="/labs/shared.css?v=4">
-    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="/labs/shared.css?v=5">
+    <link rel="stylesheet" href="style.css?v=2">
     <link rel="stylesheet" href="mobile.css">
     <script src="/labs/videogame/lib/nostalgist.umd.js" defer></script>
-    <script src="/labs/shared.js?v=5" defer></script>
+    <script src="/labs/shared.js?v=6" defer></script>
     <script src="games.js" defer></script>
-    <script src="script.js" defer></script>
+    <script src="script.js?v=2" defer></script>
 </head>
 
 <body>

--- a/labs/videogame/script.js
+++ b/labs/videogame/script.js
@@ -284,7 +284,7 @@ const App = {
         this.ui.home.classList.remove('hidden');
         this.ui.player.classList.add('hidden');
         this.ui.player.setAttribute('aria-hidden', 'true');
-        this.ui.header.style.display = 'flex';
+        this.ui.header.style.removeProperty('display');
         this.ui.footer.style.display = 'block';
         if (this.isNativeFullscreenActive()) this.exitFullscreenSafe();
         if (this.isManualFullscreen) this.exitManualFullscreen();

--- a/labs/videogame/style.css
+++ b/labs/videogame/style.css
@@ -1,3 +1,8 @@
+.app-container {
+    width: 100%;
+    min-width: 0;
+}
+
 main {
     flex: 1;
     display: flex;

--- a/labs/winamp/index.html
+++ b/labs/winamp/index.html
@@ -8,13 +8,22 @@
     <meta name="description"
         content="Winamp 2.91 no navegador: player clássico completo, equalizador, playlist, visualizador, skins e músicas demo.">
     <title>Winamp 2.91 — Diogo Labs</title>
-    <link rel="stylesheet" href="style.css?v=4">
+    <link rel="stylesheet" href="/labs/shared.css?v=5">
+    <link rel="stylesheet" href="style.css?v=5">
+    <script src="/labs/shared.js?v=6" defer></script>
 </head>
 
 <body>
     <a class="skip-link" href="#winamp-stage">Pular para o Winamp</a>
 
     <div class="desktop" id="desktop">
+        <header class="winamp-lab-header" data-lab-header data-title="Winamp 2.91"
+            data-back-href="/labs/">
+            <template data-slot="logo">
+                <div class="app-logo">⚡ Winamp 2.91</div>
+            </template>
+        </header>
+
         <nav class="desktop-icons" aria-label="Atalhos da área de trabalho">
             <a class="desktop-icon" href="/labs/" aria-label="Voltar para todos os Labs">
                 <span class="icon-art icon-computer" aria-hidden="true">

--- a/labs/winamp/style.css
+++ b/labs/winamp/style.css
@@ -31,10 +31,77 @@ body {
 body {
     background: var(--desktop);
     color: #000;
+    display: block;
+    padding: 0;
+    align-items: initial;
     font-family: "MS Sans Serif", Tahoma, Geneva, sans-serif;
     font-size: 12px;
     -webkit-font-smoothing: none;
     image-rendering: pixelated;
+}
+
+.winamp-lab-header {
+    position: absolute;
+    z-index: 30;
+    top: 10px;
+    right: 18px;
+    left: 112px;
+    width: auto;
+    max-width: none;
+    height: 40px;
+    margin: 0;
+    padding: 0;
+}
+
+.winamp-lab-header .back-link,
+.winamp-lab-header .theme-toggle {
+    border: 2px outset var(--win-light);
+    border-radius: 0;
+    background: var(--win-gray);
+    color: #000;
+    box-shadow: none;
+}
+
+.winamp-lab-header .back-link {
+    height: 32px;
+    padding: 4px 10px;
+}
+
+.winamp-lab-header .back-link:hover,
+.winamp-lab-header .theme-toggle:hover {
+    border-color: var(--win-light);
+    color: #000;
+    transform: none;
+    box-shadow: none;
+}
+
+.winamp-lab-header .app-logo {
+    color: #fff;
+    font-family: "MS Sans Serif", Tahoma, Geneva, sans-serif;
+    font-size: 13px;
+    font-weight: 700;
+    text-shadow: 1px 1px #000;
+}
+
+.winamp-lab-header .theme-toggle {
+    width: 50px;
+    height: 30px;
+}
+
+.winamp-lab-header .theme-toggle-track {
+    inset: 2px;
+}
+
+.winamp-lab-header .theme-toggle-thumb {
+    width: 22px;
+    height: 22px;
+    border-radius: 0;
+    background: var(--win-blue);
+}
+
+[data-theme="dark"] .winamp-lab-header .theme-toggle-thumb {
+    transform: translateX(20px);
+    background: #000;
 }
 
 button,
@@ -236,7 +303,7 @@ a:focus-visible {
 .player-workspace {
     position: absolute;
     z-index: 10;
-    inset: 10px 18px calc(var(--taskbar-height) + 14px) 112px;
+    inset: 58px 18px calc(var(--taskbar-height) + 14px) 112px;
     display: grid;
     place-items: center;
 }
@@ -726,7 +793,13 @@ noscript {
     }
 
     .player-workspace {
-        inset: 7px 7px calc(var(--taskbar-height) + 10px) 77px;
+        inset: 55px 7px calc(var(--taskbar-height) + 10px) 77px;
+    }
+
+    .winamp-lab-header {
+        top: 7px;
+        right: 7px;
+        left: 77px;
     }
 
     .desktop-tip {


### PR DESCRIPTION
## What changed

- standardized all 20 Labs pages on the shared header component
- migrated Riff Rumble and Winamp to the shared Lab header while preserving their visual identity
- scoped shared header/footer CSS to the Lab shell elements
- fixed the Videogame header layout at narrow mobile widths
- updated shared asset cache versions

## Why

Some Lab experiences bypassed the shared header structure, and the Videogame page changed the header display mode at runtime. This caused inconsistent navigation, theme controls, accessibility semantics, and mobile sizing.

## Impact

All Labs now expose consistent back navigation, branding, actions, and theme controls without affecting app-specific bars such as the Winamp taskbar.

## Validation

- visually checked all 20 Lab headers on desktop and mobile
- verified layouts down to 320px without overlap or overflow
- tested Riff Rumble header actions
- checked JavaScript syntax for shared, Riff Rumble, Videogame, and Winamp scripts
- ran git diff --check
- confirmed no console warnings or errors in Riff Rumble and Winamp