### PR TITLE
Improve Pomodoro settings, notifications, and UI

### DIFF
--- a/labs/pomodoro/index.html
+++ b/labs/pomodoro/index.html
@@ -1,15 +1,18 @@
 <!DOCTYPE html>
-<html lang="pt-br">
+<html lang="pt-BR">
 
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Pomodoro - Labs</title>
+    <meta name="description" content="Timer Pomodoro simples para alternar períodos de foco e descanso.">
+    <meta name="theme-color" content="#fafbfc">
+    <title>Pomodoro — Labs</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;600&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&display=swap"
+        rel="stylesheet">
     <link rel="stylesheet" href="/labs/shared.css?v=4">
-    <link rel="stylesheet" href="style.css?v=2">
+    <link rel="stylesheet" href="style.css?v=4">
 </head>
 
 <body>
@@ -17,93 +20,171 @@
         <header data-lab-header data-title="Pomodoro">
             <template data-slot="logo">
                 <div class="app-logo">
-                    ⏱️ Pomodoro
+                    <span class="logo-mark" aria-hidden="true"></span>
+                    Pomodoro
                 </div>
             </template>
             <template data-slot="actions">
-                <button id="btn-settings" class="icon-btn" aria-label="Settings">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none"
-                        stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <button id="btn-settings" class="icon-btn" type="button" aria-label="Abrir configurações"
+                    aria-haspopup="dialog" aria-controls="settings-modal">
+                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                        stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                         <circle cx="12" cy="12" r="3"></circle>
-                        <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"></path>
+                        <path
+                            d="M19.4 15a1.7 1.7 0 0 0 .3 1.8l.1.1a2 2 0 1 1-2.8 2.8l-.1-.1a1.7 1.7 0 0 0-1.8-.3 1.7 1.7 0 0 0-1 1.5V21a2 2 0 1 1-4 0v-.1a1.7 1.7 0 0 0-1-1.5 1.7 1.7 0 0 0-1.8.3l-.1.1a2 2 0 1 1-2.8-2.8l.1-.1a1.7 1.7 0 0 0 .3-1.8 1.7 1.7 0 0 0-1.5-1H3a2 2 0 1 1 0-4h.1a1.7 1.7 0 0 0 1.5-1 1.7 1.7 0 0 0-.3-1.8l-.1-.1a2 2 0 1 1 2.8-2.8l.1.1a1.7 1.7 0 0 0 1.8.3h.1a1.7 1.7 0 0 0 1-1.5V3a2 2 0 1 1 4 0v.1a1.7 1.7 0 0 0 1 1.5 1.7 1.7 0 0 0 1.8-.3l.1-.1a2 2 0 1 1 2.8 2.8l-.1.1a1.7 1.7 0 0 0-.3 1.8v.1a1.7 1.7 0 0 0 1.5 1h.2a2 2 0 1 1 0 4h-.1a1.7 1.7 0 0 0-1.5 1Z">
+                        </path>
                     </svg>
                 </button>
             </template>
         </header>
 
-        <main>
-            <div class="timer-circle-container">
-                <svg class="timer-svg" viewBox="0 0 100 100">
+        <main class="pomodoro-card">
+            <div class="session-heading">
+                <div>
+                    <p class="eyebrow" id="session-label">Hora de focar</p>
+                    <h1 id="session-title">Sessão de foco</h1>
+                </div>
+                <span class="cycle-pill">Ciclo <strong id="cycle-count">1</strong> de 4</span>
+            </div>
+
+            <div class="modes" role="tablist" aria-label="Tipo de sessão">
+                <button class="mode-btn active" type="button" role="tab" aria-selected="true"
+                    data-mode="focus">Foco</button>
+                <button class="mode-btn" type="button" role="tab" aria-selected="false"
+                    data-mode="short">Pausa curta</button>
+                <button class="mode-btn" type="button" role="tab" aria-selected="false"
+                    data-mode="long">Pausa longa</button>
+            </div>
+
+            <div class="timer-circle-container" aria-labelledby="session-title" aria-describedby="timer-description">
+                <svg class="timer-svg" viewBox="0 0 100 100" aria-hidden="true">
                     <circle class="timer-bg" cx="50" cy="50" r="45"></circle>
                     <circle class="timer-progress" cx="50" cy="50" r="45"></circle>
                 </svg>
                 <div class="timer-display">
-                    <div class="status-badge" id="status-badge">FOCUS</div>
-                    <div class="time" id="time-display">25:00</div>
-                    <div class="cycle-info">Cycle <span id="cycle-count">1</span>/4</div>
+                    <div class="status-badge" id="status-badge">FOCO</div>
+                    <div class="time" id="time-display" role="timer" aria-live="off">25:00</div>
+                    <p id="timer-description">Prepare-se e comece quando quiser.</p>
                 </div>
             </div>
 
             <div class="controls">
-                <button id="btn-toggle" class="btn-primary">
-                    <span class="icon-play">▶</span> Start
+                <button id="btn-toggle" class="btn-primary" type="button">
+                    <span class="control-icon" aria-hidden="true">▶</span>
+                    <span class="control-label">Começar</span>
                 </button>
-                <button id="btn-reset" class="btn-secondary">
-                    <span class="icon-reset">↻</span>
+                <button id="btn-reset" class="btn-secondary" type="button" aria-label="Reiniciar sessão"
+                    title="Reiniciar sessão">
+                    <span aria-hidden="true">↻</span>
                 </button>
             </div>
 
-            <div class="modes">
-                <button class="mode-btn active" data-mode="focus">Focus</button>
-                <button class="mode-btn" data-mode="short">Short Break</button>
-                <button class="mode-btn" data-mode="long">Long Break</button>
-            </div>
+            <button class="signal-status" id="signal-status" type="button"
+                aria-label="Configurar som e notificações">
+                <span><span class="status-dot" aria-hidden="true"></span><span id="sound-status">Som ligado</span></span>
+                <span class="status-divider" aria-hidden="true"></span>
+                <span id="notification-status">Notificações desligadas</span>
+            </button>
+            <p class="sr-only" id="timer-announcement" aria-live="assertive"></p>
         </main>
+
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
 
-    <!-- Settings Modal -->
-    <div id="settings-modal" class="modal">
+    <div class="toast" id="settings-toast" role="status" aria-live="polite" aria-atomic="true">
+        <span class="toast-check" aria-hidden="true">✓</span>
+        Configurações salvas neste navegador
+    </div>
+
+    <div id="settings-modal" class="modal" role="dialog" aria-modal="true" aria-labelledby="settings-title"
+        aria-hidden="true">
         <div class="modal-content">
             <div class="modal-header">
-                <h2>Settings</h2>
-                <button id="btn-close-settings" class="close-btn">&times;</button>
+                <div>
+                    <p class="eyebrow">Personalize seu ritmo</p>
+                    <h2 id="settings-title">Configurações</h2>
+                </div>
+                <button id="btn-close-settings" class="close-btn" type="button"
+                    aria-label="Fechar configurações">&times;</button>
             </div>
+
             <div class="modal-body">
-                <div class="setting-group">
-                    <h3>Timer (minutes)</h3>
-                    <div class="setting-row">
-                        <label>Focus</label>
-                        <input type="number" id="setting-focus" value="25" min="1" max="60">
+                <fieldset class="setting-group">
+                    <legend>Duração das sessões</legend>
+                    <div class="duration-grid">
+                        <label>
+                            <span>Foco</span>
+                            <span class="number-field"><input type="number" id="setting-focus" value="25" min="1"
+                                    max="120" inputmode="numeric"><small>min</small></span>
+                        </label>
+                        <label>
+                            <span>Pausa curta</span>
+                            <span class="number-field"><input type="number" id="setting-short" value="5" min="1"
+                                    max="60" inputmode="numeric"><small>min</small></span>
+                        </label>
+                        <label>
+                            <span>Pausa longa</span>
+                            <span class="number-field"><input type="number" id="setting-long" value="15" min="1"
+                                    max="120" inputmode="numeric"><small>min</small></span>
+                        </label>
                     </div>
-                    <div class="setting-row">
-                        <label>Short Break</label>
-                        <input type="number" id="setting-short" value="5" min="1" max="30">
+                </fieldset>
+
+                <fieldset class="setting-group">
+                    <legend>Sinais</legend>
+                    <div class="sound-controls">
+                        <label class="select-field" for="setting-sound">
+                            <span>Toque ao terminar</span>
+                            <select id="setting-sound">
+                                <option value="soft">Suave</option>
+                                <option value="digital">Digital</option>
+                                <option value="bell">Sino</option>
+                            </select>
+                        </label>
+                        <button id="btn-test-sound" class="btn-quiet" type="button">Ouvir</button>
                     </div>
-                    <div class="setting-row">
-                        <label>Long Break</label>
-                        <input type="number" id="setting-long" value="15" min="1" max="60">
-                    </div>
-                </div>
-                <div class="setting-group">
-                    <h3>Options</h3>
-                    <div class="setting-row toggle-row">
-                        <label>Auto-start Breaks</label>
+                    <label class="range-field" for="setting-volume">
+                        <span>Volume</span>
+                        <input type="range" id="setting-volume" min="0" max="100" value="65">
+                        <output id="volume-value" for="setting-volume">65%</output>
+                    </label>
+                    <label class="switch-row">
+                        <span><strong>Som</strong><small>Toca mesmo com a aba aberta.</small></span>
+                        <input type="checkbox" id="setting-sound-enabled" checked>
+                        <span class="switch" aria-hidden="true"></span>
+                    </label>
+                    <label class="switch-row">
+                        <span><strong>Notificações</strong><small id="notification-help">Avise quando a sessão
+                                terminar.</small></span>
+                        <input type="checkbox" id="setting-notifications">
+                        <span class="switch" aria-hidden="true"></span>
+                    </label>
+                </fieldset>
+
+                <fieldset class="setting-group">
+                    <legend>Automação</legend>
+                    <label class="switch-row">
+                        <span><strong>Iniciar pausas</strong><small>Começa a pausa automaticamente.</small></span>
                         <input type="checkbox" id="setting-auto-break">
-                    </div>
-                    <div class="setting-row toggle-row">
-                        <label>Auto-start Pomodoros</label>
+                        <span class="switch" aria-hidden="true"></span>
+                    </label>
+                    <label class="switch-row">
+                        <span><strong>Iniciar focos</strong><small>Começa o próximo foco automaticamente.</small></span>
                         <input type="checkbox" id="setting-auto-pomodoro">
-                    </div>
-                </div>
+                        <span class="switch" aria-hidden="true"></span>
+                    </label>
+                </fieldset>
             </div>
+
             <div class="modal-footer">
-                <button id="btn-save-settings" class="btn-primary">Save Changes</button>
+                <span>As preferências ficam salvas neste navegador.</span>
+                <button id="btn-save-settings" class="btn-primary" type="button">Salvar configurações</button>
             </div>
         </div>
     </div>
+
     <script src="/labs/shared.js?v=5" defer></script>
-    <script src="script.js" defer></script>
+    <script src="script.js?v=4" defer></script>
 </body>
 
 </html>

--- a/labs/pomodoro/script.js
+++ b/labs/pomodoro/script.js
@@ -1,81 +1,218 @@
 class PomodoroApp {
     constructor() {
-        // Default Settings
-        this.settings = {
+        this.defaults = {
             focus: 25,
             short: 5,
             long: 15,
             autoBreak: false,
-            autoPomodoro: false
+            autoPomodoro: false,
+            soundEnabled: true,
+            sound: 'soft',
+            volume: 65,
+            notifications: false
         };
 
-        this.loadSettings();
-
-        this.timeLeft = this.settings.focus * 60;
-        this.totalTime = this.settings.focus * 60;
-        this.timerId = null;
-        this.isRunning = false;
+        this.settings = this.loadSettings();
+        this.mode = 'focus';
         this.cycleCount = 1;
-        this.mode = 'focus'; // focus, short, long
+        this.timeLeft = this.settings.focus * 60;
+        this.totalTime = this.timeLeft;
+        this.timerId = null;
+        this.targetTime = null;
+        this.isRunning = false;
+        this.audioCtx = null;
+        this.lastFocusedElement = null;
+        this.toastTimer = null;
 
-        // DOM Elements
+        this.cacheElements();
+        this.init();
+    }
+
+    cacheElements() {
         this.timeDisplay = document.getElementById('time-display');
         this.progressCircle = document.querySelector('.timer-progress');
         this.statusBadge = document.getElementById('status-badge');
+        this.sessionLabel = document.getElementById('session-label');
+        this.sessionTitle = document.getElementById('session-title');
+        this.timerDescription = document.getElementById('timer-description');
+        this.timerAnnouncement = document.getElementById('timer-announcement');
+        this.pomodoroCard = document.querySelector('.pomodoro-card');
         this.cycleDisplay = document.getElementById('cycle-count');
         this.toggleBtn = document.getElementById('btn-toggle');
+        this.toggleIcon = this.toggleBtn.querySelector('.control-icon');
+        this.toggleLabel = this.toggleBtn.querySelector('.control-label');
         this.resetBtn = document.getElementById('btn-reset');
         this.modeBtns = document.querySelectorAll('.mode-btn');
+        this.signalStatus = document.getElementById('signal-status');
+        this.soundStatus = document.getElementById('sound-status');
+        this.notificationStatus = document.getElementById('notification-status');
+        this.settingsToast = document.getElementById('settings-toast');
 
-        // Settings DOM
         this.settingsBtn = document.getElementById('btn-settings');
         this.settingsModal = document.getElementById('settings-modal');
         this.closeSettingsBtn = document.getElementById('btn-close-settings');
         this.saveSettingsBtn = document.getElementById('btn-save-settings');
+        this.testSoundBtn = document.getElementById('btn-test-sound');
 
-        // Inputs
         this.inputFocus = document.getElementById('setting-focus');
         this.inputShort = document.getElementById('setting-short');
         this.inputLong = document.getElementById('setting-long');
         this.inputAutoBreak = document.getElementById('setting-auto-break');
         this.inputAutoPomodoro = document.getElementById('setting-auto-pomodoro');
-
-        // Audio Context
-        this.audioCtx = null;
-
-        this.init();
+        this.inputSoundEnabled = document.getElementById('setting-sound-enabled');
+        this.inputSound = document.getElementById('setting-sound');
+        this.inputVolume = document.getElementById('setting-volume');
+        this.volumeValue = document.getElementById('volume-value');
+        this.inputNotifications = document.getElementById('setting-notifications');
+        this.notificationHelp = document.getElementById('notification-help');
     }
 
     init() {
-        this.updateDisplay();
         this.setupEventListeners();
-        this.requestNotificationPermission();
+        this.updateModeUI();
+        this.updateDisplay();
+        this.updateSignalStatus();
     }
 
     loadSettings() {
-        const saved = localStorage.getItem('pomodoro-settings');
-        if (saved) {
-            this.settings = JSON.parse(saved);
+        try {
+            const saved = JSON.parse(localStorage.getItem('pomodoro-settings') || '{}');
+            return this.normalizeSettings(saved);
+        } catch (error) {
+            return { ...this.defaults };
         }
     }
 
-    saveSettings() {
-        this.settings = {
-            focus: parseInt(this.inputFocus.value) || 25,
-            short: parseInt(this.inputShort.value) || 5,
-            long: parseInt(this.inputLong.value) || 15,
-            autoBreak: this.inputAutoBreak.checked,
-            autoPomodoro: this.inputAutoPomodoro.checked
+    normalizeSettings(settings = {}) {
+        const numberInRange = (value, fallback, min, max) => {
+            const number = Number.parseInt(value, 10);
+            return Math.min(max, Math.max(min, Number.isFinite(number) ? number : fallback));
         };
-        localStorage.setItem('pomodoro-settings', JSON.stringify(this.settings));
+        const sounds = ['soft', 'digital', 'bell'];
 
-        // Close modal
-        this.settingsModal.classList.remove('open');
+        return {
+            focus: numberInRange(settings.focus, this.defaults.focus, 1, 120),
+            short: numberInRange(settings.short, this.defaults.short, 1, 60),
+            long: numberInRange(settings.long, this.defaults.long, 1, 120),
+            autoBreak: settings.autoBreak === true,
+            autoPomodoro: settings.autoPomodoro === true,
+            soundEnabled: settings.soundEnabled !== false,
+            sound: sounds.includes(settings.sound) ? settings.sound : this.defaults.sound,
+            volume: numberInRange(settings.volume, this.defaults.volume, 0, 100),
+            notifications: settings.notifications === true
+        };
+    }
 
-        // Reset timer to apply new settings if not running
-        if (!this.isRunning) {
-            this.resetTimer();
+    persistSettings() {
+        try {
+            localStorage.setItem('pomodoro-settings', JSON.stringify(this.settings));
+        } catch (error) {
+            // The timer still works when storage is unavailable.
         }
+    }
+
+    setupEventListeners() {
+        this.toggleBtn.addEventListener('click', () => this.toggleTimer());
+        this.resetBtn.addEventListener('click', () => this.resetTimer());
+
+        this.modeBtns.forEach((button) => {
+            button.addEventListener('click', () => this.switchMode(button.dataset.mode));
+            button.addEventListener('keydown', (event) => this.handleModeNavigation(event));
+        });
+
+        this.settingsBtn.addEventListener('click', () => this.openSettings());
+        this.signalStatus.addEventListener('click', () => this.openSettings());
+        this.closeSettingsBtn.addEventListener('click', () => this.closeSettings());
+        this.saveSettingsBtn.addEventListener('click', () => this.saveSettings());
+        this.testSoundBtn.addEventListener('click', () => this.previewSound());
+
+        this.inputVolume.addEventListener('input', () => {
+            this.volumeValue.textContent = `${this.inputVolume.value}%`;
+        });
+
+        this.inputNotifications.addEventListener('change', () => this.handleNotificationToggle());
+
+        this.settingsModal.addEventListener('click', (event) => {
+            if (event.target === this.settingsModal) this.closeSettings();
+        });
+
+        document.addEventListener('keydown', (event) => {
+            if (event.key === 'Tab' && this.settingsModal.classList.contains('open')) {
+                this.keepFocusInSettings(event);
+            }
+
+            if (event.key === 'Escape' && this.settingsModal.classList.contains('open')) {
+                this.closeSettings();
+            }
+
+            if (event.code === 'Space' && !this.settingsModal.classList.contains('open')
+                && !['INPUT', 'BUTTON', 'SELECT'].includes(document.activeElement.tagName)) {
+                event.preventDefault();
+                this.toggleTimer();
+            }
+        });
+
+        document.addEventListener('visibilitychange', () => {
+            if (this.isRunning && document.visibilityState === 'visible') this.tick();
+        });
+
+        window.addEventListener('storage', (event) => {
+            if (event.key !== 'pomodoro-settings') return;
+            this.settings = this.loadSettings();
+            this.updateSignalStatus();
+            if (!this.isRunning) this.resetTimer();
+        });
+    }
+
+    openSettings() {
+        this.populateSettings();
+        this.lastFocusedElement = document.activeElement;
+        this.settingsModal.classList.add('open');
+        this.settingsModal.setAttribute('aria-hidden', 'false');
+        document.body.classList.add('modal-open');
+        this.closeSettingsBtn.focus();
+    }
+
+    closeSettings() {
+        this.settingsModal.classList.remove('open');
+        this.settingsModal.setAttribute('aria-hidden', 'true');
+        document.body.classList.remove('modal-open');
+        this.lastFocusedElement?.focus();
+    }
+
+    keepFocusInSettings(event) {
+        const focusable = Array.from(this.settingsModal.querySelectorAll(
+            'button:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])'
+        )).filter((element) => element.offsetParent !== null);
+
+        if (!focusable.length) return;
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+
+        if (event.shiftKey && document.activeElement === first) {
+            event.preventDefault();
+            last.focus();
+        } else if (!event.shiftKey && document.activeElement === last) {
+            event.preventDefault();
+            first.focus();
+        }
+    }
+
+    handleModeNavigation(event) {
+        if (!['ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(event.key)) return;
+        event.preventDefault();
+
+        const buttons = Array.from(this.modeBtns);
+        const currentIndex = buttons.indexOf(event.currentTarget);
+        let nextIndex = currentIndex;
+
+        if (event.key === 'ArrowRight') nextIndex = (currentIndex + 1) % buttons.length;
+        if (event.key === 'ArrowLeft') nextIndex = (currentIndex - 1 + buttons.length) % buttons.length;
+        if (event.key === 'Home') nextIndex = 0;
+        if (event.key === 'End') nextIndex = buttons.length - 1;
+
+        buttons[nextIndex].focus();
+        this.switchMode(buttons[nextIndex].dataset.mode);
     }
 
     populateSettings() {
@@ -84,194 +221,337 @@ class PomodoroApp {
         this.inputLong.value = this.settings.long;
         this.inputAutoBreak.checked = this.settings.autoBreak;
         this.inputAutoPomodoro.checked = this.settings.autoPomodoro;
+        this.inputSoundEnabled.checked = this.settings.soundEnabled;
+        this.inputSound.value = this.settings.sound;
+        this.inputVolume.value = this.settings.volume;
+        this.volumeValue.textContent = `${this.settings.volume}%`;
+
+        const notificationSupported = 'Notification' in window;
+        const permission = notificationSupported ? Notification.permission : 'unsupported';
+        this.inputNotifications.disabled = !notificationSupported || permission === 'denied';
+        this.inputNotifications.checked = this.settings.notifications && permission === 'granted';
+
+        if (!notificationSupported) {
+            this.notificationHelp.textContent = 'Este navegador não oferece notificações.';
+        } else if (permission === 'denied') {
+            this.notificationHelp.textContent = 'Bloqueadas nas configurações do navegador.';
+        } else if (permission === 'granted') {
+            this.notificationHelp.textContent = 'Aviso liberado para esta página.';
+        } else {
+            this.notificationHelp.textContent = 'O navegador pedirá sua permissão.';
+        }
     }
 
-    setupEventListeners() {
-        this.toggleBtn.addEventListener('click', () => this.toggleTimer());
-        this.resetBtn.addEventListener('click', () => this.resetTimer());
-
-        this.modeBtns.forEach(btn => {
-            btn.addEventListener('click', (e) => {
-                const newMode = e.target.dataset.mode;
-                this.switchMode(newMode);
-            });
-        });
-
-        // Settings Modal
-        this.settingsBtn.addEventListener('click', () => {
-            this.populateSettings();
-            this.settingsModal.classList.add('open');
-        });
-
-        this.closeSettingsBtn.addEventListener('click', () => {
-            this.settingsModal.classList.remove('open');
-        });
-
-        this.saveSettingsBtn.addEventListener('click', () => {
-            this.saveSettings();
-        });
-
-        // Close modal on outside click
-        this.settingsModal.addEventListener('click', (e) => {
-            if (e.target === this.settingsModal) {
-                this.settingsModal.classList.remove('open');
-            }
-        });
+    clampNumber(input, fallback, min, max) {
+        const value = Number.parseInt(input.value, 10);
+        return Math.min(max, Math.max(min, Number.isFinite(value) ? value : fallback));
     }
 
-    requestNotificationPermission() {
-        if ("Notification" in window && Notification.permission !== "granted") {
-            Notification.requestPermission();
+    saveSettings() {
+        const previousDuration = this.settings[this.mode];
+
+        this.settings = {
+            focus: this.clampNumber(this.inputFocus, 25, 1, 120),
+            short: this.clampNumber(this.inputShort, 5, 1, 60),
+            long: this.clampNumber(this.inputLong, 15, 1, 120),
+            autoBreak: this.inputAutoBreak.checked,
+            autoPomodoro: this.inputAutoPomodoro.checked,
+            soundEnabled: this.inputSoundEnabled.checked,
+            sound: this.inputSound.value,
+            volume: Number.parseInt(this.inputVolume.value, 10),
+            notifications: this.inputNotifications.checked && this.hasNotificationPermission()
+        };
+
+        this.persistSettings();
+        this.closeSettings();
+        this.updateSignalStatus();
+        this.showToast();
+
+        if (!this.isRunning && previousDuration !== this.settings[this.mode]) {
+            this.resetTimer();
+        } else {
+            this.updateDisplay();
+        }
+    }
+
+    showToast() {
+        window.clearTimeout(this.toastTimer);
+        this.settingsToast.classList.add('visible');
+        this.toastTimer = window.setTimeout(() => {
+            this.settingsToast.classList.remove('visible');
+        }, 2600);
+    }
+
+    async handleNotificationToggle() {
+        if (!this.inputNotifications.checked || !('Notification' in window)) return;
+
+        if (Notification.permission === 'default') {
+            const permission = await Notification.requestPermission();
+            this.inputNotifications.checked = permission === 'granted';
+        } else if (Notification.permission !== 'granted') {
+            this.inputNotifications.checked = false;
+        }
+
+        this.populateNotificationHelp();
+    }
+
+    populateNotificationHelp() {
+        if (!('Notification' in window)) {
+            this.notificationHelp.textContent = 'Este navegador não oferece notificações.';
+        } else if (Notification.permission === 'granted') {
+            this.notificationHelp.textContent = 'Aviso liberado para esta página.';
+        } else if (Notification.permission === 'denied') {
+            this.notificationHelp.textContent = 'Bloqueadas nas configurações do navegador.';
+            this.inputNotifications.disabled = true;
+        } else {
+            this.notificationHelp.textContent = 'O navegador pedirá sua permissão.';
+        }
+    }
+
+    hasNotificationPermission() {
+        return 'Notification' in window && Notification.permission === 'granted';
+    }
+
+    updateSignalStatus() {
+        this.soundStatus.textContent = this.settings.soundEnabled ? 'Som ligado' : 'Som desligado';
+        this.signalStatus.classList.toggle('sound-off', !this.settings.soundEnabled);
+
+        if (!('Notification' in window)) {
+            this.notificationStatus.textContent = 'Notificações indisponíveis';
+        } else if (Notification.permission === 'denied') {
+            this.notificationStatus.textContent = 'Notificações bloqueadas';
+        } else if (this.settings.notifications && Notification.permission === 'granted') {
+            this.notificationStatus.textContent = 'Notificações ligadas';
+        } else {
+            this.notificationStatus.textContent = 'Notificações desligadas';
         }
     }
 
     toggleTimer() {
-        if (this.isRunning) {
-            this.pauseTimer();
-        } else {
-            this.startTimer();
-        }
+        this.isRunning ? this.pauseTimer() : this.startTimer();
     }
 
     startTimer() {
-        if (!this.isRunning) {
-            this.isRunning = true;
-            this.toggleBtn.innerHTML = '<span class="icon-pause">⏸</span> Pause';
-            this.toggleBtn.classList.add('active');
+        if (this.isRunning || this.timeLeft <= 0) return;
+        this.ensureAudioContext();
+        this.isRunning = true;
+        this.targetTime = Date.now() + this.timeLeft * 1000;
+        this.setControlState();
+        this.timerDescription.textContent = this.mode === 'focus' ? 'Mantenha o foco. Você consegue.' : 'Respire e recarregue a energia.';
+        this.timerId = window.setInterval(() => this.tick(), 250);
+    }
 
-            // Initialize audio context on first user interaction
-            if (!this.audioCtx) {
-                this.audioCtx = new (window.AudioContext || window.webkitAudioContext)();
-            }
+    tick() {
+        if (!this.isRunning) return;
 
-            this.lastTime = Date.now();
-            this.timerId = setInterval(() => {
-                const now = Date.now();
-                const delta = Math.floor((now - this.lastTime) / 1000);
+        this.timeLeft = Math.max(0, Math.ceil((this.targetTime - Date.now()) / 1000));
+        this.updateDisplay();
 
-                if (delta >= 1) {
-                    this.timeLeft -= delta;
-                    this.lastTime = now;
-                    this.updateDisplay();
-
-                    if (this.timeLeft <= 0) {
-                        this.completeTimer();
-                    }
-                }
-            }, 100);
-        }
+        if (this.timeLeft <= 0) this.completeTimer();
     }
 
     pauseTimer() {
+        if (this.isRunning && this.targetTime) {
+            this.timeLeft = Math.max(0, Math.ceil((this.targetTime - Date.now()) / 1000));
+        }
         this.isRunning = false;
-        clearInterval(this.timerId);
-        this.toggleBtn.innerHTML = '<span class="icon-play">▶</span> Start';
-        this.toggleBtn.classList.remove('active');
+        this.targetTime = null;
+        window.clearInterval(this.timerId);
+        this.timerId = null;
+        this.setControlState();
+        this.timerDescription.textContent = this.timeLeft === this.totalTime
+            ? 'Prepare-se e comece quando quiser.'
+            : 'Pausado. Continue quando estiver pronto.';
+        this.updateDisplay();
+    }
+
+    setControlState() {
+        this.toggleIcon.textContent = this.isRunning ? 'Ⅱ' : '▶';
+        this.toggleLabel.textContent = this.isRunning ? 'Pausar' : (this.timeLeft < this.totalTime ? 'Continuar' : 'Começar');
+        this.toggleBtn.setAttribute('aria-label', this.toggleLabel.textContent);
     }
 
     resetTimer() {
         this.pauseTimer();
         this.timeLeft = this.settings[this.mode] * 60;
-        this.totalTime = this.settings[this.mode] * 60;
+        this.totalTime = this.timeLeft;
+        this.timerDescription.textContent = 'Prepare-se e comece quando quiser.';
+        this.setControlState();
         this.updateDisplay();
     }
 
-    switchMode(mode) {
-        this.mode = mode;
+    switchMode(mode, shouldAutoStart = false) {
         this.pauseTimer();
+        this.mode = mode;
         this.timeLeft = this.settings[mode] * 60;
-        this.totalTime = this.settings[mode] * 60;
-
-        // Update UI
-        this.modeBtns.forEach(btn => btn.classList.remove('active'));
-        document.querySelector(`[data-mode="${mode}"]`).classList.add('active');
-
-        if (mode === 'focus') {
-            document.body.classList.remove('break-mode');
-            this.statusBadge.textContent = 'FOCUS';
-        } else {
-            document.body.classList.add('break-mode');
-            this.statusBadge.textContent = mode === 'short' ? 'SHORT BREAK' : 'LONG BREAK';
-        }
-
+        this.totalTime = this.timeLeft;
+        this.updateModeUI();
         this.updateDisplay();
+        this.setControlState();
+
+        if (shouldAutoStart) this.startTimer();
+    }
+
+    updateModeUI() {
+        const content = {
+            focus: {
+                badge: 'FOCO',
+                label: 'Hora de focar',
+                title: 'Sessão de foco'
+            },
+            short: {
+                badge: 'PAUSA',
+                label: 'Pausa rápida',
+                title: 'Pausa curta'
+            },
+            long: {
+                badge: 'DESCANSO',
+                label: 'Recupere a energia',
+                title: 'Pausa longa'
+            }
+        }[this.mode];
+
+        document.body.classList.toggle('break-mode', this.mode !== 'focus');
+        this.statusBadge.textContent = content.badge;
+        this.sessionLabel.textContent = content.label;
+        this.sessionTitle.textContent = content.title;
+        this.cycleDisplay.textContent = this.cycleCount;
+
+        this.modeBtns.forEach((button) => {
+            const active = button.dataset.mode === this.mode;
+            button.classList.toggle('active', active);
+            button.setAttribute('aria-selected', String(active));
+            button.tabIndex = active ? 0 : -1;
+        });
     }
 
     completeTimer() {
-        this.pauseTimer();
-        this.playSound();
-        this.sendNotification();
+        const completedMode = this.mode;
+        this.isRunning = false;
+        this.targetTime = null;
+        window.clearInterval(this.timerId);
+        this.timerId = null;
 
-        if (this.mode === 'focus') {
-            if (this.cycleCount % 4 === 0) {
-                this.switchMode('long');
-            } else {
-                this.switchMode('short');
-            }
-            this.cycleCount++;
-            this.cycleDisplay.textContent = this.cycleCount;
+        this.playSound(this.settings.sound, this.settings.volume);
+        this.sendNotification(completedMode);
+        this.pomodoroCard.classList.remove('session-complete');
+        window.requestAnimationFrame(() => this.pomodoroCard.classList.add('session-complete'));
+        window.setTimeout(() => this.pomodoroCard.classList.remove('session-complete'), 760);
 
-            if (this.settings.autoBreak) {
-                this.startTimer();
-            }
+        let nextMode;
+        let autoStart;
+        if (completedMode === 'focus') {
+            nextMode = this.cycleCount === 4 ? 'long' : 'short';
+            this.cycleCount = this.cycleCount === 4 ? 1 : this.cycleCount + 1;
+            autoStart = this.settings.autoBreak;
         } else {
-            this.switchMode('focus');
-
-            if (this.settings.autoPomodoro) {
-                this.startTimer();
-            }
+            nextMode = 'focus';
+            autoStart = this.settings.autoPomodoro;
         }
+
+        const message = completedMode === 'focus'
+            ? 'Sessão de foco concluída. Hora de fazer uma pausa.'
+            : 'Pausa concluída. Hora de voltar ao foco.';
+        this.timerAnnouncement.textContent = message;
+        this.switchMode(nextMode, autoStart);
+        if (!autoStart) this.timerDescription.textContent = message;
     }
 
     updateDisplay() {
         const minutes = Math.floor(this.timeLeft / 60);
         const seconds = this.timeLeft % 60;
-        const timeString = `${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`;
+        const timeString = `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
 
         this.timeDisplay.textContent = timeString;
-        document.title = `${timeString} - Pomodoro`;
+        this.timeDisplay.setAttribute('aria-label', `${minutes} minutos e ${seconds} segundos restantes`);
+        document.title = `${timeString} · ${this.sessionTitle.textContent} — Pomodoro`;
 
-        // Update Progress Circle
-        const circumference = 2 * Math.PI * 45; // r=45
-        const offset = circumference - (this.timeLeft / this.totalTime) * circumference;
-        this.progressCircle.style.strokeDashoffset = offset;
+        const circumference = 2 * Math.PI * 45;
+        const ratio = this.totalTime > 0 ? this.timeLeft / this.totalTime : 0;
+        this.progressCircle.style.strokeDashoffset = String(circumference * (1 - ratio));
     }
 
-    playSound() {
-        if (!this.audioCtx) return;
+    ensureAudioContext() {
+        if (!this.audioCtx) {
+            const AudioContextClass = window.AudioContext || window.webkitAudioContext;
+            if (AudioContextClass) this.audioCtx = new AudioContextClass();
+        }
 
-        const oscillator = this.audioCtx.createOscillator();
-        const gainNode = this.audioCtx.createGain();
-
-        oscillator.connect(gainNode);
-        gainNode.connect(this.audioCtx.destination);
-
-        // Gentle chime
-        oscillator.type = 'sine';
-        oscillator.frequency.setValueAtTime(440, this.audioCtx.currentTime);
-        oscillator.frequency.exponentialRampToValueAtTime(880, this.audioCtx.currentTime + 0.1);
-
-        gainNode.gain.setValueAtTime(0.1, this.audioCtx.currentTime);
-        gainNode.gain.exponentialRampToValueAtTime(0.001, this.audioCtx.currentTime + 0.5);
-
-        oscillator.start();
-        oscillator.stop(this.audioCtx.currentTime + 0.5);
+        if (this.audioCtx?.state === 'suspended') this.audioCtx.resume();
+        return this.audioCtx;
     }
 
-    sendNotification() {
-        if (Notification.permission === "granted") {
-            const title = this.mode === 'focus' ? "Focus Session Complete" : "Break Over";
-            const body = this.mode === 'focus' ? "Time to take a break." : "Ready to focus again?";
+    previewSound() {
+        this.ensureAudioContext();
+        this.playSound(this.inputSound.value, Number.parseInt(this.inputVolume.value, 10), true);
+    }
 
-            new Notification(title, {
-                body: body,
-                icon: '/assets/images/favicon.png'
-            });
+    playSound(sound = 'soft', volume = 65, force = false) {
+        if (!force && !this.settings.soundEnabled) return;
+        if (volume <= 0) return;
+        const context = this.ensureAudioContext();
+        if (!context) return;
+
+        const sequences = {
+            soft: [
+                { frequency: 523.25, delay: 0, duration: 0.5 },
+                { frequency: 659.25, delay: 0.18, duration: 0.7 }
+            ],
+            digital: [
+                { frequency: 784, delay: 0, duration: 0.12, type: 'square' },
+                { frequency: 988, delay: 0.16, duration: 0.12, type: 'square' },
+                { frequency: 1318, delay: 0.32, duration: 0.22, type: 'square' }
+            ],
+            bell: [
+                { frequency: 659.25, delay: 0, duration: 1.2 },
+                { frequency: 987.77, delay: 0.04, duration: 1.05 },
+                { frequency: 1318.51, delay: 0.08, duration: 0.9 }
+            ]
+        };
+
+        const masterVolume = Math.min(1, volume / 100) * 0.18;
+        (sequences[sound] || sequences.soft).forEach((note) => {
+            const oscillator = context.createOscillator();
+            const gain = context.createGain();
+            const start = context.currentTime + note.delay;
+            const end = start + note.duration;
+
+            oscillator.type = note.type || 'sine';
+            oscillator.frequency.setValueAtTime(note.frequency, start);
+            gain.gain.setValueAtTime(0.001, start);
+            gain.gain.exponentialRampToValueAtTime(masterVolume, start + 0.025);
+            gain.gain.exponentialRampToValueAtTime(0.001, end);
+            oscillator.connect(gain);
+            gain.connect(context.destination);
+            oscillator.start(start);
+            oscillator.stop(end + 0.03);
+        });
+    }
+
+    sendNotification(completedMode) {
+        if (!this.settings.notifications || !this.hasNotificationPermission()) return;
+
+        const focusCompleted = completedMode === 'focus';
+        try {
+            const notification = new Notification(
+                focusCompleted ? 'Foco concluído' : 'Pausa concluída',
+                {
+                    body: focusCompleted ? 'Ótimo trabalho. Hora de respirar um pouco.' : 'Pronto para mais uma sessão?',
+                    icon: '/favicon.ico',
+                    tag: 'pomodoro-session',
+                    renotify: true
+                }
+            );
+            notification.onclick = () => {
+                window.focus();
+                notification.close();
+            };
+        } catch (error) {
+            // Some browsers expose the API but restrict desktop notifications.
         }
     }
 }
 
-// Initialize
 document.addEventListener('DOMContentLoaded', () => {
-    const app = new PomodoroApp();
+    window.pomodoroApp = new PomodoroApp();
 });

--- a/labs/pomodoro/style.css
+++ b/labs/pomodoro/style.css
@@ -1,194 +1,174 @@
 :root {
-    --card-bg: rgba(255, 255, 255, 0.03);
-    --accent-color: #00f2ff;
-    /* Cyan for Focus */
-    --accent-glow: rgba(0, 242, 255, 0.3);
-    --break-color: #bd00ff;
-    /* Purple for Break */
-    --break-glow: rgba(189, 0, 255, 0.3);
+    --timer-accent: #2563eb;
+    --timer-accent-strong: #1d4ed8;
+    --timer-accent-soft: rgba(37, 99, 235, 0.11);
+    --timer-glow: rgba(37, 99, 235, 0.24);
+    --timer-surface: rgba(255, 255, 255, 0.76);
+    --timer-surface-strong: rgba(255, 255, 255, 0.96);
+    --timer-border: rgba(15, 23, 42, 0.09);
     --font-main: 'Outfit', sans-serif;
 }
 
+[data-theme="dark"] {
+    --timer-accent: #60a5fa;
+    --timer-accent-strong: #93c5fd;
+    --timer-accent-soft: rgba(96, 165, 250, 0.13);
+    --timer-glow: rgba(96, 165, 250, 0.22);
+    --timer-surface: rgba(23, 23, 23, 0.76);
+    --timer-surface-strong: rgba(23, 23, 23, 0.96);
+    --timer-border: rgba(255, 255, 255, 0.1);
+}
+
 body {
-    /* Background and color handled by shared.css */
     font-family: var(--font-main);
-    overflow: hidden;
+    min-height: 100svh;
+    overflow-x: hidden;
+}
+
+body::before {
+    content: '';
+    position: fixed;
+    inset: 0;
+    z-index: -1;
+    pointer-events: none;
+    background:
+        radial-gradient(circle at 50% 12%, var(--timer-accent-soft), transparent 34rem),
+        radial-gradient(circle at 14% 76%, rgba(16, 185, 129, 0.05), transparent 28rem);
 }
 
 .container {
-    /* Inherits flex column and 100vh from shared.css */
-    width: 100%;
-    max-width: 400px;
-    padding: 2rem;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 2rem;
-    position: relative;
-    overflow: hidden;
-    overflow: clip;
+    width: min(100%, 760px);
+    gap: 1.4rem;
 }
 
-/* Background ambient glow */
-.container::before {
-    content: '';
-    position: absolute;
-    top: -50%;
-    left: -50%;
-    width: 200%;
-    height: 200%;
-    background: radial-gradient(circle at 50% 50%, rgba(0, 242, 255, 0.05), transparent 60%);
-    z-index: -1;
-    pointer-events: none;
+header {
+    margin-bottom: 0.5rem;
 }
 
-.logo {
-    font-weight: 600;
-    letter-spacing: 1px;
-    text-transform: uppercase;
-    font-size: 0.8rem;
-    color: var(--accent-color);
-    text-shadow: 0 0 10px var(--accent-glow);
+.logo-mark {
+    width: 13px;
+    height: 13px;
+    border: 3px solid var(--timer-accent);
+    border-radius: 50%;
+    box-shadow: 0 0 0 5px var(--timer-accent-soft);
 }
 
-/* Timer Circle */
-.timer-circle-container {
-    position: relative;
-    width: 280px;
-    height: 280px;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-}
-
-.timer-svg {
-    width: 100%;
-    height: 100%;
-    transform: rotate(-90deg);
-}
-
-.timer-bg {
-    fill: none;
-    stroke: rgba(255, 255, 255, 0.05);
-    stroke-width: 3;
-}
-
-.timer-progress {
-    fill: none;
-    stroke: var(--accent-color);
-    stroke-width: 3;
-    stroke-linecap: round;
-    stroke-dasharray: 283;
-    /* 2 * PI * 45 */
-    stroke-dashoffset: 0;
-    transition: stroke-dashoffset 1s linear, stroke 0.5s ease;
-    filter: drop-shadow(0 0 8px var(--accent-glow));
-}
-
-.timer-display {
-    position: absolute;
-    text-align: center;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 0.5rem;
-}
-
-.time {
-    font-size: 4.5rem;
-    font-weight: 300;
-    line-height: 1;
-    font-variant-numeric: tabular-nums;
-    text-shadow: 0 0 20px rgba(255, 255, 255, 0.1);
-}
-
-.status-badge {
-    font-size: 0.75rem;
-    text-transform: uppercase;
-    letter-spacing: 2px;
-    color: var(--accent-color);
-    background: rgba(0, 242, 255, 0.1);
-    padding: 4px 12px;
-    border-radius: 20px;
-    border: 1px solid rgba(0, 242, 255, 0.2);
-    transition: all 0.5s ease;
-}
-
-.cycle-info {
-    font-size: 0.8rem;
-    color: var(--text-secondary);
-    margin-top: 0.5rem;
-}
-
-/* Controls */
-.controls {
-    display: flex;
-    gap: 1rem;
-    align-items: center;
+button,
+input,
+select {
+    font: inherit;
 }
 
 button {
-    background: none;
-    border: none;
-    cursor: pointer;
-    font-family: var(--font-main);
-    transition: all 0.3s ease;
+    border: 0;
 }
 
-.btn-primary {
-    background: var(--accent-color);
-    color: #000;
-    padding: 12px 32px;
-    border-radius: 30px;
-    font-weight: 600;
-    font-size: 1rem;
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    box-shadow: 0 0 20px var(--accent-glow);
+button:focus-visible,
+input:focus-visible,
+select:focus-visible {
+    outline: 3px solid var(--focus-ring);
+    outline-offset: 3px;
 }
 
-.btn-primary:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 0 30px var(--accent-glow);
-}
-
-.btn-primary:active {
-    transform: translateY(0);
-}
-
-.btn-secondary {
-    width: 48px;
-    height: 48px;
+.icon-btn,
+.close-btn {
+    width: 42px;
+    height: 42px;
+    display: grid;
+    place-items: center;
+    border: 1px solid var(--border-subtle);
     border-radius: 50%;
-    background: var(--card-bg);
-    color: var(--text-primary);
-    border: 1px solid rgba(255, 255, 255, 0.1);
+    color: var(--text-secondary);
+    background: var(--bg-card);
+    cursor: pointer;
+    box-shadow: 0 4px 14px var(--shadow-sm);
+    transition: transform 180ms ease, color 180ms ease, border-color 180ms ease;
+}
+
+.icon-btn:hover,
+.close-btn:hover {
+    color: var(--timer-accent);
+    border-color: var(--timer-accent);
+    transform: translateY(-1px);
+}
+
+.pomodoro-card {
+    width: min(100%, 580px);
+    padding: clamp(1.15rem, 4vw, 2rem);
+    border: 1px solid var(--timer-border);
+    border-radius: 2rem;
+    background: var(--timer-surface);
+    box-shadow: 0 24px 80px var(--shadow-lg);
+    backdrop-filter: blur(24px);
+    -webkit-backdrop-filter: blur(24px);
     display: flex;
-    justify-content: center;
+    flex-direction: column;
     align-items: center;
-    font-size: 1.2rem;
 }
 
-.btn-secondary:hover {
-    background: rgba(255, 255, 255, 0.1);
+.pomodoro-card.session-complete {
+    animation: session-complete 720ms ease;
 }
 
-/* Modes */
-.modes {
+.session-heading {
+    width: 100%;
     display: flex;
-    gap: 0.5rem;
-    background: var(--card-bg);
-    padding: 0.5rem;
-    border-radius: 12px;
-    border: 1px solid rgba(255, 255, 255, 0.05);
+    justify-content: space-between;
+    align-items: flex-end;
+    gap: 1rem;
+    margin-bottom: 1.35rem;
+}
+
+.eyebrow {
+    margin: 0 0 0.2rem;
+    color: var(--timer-accent-strong);
+    font-size: 0.72rem;
+    font-weight: 700;
+    letter-spacing: 0.11em;
+    text-transform: uppercase;
+}
+
+.session-heading h1 {
+    margin: 0;
+    font-size: clamp(1.35rem, 4vw, 1.8rem);
+    line-height: 1.15;
+    letter-spacing: -0.03em;
+}
+
+.cycle-pill {
+    flex: none;
+    padding: 0.45rem 0.7rem;
+    border: 1px solid var(--timer-border);
+    border-radius: 999px;
+    color: var(--text-secondary);
+    background: var(--bg-card);
+    font-size: 0.78rem;
+}
+
+.cycle-pill strong {
+    color: var(--text-primary);
+}
+
+.modes {
+    width: 100%;
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 0.3rem;
+    padding: 0.3rem;
+    border-radius: 0.9rem;
+    background: var(--timer-accent-soft);
 }
 
 .mode-btn {
-    padding: 8px 16px;
-    border-radius: 8px;
+    min-height: 42px;
+    padding: 0.55rem 0.65rem;
+    border-radius: 0.65rem;
     color: var(--text-secondary);
-    font-size: 0.85rem;
+    background: transparent;
+    cursor: pointer;
+    font-size: 0.83rem;
+    font-weight: 500;
+    transition: color 180ms ease, background 180ms ease, box-shadow 180ms ease;
 }
 
 .mode-btn:hover {
@@ -196,157 +176,628 @@ button {
 }
 
 .mode-btn.active {
-    background: rgba(255, 255, 255, 0.1);
-    color: var(--text-primary);
+    color: var(--timer-accent-strong);
+    background: var(--timer-surface-strong);
+    box-shadow: 0 4px 16px var(--shadow-sm);
+    font-weight: 600;
 }
 
-.header-actions {
-    grid-column: 3;
-    justify-self: end;
-    display: flex;
-    gap: 0.5rem;
-    align-items: center;
+.timer-circle-container {
+    position: relative;
+    width: clamp(250px, 70vw, 320px);
+    aspect-ratio: 1;
+    margin: clamp(1rem, 4vw, 1.7rem) 0;
+    display: grid;
+    place-items: center;
 }
 
-.icon-btn {
-    background: none;
-    border: none;
-    cursor: pointer;
-    color: var(--text-primary);
-    padding: 8px;
+.timer-circle-container::before {
+    content: '';
+    position: absolute;
+    inset: 11%;
     border-radius: 50%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    transition: background-color 0.3s ease;
+    background: radial-gradient(circle, var(--timer-accent-soft), transparent 70%);
+    filter: blur(10px);
 }
 
-.icon-btn:hover {
-    background-color: rgba(255, 255, 255, 0.1);
-}
-
-/* Modal Styles */
-.modal {
-    display: none;
-    position: fixed;
-    top: 0;
-    left: 0;
+.timer-svg {
+    position: absolute;
+    inset: 0;
     width: 100%;
     height: 100%;
-    background-color: rgba(0, 0, 0, 0.5);
-    backdrop-filter: blur(5px);
-    z-index: 1000;
-    justify-content: center;
+    transform: rotate(-90deg);
+}
+
+.timer-bg,
+.timer-progress {
+    fill: none;
+    stroke-width: 2.6;
+}
+
+.timer-bg {
+    stroke: var(--timer-border);
+}
+
+.timer-progress {
+    stroke: var(--timer-accent);
+    stroke-linecap: round;
+    stroke-dasharray: 282.743;
+    stroke-dashoffset: 0;
+    filter: drop-shadow(0 0 5px var(--timer-glow));
+    transition: stroke-dashoffset 300ms linear, stroke 350ms ease;
+}
+
+.timer-display {
+    position: relative;
+    z-index: 1;
+    max-width: 78%;
+    display: flex;
+    flex-direction: column;
     align-items: center;
-    opacity: 0;
-    transition: opacity 0.3s ease;
+    text-align: center;
+}
+
+.status-badge {
+    padding: 0.35rem 0.75rem;
+    border: 1px solid color-mix(in srgb, var(--timer-accent) 28%, transparent);
+    border-radius: 999px;
+    color: var(--timer-accent-strong);
+    background: var(--timer-accent-soft);
+    font-size: 0.7rem;
+    font-weight: 700;
+    letter-spacing: 0.14em;
+}
+
+.time {
+    margin: 0.65rem 0 0.45rem;
+    color: var(--text-primary);
+    font-size: clamp(4.1rem, 17vw, 5.4rem);
+    font-weight: 300;
+    line-height: 0.95;
+    letter-spacing: -0.07em;
+    font-variant-numeric: tabular-nums;
+}
+
+#timer-description {
+    min-height: 1.3em;
+    color: var(--text-secondary);
+    font-size: 0.84rem;
+}
+
+.controls {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.75rem;
+}
+
+.btn-primary,
+.btn-secondary,
+.btn-quiet {
+    cursor: pointer;
+    transition: transform 180ms ease, box-shadow 180ms ease, background 180ms ease;
+}
+
+.btn-primary {
+    min-height: 52px;
+    padding: 0.8rem 1.5rem;
+    border-radius: 999px;
+    color: #fff;
+    background: var(--timer-accent);
+    box-shadow: 0 10px 28px var(--timer-glow);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.65rem;
+    font-weight: 600;
+}
+
+.btn-primary:hover,
+.btn-secondary:hover,
+.btn-quiet:hover {
+    transform: translateY(-2px);
+}
+
+.btn-primary:hover {
+    background: var(--timer-accent-strong);
+    box-shadow: 0 14px 34px var(--timer-glow);
+}
+
+.btn-primary:active,
+.btn-secondary:active,
+.btn-quiet:active {
+    transform: translateY(0);
+}
+
+.btn-secondary {
+    width: 52px;
+    height: 52px;
+    border: 1px solid var(--timer-border);
+    border-radius: 50%;
+    color: var(--text-primary);
+    background: var(--bg-card);
+    box-shadow: 0 6px 18px var(--shadow-sm);
+    font-size: 1.35rem;
+}
+
+.signal-status {
+    margin-top: 1.3rem;
+    padding: 0.45rem 0.6rem;
+    border: 1px solid transparent;
+    border-radius: 999px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.6rem;
+    color: var(--text-tertiary);
+    background: transparent;
+    font-size: 0.72rem;
+    cursor: pointer;
+    transition: color 180ms ease, border-color 180ms ease, background 180ms ease;
+}
+
+.signal-status:hover {
+    color: var(--text-secondary);
+    border-color: var(--timer-border);
+    background: var(--timer-accent-soft);
+}
+
+.signal-status > span {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+}
+
+.status-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: #16a34a;
+    box-shadow: 0 0 0 3px rgba(22, 163, 74, 0.12);
+}
+
+.signal-status.sound-off .status-dot {
+    background: var(--text-tertiary);
+    box-shadow: none;
+}
+
+.status-divider {
+    width: 3px;
+    height: 3px;
+    border-radius: 50%;
+    background: var(--border-strong);
+}
+
+.modal {
+    position: fixed;
+    inset: 0;
+    z-index: 1000;
+    padding: 1rem;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    background: rgba(2, 6, 23, 0.48);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
 }
 
 .modal.open {
     display: flex;
-    opacity: 1;
+    animation: fade-in 180ms ease both;
 }
 
 .modal-content {
-    background: var(--bg-card);
-    border: 1px solid var(--border-subtle);
-    border-radius: 16px;
-    width: 90%;
-    max-width: 400px;
-    padding: 1.5rem;
-    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.3);
-    transform: translateY(20px);
-    transition: transform 0.3s ease;
-}
-
-.modal.open .modal-content {
-    transform: translateY(0);
+    --modal-padding: clamp(1.25rem, 4vw, 1.7rem);
+    width: min(100%, 510px);
+    max-height: min(88svh, 760px);
+    overflow-y: auto;
+    padding: var(--modal-padding);
+    border: 1px solid var(--timer-border);
+    border-radius: 1.5rem;
+    background: var(--timer-surface-strong);
+    box-shadow: 0 28px 90px rgba(2, 6, 23, 0.28);
+    animation: modal-in 220ms ease both;
+    scrollbar-width: thin;
+    scrollbar-color: var(--border-strong) transparent;
 }
 
 .modal-header {
     display: flex;
     justify-content: space-between;
-    align-items: center;
+    align-items: flex-start;
+    gap: 1rem;
     margin-bottom: 1.5rem;
 }
 
 .modal-header h2 {
-    font-size: 1.25rem;
-    font-weight: 600;
     margin: 0;
+    font-size: 1.5rem;
+    letter-spacing: -0.02em;
 }
 
 .close-btn {
-    background: none;
-    border: none;
-    font-size: 1.5rem;
-    cursor: pointer;
-    color: var(--text-secondary);
-    padding: 0;
-    line-height: 1;
-}
-
-.close-btn:hover {
-    color: var(--text-primary);
+    flex: none;
+    font-size: 1.45rem;
 }
 
 .setting-group {
-    margin-bottom: 1.5rem;
+    min-width: 0;
+    margin: 0 0 1.35rem;
+    padding: 0 0 1.35rem;
+    border: 0;
+    border-bottom: 1px solid var(--timer-border);
 }
 
-.setting-group h3 {
-    font-size: 0.9rem;
+.setting-group:last-child {
+    margin-bottom: 0;
+}
+
+.setting-group legend {
+    width: 100%;
+    margin-bottom: 0.85rem;
     color: var(--text-secondary);
+    font-size: 0.73rem;
+    font-weight: 700;
+    letter-spacing: 0.09em;
     text-transform: uppercase;
-    letter-spacing: 1px;
-    margin-bottom: 1rem;
 }
 
-.setting-row {
+.duration-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 0.65rem;
+}
+
+.duration-grid label,
+.select-field {
     display: flex;
-    justify-content: space-between;
+    flex-direction: column;
+    gap: 0.35rem;
+    color: var(--text-secondary);
+    font-size: 0.78rem;
+}
+
+.number-field {
+    display: flex;
     align-items: center;
-    margin-bottom: 0.75rem;
+    border: 1px solid var(--timer-border);
+    border-radius: 0.7rem;
+    background: var(--bg-body);
 }
 
-.setting-row label {
-    font-size: 0.95rem;
-}
-
-.setting-row input[type="number"] {
-    background: rgba(255, 255, 255, 0.05);
-    border: 1px solid rgba(255, 255, 255, 0.1);
-    border-radius: 6px;
-    padding: 6px 10px;
+.number-field input {
+    min-width: 0;
+    width: 100%;
+    padding: 0.7rem 0 0.7rem 0.75rem;
+    border: 0;
+    outline: 0;
     color: var(--text-primary);
-    width: 60px;
-    font-family: var(--font-main);
+    background: transparent;
 }
 
-.setting-row input[type="checkbox"] {
-    width: 18px;
-    height: 18px;
-    accent-color: var(--accent-color);
+.number-field small {
+    padding-right: 0.7rem;
+    color: var(--text-tertiary);
+}
+
+.sound-controls {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    align-items: end;
+    gap: 0.65rem;
+    margin-bottom: 0.9rem;
+}
+
+.select-field select {
+    min-height: 43px;
+    padding: 0 2.2rem 0 0.75rem;
+    border: 1px solid var(--timer-border);
+    border-radius: 0.7rem;
+    color: var(--text-primary);
+    background: var(--bg-body);
+}
+
+.btn-quiet {
+    min-height: 43px;
+    padding: 0 0.9rem;
+    border: 1px solid var(--timer-border);
+    border-radius: 0.7rem;
+    color: var(--timer-accent-strong);
+    background: var(--timer-accent-soft);
+    font-weight: 600;
+}
+
+.range-field {
+    display: grid;
+    grid-template-columns: auto 1fr 2.4rem;
+    align-items: center;
+    gap: 0.65rem;
+    margin-bottom: 0.7rem;
+    color: var(--text-secondary);
+    font-size: 0.78rem;
+}
+
+.range-field input {
+    width: 100%;
+    accent-color: var(--timer-accent);
+}
+
+.range-field output {
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+}
+
+.switch-row {
+    position: relative;
+    min-height: 58px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
     cursor: pointer;
 }
 
-.modal-footer {
+.switch-row > span:first-child {
     display: flex;
+    flex-direction: column;
+    gap: 0.13rem;
+}
+
+.switch-row strong {
+    color: var(--text-primary);
+    font-size: 0.9rem;
+    font-weight: 500;
+}
+
+.switch-row small {
+    color: var(--text-tertiary);
+    font-size: 0.73rem;
+    line-height: 1.25;
+}
+
+.switch-row input {
+    position: absolute;
+    opacity: 0;
+    pointer-events: none;
+}
+
+.switch {
+    position: relative;
+    flex: none;
+    width: 44px;
+    height: 25px;
+    border-radius: 999px;
+    background: var(--border-strong);
+    transition: background 180ms ease;
+}
+
+.switch::after {
+    content: '';
+    position: absolute;
+    top: 3px;
+    left: 3px;
+    width: 19px;
+    height: 19px;
+    border-radius: 50%;
+    background: #fff;
+    box-shadow: 0 2px 5px rgba(2, 6, 23, 0.2);
+    transition: transform 180ms ease;
+}
+
+.switch-row input:checked + .switch {
+    background: var(--timer-accent);
+}
+
+.switch-row input:checked + .switch::after {
+    transform: translateX(19px);
+}
+
+.switch-row input:focus-visible + .switch {
+    outline: 3px solid var(--focus-ring);
+    outline-offset: 3px;
+}
+
+.switch-row input:disabled + .switch {
+    opacity: 0.45;
+}
+
+.switch-row:has(input:disabled) {
+    cursor: not-allowed;
+}
+
+.modal-footer {
+    position: sticky;
+    bottom: calc(0px - var(--modal-padding));
+    z-index: 2;
+    margin: 0 calc(0px - var(--modal-padding)) calc(0px - var(--modal-padding));
+    padding: 0.9rem var(--modal-padding) var(--modal-padding);
+    display: flex;
+    align-items: center;
     justify-content: flex-end;
-    margin-top: 1rem;
+    gap: 1rem;
+    border-top: 1px solid var(--timer-border);
+    background: linear-gradient(to bottom, color-mix(in srgb, var(--timer-surface-strong) 84%, transparent),
+            var(--timer-surface-strong) 26%);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
 }
 
-/* Break Mode Styles */
+.modal-footer > span {
+    margin-right: auto;
+    color: var(--text-tertiary);
+    font-size: 0.7rem;
+    line-height: 1.25;
+}
+
+.toast {
+    position: fixed;
+    left: 50%;
+    bottom: max(1rem, env(safe-area-inset-bottom));
+    z-index: 1200;
+    padding: 0.7rem 0.95rem;
+    border: 1px solid var(--timer-border);
+    border-radius: 999px;
+    color: var(--text-primary);
+    background: var(--timer-surface-strong);
+    box-shadow: 0 14px 42px rgba(2, 6, 23, 0.18);
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.78rem;
+    font-weight: 500;
+    opacity: 0;
+    pointer-events: none;
+    transform: translate(-50%, 14px);
+    transition: opacity 180ms ease, transform 180ms ease;
+}
+
+.toast.visible {
+    opacity: 1;
+    transform: translate(-50%, 0);
+}
+
+.toast-check {
+    width: 20px;
+    height: 20px;
+    display: grid;
+    place-items: center;
+    border-radius: 50%;
+    color: #fff;
+    background: #16a34a;
+    font-size: 0.72rem;
+}
+
 body.break-mode {
-    --accent-color: var(--break-color);
-    --accent-glow: var(--break-glow);
+    --timer-accent: #7c3aed;
+    --timer-accent-strong: #6d28d9;
+    --timer-accent-soft: rgba(124, 58, 237, 0.11);
+    --timer-glow: rgba(124, 58, 237, 0.22);
 }
 
-body.break-mode .container::before {
-    background: radial-gradient(circle at 50% 50%, rgba(189, 0, 255, 0.05), transparent 60%);
+[data-theme="dark"] body.break-mode {
+    --timer-accent: #c084fc;
+    --timer-accent-strong: #d8b4fe;
+    --timer-accent-soft: rgba(192, 132, 252, 0.13);
 }
 
-body.break-mode .status-badge {
-    background: rgba(189, 0, 255, 0.1);
-    border-color: rgba(189, 0, 255, 0.2);
+body.modal-open {
+    overflow: hidden;
+}
+
+@keyframes fade-in {
+    from { opacity: 0; }
+    to { opacity: 1; }
+}
+
+@keyframes modal-in {
+    from { opacity: 0; transform: translateY(10px) scale(0.98); }
+    to { opacity: 1; transform: translateY(0) scale(1); }
+}
+
+@keyframes session-complete {
+    0%, 100% { box-shadow: 0 24px 80px var(--shadow-lg); }
+    38% { box-shadow: 0 24px 95px var(--timer-glow), 0 0 0 5px var(--timer-accent-soft); }
+}
+
+@media (max-width: 560px) {
+    body {
+        padding: 1rem 0.75rem;
+    }
+
+    header {
+        padding: 0;
+    }
+
+    header .back-link {
+        width: 42px;
+        height: 42px;
+        padding: 0;
+        justify-content: center;
+    }
+
+    header .back-link span {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        overflow: hidden;
+        clip: rect(0, 0, 0, 0);
+    }
+
+    .pomodoro-card {
+        border-radius: 1.5rem;
+    }
+
+    .session-heading {
+        align-items: center;
+    }
+
+    .mode-btn {
+        padding-inline: 0.35rem;
+        font-size: 0.76rem;
+    }
+
+    .signal-status {
+        flex-wrap: wrap;
+    }
+
+    .duration-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .duration-grid label {
+        display: grid;
+        grid-template-columns: 1fr 7.5rem;
+        align-items: center;
+    }
+
+    .modal-footer {
+        align-items: stretch;
+        flex-direction: column;
+        gap: 0.6rem;
+    }
+
+    .modal-footer > span {
+        margin: 0;
+        text-align: center;
+    }
+
+    .modal-footer .btn-primary {
+        width: 100%;
+    }
+
+    .toast {
+        width: max-content;
+        max-width: calc(100vw - 2rem);
+        justify-content: center;
+        text-align: center;
+    }
+}
+
+@media (max-height: 740px) and (min-width: 561px) {
+    body {
+        padding-block: 1rem;
+    }
+
+    header {
+        margin-bottom: 0;
+    }
+
+    .timer-circle-container {
+        width: 240px;
+        margin-block: 0.65rem;
+    }
+
+    .pomodoro-card {
+        padding-block: 1.15rem;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+        scroll-behavior: auto !important;
+        animation-duration: 0.01ms !important;
+        transition-duration: 0.01ms !important;
+    }
 }


### PR DESCRIPTION
## O que mudou

- adiciona preferências de duração, automação, som, toque e volume
- salva as configurações no `localStorage` com validação de valores
- permite ativar notificações do navegador por ação explícita do usuário
- inclui três sinais sonoros sintetizados e prévia do toque
- toca o sinal configurado quando uma sessão termina
- refina a interface responsiva, estados visuais, modal e navegação por teclado

## Por quê

O Pomodoro precisava sinalizar o fim das sessões e oferecer controles claros sem abandonar a experiência minimalista. A permissão de notificações também era solicitada cedo demais e não havia uma forma completa de personalizar ou persistir as preferências.

## Impacto

A experiência fica mais previsível em desktop e mobile. As preferências permanecem no navegador, notificações só são solicitadas quando o usuário escolhe ativá-las e o fim das sessões é informado por som e feedback visual.

## Validação

- `node --check labs/pomodoro/script.js`
- `git diff --check`
- teste do cronômetro e alternância de modos no navegador
- teste dos três sons e do controle de volume
- confirmação de persistência após recarregar a página
- revisão visual em desktop e viewport mobile
- console do navegador sem erros ou avisos