### PR TITLE
feat(pomodoro): redesign completo com tarefas, estatísticas, sons e n…

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ O **Labs** reúne jogos, ferramentas e experimentos interativos feitos para expl
 |---------|-----------|
 | **[Image Optimizer](https://diogopaulino.com.br/labs/image-optimizer/)** | Minificador e conversor de imagens com suporte a múltiplos formatos |
 | **[Fun Calculator](https://diogopaulino.com.br/labs/calculator/)** | Calculadora moderna com conversão de moedas em tempo real |
-| **[AI Focus](https://diogopaulino.com.br/labs/pomodoro/)** | Pomodoro timer futurista com sons suaves e notificações inteligentes |
+| **[Pomodoro](https://diogopaulino.com.br/labs/pomodoro/)** | Timer de foco com tarefas, estatísticas, sons e notificações do navegador |
 
 ### 🎵 Music & Audio — som também é interface
 

--- a/labs/.corrections-status.md
+++ b/labs/.corrections-status.md
@@ -3,6 +3,7 @@
 ## ✅ Concluído
 1. **Videogame** - Header centralizado (adicionado wrapper `.container`)
 2. **Aurora Flow** - Parcialmente corrigido (event listeners com null checks iniciados)
+8. **Pomodoro** - Header corrigido e app redesenhado (tarefas, estatísticas, sons, notificações, light mode)
 
 ## 🔧 Em Progresso  
 3. **Aurora Flow** - Precisa completar null checks para todos os event listeners restantes:
@@ -24,7 +25,6 @@
 
 ### UI/UX
 7. **Calculator** - Melhorar interface do currency converter
-8. **Pomodoro** - Header apertado (ajustar espaçamento)
 
 ### Temas (Light Mode)
 9. **Lander** - Modo light (já usa var(--bg-body), verificar se funciona)
@@ -40,5 +40,5 @@
 1. Completar correções do Aurora Flow
 2. Verificar e corrigir Gravity
 3. Implementar funcionalidades faltantes (Winamp play, Image Editor filtro)
-4. Ajustar UIs (Calculator currency, Pomodoro header)
+4. Ajustar UIs (Calculator currency)
 5. Testar e ajustar temas light mode em todos os apps

--- a/labs/.corrections.md
+++ b/labs/.corrections.md
@@ -23,8 +23,9 @@
 ## 7. Image Editor - Filtro 1080 retro
 - Verificar implementação do filtro
 
-## 8. Pomodoro - Header apertado
-- Ajustar espaçamento do header-actions
+## 8. ✅ Pomodoro - Header apertado
+- App redesenhado: `.container` não é mais limitado a 400px (era o que espremia o header)
+- `.icon-btn` padronizado e alinhado ao `.header-actions` do shared.css
 
 ## 9. Jungle Run - Cores light mode
 - Melhorar contraste no modo claro

--- a/labs/index.html
+++ b/labs/index.html
@@ -393,8 +393,8 @@
           </svg>
         </div>
         <div class="project-content">
-          <h2>AI Focus</h2>
-          <p>Pomodoro timer futurista com sons suaves e notificações inteligentes</p>
+          <h2>Pomodoro</h2>
+          <p>Timer de foco com tarefas, estatísticas, sons e notificações do navegador</p>
           <div class="project-tags">
             <span class="tag">Productivity</span>
             <span class="tag">AI</span>

--- a/labs/pomodoro/index.html
+++ b/labs/pomodoro/index.html
@@ -5,105 +5,298 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Pomodoro - Labs</title>
+    <meta name="description"
+        content="Timer Pomodoro com tarefas, estatísticas, sons personalizáveis e notificações do navegador.">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;600&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/labs/shared.css?v=4">
-    <link rel="stylesheet" href="style.css?v=2">
+    <link rel="stylesheet" href="style.css?v=3">
 </head>
 
 <body>
+    <div class="ambient" aria-hidden="true"></div>
+
     <div class="container">
         <header data-lab-header data-title="Pomodoro">
             <template data-slot="logo">
                 <div class="app-logo">
-                    ⏱️ Pomodoro
+                    <span class="logo-mark" aria-hidden="true">🍅</span> Pomodoro
                 </div>
             </template>
             <template data-slot="actions">
-                <button id="btn-settings" class="icon-btn" aria-label="Settings">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none"
-                        stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <button id="btn-sound" class="icon-btn" type="button" aria-label="Desativar som"
+                    title="Som ligado" aria-pressed="true">
+                    <svg class="icon-sound-on" width="20" height="20" viewBox="0 0 24 24" fill="none"
+                        stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+                        aria-hidden="true">
+                        <path d="M11 5L6 9H2v6h4l5 4V5z"></path>
+                        <path d="M15.54 8.46a5 5 0 0 1 0 7.07"></path>
+                        <path d="M19.07 4.93a10 10 0 0 1 0 14.14"></path>
+                    </svg>
+                    <svg class="icon-sound-off" width="20" height="20" viewBox="0 0 24 24" fill="none"
+                        stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+                        aria-hidden="true">
+                        <path d="M11 5L6 9H2v6h4l5 4V5z"></path>
+                        <line x1="23" y1="9" x2="17" y2="15"></line>
+                        <line x1="17" y1="9" x2="23" y2="15"></line>
+                    </svg>
+                </button>
+                <button id="btn-settings" class="icon-btn" type="button" aria-label="Abrir configurações"
+                    title="Configurações" aria-haspopup="dialog">
+                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                        stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                         <circle cx="12" cy="12" r="3"></circle>
-                        <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"></path>
+                        <path
+                            d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z">
+                        </path>
                     </svg>
                 </button>
             </template>
         </header>
 
-        <main>
-            <div class="timer-circle-container">
-                <svg class="timer-svg" viewBox="0 0 100 100">
-                    <circle class="timer-bg" cx="50" cy="50" r="45"></circle>
-                    <circle class="timer-progress" cx="50" cy="50" r="45"></circle>
-                </svg>
-                <div class="timer-display">
-                    <div class="status-badge" id="status-badge">FOCUS</div>
-                    <div class="time" id="time-display">25:00</div>
-                    <div class="cycle-info">Cycle <span id="cycle-count">1</span>/4</div>
+        <main class="app">
+            <!-- Timer -->
+            <section class="card timer-card" aria-labelledby="timer-heading">
+                <h2 id="timer-heading" class="sr-only">Cronômetro</h2>
+
+                <div class="mode-tabs" role="tablist" aria-label="Modo do cronômetro">
+                    <button class="mode-btn is-active" type="button" role="tab" aria-selected="true"
+                        data-mode="focus">Foco</button>
+                    <button class="mode-btn" type="button" role="tab" aria-selected="false" data-mode="short">Pausa
+                        curta</button>
+                    <button class="mode-btn" type="button" role="tab" aria-selected="false" data-mode="long">Pausa
+                        longa</button>
                 </div>
-            </div>
 
-            <div class="controls">
-                <button id="btn-toggle" class="btn-primary">
-                    <span class="icon-play">▶</span> Start
-                </button>
-                <button id="btn-reset" class="btn-secondary">
-                    <span class="icon-reset">↻</span>
-                </button>
-            </div>
+                <div class="timer-ring">
+                    <svg class="ring-svg" viewBox="0 0 200 200" aria-hidden="true">
+                        <circle class="ring-track" cx="100" cy="100" r="88"></circle>
+                        <circle class="ring-progress" cx="100" cy="100" r="88"></circle>
+                    </svg>
+                    <div class="ring-content">
+                        <span class="status-badge" id="status-badge">Foco</span>
+                        <span class="time" id="time-display">25:00</span>
+                        <span class="cycle-info">Ciclo <b id="cycle-count">1</b> de <b id="cycle-total">4</b></span>
+                    </div>
+                </div>
 
-            <div class="modes">
-                <button class="mode-btn active" data-mode="focus">Focus</button>
-                <button class="mode-btn" data-mode="short">Short Break</button>
-                <button class="mode-btn" data-mode="long">Long Break</button>
+                <p class="active-task" id="active-task">
+                    <span class="active-task-label">Tarefa atual</span>
+                    <span class="active-task-name" id="active-task-name">Nenhuma tarefa selecionada</span>
+                </p>
+
+                <div class="controls">
+                    <button id="btn-reset" class="btn-ghost" type="button" aria-label="Reiniciar ciclo"
+                        title="Reiniciar (R)">
+                        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                            stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                            <path d="M3 12a9 9 0 1 0 3-6.7L3 8"></path>
+                            <path d="M3 3v5h5"></path>
+                        </svg>
+                    </button>
+                    <button id="btn-toggle" class="btn-primary" type="button">
+                        <svg class="icon-play" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"
+                            aria-hidden="true">
+                            <path d="M8 5.5v13l11-6.5z"></path>
+                        </svg>
+                        <svg class="icon-pause" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"
+                            aria-hidden="true">
+                            <path d="M7 5h3.5v14H7zM13.5 5H17v14h-3.5z"></path>
+                        </svg>
+                        <span id="toggle-label">Iniciar</span>
+                    </button>
+                    <button id="btn-skip" class="btn-ghost" type="button" aria-label="Pular para o próximo ciclo"
+                        title="Pular (S)">
+                        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                            stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                            <path d="M5 4l10 8-10 8z"></path>
+                            <line x1="19" y1="5" x2="19" y2="19"></line>
+                        </svg>
+                    </button>
+                </div>
+
+                <p class="shortcuts-hint">
+                    <kbd>Espaço</kbd> iniciar/pausar · <kbd>R</kbd> reiniciar · <kbd>S</kbd> pular ·
+                    <kbd>1</kbd><kbd>2</kbd><kbd>3</kbd> modos
+                </p>
+            </section>
+
+            <div class="side-column">
+                <!-- Tarefas -->
+                <section class="card tasks-card" aria-labelledby="tasks-heading">
+                    <div class="card-head">
+                        <h2 id="tasks-heading">Tarefas</h2>
+                        <button id="btn-clear-done" class="link-btn" type="button" hidden>Limpar concluídas</button>
+                    </div>
+
+                    <form class="task-form" id="task-form" autocomplete="off">
+                        <input type="text" id="task-input" maxlength="80" placeholder="No que você vai focar?"
+                            aria-label="Nova tarefa">
+                        <input type="number" id="task-estimate" min="1" max="20" value="1"
+                            aria-label="Pomodoros estimados" title="Pomodoros estimados">
+                        <button class="btn-add" type="submit" aria-label="Adicionar tarefa" title="Adicionar tarefa">
+                            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                                stroke-width="2.5" stroke-linecap="round" aria-hidden="true">
+                                <line x1="12" y1="5" x2="12" y2="19"></line>
+                                <line x1="5" y1="12" x2="19" y2="12"></line>
+                            </svg>
+                        </button>
+                    </form>
+
+                    <ul class="task-list" id="task-list"></ul>
+                    <p class="empty-state" id="tasks-empty">Adicione uma tarefa para acompanhar seus pomodoros.</p>
+                    <p class="task-summary" id="task-summary" hidden></p>
+                </section>
+
+                <!-- Estatísticas -->
+                <section class="card stats-card" aria-labelledby="stats-heading">
+                    <div class="card-head">
+                        <h2 id="stats-heading">Estatísticas</h2>
+                        <span class="card-head-note">Últimos 7 dias</span>
+                    </div>
+
+                    <div class="stats-grid">
+                        <div class="stat">
+                            <span class="stat-value" id="stat-today">0</span>
+                            <span class="stat-label">Pomodoros hoje</span>
+                        </div>
+                        <div class="stat">
+                            <span class="stat-value" id="stat-time">0min</span>
+                            <span class="stat-label">Foco hoje</span>
+                        </div>
+                        <div class="stat">
+                            <span class="stat-value" id="stat-streak">0</span>
+                            <span class="stat-label">Dias seguidos</span>
+                        </div>
+                        <div class="stat">
+                            <span class="stat-value" id="stat-total">0</span>
+                            <span class="stat-label">Total geral</span>
+                        </div>
+                    </div>
+
+                    <div class="chart" id="week-chart" role="img" aria-label="Pomodoros dos últimos 7 dias"></div>
+                </section>
             </div>
         </main>
+
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
 
-    <!-- Settings Modal -->
-    <div id="settings-modal" class="modal">
-        <div class="modal-content">
+    <!-- Configurações -->
+    <div id="settings-modal" class="modal" hidden>
+        <div class="modal-backdrop" data-close-modal></div>
+        <div class="modal-content" role="dialog" aria-modal="true" aria-labelledby="settings-title">
             <div class="modal-header">
-                <h2>Settings</h2>
-                <button id="btn-close-settings" class="close-btn">&times;</button>
+                <h2 id="settings-title">Configurações</h2>
+                <button id="btn-close-settings" class="close-btn" type="button" aria-label="Fechar configurações"
+                    data-close-modal>
+                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                        stroke-linecap="round" aria-hidden="true">
+                        <line x1="18" y1="6" x2="6" y2="18"></line>
+                        <line x1="6" y1="6" x2="18" y2="18"></line>
+                    </svg>
+                </button>
             </div>
+
             <div class="modal-body">
-                <div class="setting-group">
-                    <h3>Timer (minutes)</h3>
+                <fieldset class="setting-group">
+                    <legend>Duração (minutos)</legend>
+                    <div class="duration-grid">
+                        <label class="duration-field">
+                            <span>Foco</span>
+                            <input type="number" id="setting-focus" min="1" max="180" step="1" value="25">
+                        </label>
+                        <label class="duration-field">
+                            <span>Pausa curta</span>
+                            <input type="number" id="setting-short" min="1" max="60" step="1" value="5">
+                        </label>
+                        <label class="duration-field">
+                            <span>Pausa longa</span>
+                            <input type="number" id="setting-long" min="1" max="90" step="1" value="15">
+                        </label>
+                        <label class="duration-field">
+                            <span>Ciclos até a pausa longa</span>
+                            <input type="number" id="setting-interval" min="2" max="12" step="1" value="4">
+                        </label>
+                    </div>
+                </fieldset>
+
+                <fieldset class="setting-group">
+                    <legend>Automação</legend>
+                    <label class="setting-row">
+                        <span>Iniciar pausas automaticamente</span>
+                        <input type="checkbox" id="setting-auto-break" class="switch">
+                    </label>
+                    <label class="setting-row">
+                        <span>Iniciar focos automaticamente</span>
+                        <input type="checkbox" id="setting-auto-pomodoro" class="switch">
+                    </label>
+                    <label class="setting-row">
+                        <span>Manter a tela ligada durante o foco</span>
+                        <input type="checkbox" id="setting-wake-lock" class="switch">
+                    </label>
+                </fieldset>
+
+                <fieldset class="setting-group">
+                    <legend>Som</legend>
+                    <label class="setting-row">
+                        <span>Alarme</span>
+                        <select id="setting-alarm">
+                            <option value="bell">Sino</option>
+                            <option value="marimba">Marimba</option>
+                            <option value="digital">Digital</option>
+                            <option value="gong">Gongo</option>
+                            <option value="none">Nenhum</option>
+                        </select>
+                    </label>
+                    <label class="setting-row">
+                        <span>Volume <b id="volume-value">70%</b></span>
+                        <input type="range" id="setting-volume" min="0" max="100" step="5" value="70">
+                    </label>
+                    <label class="setting-row">
+                        <span>Tique-taque durante o foco</span>
+                        <input type="checkbox" id="setting-ticking" class="switch">
+                    </label>
                     <div class="setting-row">
-                        <label>Focus</label>
-                        <input type="number" id="setting-focus" value="25" min="1" max="60">
+                        <span>Testar o alarme</span>
+                        <button id="btn-test-sound" class="btn-soft" type="button">Tocar</button>
+                    </div>
+                </fieldset>
+
+                <fieldset class="setting-group">
+                    <legend>Notificações</legend>
+                    <label class="setting-row">
+                        <span>Avisar quando o ciclo terminar</span>
+                        <input type="checkbox" id="setting-notifications" class="switch">
+                    </label>
+                    <p class="setting-note" id="notification-status">O navegador vai pedir sua permissão.</p>
+                </fieldset>
+
+                <fieldset class="setting-group">
+                    <legend>Dados</legend>
+                    <div class="setting-row">
+                        <span>Restaurar padrões</span>
+                        <button id="btn-reset-settings" class="btn-soft" type="button">Restaurar</button>
                     </div>
                     <div class="setting-row">
-                        <label>Short Break</label>
-                        <input type="number" id="setting-short" value="5" min="1" max="30">
+                        <span>Apagar estatísticas</span>
+                        <button id="btn-clear-stats" class="btn-soft btn-danger" type="button">Apagar</button>
                     </div>
-                    <div class="setting-row">
-                        <label>Long Break</label>
-                        <input type="number" id="setting-long" value="15" min="1" max="60">
-                    </div>
-                </div>
-                <div class="setting-group">
-                    <h3>Options</h3>
-                    <div class="setting-row toggle-row">
-                        <label>Auto-start Breaks</label>
-                        <input type="checkbox" id="setting-auto-break">
-                    </div>
-                    <div class="setting-row toggle-row">
-                        <label>Auto-start Pomodoros</label>
-                        <input type="checkbox" id="setting-auto-pomodoro">
-                    </div>
-                </div>
+                </fieldset>
             </div>
+
             <div class="modal-footer">
-                <button id="btn-save-settings" class="btn-primary">Save Changes</button>
+                <button id="btn-save-settings" class="btn-primary" type="button">Salvar alterações</button>
             </div>
         </div>
     </div>
+
+    <div class="toast-region" id="toast-region" aria-live="polite" aria-atomic="false"></div>
+    <p class="sr-only" id="live-region" role="status" aria-live="polite"></p>
+
     <script src="/labs/shared.js?v=5" defer></script>
-    <script src="script.js" defer></script>
+    <script src="script.js?v=3" defer></script>
 </body>
 
 </html>

--- a/labs/pomodoro/script.js
+++ b/labs/pomodoro/script.js
@@ -1,277 +1,1349 @@
-class PomodoroApp {
-    constructor() {
-        // Default Settings
-        this.settings = {
-            focus: 25,
-            short: 5,
-            long: 15,
-            autoBreak: false,
-            autoPomodoro: false
-        };
+/* =========================================================
+   Pomodoro - Labs
+   Timer baseado em timestamp (imune ao throttling de aba),
+   tarefas, estatísticas, sons sintetizados e notificações.
+   ========================================================= */
 
-        this.loadSettings();
+(function () {
+    'use strict';
 
-        this.timeLeft = this.settings.focus * 60;
-        this.totalTime = this.settings.focus * 60;
-        this.timerId = null;
-        this.isRunning = false;
-        this.cycleCount = 1;
-        this.mode = 'focus'; // focus, short, long
+    const KEYS = {
+        settings: 'pomodoro:settings',
+        tasks: 'pomodoro:tasks',
+        stats: 'pomodoro:stats',
+        state: 'pomodoro:state',
+        legacy: 'pomodoro-settings'
+    };
 
-        // DOM Elements
-        this.timeDisplay = document.getElementById('time-display');
-        this.progressCircle = document.querySelector('.timer-progress');
-        this.statusBadge = document.getElementById('status-badge');
-        this.cycleDisplay = document.getElementById('cycle-count');
-        this.toggleBtn = document.getElementById('btn-toggle');
-        this.resetBtn = document.getElementById('btn-reset');
-        this.modeBtns = document.querySelectorAll('.mode-btn');
+    const DEFAULTS = {
+        focus: 25,
+        short: 5,
+        long: 15,
+        interval: 4,
+        autoBreak: false,
+        autoPomodoro: false,
+        wakeLock: false,
+        alarm: 'bell',
+        volume: 70,
+        muted: false,
+        ticking: false,
+        notifications: true,
+        askedNotifications: false
+    };
 
-        // Settings DOM
-        this.settingsBtn = document.getElementById('btn-settings');
-        this.settingsModal = document.getElementById('settings-modal');
-        this.closeSettingsBtn = document.getElementById('btn-close-settings');
-        this.saveSettingsBtn = document.getElementById('btn-save-settings');
+    const LIMITS = {
+        focus: [1, 180],
+        short: [1, 60],
+        long: [1, 90],
+        interval: [2, 12]
+    };
 
-        // Inputs
-        this.inputFocus = document.getElementById('setting-focus');
-        this.inputShort = document.getElementById('setting-short');
-        this.inputLong = document.getElementById('setting-long');
-        this.inputAutoBreak = document.getElementById('setting-auto-break');
-        this.inputAutoPomodoro = document.getElementById('setting-auto-pomodoro');
+    const MODES = {
+        focus: { label: 'Foco', badge: 'Foco', title: 'Foco' },
+        short: { label: 'Pausa curta', badge: 'Pausa curta', title: 'Pausa' },
+        long: { label: 'Pausa longa', badge: 'Pausa longa', title: 'Pausa' }
+    };
 
-        // Audio Context
-        this.audioCtx = null;
+    const RING_CIRCUMFERENCE = 2 * Math.PI * 88;
+    const TICK_MS = 250;
+    const STATS_HISTORY_DAYS = 60;
+    const WEEK_LABELS = ['dom', 'seg', 'ter', 'qua', 'qui', 'sex', 'sáb'];
 
-        this.init();
-    }
-
-    init() {
-        this.updateDisplay();
-        this.setupEventListeners();
-        this.requestNotificationPermission();
-    }
-
-    loadSettings() {
-        const saved = localStorage.getItem('pomodoro-settings');
-        if (saved) {
-            this.settings = JSON.parse(saved);
-        }
-    }
-
-    saveSettings() {
-        this.settings = {
-            focus: parseInt(this.inputFocus.value) || 25,
-            short: parseInt(this.inputShort.value) || 5,
-            long: parseInt(this.inputLong.value) || 15,
-            autoBreak: this.inputAutoBreak.checked,
-            autoPomodoro: this.inputAutoPomodoro.checked
-        };
-        localStorage.setItem('pomodoro-settings', JSON.stringify(this.settings));
-
-        // Close modal
-        this.settingsModal.classList.remove('open');
-
-        // Reset timer to apply new settings if not running
-        if (!this.isRunning) {
-            this.resetTimer();
-        }
-    }
-
-    populateSettings() {
-        this.inputFocus.value = this.settings.focus;
-        this.inputShort.value = this.settings.short;
-        this.inputLong.value = this.settings.long;
-        this.inputAutoBreak.checked = this.settings.autoBreak;
-        this.inputAutoPomodoro.checked = this.settings.autoPomodoro;
-    }
-
-    setupEventListeners() {
-        this.toggleBtn.addEventListener('click', () => this.toggleTimer());
-        this.resetBtn.addEventListener('click', () => this.resetTimer());
-
-        this.modeBtns.forEach(btn => {
-            btn.addEventListener('click', (e) => {
-                const newMode = e.target.dataset.mode;
-                this.switchMode(newMode);
-            });
-        });
-
-        // Settings Modal
-        this.settingsBtn.addEventListener('click', () => {
-            this.populateSettings();
-            this.settingsModal.classList.add('open');
-        });
-
-        this.closeSettingsBtn.addEventListener('click', () => {
-            this.settingsModal.classList.remove('open');
-        });
-
-        this.saveSettingsBtn.addEventListener('click', () => {
-            this.saveSettings();
-        });
-
-        // Close modal on outside click
-        this.settingsModal.addEventListener('click', (e) => {
-            if (e.target === this.settingsModal) {
-                this.settingsModal.classList.remove('open');
+    /* ---------------------------------------------------------
+       Armazenamento tolerante a falhas (modo privado, cotas)
+       --------------------------------------------------------- */
+    const store = {
+        read(key, fallback) {
+            try {
+                const raw = localStorage.getItem(key);
+                if (!raw) return fallback;
+                const parsed = JSON.parse(raw);
+                return parsed === null || parsed === undefined ? fallback : parsed;
+            } catch (err) {
+                return fallback;
             }
-        });
-    }
-
-    requestNotificationPermission() {
-        if ("Notification" in window && Notification.permission !== "granted") {
-            Notification.requestPermission();
+        },
+        write(key, value) {
+            try {
+                localStorage.setItem(key, JSON.stringify(value));
+            } catch (err) {
+                /* Storage indisponível: o app segue funcionando em memória. */
+            }
+        },
+        remove(key) {
+            try {
+                localStorage.removeItem(key);
+            } catch (err) {
+                /* noop */
+            }
         }
-    }
+    };
 
-    toggleTimer() {
-        if (this.isRunning) {
-            this.pauseTimer();
-        } else {
-            this.startTimer();
+    const clamp = (value, min, max) => Math.min(max, Math.max(min, value));
+
+    const toInt = (value, fallback, [min, max]) => {
+        const parsed = parseInt(value, 10);
+        return Number.isFinite(parsed) ? clamp(parsed, min, max) : fallback;
+    };
+
+    const dayKey = (date) => {
+        const d = date || new Date();
+        return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+    };
+
+    /* ---------------------------------------------------------
+       Sons sintetizados via Web Audio (sem arquivos externos)
+       --------------------------------------------------------- */
+    class SoundKit {
+        constructor() {
+            this.ctx = null;
+            this.master = null;
+            this.volume = 0.7;
+            this.muted = false;
         }
-    }
 
-    startTimer() {
-        if (!this.isRunning) {
-            this.isRunning = true;
-            this.toggleBtn.innerHTML = '<span class="icon-pause">⏸</span> Pause';
-            this.toggleBtn.classList.add('active');
+        unlock() {
+            if (!this.ctx) {
+                const Ctx = window.AudioContext || window.webkitAudioContext;
+                if (!Ctx) return null;
+                this.ctx = new Ctx();
+                this.master = this.ctx.createGain();
+                this.master.gain.value = this.volume;
+                this.master.connect(this.ctx.destination);
+            }
+            if (this.ctx.state === 'suspended') this.ctx.resume();
+            return this.ctx;
+        }
 
-            // Initialize audio context on first user interaction
-            if (!this.audioCtx) {
-                this.audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+        setVolume(percent) {
+            this.volume = clamp(percent, 0, 100) / 100;
+            if (this.master) this.master.gain.value = this.volume;
+        }
+
+        setMuted(muted) {
+            this.muted = !!muted;
+        }
+
+        get enabled() {
+            return !this.muted && this.volume > 0;
+        }
+
+        tone({ freq = 440, type = 'sine', at = 0, duration = 0.4, gain = 0.3, sweepTo = null }) {
+            const ctx = this.ctx;
+            if (!ctx) return;
+
+            const start = ctx.currentTime + at;
+            const osc = ctx.createOscillator();
+            const env = ctx.createGain();
+
+            osc.type = type;
+            osc.frequency.setValueAtTime(freq, start);
+            if (sweepTo) osc.frequency.exponentialRampToValueAtTime(sweepTo, start + duration);
+
+            env.gain.setValueAtTime(0.0001, start);
+            env.gain.exponentialRampToValueAtTime(gain, start + 0.012);
+            env.gain.exponentialRampToValueAtTime(0.0001, start + duration);
+
+            osc.connect(env);
+            env.connect(this.master);
+            osc.start(start);
+            osc.stop(start + duration + 0.05);
+        }
+
+        noise({ at = 0, duration = 1.2, gain = 0.2, cutoff = 900 }) {
+            const ctx = this.ctx;
+            if (!ctx) return;
+
+            const start = ctx.currentTime + at;
+            const frames = Math.floor(ctx.sampleRate * duration);
+            const buffer = ctx.createBuffer(1, frames, ctx.sampleRate);
+            const data = buffer.getChannelData(0);
+            for (let i = 0; i < frames; i += 1) {
+                data[i] = (Math.random() * 2 - 1) * (1 - i / frames);
             }
 
-            this.lastTime = Date.now();
-            this.timerId = setInterval(() => {
-                const now = Date.now();
-                const delta = Math.floor((now - this.lastTime) / 1000);
+            const src = ctx.createBufferSource();
+            src.buffer = buffer;
 
-                if (delta >= 1) {
-                    this.timeLeft -= delta;
-                    this.lastTime = now;
-                    this.updateDisplay();
+            const filter = ctx.createBiquadFilter();
+            filter.type = 'lowpass';
+            filter.frequency.value = cutoff;
 
-                    if (this.timeLeft <= 0) {
-                        this.completeTimer();
+            const env = ctx.createGain();
+            env.gain.setValueAtTime(gain, start);
+            env.gain.exponentialRampToValueAtTime(0.0001, start + duration);
+
+            src.connect(filter);
+            filter.connect(env);
+            env.connect(this.master);
+            src.start(start);
+        }
+
+        alarm(kind) {
+            if (!this.enabled || kind === 'none') return;
+            if (!this.unlock()) return;
+
+            switch (kind) {
+                case 'marimba':
+                    [523.25, 659.25, 783.99].forEach((freq, i) => {
+                        this.tone({ freq, type: 'sine', at: i * 0.16, duration: 0.5, gain: 0.32 });
+                        this.tone({ freq: freq * 2, type: 'sine', at: i * 0.16, duration: 0.25, gain: 0.1 });
+                    });
+                    break;
+                case 'digital':
+                    for (let i = 0; i < 3; i += 1) {
+                        this.tone({ freq: 1180, type: 'square', at: i * 0.22, duration: 0.11, gain: 0.16 });
                     }
+                    break;
+                case 'gong':
+                    this.tone({ freq: 174, type: 'sine', at: 0, duration: 2.6, gain: 0.34 });
+                    this.tone({ freq: 261, type: 'sine', at: 0.02, duration: 2.2, gain: 0.16 });
+                    this.noise({ at: 0, duration: 1.6, gain: 0.14, cutoff: 700 });
+                    break;
+                case 'bell':
+                default:
+                    for (let i = 0; i < 2; i += 1) {
+                        const at = i * 0.55;
+                        this.tone({ freq: 880, type: 'sine', at, duration: 1.5, gain: 0.3 });
+                        this.tone({ freq: 1320, type: 'sine', at, duration: 0.9, gain: 0.12 });
+                        this.tone({ freq: 2640, type: 'sine', at, duration: 0.35, gain: 0.05 });
+                    }
+                    break;
+            }
+        }
+
+        click() {
+            if (!this.enabled || !this.ctx) return;
+            this.tone({ freq: 660, type: 'triangle', duration: 0.06, gain: 0.06, sweepTo: 440 });
+        }
+
+        tick() {
+            if (!this.enabled || !this.ctx) return;
+            this.tone({ freq: 1000, type: 'sine', duration: 0.03, gain: 0.035 });
+        }
+    }
+
+    /* ---------------------------------------------------------
+       App
+       --------------------------------------------------------- */
+    class PomodoroApp {
+        constructor() {
+            this.el = {
+                body: document.body,
+                time: document.getElementById('time-display'),
+                badge: document.getElementById('status-badge'),
+                cycle: document.getElementById('cycle-count'),
+                cycleTotal: document.getElementById('cycle-total'),
+                ring: document.querySelector('.ring-progress'),
+                toggle: document.getElementById('btn-toggle'),
+                toggleLabel: document.getElementById('toggle-label'),
+                reset: document.getElementById('btn-reset'),
+                skip: document.getElementById('btn-skip'),
+                modeBtns: Array.from(document.querySelectorAll('.mode-btn')),
+                activeTask: document.getElementById('active-task'),
+                activeTaskName: document.getElementById('active-task-name'),
+                soundBtn: document.getElementById('btn-sound'),
+                settingsBtn: document.getElementById('btn-settings'),
+                modal: document.getElementById('settings-modal'),
+                modalContent: document.querySelector('.modal-content'),
+                saveBtn: document.getElementById('btn-save-settings'),
+                taskForm: document.getElementById('task-form'),
+                taskInput: document.getElementById('task-input'),
+                taskEstimate: document.getElementById('task-estimate'),
+                taskList: document.getElementById('task-list'),
+                tasksEmpty: document.getElementById('tasks-empty'),
+                taskSummary: document.getElementById('task-summary'),
+                clearDone: document.getElementById('btn-clear-done'),
+                statToday: document.getElementById('stat-today'),
+                statTime: document.getElementById('stat-time'),
+                statStreak: document.getElementById('stat-streak'),
+                statTotal: document.getElementById('stat-total'),
+                chart: document.getElementById('week-chart'),
+                toasts: document.getElementById('toast-region'),
+                live: document.getElementById('live-region'),
+                notificationStatus: document.getElementById('notification-status'),
+                volumeValue: document.getElementById('volume-value'),
+                inputs: {
+                    focus: document.getElementById('setting-focus'),
+                    short: document.getElementById('setting-short'),
+                    long: document.getElementById('setting-long'),
+                    interval: document.getElementById('setting-interval'),
+                    autoBreak: document.getElementById('setting-auto-break'),
+                    autoPomodoro: document.getElementById('setting-auto-pomodoro'),
+                    wakeLock: document.getElementById('setting-wake-lock'),
+                    alarm: document.getElementById('setting-alarm'),
+                    volume: document.getElementById('setting-volume'),
+                    ticking: document.getElementById('setting-ticking'),
+                    notifications: document.getElementById('setting-notifications')
                 }
-            }, 100);
-        }
-    }
+            };
 
-    pauseTimer() {
-        this.isRunning = false;
-        clearInterval(this.timerId);
-        this.toggleBtn.innerHTML = '<span class="icon-play">▶</span> Start';
-        this.toggleBtn.classList.remove('active');
-    }
+            this.sound = new SoundKit();
+            this.settings = this.loadSettings();
+            this.tasks = store.read(KEYS.tasks, []);
+            this.activeTaskId = null;
+            this.stats = this.loadStats();
 
-    resetTimer() {
-        this.pauseTimer();
-        this.timeLeft = this.settings[this.mode] * 60;
-        this.totalTime = this.settings[this.mode] * 60;
-        this.updateDisplay();
-    }
+            this.mode = 'focus';
+            this.round = 0;
+            this.running = false;
+            this.remaining = this.settings.focus * 60000;
+            this.endsAt = 0;
+            this.timerId = null;
+            this.completionId = null;
+            this.tickSecond = -1;
+            this.lastTitle = '';
+            this.lastFaviconStep = -1;
+            this.wakeLockSentinel = null;
+            this.lastFocusedElement = null;
+            this.pendingAwayMessage = false;
 
-    switchMode(mode) {
-        this.mode = mode;
-        this.pauseTimer();
-        this.timeLeft = this.settings[mode] * 60;
-        this.totalTime = this.settings[mode] * 60;
+            this.sound.setVolume(this.settings.volume);
+            this.sound.setMuted(this.settings.muted);
 
-        // Update UI
-        this.modeBtns.forEach(btn => btn.classList.remove('active'));
-        document.querySelector(`[data-mode="${mode}"]`).classList.add('active');
+            this.restoreState();
+            this.bindEvents();
+            this.renderAll();
 
-        if (mode === 'focus') {
-            document.body.classList.remove('break-mode');
-            this.statusBadge.textContent = 'FOCUS';
-        } else {
-            document.body.classList.add('break-mode');
-            this.statusBadge.textContent = mode === 'short' ? 'SHORT BREAK' : 'LONG BREAK';
-        }
-
-        this.updateDisplay();
-    }
-
-    completeTimer() {
-        this.pauseTimer();
-        this.playSound();
-        this.sendNotification();
-
-        if (this.mode === 'focus') {
-            if (this.cycleCount % 4 === 0) {
-                this.switchMode('long');
-            } else {
-                this.switchMode('short');
-            }
-            this.cycleCount++;
-            this.cycleDisplay.textContent = this.cycleCount;
-
-            if (this.settings.autoBreak) {
-                this.startTimer();
-            }
-        } else {
-            this.switchMode('focus');
-
-            if (this.settings.autoPomodoro) {
-                this.startTimer();
+            if (this.running) {
+                this.startLoop();
+                this.requestWakeLock();
             }
         }
-    }
 
-    updateDisplay() {
-        const minutes = Math.floor(this.timeLeft / 60);
-        const seconds = this.timeLeft % 60;
-        const timeString = `${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`;
+        /* ------------------------- dados ------------------------- */
 
-        this.timeDisplay.textContent = timeString;
-        document.title = `${timeString} - Pomodoro`;
+        loadSettings() {
+            const legacy = store.read(KEYS.legacy, null);
+            if (legacy) {
+                store.write(KEYS.settings, Object.assign({}, DEFAULTS, legacy));
+                store.remove(KEYS.legacy);
+            }
+            const saved = store.read(KEYS.settings, {});
+            const merged = Object.assign({}, DEFAULTS, saved);
 
-        // Update Progress Circle
-        const circumference = 2 * Math.PI * 45; // r=45
-        const offset = circumference - (this.timeLeft / this.totalTime) * circumference;
-        this.progressCircle.style.strokeDashoffset = offset;
-    }
+            Object.keys(LIMITS).forEach((key) => {
+                merged[key] = toInt(merged[key], DEFAULTS[key], LIMITS[key]);
+            });
+            merged.volume = toInt(merged.volume, DEFAULTS.volume, [0, 100]);
+            merged.alarm = ['bell', 'marimba', 'digital', 'gong', 'none'].includes(merged.alarm)
+                ? merged.alarm
+                : DEFAULTS.alarm;
 
-    playSound() {
-        if (!this.audioCtx) return;
+            return merged;
+        }
 
-        const oscillator = this.audioCtx.createOscillator();
-        const gainNode = this.audioCtx.createGain();
+        persistSettings() {
+            store.write(KEYS.settings, this.settings);
+        }
 
-        oscillator.connect(gainNode);
-        gainNode.connect(this.audioCtx.destination);
+        loadStats() {
+            const stats = store.read(KEYS.stats, { days: {}, total: 0, minutes: 0 });
+            if (!stats.days || typeof stats.days !== 'object') stats.days = {};
+            stats.total = Number(stats.total) || 0;
+            stats.minutes = Number(stats.minutes) || 0;
 
-        // Gentle chime
-        oscillator.type = 'sine';
-        oscillator.frequency.setValueAtTime(440, this.audioCtx.currentTime);
-        oscillator.frequency.exponentialRampToValueAtTime(880, this.audioCtx.currentTime + 0.1);
+            // Mantém o histórico enxuto no localStorage.
+            const limit = new Date();
+            limit.setDate(limit.getDate() - STATS_HISTORY_DAYS);
+            Object.keys(stats.days).forEach((key) => {
+                if (new Date(`${key}T00:00:00`) < limit) delete stats.days[key];
+            });
 
-        gainNode.gain.setValueAtTime(0.1, this.audioCtx.currentTime);
-        gainNode.gain.exponentialRampToValueAtTime(0.001, this.audioCtx.currentTime + 0.5);
+            return stats;
+        }
 
-        oscillator.start();
-        oscillator.stop(this.audioCtx.currentTime + 0.5);
-    }
+        persistStats() {
+            store.write(KEYS.stats, this.stats);
+        }
 
-    sendNotification() {
-        if (Notification.permission === "granted") {
-            const title = this.mode === 'focus' ? "Focus Session Complete" : "Break Over";
-            const body = this.mode === 'focus' ? "Time to take a break." : "Ready to focus again?";
+        persistTasks() {
+            store.write(KEYS.tasks, this.tasks);
+        }
 
-            new Notification(title, {
-                body: body,
-                icon: '/assets/images/favicon.png'
+        persistState() {
+            store.write(KEYS.state, {
+                mode: this.mode,
+                round: this.round,
+                running: this.running,
+                remaining: this.remaining,
+                endsAt: this.endsAt,
+                activeTaskId: this.activeTaskId,
+                savedAt: Date.now()
             });
         }
-    }
-}
 
-// Initialize
-document.addEventListener('DOMContentLoaded', () => {
-    const app = new PomodoroApp();
-});
+        restoreState() {
+            const saved = store.read(KEYS.state, null);
+            if (!saved || !MODES[saved.mode]) {
+                this.remaining = this.durationFor(this.mode);
+                return;
+            }
+
+            this.mode = saved.mode;
+            this.round = clamp(Number(saved.round) || 0, 0, this.settings.interval);
+            this.activeTaskId = this.tasks.some((task) => task.id === saved.activeTaskId)
+                ? saved.activeTaskId
+                : null;
+
+            const total = this.durationFor(this.mode);
+
+            if (saved.running && saved.endsAt) {
+                const left = saved.endsAt - Date.now();
+                if (left > 0) {
+                    this.remaining = Math.min(left, total);
+                    this.endsAt = saved.endsAt;
+                    this.running = true;
+                    return;
+                }
+                // O ciclo terminou com a aba fechada: contabiliza e avança.
+                this.remaining = 0;
+                this.completeSession({ silent: true, autoStart: false });
+                this.pendingAwayMessage = true;
+                return;
+            }
+
+            this.remaining = clamp(Number(saved.remaining) || total, 0, total) || total;
+        }
+
+        durationFor(mode) {
+            return this.settings[mode] * 60000;
+        }
+
+        /* ------------------------- eventos ------------------------- */
+
+        bindEvents() {
+            this.el.toggle.addEventListener('click', () => {
+                this.sound.unlock();
+                this.toggle();
+            });
+
+            this.el.reset.addEventListener('click', () => {
+                this.sound.unlock();
+                this.sound.click();
+                this.resetTimer();
+                this.toast('Ciclo reiniciado');
+            });
+
+            this.el.skip.addEventListener('click', () => {
+                this.sound.unlock();
+                this.sound.click();
+                this.skipSession();
+            });
+
+            this.el.modeBtns.forEach((btn) => {
+                btn.addEventListener('click', () => {
+                    this.sound.unlock();
+                    this.sound.click();
+                    this.switchMode(btn.dataset.mode, { manual: true });
+                });
+            });
+
+            this.el.soundBtn.addEventListener('click', () => {
+                this.settings.muted = !this.settings.muted;
+                this.sound.setMuted(this.settings.muted);
+                this.persistSettings();
+                this.renderSoundButton();
+                if (!this.settings.muted) {
+                    this.sound.unlock();
+                    this.sound.click();
+                }
+                this.toast(this.settings.muted ? 'Som desativado' : 'Som ativado');
+            });
+
+            // Configurações
+            this.el.settingsBtn.addEventListener('click', () => this.openSettings());
+            this.el.saveBtn.addEventListener('click', () => this.saveSettings());
+            this.el.modal.querySelectorAll('[data-close-modal]').forEach((node) => {
+                node.addEventListener('click', () => this.closeSettings());
+            });
+            this.el.modal.addEventListener('keydown', (event) => this.handleModalKeydown(event));
+
+            this.el.inputs.volume.addEventListener('input', (event) => {
+                const value = Number(event.target.value);
+                this.el.volumeValue.textContent = `${value}%`;
+                this.sound.setVolume(value);
+            });
+
+            this.el.inputs.notifications.addEventListener('change', (event) => {
+                if (event.target.checked) this.enableNotifications(event.target);
+                else this.renderNotificationStatus();
+            });
+
+            document.getElementById('btn-test-sound').addEventListener('click', () => {
+                this.sound.unlock();
+                this.sound.setMuted(false);
+                this.sound.alarm(this.el.inputs.alarm.value);
+                this.sound.setMuted(this.settings.muted);
+            });
+
+            document.getElementById('btn-reset-settings').addEventListener('click', () => {
+                this.settings = Object.assign({}, DEFAULTS, { muted: this.settings.muted });
+                this.persistSettings();
+                this.fillSettingsForm();
+                this.sound.setVolume(this.settings.volume);
+                this.applySettingsToTimer();
+                this.toast('Configurações restauradas');
+            });
+
+            document.getElementById('btn-clear-stats').addEventListener('click', () => {
+                this.stats = { days: {}, total: 0, minutes: 0 };
+                this.persistStats();
+                this.renderStats();
+                this.toast('Estatísticas apagadas');
+            });
+
+            // Tarefas
+            this.el.taskForm.addEventListener('submit', (event) => {
+                event.preventDefault();
+                this.addTask();
+            });
+            this.el.taskList.addEventListener('click', (event) => this.handleTaskClick(event));
+            this.el.clearDone.addEventListener('click', () => {
+                this.tasks = this.tasks.filter((task) => !task.done);
+                if (!this.tasks.some((task) => task.id === this.activeTaskId)) this.activeTaskId = null;
+                this.persistTasks();
+                this.renderTasks();
+                this.toast('Tarefas concluídas removidas');
+            });
+
+            // Atalhos de teclado
+            document.addEventListener('keydown', (event) => this.handleShortcut(event));
+
+            // A aba voltou: sincroniza o relógio e o wake lock
+            document.addEventListener('visibilitychange', () => {
+                if (document.hidden) return;
+                this.syncFromTimestamp();
+                if (this.running) this.requestWakeLock();
+            });
+
+            window.addEventListener('pagehide', () => this.persistState());
+        }
+
+        /* ------------------------- timer ------------------------- */
+
+        toggle() {
+            if (this.running) this.pause();
+            else this.start();
+        }
+
+        start() {
+            if (this.running) return;
+            if (this.remaining <= 0) this.remaining = this.durationFor(this.mode);
+
+            this.running = true;
+            this.endsAt = Date.now() + this.remaining;
+            this.tickSecond = -1;
+            this.sound.click();
+            this.askNotificationsOnce();
+            this.startLoop();
+            this.requestWakeLock();
+            this.renderControls();
+            this.persistState();
+            this.announce(`${MODES[this.mode].label} iniciado`);
+        }
+
+        pause() {
+            if (!this.running) return;
+            this.syncFromTimestamp();
+            this.running = false;
+            this.stopLoop();
+            this.releaseWakeLock();
+            this.sound.click();
+            this.renderControls();
+            this.renderTime();
+            this.persistState();
+            this.announce('Cronômetro pausado');
+        }
+
+        startLoop() {
+            this.stopLoop();
+            this.timerId = setInterval(() => this.tick(), TICK_MS);
+            // Abas em segundo plano sofrem throttling do setInterval; este timeout
+            // único costuma acordar mais perto do fim real do ciclo.
+            this.completionId = setTimeout(() => this.syncFromTimestamp(), Math.max(0, this.remaining) + 60);
+        }
+
+        stopLoop() {
+            if (this.timerId) clearInterval(this.timerId);
+            if (this.completionId) clearTimeout(this.completionId);
+            this.timerId = null;
+            this.completionId = null;
+        }
+
+        tick() {
+            const left = this.endsAt - Date.now();
+            this.remaining = Math.max(0, left);
+
+            const second = Math.ceil(this.remaining / 1000);
+            if (second !== this.tickSecond) {
+                this.tickSecond = second;
+                if (this.settings.ticking && this.mode === 'focus' && second > 0) this.sound.tick();
+            }
+
+            this.renderTime();
+
+            if (left <= 0) this.completeSession({});
+        }
+
+        syncFromTimestamp() {
+            if (!this.running) return;
+            this.remaining = Math.max(0, this.endsAt - Date.now());
+            if (this.remaining === 0) this.completeSession({});
+            else this.renderTime();
+        }
+
+        resetTimer() {
+            this.stopLoop();
+            this.running = false;
+            this.releaseWakeLock();
+            this.remaining = this.durationFor(this.mode);
+            this.renderControls();
+            this.renderTime({ jump: true });
+            this.persistState();
+        }
+
+        switchMode(mode, options = {}) {
+            if (!MODES[mode]) return;
+
+            this.stopLoop();
+            this.running = false;
+            this.releaseWakeLock();
+            this.mode = mode;
+            this.remaining = this.durationFor(mode);
+
+            this.renderMode();
+            this.renderControls();
+            this.renderTime({ jump: true });
+            this.persistState();
+
+            if (options.manual) this.announce(`Modo ${MODES[mode].label}`);
+
+            if (options.autoStart) this.start();
+        }
+
+        skipSession() {
+            const next = this.nextMode();
+            if (this.mode === 'long') this.round = 0;
+            this.switchMode(next, { manual: false });
+            this.renderCycle();
+            this.toast(`Pulou para ${MODES[next].label.toLowerCase()}`);
+        }
+
+        nextMode() {
+            if (this.mode !== 'focus') return 'focus';
+            const done = this.round + 1;
+            return done % this.settings.interval === 0 ? 'long' : 'short';
+        }
+
+        completeSession(options = {}) {
+            this.stopLoop();
+            this.running = false;
+            this.remaining = 0;
+            this.releaseWakeLock();
+
+            const finishedMode = this.mode;
+            let next;
+
+            if (finishedMode === 'focus') {
+                this.round += 1;
+                this.recordSession(this.settings.focus);
+                this.creditActiveTask();
+                next = this.round % this.settings.interval === 0 ? 'long' : 'short';
+            } else {
+                if (finishedMode === 'long') this.round = 0;
+                next = 'focus';
+            }
+
+            if (!options.silent) {
+                this.sound.alarm(this.settings.alarm);
+                this.notify(finishedMode);
+                this.toast(finishedMode === 'focus' ? 'Pomodoro concluído! Hora da pausa.' : 'Pausa encerrada. Bora focar!');
+                this.announce(finishedMode === 'focus' ? 'Pomodoro concluído' : 'Pausa encerrada');
+            }
+
+            const autoStart = options.autoStart === false
+                ? false
+                : (next === 'focus' ? this.settings.autoPomodoro : this.settings.autoBreak);
+
+            this.switchMode(next, { autoStart });
+            this.renderCycle();
+            this.renderStats();
+        }
+
+        applySettingsToTimer() {
+            this.el.cycleTotal.textContent = this.settings.interval;
+            this.round = clamp(this.round, 0, this.settings.interval);
+            if (!this.running) {
+                this.remaining = this.durationFor(this.mode);
+                this.renderTime({ jump: true });
+            }
+            this.renderCycle();
+            this.persistState();
+        }
+
+        /* ------------------------- estatísticas ------------------------- */
+
+        recordSession(minutes) {
+            const key = dayKey();
+            const day = this.stats.days[key] || { sessions: 0, minutes: 0 };
+            day.sessions += 1;
+            day.minutes += minutes;
+            this.stats.days[key] = day;
+            this.stats.total += 1;
+            this.stats.minutes += minutes;
+            this.persistStats();
+        }
+
+        currentStreak() {
+            let streak = 0;
+            const cursor = new Date();
+
+            // A sequência continua válida se hoje ainda não teve pomodoro.
+            if (!this.stats.days[dayKey(cursor)]) cursor.setDate(cursor.getDate() - 1);
+
+            while (this.stats.days[dayKey(cursor)]) {
+                streak += 1;
+                cursor.setDate(cursor.getDate() - 1);
+            }
+
+            return streak;
+        }
+
+        /* ------------------------- tarefas ------------------------- */
+
+        addTask() {
+            const name = this.el.taskInput.value.trim();
+            if (!name) return;
+
+            const task = {
+                id: `t${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`,
+                name: name.slice(0, 80),
+                estimate: toInt(this.el.taskEstimate.value, 1, [1, 20]),
+                done: false,
+                completed: 0
+            };
+
+            this.tasks.push(task);
+            if (!this.activeTaskId) this.activeTaskId = task.id;
+
+            this.el.taskInput.value = '';
+            this.el.taskEstimate.value = 1;
+            this.persistTasks();
+            this.persistState();
+            this.renderTasks();
+            this.sound.click();
+        }
+
+        handleTaskClick(event) {
+            const button = event.target.closest('button');
+            if (!button) return;
+
+            const item = button.closest('.task-item');
+            const id = item && item.dataset.id;
+            const task = this.tasks.find((entry) => entry.id === id);
+            if (!task) return;
+
+            if (button.classList.contains('task-check')) {
+                task.done = !task.done;
+                if (task.done && this.activeTaskId === task.id) {
+                    const next = this.tasks.find((entry) => !entry.done);
+                    this.activeTaskId = next ? next.id : null;
+                }
+            } else if (button.classList.contains('task-remove')) {
+                this.tasks = this.tasks.filter((entry) => entry.id !== id);
+                if (this.activeTaskId === id) this.activeTaskId = null;
+            } else if (button.classList.contains('task-name')) {
+                this.activeTaskId = task.done ? this.activeTaskId : task.id;
+            }
+
+            this.sound.click();
+            this.persistTasks();
+            this.persistState();
+            this.renderTasks();
+        }
+
+        creditActiveTask() {
+            const task = this.tasks.find((entry) => entry.id === this.activeTaskId);
+            if (!task) return;
+            task.completed += 1;
+            this.persistTasks();
+            this.renderTasks();
+        }
+
+        /* ------------------------- notificações ------------------------- */
+
+        notificationsSupported() {
+            return typeof window.Notification !== 'undefined';
+        }
+
+        notificationsGranted() {
+            return this.notificationsSupported() && Notification.permission === 'granted';
+        }
+
+        /** Pede a permissão uma única vez, no primeiro "Iniciar" (gesto do usuário). */
+        askNotificationsOnce() {
+            if (!this.settings.notifications || this.settings.askedNotifications) return;
+            if (!this.notificationsSupported() || Notification.permission !== 'default') return;
+
+            this.settings.askedNotifications = true;
+            this.persistSettings();
+
+            Notification.requestPermission().then((result) => {
+                if (result === 'granted') this.toast('Notificações ativadas');
+                this.renderNotificationStatus();
+            }).catch(() => { });
+        }
+
+        enableNotifications(checkbox) {
+            if (!this.notificationsSupported()) {
+                checkbox.checked = false;
+                this.renderNotificationStatus('Seu navegador não oferece notificações nesta página.');
+                return;
+            }
+
+            if (Notification.permission === 'granted') {
+                this.renderNotificationStatus();
+                return;
+            }
+
+            if (Notification.permission === 'denied') {
+                checkbox.checked = false;
+                this.renderNotificationStatus('Permissão bloqueada. Libere as notificações nas configurações do navegador.', true);
+                return;
+            }
+
+            Notification.requestPermission().then((result) => {
+                if (result !== 'granted') {
+                    checkbox.checked = false;
+                    this.renderNotificationStatus('Permissão negada pelo navegador.', true);
+                } else {
+                    this.renderNotificationStatus();
+                    this.toast('Notificações ativadas');
+                }
+            }).catch(() => {
+                checkbox.checked = false;
+                this.renderNotificationStatus('Não foi possível pedir a permissão.', true);
+            });
+        }
+
+        notify(finishedMode) {
+            if (!this.settings.notifications || !this.notificationsGranted()) return;
+
+            const isFocus = finishedMode === 'focus';
+            const task = this.tasks.find((entry) => entry.id === this.activeTaskId);
+            const title = isFocus ? '🍅 Pomodoro concluído!' : '✅ Pausa encerrada';
+            const body = isFocus
+                ? `${task ? `"${task.name}" · ` : ''}Hora de descansar um pouco.`
+                : 'Respire fundo e volte ao foco.';
+
+            try {
+                const notification = new Notification(title, {
+                    body,
+                    tag: 'pomodoro-labs',
+                    renotify: true,
+                    icon: '/favicon.ico',
+                    badge: '/favicon.ico'
+                });
+                notification.onclick = () => {
+                    window.focus();
+                    notification.close();
+                };
+            } catch (err) {
+                /* Alguns navegadores exigem service worker; o alarme sonoro cobre o aviso. */
+            }
+        }
+
+        /* ------------------------- wake lock ------------------------- */
+
+        requestWakeLock() {
+            if (!this.settings.wakeLock || !this.running) return;
+            if (!('wakeLock' in navigator) || this.wakeLockSentinel) return;
+
+            navigator.wakeLock.request('screen').then((sentinel) => {
+                this.wakeLockSentinel = sentinel;
+                sentinel.addEventListener('release', () => {
+                    this.wakeLockSentinel = null;
+                });
+            }).catch(() => {
+                /* Recurso indisponível (aba oculta, bateria baixa, navegador sem suporte). */
+            });
+        }
+
+        releaseWakeLock() {
+            if (!this.wakeLockSentinel) return;
+            this.wakeLockSentinel.release().catch(() => { });
+            this.wakeLockSentinel = null;
+        }
+
+        /* ------------------------- configurações (modal) ------------------------- */
+
+        openSettings() {
+            this.fillSettingsForm();
+            this.lastFocusedElement = document.activeElement;
+            this.el.modal.hidden = false;
+            document.body.style.overflow = 'hidden';
+            this.el.settingsBtn.setAttribute('aria-expanded', 'true');
+            const first = this.el.modal.querySelector('input, select, button');
+            if (first) first.focus();
+        }
+
+        closeSettings() {
+            this.el.modal.hidden = true;
+            document.body.style.overflow = '';
+            this.el.settingsBtn.setAttribute('aria-expanded', 'false');
+            // Descarta ajustes de volume não salvos.
+            this.sound.setVolume(this.settings.volume);
+            if (this.lastFocusedElement) this.lastFocusedElement.focus();
+        }
+
+        handleModalKeydown(event) {
+            if (event.key === 'Escape') {
+                event.stopPropagation();
+                this.closeSettings();
+                return;
+            }
+
+            if (event.key !== 'Tab') return;
+
+            const focusable = Array.from(
+                this.el.modalContent.querySelectorAll('button, input, select, [tabindex]:not([tabindex="-1"])')
+            ).filter((node) => !node.disabled && node.offsetParent !== null);
+            if (!focusable.length) return;
+
+            const first = focusable[0];
+            const last = focusable[focusable.length - 1];
+
+            if (event.shiftKey && document.activeElement === first) {
+                event.preventDefault();
+                last.focus();
+            } else if (!event.shiftKey && document.activeElement === last) {
+                event.preventDefault();
+                first.focus();
+            }
+        }
+
+        fillSettingsForm() {
+            const inputs = this.el.inputs;
+            inputs.focus.value = this.settings.focus;
+            inputs.short.value = this.settings.short;
+            inputs.long.value = this.settings.long;
+            inputs.interval.value = this.settings.interval;
+            inputs.autoBreak.checked = this.settings.autoBreak;
+            inputs.autoPomodoro.checked = this.settings.autoPomodoro;
+            inputs.wakeLock.checked = this.settings.wakeLock;
+            inputs.alarm.value = this.settings.alarm;
+            inputs.volume.value = this.settings.volume;
+            inputs.ticking.checked = this.settings.ticking;
+            inputs.notifications.checked = this.settings.notifications
+                && this.notificationsSupported()
+                && Notification.permission !== 'denied';
+            this.el.volumeValue.textContent = `${this.settings.volume}%`;
+            this.renderNotificationStatus();
+        }
+
+        saveSettings() {
+            const inputs = this.el.inputs;
+            const previousDurations = {
+                focus: this.settings.focus,
+                short: this.settings.short,
+                long: this.settings.long
+            };
+
+            this.settings = Object.assign({}, this.settings, {
+                focus: toInt(inputs.focus.value, DEFAULTS.focus, LIMITS.focus),
+                short: toInt(inputs.short.value, DEFAULTS.short, LIMITS.short),
+                long: toInt(inputs.long.value, DEFAULTS.long, LIMITS.long),
+                interval: toInt(inputs.interval.value, DEFAULTS.interval, LIMITS.interval),
+                autoBreak: inputs.autoBreak.checked,
+                autoPomodoro: inputs.autoPomodoro.checked,
+                wakeLock: inputs.wakeLock.checked,
+                alarm: inputs.alarm.value,
+                volume: toInt(inputs.volume.value, DEFAULTS.volume, [0, 100]),
+                ticking: inputs.ticking.checked,
+                notifications: inputs.notifications.checked
+            });
+
+            this.persistSettings();
+            this.sound.setVolume(this.settings.volume);
+
+            if (this.settings.wakeLock) this.requestWakeLock();
+            else this.releaseWakeLock();
+
+            const durationChanged = previousDurations[this.mode] !== this.settings[this.mode];
+            this.applySettingsToTimer();
+
+            this.closeSettings();
+            this.toast(durationChanged && this.running
+                ? 'Configurações salvas (valem no próximo ciclo)'
+                : 'Configurações salvas');
+        }
+
+        /* ------------------------- atalhos ------------------------- */
+
+        handleShortcut(event) {
+            if (event.metaKey || event.ctrlKey || event.altKey) return;
+
+            if (!this.el.modal.hidden) {
+                if (event.key === 'Escape') this.closeSettings();
+                return;
+            }
+
+            const target = event.target;
+            const typing = target && (target.tagName === 'INPUT' || target.tagName === 'SELECT' || target.isContentEditable);
+            if (typing) return;
+
+            // Espaço em um botão focado já dispara o clique nativo.
+            const onButton = target && target.tagName === 'BUTTON';
+
+            switch (event.key) {
+                case ' ':
+                case 'Spacebar':
+                    if (onButton) return;
+                    event.preventDefault();
+                    this.sound.unlock();
+                    this.toggle();
+                    break;
+                case 'r':
+                case 'R':
+                    this.resetTimer();
+                    this.toast('Ciclo reiniciado');
+                    break;
+                case 's':
+                case 'S':
+                    this.skipSession();
+                    break;
+                case '1':
+                    this.switchMode('focus', { manual: true });
+                    break;
+                case '2':
+                    this.switchMode('short', { manual: true });
+                    break;
+                case '3':
+                    this.switchMode('long', { manual: true });
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        /* ------------------------- render ------------------------- */
+
+        renderAll() {
+            this.el.cycleTotal.textContent = this.settings.interval;
+            this.renderMode();
+            this.renderControls();
+            this.renderTime({ jump: true });
+            this.renderCycle();
+            this.renderTasks();
+            this.renderStats();
+            this.renderSoundButton();
+
+            if (this.pendingAwayMessage) {
+                this.pendingAwayMessage = false;
+                this.toast('Um ciclo terminou enquanto você estava fora');
+            }
+        }
+
+        renderMode() {
+            this.el.body.dataset.mode = this.mode;
+            this.el.badge.textContent = MODES[this.mode].badge;
+            this.el.modeBtns.forEach((btn) => {
+                const active = btn.dataset.mode === this.mode;
+                btn.classList.toggle('is-active', active);
+                btn.setAttribute('aria-selected', active ? 'true' : 'false');
+            });
+        }
+
+        renderControls() {
+            this.el.toggle.classList.toggle('is-running', this.running);
+            this.el.toggleLabel.textContent = this.running ? 'Pausar' : 'Iniciar';
+        }
+
+        renderTime(options = {}) {
+            const total = this.durationFor(this.mode) || 1;
+            const remaining = clamp(this.remaining, 0, total);
+            const seconds = Math.ceil(remaining / 1000);
+            const text = `${String(Math.floor(seconds / 60)).padStart(2, '0')}:${String(seconds % 60).padStart(2, '0')}`;
+
+            if (this.el.time.textContent !== text) this.el.time.textContent = text;
+
+            const progress = remaining / total;
+            const offset = RING_CIRCUMFERENCE * (1 - progress);
+
+            if (options.jump) {
+                this.el.ring.classList.add('is-jumping');
+                this.el.ring.style.strokeDashoffset = offset;
+                // Reativa a transição só depois que o navegador aplicou o salto.
+                requestAnimationFrame(() => {
+                    requestAnimationFrame(() => this.el.ring.classList.remove('is-jumping'));
+                });
+            } else {
+                this.el.ring.style.strokeDashoffset = offset;
+            }
+
+            this.renderTitle(text);
+            this.renderFavicon(progress);
+        }
+
+        renderTitle(text) {
+            const suffix = MODES[this.mode].title;
+            const title = this.running || this.remaining < this.durationFor(this.mode)
+                ? `${text} · ${suffix} — Pomodoro`
+                : 'Pomodoro - Labs';
+
+            if (title !== this.lastTitle) {
+                this.lastTitle = title;
+                document.title = title;
+            }
+        }
+
+        renderFavicon(progress) {
+            const step = Math.round(progress * 40); // ~2,5% por atualização
+            if (step === this.lastFaviconStep) return;
+            this.lastFaviconStep = step;
+
+            try {
+                const size = 64;
+                if (!this.faviconCanvas) {
+                    this.faviconCanvas = document.createElement('canvas');
+                    this.faviconCanvas.width = size;
+                    this.faviconCanvas.height = size;
+                }
+
+                const ctx = this.faviconCanvas.getContext('2d');
+                const color = getComputedStyle(document.body).getPropertyValue('--mode-color').trim() || '#e2503f';
+                const center = size / 2;
+                const radius = 26;
+
+                ctx.clearRect(0, 0, size, size);
+
+                ctx.beginPath();
+                ctx.arc(center, center, radius, 0, Math.PI * 2);
+                ctx.strokeStyle = 'rgba(128, 128, 128, 0.3)';
+                ctx.lineWidth = 8;
+                ctx.stroke();
+
+                if (progress > 0) {
+                    ctx.beginPath();
+                    ctx.arc(center, center, radius, -Math.PI / 2, -Math.PI / 2 + Math.PI * 2 * progress);
+                    ctx.strokeStyle = color;
+                    ctx.lineWidth = 8;
+                    ctx.lineCap = 'round';
+                    ctx.stroke();
+                }
+
+                ctx.beginPath();
+                ctx.arc(center, center, 9, 0, Math.PI * 2);
+                ctx.fillStyle = color;
+                ctx.fill();
+
+                let link = document.querySelector('link[rel="icon"][data-dynamic]');
+                if (!link) {
+                    link = document.createElement('link');
+                    link.rel = 'icon';
+                    link.dataset.dynamic = 'true';
+                    document.head.appendChild(link);
+                }
+                link.href = this.faviconCanvas.toDataURL('image/png');
+            } catch (err) {
+                /* Canvas indisponível: o favicon padrão continua valendo. */
+            }
+        }
+
+        renderCycle() {
+            const interval = this.settings.interval;
+            const position = this.mode === 'focus'
+                ? Math.min(this.round + 1, interval)
+                : Math.max(1, Math.min(this.round, interval));
+
+            this.el.cycle.textContent = position;
+            this.el.cycleTotal.textContent = interval;
+        }
+
+        renderSoundButton() {
+            const muted = this.settings.muted;
+            this.el.soundBtn.classList.toggle('is-muted', muted);
+            this.el.soundBtn.setAttribute('aria-pressed', muted ? 'false' : 'true');
+            this.el.soundBtn.setAttribute('aria-label', muted ? 'Ativar som' : 'Desativar som');
+            this.el.soundBtn.title = muted ? 'Som desligado' : 'Som ligado';
+        }
+
+        renderTasks() {
+            const list = this.el.taskList;
+            list.textContent = '';
+
+            const activeTask = this.tasks.find((task) => task.id === this.activeTaskId && !task.done);
+            if (!activeTask) this.activeTaskId = null;
+
+            this.tasks.forEach((task) => {
+                const item = document.createElement('li');
+                item.className = 'task-item';
+                item.dataset.id = task.id;
+                item.classList.toggle('is-done', task.done);
+                item.classList.toggle('is-active', task.id === this.activeTaskId && !task.done);
+
+                const check = document.createElement('button');
+                check.type = 'button';
+                check.className = 'task-check';
+                check.setAttribute('aria-label', task.done ? `Reabrir ${task.name}` : `Concluir ${task.name}`);
+                check.innerHTML = '<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"></polyline></svg>';
+
+                const name = document.createElement('button');
+                name.type = 'button';
+                name.className = 'task-name';
+                name.textContent = task.name;
+                name.title = task.name;
+                name.setAttribute('aria-label', `Focar em ${task.name}`);
+
+                const count = document.createElement('span');
+                count.className = 'task-count';
+                count.textContent = `${task.completed}/${task.estimate}`;
+                count.title = 'Pomodoros concluídos / estimados';
+
+                const remove = document.createElement('button');
+                remove.type = 'button';
+                remove.className = 'task-remove';
+                remove.setAttribute('aria-label', `Remover ${task.name}`);
+                remove.innerHTML = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>';
+
+                item.append(check, name, count, remove);
+                list.appendChild(item);
+            });
+
+            const hasTasks = this.tasks.length > 0;
+            this.el.tasksEmpty.hidden = hasTasks;
+            this.el.clearDone.hidden = !this.tasks.some((task) => task.done);
+
+            const pending = this.tasks.filter((task) => !task.done);
+            const estimated = pending.reduce((acc, task) => acc + Math.max(0, task.estimate - task.completed), 0);
+
+            this.el.taskSummary.hidden = !hasTasks;
+            if (hasTasks) {
+                this.el.taskSummary.textContent = '';
+                const left = document.createElement('span');
+                left.textContent = `${pending.length} pendente${pending.length === 1 ? '' : 's'}`;
+                const right = document.createElement('span');
+                right.textContent = `≈ ${this.formatMinutes(estimated * this.settings.focus)} restantes`;
+                this.el.taskSummary.append(left, right);
+            }
+
+            this.renderActiveTask();
+        }
+
+        renderActiveTask() {
+            const task = this.tasks.find((entry) => entry.id === this.activeTaskId);
+            this.el.activeTask.classList.toggle('is-empty', !task);
+            this.el.activeTaskName.textContent = task ? task.name : 'Nenhuma tarefa selecionada';
+            if (task) this.el.activeTaskName.title = task.name;
+        }
+
+        formatMinutes(minutes) {
+            const total = Math.max(0, Math.round(minutes));
+            const hours = Math.floor(total / 60);
+            const rest = total % 60;
+            if (!hours) return `${rest}min`;
+            return rest ? `${hours}h${String(rest).padStart(2, '0')}` : `${hours}h`;
+        }
+
+        renderStats() {
+            const today = this.stats.days[dayKey()] || { sessions: 0, minutes: 0 };
+
+            this.el.statToday.textContent = today.sessions;
+            this.el.statTime.textContent = this.formatMinutes(today.minutes);
+            this.el.statStreak.textContent = this.currentStreak();
+            this.el.statTotal.textContent = this.stats.total;
+
+            const days = [];
+            for (let i = 6; i >= 0; i -= 1) {
+                const date = new Date();
+                date.setDate(date.getDate() - i);
+                const entry = this.stats.days[dayKey(date)];
+                days.push({
+                    label: WEEK_LABELS[date.getDay()],
+                    sessions: entry ? entry.sessions : 0,
+                    isToday: i === 0
+                });
+            }
+
+            const max = Math.max(4, ...days.map((day) => day.sessions));
+            this.el.chart.textContent = '';
+
+            days.forEach((day) => {
+                const col = document.createElement('div');
+                col.className = 'chart-col';
+                col.classList.toggle('has-value', day.sessions > 0);
+                col.classList.toggle('is-today', day.isToday);
+                col.title = `${day.label}: ${day.sessions} pomodoro${day.sessions === 1 ? '' : 's'}`;
+
+                const bar = document.createElement('div');
+                bar.className = 'chart-bar';
+                bar.style.height = `${Math.max(6, (day.sessions / max) * 100)}%`;
+
+                const label = document.createElement('span');
+                label.className = 'chart-label';
+                label.textContent = day.label;
+
+                col.append(bar, label);
+                this.el.chart.appendChild(col);
+            });
+
+            this.el.chart.setAttribute(
+                'aria-label',
+                `Pomodoros dos últimos 7 dias: ${days.map((day) => `${day.label} ${day.sessions}`).join(', ')}`
+            );
+        }
+
+        renderNotificationStatus(message, isWarning) {
+            const node = this.el.notificationStatus;
+
+            if (message) {
+                node.textContent = message;
+                node.classList.toggle('is-warning', !!isWarning);
+                return;
+            }
+
+            node.classList.remove('is-warning');
+
+            if (!this.notificationsSupported()) {
+                node.textContent = 'Seu navegador não oferece notificações nesta página.';
+                return;
+            }
+
+            if (Notification.permission === 'granted') {
+                node.textContent = 'Permissão concedida — você será avisado mesmo com a aba em segundo plano.';
+            } else if (Notification.permission === 'denied') {
+                node.textContent = 'Permissão bloqueada. Libere as notificações nas configurações do navegador.';
+                node.classList.add('is-warning');
+            } else {
+                node.textContent = 'Ative para o navegador pedir sua permissão.';
+            }
+        }
+
+        /* ------------------------- feedback ------------------------- */
+
+        toast(message) {
+            const node = document.createElement('div');
+            node.className = 'toast';
+            node.textContent = message;
+            this.el.toasts.appendChild(node);
+
+            setTimeout(() => {
+                node.classList.add('is-leaving');
+                setTimeout(() => node.remove(), 300);
+            }, 2600);
+        }
+
+        announce(message) {
+            this.el.live.textContent = message;
+        }
+    }
+
+    const boot = () => new PomodoroApp();
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', boot, { once: true });
+    } else {
+        boot();
+    }
+})();

--- a/labs/pomodoro/style.css
+++ b/labs/pomodoro/style.css
@@ -1,352 +1,1032 @@
+/* =========================================================
+   Pomodoro - Labs
+   Tema por modo (foco / pausa curta / pausa longa) em cima
+   dos tokens compartilhados de /assets/css/tokens.css
+   ========================================================= */
+
 :root {
-    --card-bg: rgba(255, 255, 255, 0.03);
-    --accent-color: #00f2ff;
-    /* Cyan for Focus */
-    --accent-glow: rgba(0, 242, 255, 0.3);
-    --break-color: #bd00ff;
-    /* Purple for Break */
-    --break-glow: rgba(189, 0, 255, 0.3);
-    --font-main: 'Outfit', sans-serif;
+    --mode-color: #e2503f;
+    --mode-color-strong: #c73f2f;
+    --mode-soft: rgba(226, 80, 63, 0.12);
+    --mode-glow: rgba(226, 80, 63, 0.28);
+    --mode-contrast: #ffffff;
+    --ring-track: rgba(15, 23, 42, 0.08);
+    --card-radius: 20px;
+}
+
+[data-theme="dark"] {
+    --ring-track: rgba(255, 255, 255, 0.08);
+}
+
+body[data-mode="focus"] {
+    --mode-color: #e2503f;
+    --mode-color-strong: #c73f2f;
+    --mode-soft: rgba(226, 80, 63, 0.12);
+    --mode-glow: rgba(226, 80, 63, 0.28);
+}
+
+body[data-mode="short"] {
+    --mode-color: #0f9d76;
+    --mode-color-strong: #0b8362;
+    --mode-soft: rgba(15, 157, 118, 0.12);
+    --mode-glow: rgba(15, 157, 118, 0.26);
+}
+
+body[data-mode="long"] {
+    --mode-color: #3b74e8;
+    --mode-color-strong: #2f5fc4;
+    --mode-soft: rgba(59, 116, 232, 0.12);
+    --mode-glow: rgba(59, 116, 232, 0.26);
+}
+
+[data-theme="dark"] body[data-mode="focus"],
+[data-theme="dark"] body[data-mode="short"],
+[data-theme="dark"] body[data-mode="long"] {
+    --mode-contrast: #0a0a0a;
+}
+
+[data-theme="dark"] body[data-mode="focus"] {
+    --mode-color: #ff7a68;
+    --mode-color-strong: #ff9385;
+}
+
+[data-theme="dark"] body[data-mode="short"] {
+    --mode-color: #34d3a6;
+    --mode-color-strong: #5ce0ba;
+}
+
+[data-theme="dark"] body[data-mode="long"] {
+    --mode-color: #6d9bff;
+    --mode-color-strong: #8fb3ff;
 }
 
 body {
-    /* Background and color handled by shared.css */
-    font-family: var(--font-main);
-    overflow: hidden;
+    font-family: 'Outfit', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    background-image: none;
+}
+
+/* Brilho ambiente que acompanha o modo atual */
+.ambient {
+    position: fixed;
+    inset: 0;
+    z-index: -1;
+    pointer-events: none;
+    background:
+        radial-gradient(circle at 50% -10%, var(--mode-glow), transparent 55%),
+        radial-gradient(circle at 10% 100%, var(--mode-soft), transparent 45%);
+    opacity: 0.9;
+    transition: background 0.6s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 .container {
-    /* Inherits flex column and 100vh from shared.css */
-    width: 100%;
-    max-width: 400px;
-    padding: 2rem;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 2rem;
-    position: relative;
-    overflow: hidden;
-    overflow: clip;
+    align-items: stretch;
 }
 
-/* Background ambient glow */
-.container::before {
-    content: '';
-    position: absolute;
-    top: -50%;
-    left: -50%;
-    width: 200%;
-    height: 200%;
-    background: radial-gradient(circle at 50% 50%, rgba(0, 242, 255, 0.05), transparent 60%);
-    z-index: -1;
-    pointer-events: none;
-}
-
-.logo {
-    font-weight: 600;
-    letter-spacing: 1px;
-    text-transform: uppercase;
-    font-size: 0.8rem;
-    color: var(--accent-color);
-    text-shadow: 0 0 10px var(--accent-glow);
-}
-
-/* Timer Circle */
-.timer-circle-container {
-    position: relative;
-    width: 280px;
-    height: 280px;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-}
-
-.timer-svg {
-    width: 100%;
-    height: 100%;
-    transform: rotate(-90deg);
-}
-
-.timer-bg {
-    fill: none;
-    stroke: rgba(255, 255, 255, 0.05);
-    stroke-width: 3;
-}
-
-.timer-progress {
-    fill: none;
-    stroke: var(--accent-color);
-    stroke-width: 3;
-    stroke-linecap: round;
-    stroke-dasharray: 283;
-    /* 2 * PI * 45 */
-    stroke-dashoffset: 0;
-    transition: stroke-dashoffset 1s linear, stroke 0.5s ease;
-    filter: drop-shadow(0 0 8px var(--accent-glow));
-}
-
-.timer-display {
-    position: absolute;
-    text-align: center;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 0.5rem;
-}
-
-.time {
-    font-size: 4.5rem;
-    font-weight: 300;
+header .logo-mark {
+    font-size: 1.35rem;
     line-height: 1;
-    font-variant-numeric: tabular-nums;
-    text-shadow: 0 0 20px rgba(255, 255, 255, 0.1);
 }
 
-.status-badge {
-    font-size: 0.75rem;
-    text-transform: uppercase;
-    letter-spacing: 2px;
-    color: var(--accent-color);
-    background: rgba(0, 242, 255, 0.1);
-    padding: 4px 12px;
-    border-radius: 20px;
-    border: 1px solid rgba(0, 242, 255, 0.2);
-    transition: all 0.5s ease;
-}
-
-.cycle-info {
-    font-size: 0.8rem;
-    color: var(--text-secondary);
-    margin-top: 0.5rem;
-}
-
-/* Controls */
-.controls {
-    display: flex;
-    gap: 1rem;
+/* ---------- Botões do header ---------- */
+.icon-btn {
+    width: 40px;
+    height: 40px;
+    display: inline-flex;
     align-items: center;
-}
-
-button {
-    background: none;
-    border: none;
-    cursor: pointer;
-    font-family: var(--font-main);
-    transition: all 0.3s ease;
-}
-
-.btn-primary {
-    background: var(--accent-color);
-    color: #000;
-    padding: 12px 32px;
-    border-radius: 30px;
-    font-weight: 600;
-    font-size: 1rem;
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    box-shadow: 0 0 20px var(--accent-glow);
-}
-
-.btn-primary:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 0 30px var(--accent-glow);
-}
-
-.btn-primary:active {
-    transform: translateY(0);
-}
-
-.btn-secondary {
-    width: 48px;
-    height: 48px;
-    border-radius: 50%;
-    background: var(--card-bg);
-    color: var(--text-primary);
-    border: 1px solid rgba(255, 255, 255, 0.1);
-    display: flex;
     justify-content: center;
-    align-items: center;
-    font-size: 1.2rem;
+    border-radius: 50%;
+    border: 1px solid var(--border-subtle);
+    background: var(--bg-card);
+    color: var(--text-secondary);
+    cursor: pointer;
+    box-shadow: 0 1px 2px var(--shadow-sm);
+    transition: color 0.25s ease, border-color 0.25s ease, transform 0.25s ease, background 0.25s ease;
 }
 
-.btn-secondary:hover {
-    background: rgba(255, 255, 255, 0.1);
+.icon-btn:hover {
+    color: var(--mode-color);
+    border-color: var(--mode-color);
+    transform: translateY(-1px);
 }
 
-/* Modes */
-.modes {
+.icon-btn:focus-visible,
+.btn-primary:focus-visible,
+.btn-ghost:focus-visible,
+.btn-soft:focus-visible,
+.mode-btn:focus-visible,
+.link-btn:focus-visible,
+.btn-add:focus-visible,
+.task-check:focus-visible,
+.task-name:focus-visible,
+.task-remove:focus-visible,
+input:focus-visible,
+select:focus-visible {
+    outline: 3px solid var(--focus-ring);
+    outline-offset: 2px;
+}
+
+.icon-btn .icon-sound-off {
+    display: none;
+}
+
+.icon-btn.is-muted .icon-sound-on {
+    display: none;
+}
+
+.icon-btn.is-muted .icon-sound-off {
+    display: block;
+}
+
+/* ---------- Layout principal ---------- */
+.app {
+    width: 100%;
+    display: grid;
+    grid-template-columns: minmax(0, 1.15fr) minmax(0, 0.85fr);
+    gap: 1.5rem;
+    align-items: start;
+}
+
+.side-column {
     display: flex;
-    gap: 0.5rem;
-    background: var(--card-bg);
-    padding: 0.5rem;
-    border-radius: 12px;
-    border: 1px solid rgba(255, 255, 255, 0.05);
+    flex-direction: column;
+    gap: 1.5rem;
+    min-width: 0;
+}
+
+.card {
+    background: var(--bg-card);
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--card-radius);
+    box-shadow: 0 12px 32px var(--shadow-sm);
+    padding: 1.75rem;
+}
+
+.card-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-bottom: 1.1rem;
+}
+
+.card-head h2 {
+    font-size: 1.05rem;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+}
+
+.card-head-note {
+    font-size: 0.78rem;
+    color: var(--text-tertiary);
+}
+
+/* ---------- Card do timer ---------- */
+.timer-card {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1.5rem;
+    padding: 2rem 1.75rem 1.75rem;
+}
+
+.mode-tabs {
+    display: flex;
+    gap: 0.25rem;
+    padding: 0.3rem;
+    border-radius: 999px;
+    background: var(--bg-body);
+    border: 1px solid var(--border-subtle);
+    max-width: 100%;
 }
 
 .mode-btn {
-    padding: 8px 16px;
-    border-radius: 8px;
+    border: none;
+    background: transparent;
     color: var(--text-secondary);
-    font-size: 0.85rem;
+    font-family: inherit;
+    font-size: 0.9rem;
+    font-weight: 500;
+    padding: 0.55rem 1.1rem;
+    border-radius: 999px;
+    cursor: pointer;
+    white-space: nowrap;
+    transition: background 0.25s ease, color 0.25s ease;
 }
 
 .mode-btn:hover {
     color: var(--text-primary);
 }
 
-.mode-btn.active {
-    background: rgba(255, 255, 255, 0.1);
-    color: var(--text-primary);
+.mode-btn.is-active {
+    background: var(--mode-color);
+    color: var(--mode-contrast);
+    box-shadow: 0 4px 14px var(--mode-glow);
 }
 
-.header-actions {
-    grid-column: 3;
-    justify-self: end;
-    display: flex;
-    gap: 0.5rem;
-    align-items: center;
+/* Anel de progresso */
+.timer-ring {
+    position: relative;
+    width: min(320px, 78vw);
+    aspect-ratio: 1;
+    display: grid;
+    place-items: center;
 }
 
-.icon-btn {
-    background: none;
-    border: none;
-    cursor: pointer;
-    color: var(--text-primary);
-    padding: 8px;
-    border-radius: 50%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    transition: background-color 0.3s ease;
-}
-
-.icon-btn:hover {
-    background-color: rgba(255, 255, 255, 0.1);
-}
-
-/* Modal Styles */
-.modal {
-    display: none;
-    position: fixed;
-    top: 0;
-    left: 0;
+.ring-svg {
     width: 100%;
     height: 100%;
-    background-color: rgba(0, 0, 0, 0.5);
-    backdrop-filter: blur(5px);
-    z-index: 1000;
-    justify-content: center;
-    align-items: center;
-    opacity: 0;
-    transition: opacity 0.3s ease;
+    transform: rotate(-90deg);
+    overflow: visible;
 }
 
-.modal.open {
+.ring-track {
+    fill: none;
+    stroke: var(--ring-track);
+    stroke-width: 6;
+}
+
+.ring-progress {
+    fill: none;
+    stroke: var(--mode-color);
+    stroke-width: 6;
+    stroke-linecap: round;
+    stroke-dasharray: 552.92;
+    /* 2 * PI * 88 */
+    stroke-dashoffset: 0;
+    filter: drop-shadow(0 0 6px var(--mode-glow));
+    transition: stroke-dashoffset 0.25s linear, stroke 0.4s ease;
+}
+
+.ring-progress.is-jumping {
+    transition: stroke 0.4s ease;
+}
+
+.ring-content {
+    position: absolute;
     display: flex;
-    opacity: 1;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.6rem;
+    text-align: center;
+}
+
+.status-badge {
+    font-size: 0.72rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.14em;
+    color: var(--mode-color);
+    background: var(--mode-soft);
+    border: 1px solid var(--mode-soft);
+    padding: 0.3rem 0.85rem;
+    border-radius: 999px;
+    transition: color 0.4s ease, background 0.4s ease;
+}
+
+.time {
+    font-size: clamp(3.2rem, 12vw, 4.5rem);
+    font-weight: 300;
+    line-height: 1;
+    letter-spacing: -0.02em;
+    font-variant-numeric: tabular-nums;
+    font-feature-settings: 'tnum';
+}
+
+.cycle-info {
+    font-size: 0.85rem;
+    color: var(--text-tertiary);
+}
+
+.cycle-info b {
+    font-weight: 600;
+    color: var(--text-secondary);
+}
+
+/* Tarefa ativa */
+.active-task {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.2rem;
+    text-align: center;
+    max-width: 100%;
+}
+
+.active-task-label {
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: var(--text-tertiary);
+}
+
+.active-task-name {
+    font-size: 1rem;
+    font-weight: 500;
+    color: var(--text-primary);
+    max-width: 22ch;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.active-task.is-empty .active-task-name {
+    color: var(--text-tertiary);
+    font-weight: 400;
+}
+
+/* Controles */
+.controls {
+    display: flex;
+    align-items: center;
+    gap: 0.85rem;
+}
+
+.btn-primary {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.6rem;
+    min-width: 168px;
+    padding: 0.9rem 2rem;
+    border: none;
+    border-radius: 999px;
+    background: var(--mode-color);
+    color: var(--mode-contrast);
+    font-family: inherit;
+    font-size: 1.05rem;
+    font-weight: 600;
+    cursor: pointer;
+    box-shadow: 0 8px 22px var(--mode-glow);
+    transition: transform 0.2s ease, box-shadow 0.25s ease, background 0.3s ease;
+}
+
+.btn-primary:hover {
+    background: var(--mode-color-strong);
+    transform: translateY(-2px);
+    box-shadow: 0 12px 26px var(--mode-glow);
+}
+
+.btn-primary:active {
+    transform: translateY(0);
+}
+
+.btn-primary .icon-pause {
+    display: none;
+}
+
+.btn-primary.is-running .icon-play {
+    display: none;
+}
+
+.btn-primary.is-running .icon-pause {
+    display: block;
+}
+
+.btn-ghost {
+    width: 48px;
+    height: 48px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    border: 1px solid var(--border-subtle);
+    background: var(--bg-body);
+    color: var(--text-secondary);
+    cursor: pointer;
+    transition: color 0.25s ease, border-color 0.25s ease, transform 0.25s ease;
+}
+
+.btn-ghost:hover {
+    color: var(--mode-color);
+    border-color: var(--mode-color);
+    transform: translateY(-2px);
+}
+
+.shortcuts-hint {
+    font-size: 0.75rem;
+    color: var(--text-tertiary);
+    text-align: center;
+}
+
+kbd {
+    font-family: inherit;
+    font-size: 0.7rem;
+    padding: 0.1rem 0.4rem;
+    margin: 0 0.05rem;
+    border-radius: 5px;
+    border: 1px solid var(--border-subtle);
+    background: var(--bg-body);
+    color: var(--text-secondary);
+}
+
+/* ---------- Tarefas ---------- */
+.link-btn {
+    border: none;
+    background: none;
+    color: var(--text-tertiary);
+    font-family: inherit;
+    font-size: 0.8rem;
+    cursor: pointer;
+    padding: 0.2rem 0.3rem;
+    border-radius: 6px;
+    transition: color 0.25s ease;
+}
+
+.link-btn:hover {
+    color: var(--mode-color);
+}
+
+.task-form {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 68px 42px;
+    gap: 0.5rem;
+    margin-bottom: 1rem;
+}
+
+.task-form input {
+    font-family: inherit;
+    font-size: 0.9rem;
+    color: var(--text-primary);
+    background: var(--bg-body);
+    border: 1px solid var(--border-subtle);
+    border-radius: 10px;
+    padding: 0.65rem 0.8rem;
+    min-width: 0;
+    transition: border-color 0.25s ease;
+}
+
+.task-form input:focus {
+    border-color: var(--mode-color);
+}
+
+.task-form input::placeholder {
+    color: var(--text-tertiary);
+}
+
+.btn-add {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border: none;
+    border-radius: 10px;
+    background: var(--mode-color);
+    color: var(--mode-contrast);
+    cursor: pointer;
+    transition: background 0.25s ease, transform 0.2s ease;
+}
+
+.btn-add:hover {
+    background: var(--mode-color-strong);
+    transform: translateY(-1px);
+}
+
+.task-list {
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    max-height: 300px;
+    overflow-y: auto;
+    margin: 0 -0.25rem;
+    padding: 0 0.25rem;
+}
+
+.task-item {
+    display: flex;
+    align-items: center;
+    gap: 0.65rem;
+    padding: 0.7rem 0.8rem;
+    border-radius: 12px;
+    border: 1px solid var(--border-subtle);
+    background: var(--bg-body);
+    transition: border-color 0.25s ease, background 0.25s ease;
+}
+
+.task-item.is-active {
+    border-color: var(--mode-color);
+    background: var(--mode-soft);
+}
+
+.task-item.is-done {
+    opacity: 0.55;
+}
+
+.task-check {
+    flex-shrink: 0;
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    border: 2px solid var(--border-strong);
+    background: transparent;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: transparent;
+    transition: border-color 0.2s ease, background 0.2s ease, color 0.2s ease;
+}
+
+.task-check:hover {
+    border-color: var(--mode-color);
+}
+
+.task-item.is-done .task-check {
+    background: var(--mode-color);
+    border-color: var(--mode-color);
+    color: var(--mode-contrast);
+}
+
+.task-name {
+    flex: 1;
+    min-width: 0;
+    text-align: left;
+    border: none;
+    background: none;
+    font-family: inherit;
+    font-size: 0.92rem;
+    color: var(--text-primary);
+    cursor: pointer;
+    padding: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    border-radius: 4px;
+}
+
+.task-item.is-done .task-name {
+    text-decoration: line-through;
+    color: var(--text-tertiary);
+}
+
+.task-count {
+    flex-shrink: 0;
+    font-size: 0.78rem;
+    font-variant-numeric: tabular-nums;
+    color: var(--text-tertiary);
+    background: var(--bg-card);
+    border: 1px solid var(--border-subtle);
+    border-radius: 999px;
+    padding: 0.15rem 0.5rem;
+}
+
+.task-remove {
+    flex-shrink: 0;
+    width: 26px;
+    height: 26px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border: none;
+    border-radius: 50%;
+    background: transparent;
+    color: var(--text-tertiary);
+    cursor: pointer;
+    transition: color 0.2s ease, background 0.2s ease;
+}
+
+.task-remove:hover {
+    color: #ef4444;
+    background: rgba(239, 68, 68, 0.12);
+}
+
+.empty-state {
+    font-size: 0.85rem;
+    color: var(--text-tertiary);
+    text-align: center;
+    padding: 0.75rem 0;
+}
+
+.task-summary {
+    margin-top: 0.9rem;
+    padding-top: 0.9rem;
+    border-top: 1px solid var(--border-subtle);
+    font-size: 0.8rem;
+    color: var(--text-tertiary);
+    display: flex;
+    justify-content: space-between;
+    gap: 0.5rem;
+}
+
+/* ---------- Estatísticas ---------- */
+.stats-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.6rem;
+}
+
+.stat {
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+    padding: 0.8rem 0.9rem;
+    border-radius: 12px;
+    background: var(--bg-body);
+    border: 1px solid var(--border-subtle);
+}
+
+.stat-value {
+    font-size: 1.5rem;
+    font-weight: 600;
+    line-height: 1.1;
+    font-variant-numeric: tabular-nums;
+    color: var(--text-primary);
+}
+
+.stat-label {
+    font-size: 0.75rem;
+    color: var(--text-tertiary);
+}
+
+.chart {
+    display: grid;
+    grid-template-columns: repeat(7, minmax(0, 1fr));
+    align-items: end;
+    gap: 0.4rem;
+    height: 96px;
+    margin-top: 1.1rem;
+}
+
+.chart-col {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 0.35rem;
+    height: 100%;
+}
+
+.chart-bar {
+    width: 100%;
+    max-width: 26px;
+    min-height: 4px;
+    border-radius: 6px 6px 3px 3px;
+    background: var(--mode-soft);
+    border: 1px solid transparent;
+    transition: height 0.4s cubic-bezier(0.4, 0, 0.2, 1), background 0.4s ease;
+}
+
+.chart-col.has-value .chart-bar {
+    background: var(--mode-color);
+}
+
+.chart-col.is-today .chart-bar {
+    border-color: var(--mode-color);
+}
+
+.chart-label {
+    font-size: 0.68rem;
+    color: var(--text-tertiary);
+    text-transform: capitalize;
+}
+
+.chart-col.is-today .chart-label {
+    color: var(--mode-color);
+    font-weight: 600;
+}
+
+/* ---------- Modal ---------- */
+.modal {
+    position: fixed;
+    inset: 0;
+    z-index: 1000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 1rem;
+}
+
+.modal[hidden] {
+    display: none;
+}
+
+.modal-backdrop {
+    position: absolute;
+    inset: 0;
+    background: rgba(15, 23, 42, 0.45);
+    backdrop-filter: blur(4px);
+    -webkit-backdrop-filter: blur(4px);
+    animation: fade-in 0.25s ease;
 }
 
 .modal-content {
+    position: relative;
+    width: 100%;
+    max-width: 460px;
+    max-height: min(88vh, 760px);
+    display: flex;
+    flex-direction: column;
     background: var(--bg-card);
     border: 1px solid var(--border-subtle);
-    border-radius: 16px;
-    width: 90%;
-    max-width: 400px;
-    padding: 1.5rem;
-    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.3);
-    transform: translateY(20px);
-    transition: transform 0.3s ease;
+    border-radius: var(--card-radius);
+    box-shadow: 0 24px 60px var(--shadow-xl);
+    animation: modal-in 0.28s cubic-bezier(0.34, 1.4, 0.64, 1);
 }
 
-.modal.open .modal-content {
-    transform: translateY(0);
+@keyframes fade-in {
+    from {
+        opacity: 0;
+    }
+}
+
+@keyframes modal-in {
+    from {
+        opacity: 0;
+        transform: translateY(16px) scale(0.98);
+    }
 }
 
 .modal-header {
     display: flex;
-    justify-content: space-between;
     align-items: center;
-    margin-bottom: 1.5rem;
+    justify-content: space-between;
+    padding: 1.25rem 1.5rem;
+    border-bottom: 1px solid var(--border-subtle);
 }
 
 .modal-header h2 {
-    font-size: 1.25rem;
+    font-size: 1.15rem;
     font-weight: 600;
-    margin: 0;
 }
 
 .close-btn {
-    background: none;
+    width: 34px;
+    height: 34px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
     border: none;
-    font-size: 1.5rem;
-    cursor: pointer;
+    border-radius: 50%;
+    background: transparent;
     color: var(--text-secondary);
-    padding: 0;
-    line-height: 1;
+    cursor: pointer;
+    transition: background 0.2s ease, color 0.2s ease;
 }
 
 .close-btn:hover {
+    background: var(--bg-body);
     color: var(--text-primary);
 }
 
-.setting-group {
-    margin-bottom: 1.5rem;
+.modal-body {
+    padding: 1.25rem 1.5rem;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
 }
 
-.setting-group h3 {
-    font-size: 0.9rem;
-    color: var(--text-secondary);
+.setting-group {
+    border: none;
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+}
+
+.setting-group legend {
+    font-size: 0.72rem;
+    font-weight: 600;
     text-transform: uppercase;
-    letter-spacing: 1px;
-    margin-bottom: 1rem;
+    letter-spacing: 0.12em;
+    color: var(--text-tertiary);
+    margin-bottom: 0.6rem;
+    padding: 0;
+}
+
+.duration-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.6rem;
+}
+
+.duration-field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    padding: 0.7rem 0.8rem;
+    border-radius: 12px;
+    background: var(--bg-body);
+    border: 1px solid var(--border-subtle);
+}
+
+.duration-field span {
+    font-size: 0.75rem;
+    color: var(--text-secondary);
+}
+
+.duration-field input {
+    width: 100%;
+    border: none;
+    background: transparent;
+    font-family: inherit;
+    font-size: 1.25rem;
+    font-weight: 600;
+    color: var(--text-primary);
+    font-variant-numeric: tabular-nums;
+    padding: 0;
 }
 
 .setting-row {
     display: flex;
-    justify-content: space-between;
     align-items: center;
-    margin-bottom: 0.75rem;
-}
-
-.setting-row label {
-    font-size: 0.95rem;
-}
-
-.setting-row input[type="number"] {
-    background: rgba(255, 255, 255, 0.05);
-    border: 1px solid rgba(255, 255, 255, 0.1);
-    border-radius: 6px;
-    padding: 6px 10px;
+    justify-content: space-between;
+    gap: 1rem;
+    min-height: 38px;
+    font-size: 0.9rem;
     color: var(--text-primary);
-    width: 60px;
-    font-family: var(--font-main);
 }
 
-.setting-row input[type="checkbox"] {
-    width: 18px;
-    height: 18px;
-    accent-color: var(--accent-color);
+.setting-row b {
+    font-weight: 600;
+    color: var(--text-tertiary);
+    font-variant-numeric: tabular-nums;
+}
+
+.setting-note {
+    font-size: 0.78rem;
+    color: var(--text-tertiary);
+}
+
+.setting-note.is-warning {
+    color: #d97706;
+}
+
+select {
+    font-family: inherit;
+    font-size: 0.88rem;
+    color: var(--text-primary);
+    background: var(--bg-body);
+    border: 1px solid var(--border-subtle);
+    border-radius: 10px;
+    padding: 0.5rem 0.7rem;
     cursor: pointer;
 }
 
+input[type="range"] {
+    width: 140px;
+    accent-color: var(--mode-color);
+    cursor: pointer;
+}
+
+/* Switch */
+.switch {
+    appearance: none;
+    -webkit-appearance: none;
+    position: relative;
+    flex-shrink: 0;
+    width: 46px;
+    height: 26px;
+    border-radius: 999px;
+    background: var(--border-strong);
+    border: none;
+    cursor: pointer;
+    transition: background 0.25s ease;
+}
+
+.switch::after {
+    content: '';
+    position: absolute;
+    top: 3px;
+    left: 3px;
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    background: #fff;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.25);
+    transition: transform 0.25s cubic-bezier(0.34, 1.4, 0.64, 1);
+}
+
+.switch:checked {
+    background: var(--mode-color);
+}
+
+.switch:checked::after {
+    transform: translateX(20px);
+}
+
+.btn-soft {
+    font-family: inherit;
+    font-size: 0.85rem;
+    font-weight: 500;
+    color: var(--text-primary);
+    background: var(--bg-body);
+    border: 1px solid var(--border-subtle);
+    border-radius: 10px;
+    padding: 0.5rem 1rem;
+    cursor: pointer;
+    transition: border-color 0.25s ease, color 0.25s ease;
+}
+
+.btn-soft:hover {
+    border-color: var(--mode-color);
+    color: var(--mode-color);
+}
+
+.btn-soft.btn-danger:hover {
+    border-color: #ef4444;
+    color: #ef4444;
+}
+
 .modal-footer {
+    padding: 1.1rem 1.5rem;
+    border-top: 1px solid var(--border-subtle);
     display: flex;
     justify-content: flex-end;
-    margin-top: 1rem;
 }
 
-/* Break Mode Styles */
-body.break-mode {
-    --accent-color: var(--break-color);
-    --accent-glow: var(--break-glow);
+.modal-footer .btn-primary {
+    min-width: 0;
+    padding: 0.7rem 1.5rem;
+    font-size: 0.95rem;
 }
 
-body.break-mode .container::before {
-    background: radial-gradient(circle at 50% 50%, rgba(189, 0, 255, 0.05), transparent 60%);
+/* ---------- Toasts ---------- */
+.toast-region {
+    position: fixed;
+    left: 50%;
+    bottom: 1.5rem;
+    transform: translateX(-50%);
+    z-index: 1100;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.5rem;
+    pointer-events: none;
+    width: min(92vw, 380px);
 }
 
-body.break-mode .status-badge {
-    background: rgba(189, 0, 255, 0.1);
-    border-color: rgba(189, 0, 255, 0.2);
+.toast {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.7rem 1.1rem;
+    border-radius: 999px;
+    background: var(--bg-card);
+    border: 1px solid var(--border-subtle);
+    box-shadow: 0 10px 30px var(--shadow-lg);
+    font-size: 0.88rem;
+    color: var(--text-primary);
+    animation: toast-in 0.3s cubic-bezier(0.34, 1.4, 0.64, 1);
+}
+
+.toast.is-leaving {
+    animation: toast-out 0.3s ease forwards;
+}
+
+@keyframes toast-in {
+    from {
+        opacity: 0;
+        transform: translateY(12px);
+    }
+}
+
+@keyframes toast-out {
+    to {
+        opacity: 0;
+        transform: translateY(12px);
+    }
+}
+
+/* ---------- Responsivo ---------- */
+@media (max-width: 900px) {
+    .app {
+        grid-template-columns: minmax(0, 1fr);
+    }
+
+    .timer-card {
+        padding: 1.5rem 1.25rem;
+    }
+}
+
+@media (max-width: 480px) {
+    .card {
+        padding: 1.25rem;
+    }
+
+    .mode-btn {
+        padding: 0.5rem 0.75rem;
+        font-size: 0.82rem;
+    }
+
+    .btn-primary {
+        min-width: 140px;
+        padding: 0.85rem 1.5rem;
+    }
+
+    .shortcuts-hint {
+        display: none;
+    }
+
+    .stats-grid {
+        gap: 0.5rem;
+    }
+
+    .modal {
+        padding: 0.5rem;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .ring-progress {
+        transition: none;
+    }
 }


### PR DESCRIPTION
Interface refeita em pt-BR seguindo o padrão dos outros labs (header/footer compartilhados, tokens de tema, light + dark mode reais).

- Timer baseado em timestamp: imune ao throttling de aba, sobrevive a reload e contabiliza ciclos concluídos com a aba fechada
- Modos com identidade visual própria (foco/pausa curta/pausa longa)
- Lista de tarefas com estimativa de pomodoros, tarefa ativa e persistência
- Estatísticas: pomodoros e tempo do dia, sequência de dias, total e gráfico dos últimos 7 dias
- Configurações: durações, ciclos até a pausa longa, auto-início, alarme (5 opções sintetizadas via Web Audio), volume, tique-taque e wake lock
- Notificações do navegador com permissão pedida em gesto do usuário
- Tudo salvo em localStorage (migra a chave antiga pomodoro-settings)
- Atalhos de teclado, foco preso no modal, aria-live, favicon dinâmico e título da aba com o tempo restante

Corrige o item 8 de labs/.corrections.md (header apertado).