### PR TITLE
feat(matrix): add film-accurate Matrix digital rain lab

### DIFF
--- a/labs/index.html
+++ b/labs/index.html
@@ -55,6 +55,29 @@
     </div>
 
     <div class="projects-grid">
+      <a href="/labs/matrix/" class="project-card" data-groups="creative">
+        <div class="project-icon">
+          <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+            stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M4 3v9" />
+            <path d="M9 3v15" />
+            <path d="M14 3v7" />
+            <path d="M19 3v12" />
+            <path d="M4 15v2" opacity="0.5" />
+            <path d="M14 13v2" opacity="0.5" />
+            <path d="M19 18v2" opacity="0.5" />
+          </svg>
+        </div>
+        <div class="project-content">
+          <h2>Matrix</h2>
+          <p>Chuva digital fiel ao filme, com katakana espelhado, bloom CRT e controles completos</p>
+          <div class="project-tags">
+            <span class="tag">Canvas</span>
+            <span class="tag">Cinema</span>
+            <span class="tag">Screensaver</span>
+          </div>
+        </div>
+      </a>
       <a href="/labs/rock-kombat/" class="project-card" data-groups="game,music">
         <div class="project-icon">
           <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"

--- a/labs/matrix/index.html
+++ b/labs/matrix/index.html
@@ -1,0 +1,281 @@
+<!DOCTYPE html>
+<html lang="pt-br">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+    <title>Matrix - Diogo Paulino</title>
+    <meta name="description"
+        content="Simulação fiel da chuva digital de Matrix: glifos katakana espelhados, bloom CRT, scanlines e controles completos.">
+    <meta name="theme-color" content="#000000">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Share+Tech+Mono&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="/labs/shared.css?v=4">
+    <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+    <div class="container">
+        <canvas id="matrix"></canvas>
+
+        <header data-lab-header data-title="Matrix">
+            <template data-slot="logo">
+                <div class="app-logo">
+                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                        stroke-linecap="round" aria-hidden="true">
+                        <path d="M4 3v9" />
+                        <path d="M9 3v15" />
+                        <path d="M14 3v7" />
+                        <path d="M19 3v12" />
+                        <path d="M4 15v2" opacity="0.5" />
+                        <path d="M14 13v2" opacity="0.5" />
+                        <path d="M19 18v2" opacity="0.5" />
+                    </svg>
+                    MATRIX
+                </div>
+            </template>
+            <template data-slot="actions">
+                <button id="cinema" class="icon-btn" aria-label="Modo cinema" title="Modo cinema (H)" type="button">
+                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                        stroke-linecap="round">
+                        <path d="M2 12s3.5-7 10-7 10 7 10 7-3.5 7-10 7-10-7-10-7z" />
+                        <circle cx="12" cy="12" r="3" />
+                    </svg>
+                </button>
+                <button id="fullscreen" class="icon-btn" aria-label="Tela cheia" title="Tela cheia (F)" type="button">
+                    <svg class="fs-enter" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                        stroke-width="2" stroke-linecap="round">
+                        <path d="M8 3H5a2 2 0 0 0-2 2v3m18 0V5a2 2 0 0 0-2-2h-3m0 18h3a2 2 0 0 0 2-2v-3M3 16v3a2 2 0 0 0 2 2h3" />
+                    </svg>
+                    <svg class="fs-exit" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                        stroke-width="2" stroke-linecap="round" hidden>
+                        <path d="M8 3v3a2 2 0 0 1-2 2H3m18 0h-3a2 2 0 0 1-2-2V3m0 18v-3a2 2 0 0 1 2-2h3M3 16h3a2 2 0 0 1 2 2v3" />
+                    </svg>
+                </button>
+            </template>
+        </header>
+
+        <button id="cinemaExit" class="cinema-exit" type="button">sair [esc]</button>
+
+        <button id="toggleControls" class="toggle-controls-btn" type="button"
+            aria-label="Mostrar configurações" title="Configurações (C)">
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <path
+                    d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z" />
+                <circle cx="12" cy="12" r="3" />
+            </svg>
+        </button>
+
+        <aside class="controls" id="controls" aria-label="Configurações da simulação">
+            <div class="controls-header">
+                <span>&gt; config.sys</span>
+                <button id="closeControls" class="close-btn" type="button" aria-label="Fechar configurações">
+                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <path d="M18 6L6 18M6 6l12 12" />
+                    </svg>
+                </button>
+            </div>
+
+            <div class="controls-scroll">
+                <section class="control-section">
+                    <h2 class="section-title">Modo</h2>
+                    <div class="preset-grid" id="presetGrid">
+                        <button class="preset-btn is-active" data-preset="matrix" type="button">
+                            <span style="background:#00ff41"></span><small>1999</small>
+                        </button>
+                        <button class="preset-btn" data-preset="reloaded" type="button">
+                            <span style="background:#8fff2b"></span><small>Reloaded</small>
+                        </button>
+                        <button class="preset-btn" data-preset="nabucodonosor" type="button">
+                            <span style="background:#ffb000"></span><small>Nabucco</small>
+                        </button>
+                        <button class="preset-btn" data-preset="sentinela" type="button">
+                            <span style="background:#ff2d2d"></span><small>Sentinela</small>
+                        </button>
+                        <button class="preset-btn" data-preset="pilulaazul" type="button">
+                            <span style="background:#2ea8ff"></span><small>Azul</small>
+                        </button>
+                        <button class="preset-btn" data-preset="fantasma" type="button">
+                            <span style="background:#c8f7ff"></span><small>Fantasma</small>
+                        </button>
+                    </div>
+                </section>
+
+                <section class="control-section">
+                    <h2 class="section-title">Código-fonte</h2>
+                    <div class="glyph-grid" id="glyphGrid">
+                        <button class="glyph-btn is-active" data-glyphs="matrix" type="button">
+                            <em class="glyph-sample">ﾊﾐ7</em><span>Filme</span>
+                        </button>
+                        <button class="glyph-btn" data-glyphs="kana" type="button">
+                            <em class="glyph-sample">ｱｲｳ</em><span>Kana</span>
+                        </button>
+                        <button class="glyph-btn" data-glyphs="binary" type="button">
+                            <em class="glyph-sample">010</em><span>Binário</span>
+                        </button>
+                        <button class="glyph-btn" data-glyphs="latin" type="button">
+                            <em class="glyph-sample">A9Z</em><span>Latino</span>
+                        </button>
+                        <button class="glyph-btn" data-glyphs="terminal" type="button">
+                            <em class="glyph-sample">&lt;#&gt;</em><span>Terminal</span>
+                        </button>
+                    </div>
+                </section>
+
+                <section class="control-section">
+                    <h2 class="section-title">Profundidade</h2>
+                    <div class="depth-grid" id="depthGrid">
+                        <button class="depth-btn" data-depth="1" type="button">1 camada</button>
+                        <button class="depth-btn is-active" data-depth="2" type="button">2 camadas</button>
+                        <button class="depth-btn" data-depth="3" type="button">3 camadas</button>
+                    </div>
+                </section>
+
+                <section class="control-section">
+                    <h2 class="section-title">Ajustes</h2>
+                    <div class="sliders-grid">
+                        <div class="slider-group">
+                            <div class="slider-header"><label for="speed">Velocidade</label><span class="slider-value"
+                                    id="speedValue">1.0x</span></div>
+                            <input type="range" id="speed" min="0.1" max="3" step="0.1" value="1">
+                        </div>
+                        <div class="slider-group">
+                            <div class="slider-header"><label for="fontSize">Tamanho</label><span class="slider-value"
+                                    id="fontSizeValue">16px</span></div>
+                            <input type="range" id="fontSize" min="8" max="34" step="1" value="16">
+                        </div>
+                        <div class="slider-group">
+                            <div class="slider-header"><label for="trail">Rastro</label><span class="slider-value"
+                                    id="trailValue">1.0x</span></div>
+                            <input type="range" id="trail" min="0.3" max="2.5" step="0.1" value="1">
+                        </div>
+                        <div class="slider-group">
+                            <div class="slider-header"><label for="density">Densidade</label><span class="slider-value"
+                                    id="densityValue">100%</span></div>
+                            <input type="range" id="density" min="20" max="200" step="5" value="100">
+                        </div>
+                        <div class="slider-group">
+                            <div class="slider-header"><label for="mutation">Mutação</label><span class="slider-value"
+                                    id="mutationValue">1.0x</span></div>
+                            <input type="range" id="mutation" min="0" max="4" step="0.1" value="1">
+                        </div>
+                        <div class="slider-group">
+                            <div class="slider-header"><label for="glow">Brilho</label><span class="slider-value"
+                                    id="glowValue">1.0x</span></div>
+                            <input type="range" id="glow" min="0" max="2" step="0.05" value="1">
+                        </div>
+                    </div>
+                </section>
+
+                <section class="control-section">
+                    <h2 class="section-title">Efeitos</h2>
+                    <div class="switch-list">
+                        <label class="switch-row">
+                            <span>Glifos espelhados</span>
+                            <input type="checkbox" id="mirror" checked>
+                            <i class="switch" aria-hidden="true"></i>
+                        </label>
+                        <label class="switch-row">
+                            <span>Cintilação</span>
+                            <input type="checkbox" id="flicker" checked>
+                            <i class="switch" aria-hidden="true"></i>
+                        </label>
+                        <label class="switch-row">
+                            <span>Scanlines CRT</span>
+                            <input type="checkbox" id="scanlines" checked>
+                            <i class="switch" aria-hidden="true"></i>
+                        </label>
+                        <label class="switch-row">
+                            <span>Vinheta</span>
+                            <input type="checkbox" id="vignette" checked>
+                            <i class="switch" aria-hidden="true"></i>
+                        </label>
+                        <label class="switch-row">
+                            <span>Zumbido do sistema</span>
+                            <input type="checkbox" id="sound">
+                            <i class="switch" aria-hidden="true"></i>
+                        </label>
+                    </div>
+                </section>
+
+                <section class="control-section">
+                    <h2 class="section-title">Mensagem no código</h2>
+                    <div class="message-row">
+                        <input type="text" id="message" maxlength="42" placeholder="WAKE UP NEO" autocomplete="off"
+                            spellcheck="false" aria-label="Mensagem injetada no código">
+                        <button id="injectMessage" class="mini-btn" type="button" title="Injetar agora">
+                            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                                stroke-width="2" stroke-linecap="round">
+                                <path d="M12 5v14M5 12l7 7 7-7" />
+                            </svg>
+                        </button>
+                    </div>
+                    <p class="hint">A frase desce entre os glifos, legível, a cada poucos segundos.</p>
+                </section>
+
+                <section class="control-section">
+                    <h2 class="section-title">Sistema</h2>
+                    <button id="replayIntro" class="wide-btn" type="button">
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                            stroke-width="2" stroke-linecap="round">
+                            <path d="M4 17V7a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2z" />
+                            <path d="M8 9l3 3-3 3M13 15h4" />
+                        </svg>
+                        Rodar sequência de abertura
+                    </button>
+                </section>
+            </div>
+
+            <div class="control-footer">
+                <div class="action-buttons">
+                    <button id="random" class="action-btn random-btn" type="button">
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                            stroke-width="2" stroke-linecap="round">
+                            <path d="M2 18h1.4c1.3 0 2.5-.6 3.3-1.7l6.1-8.6c.7-1.1 2-1.7 3.3-1.7H22" />
+                            <path d="m18 2 4 4-4 4" />
+                            <path d="M2 6h1.9c1.5 0 2.9.9 3.6 2.2" />
+                            <path d="M22 18h-5.9c-1.3 0-2.6-.7-3.3-1.8l-.5-.8" />
+                            <path d="m18 14 4 4-4 4" />
+                        </svg>
+                        Anomalia
+                    </button>
+                    <button id="reset" class="action-btn reset-btn" type="button">
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                            stroke-width="2" stroke-linecap="round">
+                            <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" />
+                            <path d="M3 3v5h5" />
+                        </svg>
+                        Reset
+                    </button>
+                </div>
+                <div class="stats-bar">
+                    <div class="stat"><span class="stat-value" id="fps">60</span><span class="stat-label">fps</span></div>
+                    <div class="stat-divider"></div>
+                    <div class="stat"><span class="stat-value" id="streamCount">0</span><span
+                            class="stat-label">streams</span></div>
+                </div>
+            </div>
+        </aside>
+
+        <div class="hud" id="hud" aria-hidden="true">
+            <span><b>C</b> config</span>
+            <span><b>H</b> cinema</span>
+            <span><b>F</b> tela cheia</span>
+            <span><b>Espaço</b> pausar</span>
+            <span><b>Clique</b> pulso</span>
+        </div>
+
+        <div class="boot" id="boot" hidden>
+            <pre class="boot-text" id="bootText"></pre>
+            <button class="boot-skip" id="bootSkip" type="button">pular [esc]</button>
+        </div>
+
+        <footer data-lab-footer data-home-href="/"></footer>
+    </div>
+
+    <script src="/labs/shared.js?v=5" defer></script>
+    <script src="script.js" defer></script>
+</body>
+
+</html>

--- a/labs/matrix/script.js
+++ b/labs/matrix/script.js
@@ -1,0 +1,1078 @@
+/**
+ * Matrix - chuva digital.
+ *
+ * Renderização: os glifos são pré-desenhados uma única vez num atlas offscreen
+ * (espelhados na horizontal, como a fonte usada no filme) e depois compostos
+ * com drawImage, o que permite milhares de células por frame sem custo de texto.
+ * Cada camada guarda os glifos numa grade fixa: os streams só controlam a
+ * posição da cabeça, então glifos que já passaram continuam mutando no lugar.
+ */
+(function () {
+    'use strict';
+
+    const canvas = document.getElementById('matrix');
+    const ctx = canvas.getContext('2d', { alpha: false });
+    const bloomCanvas = document.createElement('canvas');
+    const bloomCtx = bloomCanvas.getContext('2d');
+
+    const STORAGE_KEY = 'labs:matrix:v1';
+    const FONT_STACK = "'MS Gothic', 'Osaka-Mono', 'Hiragino Kaku Gothic ProN', 'Yu Gothic', 'Noto Sans JP', monospace";
+    const ATLAS_COLS = 12;
+    const CELL_RATIO = 1.12;
+
+    const GLYPH_SETS = {
+        matrix: 'ﾊﾐﾋｰｳｼﾅﾓﾆｻﾜﾂｵﾘｱﾎﾃﾏｹﾒｴｶｷﾑﾕﾗｾﾈｽﾀﾇﾍｦｲｸｺｿﾁﾄﾉﾌﾔﾖﾙﾚﾛﾝ0123456789:."=*+-<>¦｜ç',
+        kana: 'ｱｲｳｴｵｶｷｸｹｺｻｼｽｾｿﾀﾁﾂﾃﾄﾅﾆﾇﾈﾉﾊﾋﾌﾍﾎﾏﾐﾑﾒﾓﾔﾕﾖﾗﾘﾙﾚﾛﾜﾝ',
+        binary: '01',
+        latin: 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789',
+        terminal: '<>[]{}()/\\|=+-*#@$%&!?:;.,^~_'
+    };
+
+    const PRESETS = {
+        matrix: { body: '#00ff41', head: '#d8ffe2', glow: '#00ff41', bg: '#000300' },
+        reloaded: { body: '#8fff2b', head: '#f4ffd8', glow: '#b6ff3d', bg: '#010400' },
+        nabucodonosor: { body: '#ffb000', head: '#fff2cf', glow: '#ff8a00', bg: '#070300' },
+        sentinela: { body: '#ff2d2d', head: '#ffdbdb', glow: '#ff0033', bg: '#080000' },
+        pilulaazul: { body: '#2ea8ff', head: '#dcefff', glow: '#0077ff', bg: '#000308' },
+        fantasma: { body: '#c8f7ff', head: '#ffffff', glow: '#9fe8ff', bg: '#000203' }
+    };
+
+    // Camadas de profundidade: as de trás são menores, mais lentas e mais fracas.
+    const DEPTH_LAYERS = {
+        1: [{ scale: 1, alpha: 1, speed: 1 }],
+        2: [
+            { scale: 0.62, alpha: 0.32, speed: 0.7 },
+            { scale: 1, alpha: 1, speed: 1 }
+        ],
+        3: [
+            { scale: 0.44, alpha: 0.18, speed: 0.52 },
+            { scale: 0.68, alpha: 0.4, speed: 0.76 },
+            { scale: 1, alpha: 1, speed: 1 }
+        ]
+    };
+
+    const DEFAULTS = {
+        preset: 'matrix',
+        glyphSet: 'matrix',
+        depth: 2,
+        speed: 1,
+        fontSize: 16,
+        trail: 1,
+        density: 100,
+        mutation: 1,
+        glow: 1,
+        mirror: true,
+        flicker: true,
+        scanlines: true,
+        vignette: true,
+        sound: false,
+        message: ''
+    };
+
+    const settings = Object.assign({}, DEFAULTS, loadSettings());
+
+    let dpr = 1;
+    let width = 0;
+    let height = 0;
+    let glyphs = [];
+    let layers = [];
+    let pulses = [];
+    let messageStreams = [];
+    let messageTimer = 2;
+    let paused = false;
+    let rafId = 0;
+    let lastTime = 0;
+    let fpsAccum = 0;
+    let fpsFrames = 0;
+    let scanPattern = null;
+    let vignetteGrad = null;
+
+    const atlas = {
+        body: document.createElement('canvas'),
+        head: document.createElement('canvas'),
+        tile: 0,
+        advance: 0
+    };
+    const atlasBodyCtx = atlas.body.getContext('2d');
+    const atlasHeadCtx = atlas.head.getContext('2d');
+
+    // Queda do brilho ao longo do rastro, pré-calculada.
+    const FALLOFF = new Float32Array(129);
+    for (let i = 0; i <= 128; i++) {
+        FALLOFF[i] = Math.pow(1 - i / 128, 1.55);
+    }
+
+    /* ------------------------------------------------------------------ */
+    /* Persistência                                                        */
+    /* ------------------------------------------------------------------ */
+
+    function loadSettings() {
+        try {
+            const raw = localStorage.getItem(STORAGE_KEY);
+            return raw ? JSON.parse(raw) : {};
+        } catch (err) {
+            return {};
+        }
+    }
+
+    function saveSettings() {
+        try {
+            localStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
+        } catch (err) {
+            /* localStorage pode estar indisponível em navegação privada. */
+        }
+    }
+
+    /* ------------------------------------------------------------------ */
+    /* Atlas de glifos                                                     */
+    /* ------------------------------------------------------------------ */
+
+    function preset() {
+        return PRESETS[settings.preset] || PRESETS.matrix;
+    }
+
+    function randGlyph() {
+        return (Math.random() * glyphs.length) | 0;
+    }
+
+    function buildAtlas() {
+        glyphs = Array.from(GLYPH_SETS[settings.glyphSet] || GLYPH_SETS.matrix);
+
+        const fontPx = Math.round(settings.fontSize * dpr);
+        const pad = Math.ceil(fontPx * 0.45);
+        const tile = Math.ceil(fontPx * CELL_RATIO) + pad * 2;
+        const rows = Math.ceil(glyphs.length / ATLAS_COLS);
+        const colors = preset();
+
+        atlas.tile = tile;
+
+        // Katakana halfwidth ocupa metade de um em: medir o avanço real mantém as
+        // colunas justas como no filme, em vez de espalhadas por um em cheio.
+        atlasBodyCtx.font = fontPx + 'px ' + FONT_STACK;
+        let advance = 0;
+        for (let i = 0; i < glyphs.length; i++) {
+            const w = atlasBodyCtx.measureText(glyphs[i]).width;
+            if (w > advance) advance = w;
+        }
+        atlas.advance = Math.max(3, advance * 1.06);
+
+        [
+            [atlas.body, atlasBodyCtx, colors.body, fontPx * 0.16],
+            [atlas.head, atlasHeadCtx, colors.head, fontPx * 0.42]
+        ].forEach(function (entry) {
+            const surface = entry[0];
+            const c = entry[1];
+            const color = entry[2];
+            const blur = entry[3];
+
+            surface.width = tile * ATLAS_COLS;
+            surface.height = tile * rows;
+            c.clearRect(0, 0, surface.width, surface.height);
+            c.font = fontPx + 'px ' + FONT_STACK;
+            c.textAlign = 'center';
+            c.textBaseline = 'middle';
+            c.fillStyle = color;
+            c.shadowColor = colors.glow;
+            c.shadowBlur = blur;
+
+            for (let i = 0; i < glyphs.length; i++) {
+                const cx = (i % ATLAS_COLS) * tile + tile / 2;
+                const cy = ((i / ATLAS_COLS) | 0) * tile + tile / 2;
+                c.save();
+                c.translate(cx, cy);
+                // A fonte do filme é katakana espelhado na horizontal.
+                if (settings.mirror) c.scale(-1, 1);
+                c.fillText(glyphs[i], 0, 0);
+                c.restore();
+            }
+        });
+    }
+
+    /* ------------------------------------------------------------------ */
+    /* Camadas e streams                                                   */
+    /* ------------------------------------------------------------------ */
+
+    function newStream(layer, spread) {
+        return {
+            x: (Math.random() * layer.cols) | 0,
+            y: spread ? Math.random() * layer.rows : -Math.random() * layer.rows * 0.4 - 4,
+            speed: 6 + Math.random() * 13,
+            len: Math.max(3, Math.round((7 + Math.random() * 22) * settings.trail)),
+            bright: 0.68 + Math.random() * 0.32,
+            lastRow: -9999
+        };
+    }
+
+    function seedStreams(layer) {
+        const count = Math.max(1, Math.round(layer.cols * (settings.density / 100) * 1.2));
+        layer.streams = new Array(count);
+        for (let i = 0; i < count; i++) {
+            layer.streams[i] = newStream(layer, true);
+        }
+    }
+
+    function buildLayers() {
+        const configs = DEPTH_LAYERS[settings.depth] || DEPTH_LAYERS[2];
+
+        layers = configs.map(function (cfg) {
+            const cellW = Math.max(3, atlas.advance * cfg.scale);
+            const cellH = Math.max(4, settings.fontSize * dpr * CELL_RATIO * cfg.scale);
+            const cols = Math.max(1, Math.ceil(width / cellW));
+            const rows = Math.max(1, Math.ceil(height / cellH) + 2);
+            const grid = new Uint8Array(cols * rows);
+
+            for (let i = 0; i < grid.length; i++) {
+                grid[i] = randGlyph();
+            }
+
+            const layer = {
+                scale: cfg.scale,
+                alpha: cfg.alpha,
+                speedMul: cfg.speed,
+                cellW: cellW,
+                cellH: cellH,
+                cols: cols,
+                rows: rows,
+                grid: grid,
+                streams: []
+            };
+            seedStreams(layer);
+            return layer;
+        });
+    }
+
+    function front() {
+        return layers[layers.length - 1];
+    }
+
+    /* ------------------------------------------------------------------ */
+    /* Dimensionamento                                                     */
+    /* ------------------------------------------------------------------ */
+
+    function resize() {
+        dpr = Math.min(window.devicePixelRatio || 1, 2);
+        width = Math.max(1, Math.round(window.innerWidth * dpr));
+        height = Math.max(1, Math.round(window.innerHeight * dpr));
+
+        canvas.width = width;
+        canvas.height = height;
+        canvas.style.width = window.innerWidth + 'px';
+        canvas.style.height = window.innerHeight + 'px';
+
+        bloomCanvas.width = Math.max(1, Math.round(width / 6));
+        bloomCanvas.height = Math.max(1, Math.round(height / 6));
+
+        buildAtlas();
+        buildLayers();
+        buildOverlays();
+    }
+
+    function buildOverlays() {
+        const line = document.createElement('canvas');
+        const lineCtx = line.getContext('2d');
+        const unit = Math.max(2, Math.round(2 * dpr));
+        line.width = 1;
+        line.height = unit * 2;
+        lineCtx.fillStyle = 'rgba(0, 0, 0, 0.38)';
+        lineCtx.fillRect(0, 0, 1, unit);
+        scanPattern = ctx.createPattern(line, 'repeat');
+
+        const radius = Math.max(width, height) * 0.75;
+        vignetteGrad = ctx.createRadialGradient(
+            width / 2, height / 2, radius * 0.32,
+            width / 2, height / 2, radius
+        );
+        vignetteGrad.addColorStop(0, 'rgba(0, 0, 0, 0)');
+        vignetteGrad.addColorStop(0.65, 'rgba(0, 0, 0, 0.35)');
+        vignetteGrad.addColorStop(1, 'rgba(0, 0, 0, 0.92)');
+    }
+
+    /* ------------------------------------------------------------------ */
+    /* Atualização                                                         */
+    /* ------------------------------------------------------------------ */
+
+    function update(dt) {
+        for (let l = 0; l < layers.length; l++) {
+            const layer = layers[l];
+            const step = layer.speedMul * settings.speed * dt;
+
+            for (let s = 0; s < layer.streams.length; s++) {
+                const stream = layer.streams[s];
+                stream.y += stream.speed * step;
+
+                const head = Math.floor(stream.y);
+                if (head !== stream.lastRow) {
+                    // Cada nova célula alcançada pela cabeça recebe um glifo novo.
+                    if (head >= 0 && head < layer.rows) {
+                        layer.grid[head * layer.cols + stream.x] = randGlyph();
+                    }
+                    stream.lastRow = head;
+                }
+
+                if (stream.y - stream.len > layer.rows) {
+                    layer.streams[s] = newStream(layer, false);
+                }
+            }
+
+            // Mutação dos glifos já em tela — é o que faz o código "ferver".
+            const mutations = Math.round(layer.grid.length * 0.3 * settings.mutation * dt);
+            for (let i = 0; i < mutations; i++) {
+                layer.grid[(Math.random() * layer.grid.length) | 0] = randGlyph();
+            }
+        }
+
+        for (let i = pulses.length - 1; i >= 0; i--) {
+            const pulse = pulses[i];
+            pulse.r += pulse.speed * dt;
+            pulse.life -= dt;
+            if (pulse.life <= 0) pulses.splice(i, 1);
+        }
+
+        updateMessages(dt);
+    }
+
+    function updateMessages(dt) {
+        const layer = front();
+
+        if (settings.message) {
+            messageTimer -= dt;
+            if (messageTimer <= 0) {
+                spawnMessage();
+                messageTimer = 4 + Math.random() * 5;
+            }
+        }
+
+        for (let i = messageStreams.length - 1; i >= 0; i--) {
+            const stream = messageStreams[i];
+            stream.y += stream.speed * settings.speed * dt;
+            if (stream.y - stream.chars.length > layer.rows) {
+                messageStreams.splice(i, 1);
+            }
+        }
+    }
+
+    function spawnMessage() {
+        const text = settings.message.trim().toUpperCase();
+        if (!text) return;
+
+        const layer = front();
+        messageStreams.push({
+            x: (Math.random() * layer.cols) | 0,
+            y: -text.length - 2,
+            speed: 5 + Math.random() * 4,
+            chars: Array.from(text)
+        });
+
+        if (messageStreams.length > 4) messageStreams.shift();
+    }
+
+    /* ------------------------------------------------------------------ */
+    /* Desenho                                                             */
+    /* ------------------------------------------------------------------ */
+
+    function draw() {
+        const colors = preset();
+
+        ctx.globalCompositeOperation = 'source-over';
+        ctx.globalAlpha = 1;
+        ctx.fillStyle = colors.bg;
+        ctx.fillRect(0, 0, width, height);
+
+        ctx.globalCompositeOperation = 'lighter';
+
+        for (let l = 0; l < layers.length; l++) {
+            drawLayer(layers[l]);
+        }
+
+        drawMessages(colors);
+
+        ctx.globalCompositeOperation = 'source-over';
+        ctx.globalAlpha = 1;
+
+        if (settings.glow > 0.05) applyBloom();
+        if (settings.scanlines) drawScanlines();
+        if (settings.vignette) drawVignette();
+    }
+
+    function drawLayer(layer) {
+        const tile = atlas.tile;
+        const dest = tile * layer.scale;
+        const half = dest / 2;
+        const cellW = layer.cellW;
+        const cellH = layer.cellH;
+        const cols = layer.cols;
+        const rows = layer.rows;
+        const grid = layer.grid;
+        const hasPulses = pulses.length > 0;
+        const flicker = settings.flicker;
+
+        for (let s = 0; s < layer.streams.length; s++) {
+            const stream = layer.streams[s];
+            const headRow = Math.floor(stream.y);
+            if (headRow < 0) continue;
+
+            const cx = (stream.x + 0.5) * cellW;
+            const base = stream.bright * layer.alpha;
+            const len = stream.len;
+
+            for (let i = 0; i <= len; i++) {
+                const row = headRow - i;
+                if (row < 0) break;
+                if (row >= rows) continue;
+
+                let a = FALLOFF[((i / len) * 128) | 0] * base;
+                const cy = (row + 0.5) * cellH;
+
+                if (hasPulses) a += pulseBoost(cx, cy, row * cols + stream.x, grid);
+                if (flicker && Math.random() < 0.016) a *= 0.3;
+                if (a <= 0.025) continue;
+                if (a > 1) a = 1;
+
+                const gi = grid[row * cols + stream.x];
+                const sx = (gi % ATLAS_COLS) * tile;
+                const sy = ((gi / ATLAS_COLS) | 0) * tile;
+
+                ctx.globalAlpha = a;
+                ctx.drawImage(
+                    i === 0 ? atlas.head : atlas.body,
+                    sx, sy, tile, tile,
+                    cx - half, cy - half, dest, dest
+                );
+            }
+        }
+    }
+
+    function pulseBoost(cx, cy, index, grid) {
+        let boost = 0;
+        for (let p = 0; p < pulses.length; p++) {
+            const pulse = pulses[p];
+            const dx = cx - pulse.x;
+            const dy = cy - pulse.y;
+            const d = Math.sqrt(dx * dx + dy * dy);
+            const k = 1 - Math.abs(d - pulse.r) / pulse.band;
+            if (k > 0) {
+                boost += k * pulse.life * 0.9;
+                if (k > 0.55 && Math.random() < 0.25) grid[index] = randGlyph();
+            }
+        }
+        return boost;
+    }
+
+    function drawMessages(colors) {
+        if (!messageStreams.length) return;
+
+        const layer = front();
+        const fontPx = Math.round(settings.fontSize * dpr);
+
+        ctx.font = fontPx + 'px ' + FONT_STACK;
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'middle';
+        ctx.shadowColor = colors.glow;
+        ctx.shadowBlur = fontPx * 0.5;
+
+        for (let m = 0; m < messageStreams.length; m++) {
+            const stream = messageStreams[m];
+            const headRow = Math.floor(stream.y);
+            const cx = (stream.x + 0.5) * layer.cellW;
+            const total = stream.chars.length;
+
+            for (let i = 0; i < total; i++) {
+                const row = headRow - i;
+                if (row < 0) break;
+                if (row >= layer.rows) continue;
+
+                const a = Math.max(0, 1 - i / (total * 1.35));
+                if (a <= 0.03) continue;
+
+                ctx.globalAlpha = a;
+                ctx.fillStyle = i === 0 ? colors.head : colors.body;
+                // Invertido para a frase ser lida de cima para baixo.
+                ctx.fillText(stream.chars[total - 1 - i], cx, (row + 0.5) * layer.cellH);
+            }
+        }
+
+        ctx.shadowBlur = 0;
+        ctx.globalAlpha = 1;
+    }
+
+    function applyBloom() {
+        // Bloom barato: reduz o frame para 1/6, devolve escalado e soma por cima.
+        bloomCtx.globalCompositeOperation = 'copy';
+        bloomCtx.drawImage(canvas, 0, 0, bloomCanvas.width, bloomCanvas.height);
+
+        ctx.globalCompositeOperation = 'lighter';
+        ctx.globalAlpha = Math.min(0.75, 0.3 * settings.glow);
+        ctx.imageSmoothingEnabled = true;
+        ctx.drawImage(bloomCanvas, 0, 0, width, height);
+        ctx.globalAlpha = 1;
+        ctx.globalCompositeOperation = 'source-over';
+    }
+
+    function drawScanlines() {
+        if (!scanPattern) return;
+        ctx.fillStyle = scanPattern;
+        ctx.fillRect(0, 0, width, height);
+    }
+
+    function drawVignette() {
+        if (!vignetteGrad) return;
+        ctx.fillStyle = vignetteGrad;
+        ctx.fillRect(0, 0, width, height);
+    }
+
+    /* ------------------------------------------------------------------ */
+    /* Loop                                                                */
+    /* ------------------------------------------------------------------ */
+
+    function frame(now) {
+        rafId = requestAnimationFrame(frame);
+
+        if (!lastTime) lastTime = now;
+        const dt = Math.min((now - lastTime) / 1000, 0.05);
+        lastTime = now;
+
+        fpsAccum += dt;
+        fpsFrames++;
+        if (fpsAccum >= 0.5) {
+            ui.fps.textContent = Math.round(fpsFrames / fpsAccum);
+            fpsAccum = 0;
+            fpsFrames = 0;
+        }
+
+        if (!paused) update(dt);
+        draw();
+    }
+
+    /* ------------------------------------------------------------------ */
+    /* Áudio                                                               */
+    /* ------------------------------------------------------------------ */
+
+    const Sound = (function () {
+        let actx = null;
+        let master = null;
+        let nodes = [];
+
+        function ensure() {
+            if (actx) return actx;
+            const AC = window.AudioContext || window.webkitAudioContext;
+            if (!AC) return null;
+            actx = new AC();
+            master = actx.createGain();
+            master.gain.value = 0;
+            master.connect(actx.destination);
+            return actx;
+        }
+
+        function start() {
+            if (!ensure()) return;
+            if (actx.state === 'suspended') actx.resume();
+            if (nodes.length) {
+                master.gain.setTargetAtTime(0.09, actx.currentTime, 0.6);
+                return;
+            }
+
+            const filter = actx.createBiquadFilter();
+            filter.type = 'lowpass';
+            filter.frequency.value = 240;
+            filter.Q.value = 0.7;
+            filter.connect(master);
+
+            [55, 82.5, 110].forEach(function (freq, i) {
+                const osc = actx.createOscillator();
+                const gain = actx.createGain();
+                osc.type = i === 2 ? 'triangle' : 'sawtooth';
+                osc.frequency.value = freq;
+                osc.detune.value = (i - 1) * 7;
+                gain.gain.value = 0.35 / (i + 1);
+                osc.connect(gain);
+                gain.connect(filter);
+                osc.start();
+                nodes.push(osc);
+            });
+
+            // Respiração lenta do zumbido, para não soar estático.
+            const lfo = actx.createOscillator();
+            const lfoGain = actx.createGain();
+            lfo.frequency.value = 0.07;
+            lfoGain.gain.value = 90;
+            lfo.connect(lfoGain);
+            lfoGain.connect(filter.frequency);
+            lfo.start();
+            nodes.push(lfo);
+
+            master.gain.setTargetAtTime(0.09, actx.currentTime, 1.2);
+        }
+
+        function stop() {
+            if (!actx || !master) return;
+            master.gain.setTargetAtTime(0, actx.currentTime, 0.4);
+        }
+
+        function blip() {
+            if (!actx || !settings.sound) return;
+            const t = actx.currentTime;
+            const osc = actx.createOscillator();
+            const gain = actx.createGain();
+            osc.type = 'square';
+            osc.frequency.value = 620 + Math.random() * 900;
+            gain.gain.setValueAtTime(0.0001, t);
+            gain.gain.exponentialRampToValueAtTime(0.04, t + 0.004);
+            gain.gain.exponentialRampToValueAtTime(0.0001, t + 0.05);
+            osc.connect(gain);
+            gain.connect(master);
+            osc.start(t);
+            osc.stop(t + 0.07);
+        }
+
+        return { start: start, stop: stop, blip: blip };
+    })();
+
+    /* ------------------------------------------------------------------ */
+    /* Sequência de abertura                                               */
+    /* ------------------------------------------------------------------ */
+
+    const BOOT_SEQUENCE = [
+        { text: 'Call trans opt: received.', cps: 42, hold: 260 },
+        { text: '2-19-98 13:24:18 REC:Log>', cps: 42, hold: 420 },
+        { text: 'Trace program: running', cps: 34, hold: 900 },
+        { text: 'Wake up, Neo...', cps: 11, hold: 1300 },
+        { text: 'The Matrix has you...', cps: 11, hold: 1300 },
+        { text: 'Follow the white rabbit.', cps: 12, hold: 1500 }
+    ];
+
+    const boot = {
+        el: document.getElementById('boot'),
+        text: document.getElementById('bootText'),
+        skip: document.getElementById('bootSkip'),
+        timers: [],
+        active: false
+    };
+
+    function clearBootTimers() {
+        boot.timers.forEach(clearTimeout);
+        boot.timers = [];
+    }
+
+    function endBoot() {
+        if (!boot.active) return;
+        boot.active = false;
+        clearBootTimers();
+        boot.el.classList.add('fading');
+        setTimeout(function () {
+            boot.el.hidden = true;
+            boot.el.classList.remove('fading');
+        }, 900);
+    }
+
+    function runBoot() {
+        clearBootTimers();
+        boot.active = true;
+        boot.el.hidden = false;
+        boot.el.classList.remove('fading');
+        boot.text.textContent = '';
+
+        let delay = 500;
+
+        BOOT_SEQUENCE.forEach(function (line, lineIndex) {
+            const chars = Array.from(line.text);
+            const step = 1000 / line.cps;
+
+            boot.timers.push(setTimeout(function () {
+                boot.text.textContent = '';
+            }, delay));
+
+            chars.forEach(function (char, i) {
+                boot.timers.push(setTimeout(function () {
+                    boot.text.textContent += char;
+                    if (char !== ' ') Sound.blip();
+                }, delay + step * (i + 1)));
+            });
+
+            delay += step * (chars.length + 1) + line.hold;
+
+            if (lineIndex === BOOT_SEQUENCE.length - 1) {
+                boot.timers.push(setTimeout(endBoot, delay));
+            }
+        });
+    }
+
+    boot.skip.addEventListener('click', endBoot);
+
+    /* ------------------------------------------------------------------ */
+    /* Interface                                                           */
+    /* ------------------------------------------------------------------ */
+
+    const ui = {
+        fps: document.getElementById('fps'),
+        streamCount: document.getElementById('streamCount'),
+        controls: document.getElementById('controls'),
+        toggleControls: document.getElementById('toggleControls'),
+        closeControls: document.getElementById('closeControls'),
+        cinema: document.getElementById('cinema'),
+        cinemaExit: document.getElementById('cinemaExit'),
+        fullscreen: document.getElementById('fullscreen'),
+        message: document.getElementById('message')
+    };
+
+    const SLIDERS = {
+        speed: function (v) { return v.toFixed(1) + 'x'; },
+        fontSize: function (v) { return Math.round(v) + 'px'; },
+        trail: function (v) { return v.toFixed(1) + 'x'; },
+        density: function (v) { return Math.round(v) + '%'; },
+        mutation: function (v) { return v.toFixed(1) + 'x'; },
+        glow: function (v) { return v.toFixed(2) + 'x'; }
+    };
+
+    const SWITCHES = ['mirror', 'flicker', 'scanlines', 'vignette', 'sound'];
+
+    function selectGroup(selector, attr, value) {
+        document.querySelectorAll(selector).forEach(function (btn) {
+            btn.classList.toggle('is-active', btn.dataset[attr] === String(value));
+        });
+    }
+
+    function applyPresetColors() {
+        const colors = preset();
+        const root = document.documentElement.style;
+        root.setProperty('--mx', colors.body);
+        root.setProperty('--mx-glow', hexToRgba(colors.glow, 0.28));
+        root.setProperty('--panel-border', hexToRgba(colors.body, 0.16));
+
+        const meta = document.querySelector('meta[name="theme-color"]');
+        if (meta) meta.content = colors.bg;
+    }
+
+    function hexToRgba(hex, alpha) {
+        const value = parseInt(hex.slice(1), 16);
+        const r = (value >> 16) & 255;
+        const g = (value >> 8) & 255;
+        const b = value & 255;
+        return 'rgba(' + r + ', ' + g + ', ' + b + ', ' + alpha + ')';
+    }
+
+    function syncUI() {
+        selectGroup('.preset-btn', 'preset', settings.preset);
+        selectGroup('.glyph-btn', 'glyphs', settings.glyphSet);
+        selectGroup('.depth-btn', 'depth', settings.depth);
+
+        Object.keys(SLIDERS).forEach(function (key) {
+            const input = document.getElementById(key);
+            const label = document.getElementById(key + 'Value');
+            input.value = settings[key];
+            label.textContent = SLIDERS[key](Number(settings[key]));
+        });
+
+        SWITCHES.forEach(function (key) {
+            document.getElementById(key).checked = Boolean(settings[key]);
+        });
+
+        ui.message.value = settings.message;
+        applyPresetColors();
+    }
+
+    document.querySelectorAll('.preset-btn').forEach(function (btn) {
+        btn.addEventListener('click', function () {
+            settings.preset = btn.dataset.preset;
+            selectGroup('.preset-btn', 'preset', settings.preset);
+            applyPresetColors();
+            buildAtlas();
+            saveSettings();
+        });
+    });
+
+    document.querySelectorAll('.glyph-btn').forEach(function (btn) {
+        btn.addEventListener('click', function () {
+            settings.glyphSet = btn.dataset.glyphs;
+            selectGroup('.glyph-btn', 'glyphs', settings.glyphSet);
+            buildAtlas();
+            // A largura da célula muda junto com o conjunto de glifos.
+            buildLayers();
+            saveSettings();
+        });
+    });
+
+    document.querySelectorAll('.depth-btn').forEach(function (btn) {
+        btn.addEventListener('click', function () {
+            settings.depth = Number(btn.dataset.depth);
+            selectGroup('.depth-btn', 'depth', settings.depth);
+            buildLayers();
+            saveSettings();
+        });
+    });
+
+    Object.keys(SLIDERS).forEach(function (key) {
+        const input = document.getElementById(key);
+        const label = document.getElementById(key + 'Value');
+
+        input.addEventListener('input', function () {
+            const value = Number(input.value);
+            settings[key] = value;
+            label.textContent = SLIDERS[key](value);
+
+            if (key === 'fontSize') {
+                buildAtlas();
+                buildLayers();
+            } else if (key === 'density' || key === 'trail') {
+                layers.forEach(seedStreams);
+            }
+
+            saveSettings();
+        });
+    });
+
+    SWITCHES.forEach(function (key) {
+        const input = document.getElementById(key);
+        input.addEventListener('change', function () {
+            settings[key] = input.checked;
+
+            if (key === 'mirror') buildAtlas();
+            if (key === 'sound') {
+                if (input.checked) Sound.start();
+                else Sound.stop();
+            }
+
+            saveSettings();
+        });
+    });
+
+    ui.message.addEventListener('input', function () {
+        settings.message = ui.message.value;
+        saveSettings();
+    });
+
+    ui.message.addEventListener('keydown', function (event) {
+        if (event.key === 'Enter') spawnMessage();
+        event.stopPropagation();
+    });
+
+    document.getElementById('injectMessage').addEventListener('click', spawnMessage);
+    document.getElementById('replayIntro').addEventListener('click', function () {
+        setControls(false);
+        runBoot();
+    });
+
+    document.getElementById('random').addEventListener('click', function () {
+        const presetKeys = Object.keys(PRESETS);
+        const glyphKeys = Object.keys(GLYPH_SETS);
+
+        settings.preset = presetKeys[(Math.random() * presetKeys.length) | 0];
+        settings.glyphSet = glyphKeys[(Math.random() * glyphKeys.length) | 0];
+        settings.depth = 1 + ((Math.random() * 3) | 0);
+        settings.speed = Number((0.4 + Math.random() * 2).toFixed(1));
+        settings.fontSize = 10 + ((Math.random() * 20) | 0);
+        settings.trail = Number((0.5 + Math.random() * 1.8).toFixed(1));
+        settings.density = 40 + ((Math.random() * 140) | 0);
+        settings.mutation = Number((Math.random() * 3).toFixed(1));
+        settings.glow = Number((0.3 + Math.random() * 1.5).toFixed(2));
+
+        rebuildAll();
+    });
+
+    document.getElementById('reset').addEventListener('click', function () {
+        const message = settings.message;
+        Object.assign(settings, DEFAULTS, { message: message });
+        rebuildAll();
+    });
+
+    function rebuildAll() {
+        syncUI();
+        buildAtlas();
+        buildLayers();
+        saveSettings();
+    }
+
+    /* Painel */
+
+    function setControls(open) {
+        ui.controls.classList.toggle('visible', open);
+        ui.toggleControls.classList.toggle('hidden', open);
+        ui.toggleControls.setAttribute('aria-expanded', String(open));
+    }
+
+    ui.toggleControls.addEventListener('click', function () { setControls(true); });
+    ui.closeControls.addEventListener('click', function () { setControls(false); });
+
+    /* Modo cinema */
+
+    function setCinema(on) {
+        document.body.classList.toggle('cinema', on);
+        ui.cinema.classList.toggle('is-active', on);
+        if (on) {
+            setControls(false);
+            markPointerActive();
+        }
+    }
+
+    ui.cinema.addEventListener('click', function () {
+        setCinema(!document.body.classList.contains('cinema'));
+    });
+
+    ui.cinemaExit.addEventListener('click', leaveImmersive);
+
+    /* Tela cheia */
+
+    function isFullscreen() {
+        return Boolean(document.fullscreenElement || document.webkitFullscreenElement);
+    }
+
+    function exitFullscreen() {
+        const exit = document.exitFullscreen || document.webkitExitFullscreen;
+        if (exit) Promise.resolve(exit.call(document)).catch(function () { });
+    }
+
+    function leaveImmersive() {
+        if (isFullscreen()) exitFullscreen();
+        setCinema(false);
+    }
+
+    function toggleFullscreen() {
+        if (isFullscreen()) {
+            exitFullscreen();
+            return;
+        }
+
+        const root = document.documentElement;
+        const request = root.requestFullscreen || root.webkitRequestFullscreen;
+        const attempt = request ? request.call(root) : Promise.reject();
+
+        Promise.resolve(attempt).catch(function () {
+            // Safari no iPhone e páginas embutidas bloqueiam a Fullscreen API;
+            // o modo cinema entrega o mesmo resultado dentro da janela.
+            setCinema(true);
+        });
+    }
+
+    function onFullscreenChange() {
+        syncFullscreenIcon();
+        // Tela cheia aqui significa só o código na tela, sem cromo em volta.
+        setCinema(isFullscreen());
+        // Alguns navegadores só reportam o novo tamanho no frame seguinte.
+        requestAnimationFrame(resize);
+    }
+
+    function syncFullscreenIcon() {
+        const on = isFullscreen();
+        ui.fullscreen.querySelector('.fs-enter').hidden = on;
+        ui.fullscreen.querySelector('.fs-exit').hidden = !on;
+        ui.fullscreen.classList.toggle('is-active', on);
+    }
+
+    ui.fullscreen.addEventListener('click', toggleFullscreen);
+    document.addEventListener('fullscreenchange', onFullscreenChange);
+    document.addEventListener('webkitfullscreenchange', onFullscreenChange);
+
+    /* Pulso ao clicar */
+
+    function addPulse(clientX, clientY) {
+        pulses.push({
+            x: clientX * dpr,
+            y: clientY * dpr,
+            r: 0,
+            speed: Math.max(width, height) * 0.8,
+            band: 90 * dpr,
+            life: 1
+        });
+        if (pulses.length > 5) pulses.shift();
+    }
+
+    canvas.addEventListener('pointerdown', function (event) {
+        addPulse(event.clientX, event.clientY);
+    });
+
+    /* Teclado */
+
+    document.addEventListener('keydown', function (event) {
+        if (event.target instanceof HTMLInputElement) return;
+
+        const key = event.key.toLowerCase();
+
+        if (key === 'escape') {
+            if (boot.active) endBoot();
+            else if (document.body.classList.contains('cinema')) leaveImmersive();
+            else if (ui.controls.classList.contains('visible')) setControls(false);
+            return;
+        }
+
+        if (boot.active && key === ' ') {
+            endBoot();
+            event.preventDefault();
+            return;
+        }
+
+        switch (key) {
+            case 'c':
+                setControls(!ui.controls.classList.contains('visible'));
+                break;
+            case 'h':
+                setCinema(!document.body.classList.contains('cinema'));
+                break;
+            case 'f':
+                toggleFullscreen();
+                break;
+            case 'r':
+                document.getElementById('random').click();
+                break;
+            case ' ':
+                paused = !paused;
+                event.preventDefault();
+                break;
+            default:
+                break;
+        }
+    });
+
+    /* Esconde o cursor e o botão de saída quando o mouse fica parado no cinema */
+
+    let idleTimer = null;
+
+    function markPointerActive() {
+        document.body.classList.remove('pointer-idle');
+        clearTimeout(idleTimer);
+        idleTimer = setTimeout(function () {
+            document.body.classList.add('pointer-idle');
+        }, 2200);
+    }
+
+    document.addEventListener('pointermove', markPointerActive);
+
+    /* Ciclo de vida */
+
+    let resizeTimer = null;
+    window.addEventListener('resize', function () {
+        clearTimeout(resizeTimer);
+        resizeTimer = setTimeout(resize, 150);
+    });
+
+    document.addEventListener('visibilitychange', function () {
+        if (document.hidden) {
+            cancelAnimationFrame(rafId);
+            rafId = 0;
+        } else if (!rafId) {
+            lastTime = 0;
+            rafId = requestAnimationFrame(frame);
+        }
+    });
+
+    // O contador de streams muda pouco; atualizar fora do loop evita layout a 60fps.
+    setInterval(function () {
+        const total = layers.reduce(function (sum, layer) { return sum + layer.streams.length; }, 0);
+        ui.streamCount.textContent = total;
+    }, 500);
+
+    syncUI();
+    resize();
+
+    if (settings.sound) Sound.start();
+
+    let introSeen = false;
+    try {
+        introSeen = sessionStorage.getItem('labs:matrix:intro') === '1';
+        sessionStorage.setItem('labs:matrix:intro', '1');
+    } catch (err) {
+        /* sessionStorage pode estar indisponível. */
+    }
+
+    if (!introSeen) runBoot();
+
+    rafId = requestAnimationFrame(frame);
+})();

--- a/labs/matrix/style.css
+++ b/labs/matrix/style.css
@@ -1,0 +1,1024 @@
+:root {
+    --mx: #00ff41;
+    --mx-dim: rgba(0, 255, 65, 0.45);
+    --mx-glow: rgba(0, 255, 65, 0.25);
+    --panel-bg: rgba(2, 8, 4, 0.92);
+    --panel-border: rgba(0, 255, 65, 0.16);
+    --text-primary: rgba(215, 255, 225, 0.95);
+    --text-secondary: rgba(150, 220, 170, 0.55);
+    --mono: 'Share Tech Mono', ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+
+[data-theme="light"] {
+    --panel-bg: rgba(6, 16, 9, 0.88);
+}
+
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: var(--mono);
+    padding: 0 !important;
+    display: block !important;
+    overflow: hidden;
+    width: 100vw;
+    height: 100vh;
+    height: 100dvh;
+    background: #000;
+    color: var(--text-primary);
+}
+
+.container {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    max-width: none !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    display: block !important;
+}
+
+#matrix {
+    position: fixed;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    display: block;
+    background: #000;
+    cursor: crosshair;
+    touch-action: manipulation;
+}
+
+/* ---------- Header ---------- */
+
+header {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 20;
+    padding: 1.1rem 1.4rem !important;
+    padding-top: max(1.1rem, env(safe-area-inset-top)) !important;
+    margin: 0 !important;
+    display: grid !important;
+    grid-template-columns: auto 1fr auto !important;
+    align-items: center !important;
+    gap: 1rem !important;
+    max-width: none !important;
+    width: auto !important;
+    background: linear-gradient(to bottom, rgba(0, 0, 0, 0.85), transparent);
+    transition: opacity 0.35s ease, transform 0.35s ease;
+}
+
+header .back-link {
+    background: rgba(0, 255, 65, 0.06);
+    border: 1px solid var(--panel-border);
+    color: var(--text-secondary);
+    font-family: var(--mono);
+    box-shadow: none;
+    transition: all 0.2s ease;
+}
+
+header .back-link:hover {
+    background: rgba(0, 255, 65, 0.14);
+    border-color: rgba(0, 255, 65, 0.4);
+    color: var(--mx);
+    box-shadow: 0 0 18px var(--mx-glow);
+}
+
+header .app-logo {
+    justify-self: center;
+    display: flex;
+    align-items: center;
+    gap: 0.55rem;
+    font-size: 1.35rem;
+    font-weight: 400;
+    letter-spacing: 0.35em;
+    text-indent: 0.35em;
+    color: var(--mx);
+    text-shadow: 0 0 12px var(--mx-glow), 0 0 32px var(--mx-glow);
+}
+
+header .app-logo svg {
+    stroke: var(--mx);
+    filter: drop-shadow(0 0 6px var(--mx-glow));
+}
+
+.header-actions {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+}
+
+.icon-btn {
+    background: rgba(0, 255, 65, 0.06);
+    border: 1px solid var(--panel-border);
+    color: var(--text-secondary);
+    padding: 0.5rem;
+    border-radius: 8px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.icon-btn:hover,
+.icon-btn.is-active {
+    background: rgba(0, 255, 65, 0.15);
+    border-color: rgba(0, 255, 65, 0.4);
+    color: var(--mx);
+    box-shadow: 0 0 16px var(--mx-glow);
+}
+
+/* Deixa o switch de tema com a cara do terminal */
+.theme-toggle {
+    border-color: var(--panel-border);
+    background: rgba(0, 255, 65, 0.06);
+    box-shadow: none;
+}
+
+.theme-toggle:hover {
+    border-color: rgba(0, 255, 65, 0.4);
+}
+
+.theme-toggle-thumb {
+    background: var(--mx) !important;
+}
+
+.theme-toggle .sun-icon,
+.theme-toggle .moon-icon {
+    color: #001a06 !important;
+}
+
+/* ---------- Botão de configurações ---------- */
+
+.toggle-controls-btn {
+    position: fixed;
+    bottom: max(24px, env(safe-area-inset-bottom));
+    right: 24px;
+    z-index: 15;
+    background: var(--panel-bg);
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
+    border: 1px solid var(--panel-border);
+    color: var(--mx);
+    padding: 13px;
+    border-radius: 12px;
+    cursor: pointer;
+    transition: all 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+    box-shadow: 0 4px 24px rgba(0, 0, 0, 0.6), 0 0 32px var(--mx-glow);
+}
+
+.toggle-controls-btn:hover {
+    transform: scale(1.08);
+    box-shadow: 0 6px 30px rgba(0, 0, 0, 0.7), 0 0 48px var(--mx-glow);
+}
+
+.toggle-controls-btn.hidden {
+    opacity: 0;
+    pointer-events: none;
+    transform: scale(0.8) translateY(16px);
+}
+
+.toggle-controls-btn svg {
+    display: block;
+}
+
+/* ---------- Painel ---------- */
+
+.controls {
+    position: fixed;
+    top: 84px;
+    right: 20px;
+    bottom: 20px;
+    width: 310px;
+    display: flex;
+    flex-direction: column;
+    background: var(--panel-bg);
+    backdrop-filter: blur(20px) saturate(140%);
+    -webkit-backdrop-filter: blur(20px) saturate(140%);
+    border: 1px solid var(--panel-border);
+    border-radius: 16px;
+    box-shadow: 0 10px 50px rgba(0, 0, 0, 0.7), 0 0 70px rgba(0, 255, 65, 0.06);
+    z-index: 18;
+    overflow: hidden;
+    transform: translateX(calc(100% + 40px));
+    opacity: 0;
+    pointer-events: none;
+    transition: transform 0.4s cubic-bezier(0.16, 1, 0.3, 1), opacity 0.3s ease;
+}
+
+.controls.visible {
+    transform: translateX(0);
+    opacity: 1;
+    pointer-events: auto;
+}
+
+.controls-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 14px 16px;
+    border-bottom: 1px solid var(--panel-border);
+    background: rgba(0, 255, 65, 0.04);
+}
+
+.controls-header span {
+    font-size: 0.8rem;
+    letter-spacing: 1.5px;
+    color: var(--mx);
+    text-shadow: 0 0 10px var(--mx-glow);
+}
+
+.close-btn {
+    background: transparent;
+    border: none;
+    color: var(--text-secondary);
+    cursor: pointer;
+    padding: 4px;
+    border-radius: 6px;
+    display: flex;
+    transition: all 0.2s ease;
+}
+
+.close-btn:hover {
+    color: var(--mx);
+    background: rgba(0, 255, 65, 0.12);
+}
+
+.controls-scroll {
+    flex: 1;
+    overflow-y: auto;
+    overflow-x: hidden;
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+    scrollbar-width: thin;
+    scrollbar-color: rgba(0, 255, 65, 0.3) transparent;
+}
+
+.controls-scroll::-webkit-scrollbar {
+    width: 4px;
+}
+
+.controls-scroll::-webkit-scrollbar-thumb {
+    background: rgba(0, 255, 65, 0.3);
+    border-radius: 2px;
+}
+
+.control-section {
+    display: flex;
+    flex-direction: column;
+    gap: 9px;
+}
+
+.section-title {
+    font-size: 0.7rem;
+    font-weight: 400;
+    text-transform: uppercase;
+    letter-spacing: 2px;
+    color: var(--text-secondary);
+}
+
+.section-title::before {
+    content: '// ';
+    color: var(--mx);
+    opacity: 0.5;
+}
+
+/* Presets */
+
+.preset-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 7px;
+}
+
+.preset-btn {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 5px;
+    padding: 8px 4px 6px;
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid transparent;
+    border-radius: 8px;
+    cursor: pointer;
+    transition: all 0.22s ease;
+    font-family: var(--mono);
+}
+
+.preset-btn span {
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.preset-btn small {
+    font-size: 0.6rem;
+    letter-spacing: 0.5px;
+    color: var(--text-secondary);
+    text-transform: uppercase;
+}
+
+.preset-btn:hover {
+    background: rgba(255, 255, 255, 0.07);
+}
+
+.preset-btn:hover span {
+    transform: scale(1.12);
+}
+
+.preset-btn.is-active {
+    background: rgba(0, 255, 65, 0.08);
+    border-color: var(--panel-border);
+}
+
+.preset-btn.is-active span {
+    box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.85), 0 0 14px currentColor;
+    transform: scale(1.05);
+}
+
+.preset-btn.is-active small {
+    color: var(--text-primary);
+}
+
+/* Glifos */
+
+.glyph-grid {
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+    gap: 5px;
+}
+
+.glyph-btn {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 3px;
+    padding: 8px 2px 6px;
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid transparent;
+    border-radius: 8px;
+    cursor: pointer;
+    color: var(--text-secondary);
+    transition: all 0.22s ease;
+    font-family: var(--mono);
+}
+
+.glyph-sample {
+    font-style: normal;
+    font-size: 0.85rem;
+    line-height: 1;
+    letter-spacing: -1px;
+    transform: scaleX(-1);
+}
+
+.glyph-btn span {
+    font-size: 0.5rem;
+    text-transform: uppercase;
+    letter-spacing: 0.4px;
+}
+
+.glyph-btn:hover {
+    background: rgba(255, 255, 255, 0.07);
+    color: var(--text-primary);
+}
+
+.glyph-btn.is-active {
+    background: var(--mx);
+    color: #001204;
+    border-color: transparent;
+    box-shadow: 0 0 16px var(--mx-glow);
+}
+
+/* Profundidade */
+
+.depth-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 6px;
+}
+
+.depth-btn {
+    padding: 9px 4px;
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid transparent;
+    border-radius: 8px;
+    color: var(--text-secondary);
+    font-family: var(--mono);
+    font-size: 0.65rem;
+    letter-spacing: 0.5px;
+    cursor: pointer;
+    transition: all 0.22s ease;
+}
+
+.depth-btn:hover {
+    background: rgba(255, 255, 255, 0.07);
+    color: var(--text-primary);
+}
+
+.depth-btn.is-active {
+    background: var(--mx);
+    color: #001204;
+    box-shadow: 0 0 16px var(--mx-glow);
+}
+
+/* Sliders */
+
+.sliders-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 13px 12px;
+}
+
+.slider-group {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+    min-width: 0;
+}
+
+.slider-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 4px;
+}
+
+.slider-header label {
+    font-size: 0.6rem;
+    text-transform: uppercase;
+    letter-spacing: 0.8px;
+    color: var(--text-secondary);
+}
+
+.slider-value {
+    font-size: 0.65rem;
+    color: var(--mx);
+    font-variant-numeric: tabular-nums;
+    text-shadow: 0 0 8px var(--mx-glow);
+}
+
+input[type="range"] {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 100%;
+    height: 3px;
+    background: rgba(0, 255, 65, 0.15);
+    border-radius: 2px;
+    outline: none;
+    border: none;
+    cursor: pointer;
+}
+
+input[type="range"]::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    width: 13px;
+    height: 13px;
+    background: var(--mx);
+    border-radius: 2px;
+    cursor: pointer;
+    box-shadow: 0 0 10px var(--mx-glow);
+    transition: transform 0.15s ease;
+}
+
+input[type="range"]::-webkit-slider-thumb:hover {
+    transform: scale(1.2);
+}
+
+input[type="range"]::-moz-range-thumb {
+    width: 13px;
+    height: 13px;
+    background: var(--mx);
+    border: none;
+    border-radius: 2px;
+    cursor: pointer;
+    box-shadow: 0 0 10px var(--mx-glow);
+}
+
+input[type="range"]:focus-visible {
+    outline: 2px solid var(--mx);
+    outline-offset: 4px;
+}
+
+/* Switches */
+
+.switch-list {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.switch-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    padding: 7px 8px;
+    border-radius: 8px;
+    cursor: pointer;
+    font-size: 0.72rem;
+    color: var(--text-secondary);
+    transition: background 0.2s ease, color 0.2s ease;
+}
+
+.switch-row:hover {
+    background: rgba(255, 255, 255, 0.04);
+    color: var(--text-primary);
+}
+
+.switch-row input {
+    position: absolute;
+    opacity: 0;
+    width: 0;
+    height: 0;
+}
+
+.switch {
+    flex: none;
+    width: 34px;
+    height: 18px;
+    border-radius: 4px;
+    background: rgba(255, 255, 255, 0.08);
+    border: 1px solid var(--panel-border);
+    position: relative;
+    transition: all 0.25s ease;
+}
+
+.switch::after {
+    content: '';
+    position: absolute;
+    top: 2px;
+    left: 2px;
+    width: 12px;
+    height: 12px;
+    border-radius: 2px;
+    background: rgba(150, 220, 170, 0.4);
+    transition: all 0.25s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+.switch-row input:checked~.switch {
+    background: rgba(0, 255, 65, 0.18);
+    border-color: rgba(0, 255, 65, 0.5);
+}
+
+.switch-row input:checked~.switch::after {
+    left: 18px;
+    background: var(--mx);
+    box-shadow: 0 0 10px var(--mx-glow);
+}
+
+.switch-row input:focus-visible~.switch {
+    outline: 2px solid var(--mx);
+    outline-offset: 3px;
+}
+
+/* Mensagem */
+
+.message-row {
+    display: flex;
+    gap: 6px;
+}
+
+#message {
+    flex: 1;
+    min-width: 0;
+    background: rgba(0, 0, 0, 0.5);
+    border: 1px solid var(--panel-border);
+    border-radius: 8px;
+    padding: 9px 11px;
+    color: var(--mx);
+    font-family: var(--mono);
+    font-size: 0.78rem;
+    letter-spacing: 1px;
+    outline: none;
+    transition: all 0.2s ease;
+}
+
+#message::placeholder {
+    color: rgba(150, 220, 170, 0.3);
+}
+
+#message:focus {
+    border-color: rgba(0, 255, 65, 0.5);
+    box-shadow: 0 0 14px var(--mx-glow);
+}
+
+.mini-btn {
+    flex: none;
+    width: 36px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(0, 255, 65, 0.1);
+    border: 1px solid var(--panel-border);
+    border-radius: 8px;
+    color: var(--mx);
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.mini-btn:hover {
+    background: rgba(0, 255, 65, 0.22);
+    box-shadow: 0 0 14px var(--mx-glow);
+}
+
+.hint {
+    font-size: 0.6rem;
+    line-height: 1.5;
+    color: var(--text-secondary);
+    opacity: 0.75;
+}
+
+.wide-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    width: 100%;
+    padding: 10px;
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid var(--panel-border);
+    border-radius: 8px;
+    color: var(--text-secondary);
+    font-family: var(--mono);
+    font-size: 0.68rem;
+    letter-spacing: 0.5px;
+    cursor: pointer;
+    transition: all 0.22s ease;
+}
+
+.wide-btn:hover {
+    background: rgba(0, 255, 65, 0.12);
+    border-color: rgba(0, 255, 65, 0.4);
+    color: var(--mx);
+}
+
+/* Rodapé do painel */
+
+.control-footer {
+    padding: 12px 16px;
+    border-top: 1px solid var(--panel-border);
+    background: rgba(0, 255, 65, 0.03);
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.action-buttons {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 8px;
+}
+
+.action-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    padding: 9px 10px;
+    border-radius: 8px;
+    border: 1px solid;
+    cursor: pointer;
+    font-family: var(--mono);
+    font-size: 0.68rem;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    transition: all 0.22s ease;
+}
+
+.action-btn svg {
+    transition: transform 0.35s ease;
+}
+
+.random-btn {
+    background: rgba(0, 255, 65, 0.1);
+    border-color: rgba(0, 255, 65, 0.3);
+    color: var(--mx);
+}
+
+.random-btn:hover {
+    background: rgba(0, 255, 65, 0.2);
+    box-shadow: 0 0 18px var(--mx-glow);
+    transform: translateY(-1px);
+}
+
+.random-btn:hover svg {
+    transform: rotate(180deg);
+}
+
+.reset-btn {
+    background: rgba(255, 255, 255, 0.04);
+    border-color: var(--panel-border);
+    color: var(--text-secondary);
+}
+
+.reset-btn:hover {
+    background: rgba(255, 255, 255, 0.09);
+    color: var(--text-primary);
+    transform: translateY(-1px);
+}
+
+.reset-btn:hover svg {
+    transform: rotate(-180deg);
+}
+
+.stats-bar {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 14px;
+    padding: 7px;
+    background: rgba(0, 0, 0, 0.45);
+    border-radius: 6px;
+}
+
+.stat {
+    display: flex;
+    align-items: baseline;
+    gap: 4px;
+}
+
+.stat-value {
+    font-size: 0.85rem;
+    color: var(--mx);
+    font-variant-numeric: tabular-nums;
+    text-shadow: 0 0 8px var(--mx-glow);
+}
+
+.stat-label {
+    font-size: 0.55rem;
+    text-transform: uppercase;
+    letter-spacing: 0.8px;
+    color: var(--text-secondary);
+}
+
+.stat-divider {
+    width: 1px;
+    height: 14px;
+    background: var(--panel-border);
+}
+
+/* ---------- HUD de atalhos ---------- */
+
+.hud {
+    position: fixed;
+    left: 50%;
+    bottom: max(18px, env(safe-area-inset-bottom));
+    transform: translateX(-50%);
+    display: flex;
+    gap: 14px;
+    padding: 8px 14px;
+    border-radius: 8px;
+    background: rgba(0, 0, 0, 0.45);
+    border: 1px solid var(--panel-border);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+    font-size: 0.62rem;
+    letter-spacing: 0.5px;
+    color: var(--text-secondary);
+    white-space: nowrap;
+    z-index: 12;
+    pointer-events: none;
+    animation: hudFade 7s forwards;
+}
+
+.hud b {
+    color: var(--mx);
+    font-weight: 400;
+}
+
+@keyframes hudFade {
+    0%, 72% {
+        opacity: 1;
+    }
+
+    100% {
+        opacity: 0;
+        visibility: hidden;
+    }
+}
+
+/* ---------- Rodapé ---------- */
+
+footer {
+    position: fixed;
+    bottom: max(16px, env(safe-area-inset-bottom));
+    left: 20px;
+    width: auto;
+    max-width: none;
+    margin: 0;
+    padding: 0;
+    border: none;
+    color: var(--text-secondary);
+    font-size: 0.65rem;
+    z-index: 12;
+    transition: opacity 0.35s ease;
+}
+
+footer a {
+    color: var(--mx);
+    opacity: 0.55;
+    transition: opacity 0.2s ease;
+}
+
+footer a:hover {
+    opacity: 1;
+}
+
+/* ---------- Modo cinema / tela cheia ---------- */
+
+body.cinema header,
+body.cinema footer,
+body.cinema .hud,
+body.cinema .toggle-controls-btn,
+body.cinema .controls {
+    opacity: 0;
+    pointer-events: none;
+    transform: translateY(-10px);
+}
+
+body.cinema .controls {
+    transform: translateX(calc(100% + 40px));
+}
+
+body.cinema.pointer-idle #matrix {
+    cursor: none;
+}
+
+body.cinema .cinema-exit {
+    opacity: 1;
+    pointer-events: auto;
+}
+
+.cinema-exit {
+    position: fixed;
+    top: 16px;
+    right: 16px;
+    z-index: 30;
+    padding: 8px 12px;
+    border-radius: 8px;
+    background: rgba(0, 0, 0, 0.6);
+    border: 1px solid var(--panel-border);
+    color: var(--text-secondary);
+    font-family: var(--mono);
+    font-size: 0.62rem;
+    letter-spacing: 1px;
+    cursor: pointer;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.3s ease, color 0.2s ease;
+}
+
+body.cinema.pointer-idle .cinema-exit {
+    opacity: 0;
+    pointer-events: none;
+}
+
+.cinema-exit:hover {
+    color: var(--mx);
+    border-color: rgba(0, 255, 65, 0.4);
+}
+
+/* ---------- Sequência de abertura ---------- */
+
+.boot {
+    position: fixed;
+    inset: 0;
+    z-index: 40;
+    background: #000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 2rem;
+    transition: opacity 0.9s ease;
+}
+
+/* Precisa vencer o `display: flex` acima quando o atributo hidden é aplicado. */
+.boot[hidden] {
+    display: none;
+}
+
+.boot.fading {
+    opacity: 0;
+    pointer-events: none;
+}
+
+.boot-text {
+    font-family: var(--mono);
+    font-size: clamp(0.95rem, 2.6vw, 1.6rem);
+    line-height: 1.9;
+    color: var(--mx);
+    text-shadow: 0 0 8px var(--mx-glow), 0 0 26px var(--mx-glow);
+    white-space: pre-wrap;
+    max-width: 30ch;
+    margin: 0;
+}
+
+.boot-text::after {
+    content: '▋';
+    animation: caret 1s steps(1) infinite;
+    margin-left: 2px;
+}
+
+@keyframes caret {
+    0%, 49% {
+        opacity: 1;
+    }
+
+    50%, 100% {
+        opacity: 0;
+    }
+}
+
+.boot-skip {
+    position: absolute;
+    bottom: 28px;
+    right: 28px;
+    background: transparent;
+    border: 1px solid var(--panel-border);
+    border-radius: 6px;
+    padding: 7px 12px;
+    color: var(--text-secondary);
+    font-family: var(--mono);
+    font-size: 0.65rem;
+    letter-spacing: 1px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.boot-skip:hover {
+    color: var(--mx);
+    border-color: rgba(0, 255, 65, 0.4);
+}
+
+/* ---------- Responsivo ---------- */
+
+@media (max-width: 768px) {
+    header {
+        padding: 0.9rem 1rem !important;
+    }
+
+    header .app-logo {
+        font-size: 1.05rem;
+        letter-spacing: 0.25em;
+    }
+
+    .controls {
+        top: auto;
+        bottom: 78px;
+        right: 14px;
+        left: 14px;
+        width: auto;
+        max-height: 62vh;
+    }
+
+    .toggle-controls-btn {
+        bottom: max(18px, env(safe-area-inset-bottom));
+        right: 18px;
+    }
+
+    .hud {
+        gap: 10px;
+        font-size: 0.55rem;
+        padding: 6px 10px;
+        max-width: calc(100% - 110px);
+        left: 14px;
+        transform: none;
+        overflow: hidden;
+    }
+
+    footer {
+        left: 14px;
+        bottom: max(12px, env(safe-area-inset-bottom));
+        font-size: 0.6rem;
+    }
+}
+
+@media (max-width: 420px) {
+    .sliders-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .controls-scroll {
+        padding: 13px;
+        gap: 15px;
+    }
+
+    .hud span:nth-child(n+4) {
+        display: none;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .boot-text::after {
+        animation: none;
+    }
+}


### PR DESCRIPTION
# Motivação 💪

Faltava no Labs um experimento visual "de vitrine" — algo que funcione como screensaver e que renda uma captura boa. A chuva digital de Matrix é o candidato óbvio, mas a maioria das implementações para por aí: caracteres aleatórios caindo com um retângulo preto translúcido por cima. O objetivo aqui foi acertar os detalhes que fazem a coisa **parecer o filme**, e não uma demo genérica de caracteres caindo.

# Solução 🔧

Novo lab em `labs/matrix/` — três arquivos, sem dependências, seguindo o padrão dos outros labs (`shared.css`/`shared.js`, header/footer via `data-lab-header`).

**O que foi feito para a fidelidade:**

- **Katakana halfwidth espelhado na horizontal** — é literalmente o que a fonte usada no filme faz.
- **Largura da coluna vinda do `measureText` do glifo real.** Katakana halfwidth ocupa meio em; usar a célula cheia deixaria as colunas espalhadas. Isso também faz o layout se adaptar sozinho quando o conjunto de glifos muda.
- **Cabeça pálida sobre rastro verde com decaimento exponencial**, com halo assado no próprio glifo.
- **Os glifos continuam mutando depois que a cabeça passa** — o código "ferve" no lugar. Isso vem de guardar os glifos numa grade fixa por camada, em vez de guardá-los no stream.
- **Até três camadas de paralaxe**, bloom CRT, scanlines e vinheta.

**Renderização:** os glifos são desenhados uma única vez num atlas offscreen e depois compostos com `drawImage`. Isso tira milhares de células por frame do caminho do `fillText`. O bloom é o truque barato de reduzir o frame para 1/6 e somar de volta escalado, sem `ctx.filter`.

**Opções:** 6 modos de cor, 5 conjuntos de glifos, profundidade, 6 sliders (velocidade, tamanho, rastro, densidade, mutação, brilho), 5 toggles (espelhamento, cintilação, scanlines, vinheta, zumbido WebAudio), mensagem legível injetada no meio do código, e uma sequência de abertura pulável. Tudo persiste em `localStorage`.

**Tela cheia:** usa a Fullscreen API e já entra em modo imersivo. Onde a API é bloqueada (páginas embutidas, Safari no iPhone) cai para um modo cinema dentro da janela, para o botão nunca ficar mudo.

# Como testar 👮‍♂️

1. Abrir `/labs/` e confirmar que o card **Matrix** aparece no filtro "Experimentos".
2. Abrir `/labs/matrix/` — a sequência de abertura roda uma vez por sessão. Pular com `Esc` ou pelo botão.
3. No painel (engrenagem ou `C`): trocar entre os 6 modos de cor e os 5 conjuntos de glifos; alternar 1/2/3 camadas e conferir o paralaxe; mexer nos sliders.
4. Digitar algo em **Mensagem no código** e clicar na seta — a frase desce legível, de cima para baixo, no meio dos glifos.
5. `F` para tela cheia, `H` para modo cinema, `Esc` para sair de ambos. Mover o mouse no modo cinema faz reaparecer o botão de saída.
6. Clicar na tela: um pulso de choque expande do ponto do clique.
7. Recarregar e confirmar que as configurações foram mantidas.
8. Conferir o contador de FPS no rodapé do painel e o layout no viewport mobile.

## Notas para revisão

- **A tela cheia nativa não foi verificada.** O painel de preview roda a página num iframe sem permissão de fullscreen, então a API rejeita com `TypeError: Permissions check failed`. Foi isso que revelou a necessidade do fallback. O **fallback foi testado e funciona**; a tela cheia nativa em si precisa ser confirmada abrindo numa aba normal.
- As falas da abertura são três frases curtas e icônicas do filme, no espírito de homenagem.
- Verificado: 120fps em desktop e mobile, sem erros de console, e o toggle de tema claro/escuro global não quebra o painel (o canvas é sempre escuro, por definição).

# Imagens/GIFs

**Adicione imagens/gifs aqui**
