### PR TITLE
docs: refresh README showcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,82 +1,101 @@
-<div align="center">
-
-<img src="https://diogopaulino.com.br/assets/img/diogo.jpeg" alt="Diogo Paulino" width="120" height="120" style="border-radius:50%" />
-
-# Diogo Paulino
-
-**Tech Manager · Design & Code**
-
-Apaixonado por tecnologia — quase 20 anos explorando o mundo tech.  
-Entusiasta de **música**, **IA** e de tudo que une design, código e som.
-
-<br/>
-
-[![Website](https://img.shields.io/badge/Website-diogopaulino.com.br-3B82F6?style=flat-square&logo=firefoxbrowser&logoColor=white)](https://diogopaulino.com.br/)
-[![Labs](https://img.shields.io/badge/Labs-Playground-8B5CF6?style=flat-square&logo=codesandbox&logoColor=white)](https://diogopaulino.com.br/labs/)
-[![GitHub](https://img.shields.io/badge/GitHub-diogopaulino-181717?style=flat-square&logo=github)](https://github.com/diogopaulino)
-[![LinkedIn](https://img.shields.io/badge/LinkedIn-diogopaulino-0A66C2?style=flat-square&logo=linkedin)](https://br.linkedin.com/in/diogopaulino)
-[![Spotify](https://img.shields.io/badge/Spotify-Artist-1DB954?style=flat-square&logo=spotify&logoColor=white)](https://open.spotify.com/intl-pt/artist/0ue2WfDQ1P4XR2vXdSIrYQ)
-
-</div>
-
----
+<table>
+  <tr>
+    <td valign="middle">
+      <h1>Olá, eu sou o Diogo 👋</h1>
+      <p><strong>Tech Manager que continua perto do design e do código.</strong></p>
+      <p>
+        Há quase 20 anos transformando ideias em produtos digitais.<br/>
+        Gosto especialmente do encontro entre <strong>tecnologia, IA, música e experiências interativas</strong>.
+      </p>
+      <p>
+        <a href="https://diogopaulino.com.br/"><strong>Portfólio</strong></a>
+        &nbsp;·&nbsp;
+        <a href="https://diogopaulino.com.br/labs/"><strong>Labs</strong></a>
+        &nbsp;·&nbsp;
+        <a href="https://br.linkedin.com/in/diogopaulino"><strong>LinkedIn</strong></a>
+        &nbsp;·&nbsp;
+        <a href="https://open.spotify.com/intl-pt/artist/0ue2WfDQ1P4XR2vXdSIrYQ"><strong>Spotify</strong></a>
+      </p>
+    </td>
+    <td width="210" align="center" valign="middle">
+      <a href="https://diogopaulino.com.br/">
+        <img src="https://diogopaulino.com.br/assets/img/diogo.jpeg" width="180" alt="Foto de Diogo Paulino" />
+      </a>
+    </td>
+  </tr>
+</table>
 
 ## Playground
 
-Espaço com projetinhos que fui criando ao longo do tempo — um lab aberto pra experimentar ideias.  
-Tudo roda no navegador: jogos, ferramentas, visualizações e instrumentos.
+Um laboratório aberto de projetos que crio para aprender, testar ideias e me divertir. Jogos, ferramentas, arte generativa e experimentos musicais — tudo roda direto no navegador.
 
-### Games
+**[Explorar todos os projetos →](https://diogopaulino.com.br/labs/)**
 
-| Projeto | Sobre |
+### Destaques
+
+| | Projeto | Experiência |
+| :---: | :--- | :--- |
+| 🥊 | **[Rock Kombat](https://diogopaulino.com.br/labs/rock-kombat/)** | Luta 16-bits com lendas do rock |
+| 🕹️ | **[Videogame](https://diogopaulino.com.br/labs/videogame/)** | Emulador retrô com filtro CRT |
+| 💻 | **[CyberOS Terminal](https://diogopaulino.com.br/labs/cyberos/)** | Uma workstation hacker inteira no browser |
+| 🏎️ | **[F1 Grand Prix](https://diogopaulino.com.br/labs/f1-racing/)** | Corrida com adversários controlados por IA |
+| 🎼 | **[Partitura Quest](https://diogopaulino.com.br/labs/partitura/)** | Teoria musical transformada em jogo |
+| 🌌 | **[Aurora Flow](https://diogopaulino.com.br/labs/aurora-flow/)** | Aurora boreal desenhada por flow fields |
+
+<details>
+<summary><strong>🎮 Jogos</strong></summary>
+
+| Projeto | Experiência |
 | :--- | :--- |
-| 🥊 **[Rock Kombat](https://diogopaulino.com.br/labs/rock-kombat/)** | Luta 16-bits com lendas do rock |
-| 🕹️ **[Videogame](https://diogopaulino.com.br/labs/videogame/)** | Emulador de Mega Drive com filtro CRT |
-| 🚀 **[Lunar Lander](https://diogopaulino.com.br/labs/lander/)** | Pouso lunar com física realista |
-| 🏎️ **[F1 Grand Prix](https://diogopaulino.com.br/labs/f1-racing/)** | Corrida com IA e telemetria |
-| 🏃 **[Jungle Run](https://diogopaulino.com.br/labs/jungle-run/)** | Plataforma retrô |
-| 🌌 **[Space Shooter](https://diogopaulino.com.br/labs/space-shooter/)** | Shooter cyberpunk neon |
-| 🧱 **[Tetris 90s](https://diogopaulino.com.br/labs/tetris/)** | Clássico estilo Game Boy |
-| 🐍 **[Snake](https://diogopaulino.com.br/labs/snake/)** | Cobrinha Nokia 3310 |
-| 💣 **[Campo Minado 95](https://diogopaulino.com.br/labs/minesweeper/)** | Visual Windows 95 |
-| 🐣 **[Tamagotchi](https://diogopaulino.com.br/labs/tamagotchi/)** | Bichinho virtual dos anos 90 |
+| [Lunar Lander](https://diogopaulino.com.br/labs/lander/) | Pouso lunar com física realista |
+| [Jungle Run](https://diogopaulino.com.br/labs/jungle-run/) | Plataforma retrô |
+| [Space Shooter](https://diogopaulino.com.br/labs/space-shooter/) | Shooter cyberpunk neon |
+| [Tetris 90s](https://diogopaulino.com.br/labs/tetris/) | O clássico com estética de Game Boy |
+| [Snake](https://diogopaulino.com.br/labs/snake/) | Cobrinha inspirada no Nokia 3310 |
+| [Campo Minado 95](https://diogopaulino.com.br/labs/minesweeper/) | Nostalgia com visual de Windows 95 |
+| [Tamagotchi](https://diogopaulino.com.br/labs/tamagotchi/) | Um bichinho virtual direto dos anos 90 |
 
-### Arte & Simulações
+</details>
 
-| Projeto | Sobre |
+<details>
+<summary><strong>🎨 Arte & simulações</strong></summary>
+
+| Projeto | Experiência |
 | :--- | :--- |
-| 💻 **[CyberOS Terminal](https://diogopaulino.com.br/labs/cyberos/)** | SO hacker no browser: terminal, firewall, Oracle e cipher |
-| 🟢 **[Matrix Rain](https://diogopaulino.com.br/labs/matrix/)** | Chuva Katakana com glow CRT |
-| 🌌 **[Aurora Flow](https://diogopaulino.com.br/labs/aurora-flow/)** | Aurora boreal em flow fields |
-| 🎨 **[Paint Lab](https://diogopaulino.com.br/labs/paint/)** | Editor de arte digital |
-| 🪐 **[Gravity](https://diogopaulino.com.br/labs/gravity/)** | Sandbox gravitacional |
+| [Matrix Rain](https://diogopaulino.com.br/labs/matrix/) | Chuva Katakana com glow CRT |
+| [Paint Lab](https://diogopaulino.com.br/labs/paint/) | Editor de arte digital |
+| [Gravity](https://diogopaulino.com.br/labs/gravity/) | Sandbox gravitacional interativo |
 
-### Ferramentas
+</details>
 
-| Projeto | Sobre |
+<details>
+<summary><strong>🛠️ Ferramentas</strong></summary>
+
+| Projeto | Experiência |
 | :--- | :--- |
-| ⚡ **[Image Optimizer](https://diogopaulino.com.br/labs/image-optimizer/)** | Compressão 100% no cliente |
-| 📸 **[Image Editor](https://diogopaulino.com.br/labs/image-editor/)** | Filtros e cortes |
-| ⏱️ **[Pomodoro](https://diogopaulino.com.br/labs/pomodoro/)** | Timer de foco com sons |
-| 🗣️ **[English Duo](https://diogopaulino.com.br/labs/english-duo/)** | Treino de pronúncia |
-| 🧮 **[Calculator](https://diogopaulino.com.br/labs/calculator/)** | Calculadora + câmbio ao vivo |
+| [Image Optimizer](https://diogopaulino.com.br/labs/image-optimizer/) | Compressão de imagens 100% no cliente |
+| [Image Editor](https://diogopaulino.com.br/labs/image-editor/) | Filtros, ajustes e cortes |
+| [Pomodoro](https://diogopaulino.com.br/labs/pomodoro/) | Timer de foco com paisagens sonoras |
+| [English Duo](https://diogopaulino.com.br/labs/english-duo/) | Treino de pronúncia |
+| [Calculator](https://diogopaulino.com.br/labs/calculator/) | Calculadora com câmbio ao vivo |
 
-### Áudio & Música
+</details>
 
-| Projeto | Sobre |
+<details>
+<summary><strong>🎵 Áudio & música</strong></summary>
+
+| Projeto | Experiência |
 | :--- | :--- |
-| 🎼 **[Partitura Quest](https://diogopaulino.com.br/labs/partitura/)** | Aprendizado de partituras e escalas gamificado |
-| 🎹 **[Piano](https://diogopaulino.com.br/labs/piano/)** | Synth com 4 oitavas |
-| 📻 **[Winamp JS](https://diogopaulino.com.br/labs/winamp/)** | Player estilo Winamp 2.x |
-| ✨ **[Pulsar](https://diogopaulino.com.br/labs/pulsar/)** | Instrumento generativo |
+| [Piano](https://diogopaulino.com.br/labs/piano/) | Synth com quatro oitavas |
+| [Winamp JS](https://diogopaulino.com.br/labs/winamp/) | Player inspirado no Winamp 2.x |
+| [Pulsar](https://diogopaulino.com.br/labs/pulsar/) | Instrumento musical generativo |
+
+</details>
 
 ---
 
 <div align="center">
-
-Abre, experimenta, quebra, reconstrói.  
-Esse é o espírito do playground.
-
-**[diogopaulino.com.br/labs](https://diogopaulino.com.br/labs/)**
-
+  <sub>Feito com HTML, CSS, JavaScript e curiosidade.</sub>
+  <br/><br/>
+  <strong><a href="https://diogopaulino.com.br/labs/">Abre, experimenta, quebra, reconstrói →</a></strong>
 </div>


### PR DESCRIPTION
## O que mudou

- Reorganiza a apresentação pessoal em um hero com foto integrada.
- Destaca seis experiências do playground e agrupa o catálogo completo em seções recolhíveis.
- Simplifica a navegação para portfólio, labs, LinkedIn e Spotify.
- Padroniza a linguagem e as descrições dos projetos.

## Por quê

O README anterior concentrava uma lista longa de tabelas e deixava a identidade pessoal pouco evidente. A nova estrutura cria uma primeira dobra mais clara e escaneável, preservando todos os projetos.

## Validação

- `git diff --check`
- Links do portfólio e dos labs verificados.
- Renderização conferida no preview nativo do GitHub, incluindo carregamento da foto.