### PR TITLE
fix(f1-racing): corrige direção invertida e polish de HUD/input

### DIFF
--- a/labs/f1-racing/index.html
+++ b/labs/f1-racing/index.html
@@ -266,7 +266,7 @@
     </main>
 
     <script src="/labs/shared.js?v=5" defer></script>
-    <script type="module" src="src/main.js?v=1"></script>
+    <script type="module" src="src/main.js?v=2"></script>
 </body>
 
 </html>

--- a/labs/f1-racing/src/hud.js
+++ b/labs/f1-racing/src/hud.js
@@ -174,9 +174,18 @@ export class Hud {
                 gapEl.textContent = car.finished ? formatTime(car.finishTime) : 'LÍDER';
             } else {
                 const leader = order[0];
-                const gap = (leader.totalDistance - car.totalDistance);
-                const speed = Math.max(12, car.speed);
-                gapEl.textContent = gap > 0 ? `+${(gap / speed).toFixed(1)}s` : '—';
+                const gapMeters = leader.totalDistance - car.totalDistance;
+                const lapLen = this.circuit?.length || 5000;
+                if (gapMeters <= 0) {
+                    gapEl.textContent = '—';
+                } else if (gapMeters > lapLen * 0.85) {
+                    const laps = Math.max(1, Math.round(gapMeters / lapLen));
+                    gapEl.textContent = laps === 1 ? '+1 VOLTA' : `+${laps} VOLTAS`;
+                } else {
+                    // Use the faster of the two so a parked car doesn't show +1000s.
+                    const speed = Math.max(28, car.speed, leader.speed * 0.85);
+                    gapEl.textContent = `+${(gapMeters / speed).toFixed(1)}s`;
+                }
             }
         });
 

--- a/labs/f1-racing/src/input.js
+++ b/labs/f1-racing/src/input.js
@@ -61,8 +61,8 @@ export class InputManager {
         const pads = root.querySelectorAll('[data-control]');
         for (const pad of pads) {
             const control = pad.dataset.control;
-            const press = (on) => (event) => {
-                event.preventDefault();
+            const setPad = (on, event) => {
+                event?.preventDefault();
                 pad.classList.toggle('is-active', on);
                 if (control === 'drs') {
                     if (on) this.actions.toggleDrs?.();
@@ -75,10 +75,13 @@ export class InputManager {
                 this.touch[control] = on ? 1 : 0;
                 if (on && navigator.vibrate) navigator.vibrate(8);
             };
-            pad.addEventListener('pointerdown', press(true), { signal });
-            pad.addEventListener('pointerup', press(false), { signal });
-            pad.addEventListener('pointercancel', press(false), { signal });
-            pad.addEventListener('pointerleave', press(false), { signal });
+            pad.addEventListener('pointerdown', (event) => {
+                pad.setPointerCapture?.(event.pointerId);
+                setPad(true, event);
+            }, { signal });
+            pad.addEventListener('pointerup', (event) => setPad(false, event), { signal });
+            pad.addEventListener('pointercancel', (event) => setPad(false, event), { signal });
+            pad.addEventListener('lostpointercapture', () => setPad(false), { signal });
             pad.addEventListener('contextmenu', (e) => e.preventDefault(), { signal });
         }
     }
@@ -123,14 +126,21 @@ export class InputManager {
         this.state.throttle = ramp(this.state.throttle, throttleTarget, 7, 12);
         this.state.brake = ramp(this.state.brake, brakeTarget, 12, 16);
 
+        // Compose desired steer in "screen space" first: left = -1, right = +1.
         let steerTarget = 0;
         if (this.raw.left || this.touch.left) steerTarget -= 1;
         if (this.raw.right || this.touch.right) steerTarget += 1;
-        if (pad && pad.steer) steerTarget = pad.steer;
-        steerTarget = Math.max(-1, Math.min(1, steerTarget));
+        // Gamepad stick augments keys/touch instead of hard-replacing them
+        // (avoids a resting/drifted pad swallowing keyboard input).
+        if (pad) steerTarget += pad.steer;
+
+        // Vehicle +X is the car's right, but a chase camera looking along +Z shows
+        // world +X on the LEFT of the screen (Three.js Y-up / look-down-−Z basis).
+        // Negate so pressing left turns toward screen-left.
+        steerTarget = Math.max(-1, Math.min(1, -steerTarget));
 
         const returning = Math.sign(steerTarget) !== Math.sign(this.state.steer) || steerTarget === 0;
-        this.state.steer = ramp(this.state.steer, steerTarget, returning ? 9 : 4.5, 10);
+        this.state.steer = ramp(this.state.steer, steerTarget, returning ? 11 : 6.5, 12);
 
         this.state.ers = this.raw.ers || this.touch.ers || (pad?.ers ?? false);
 

--- a/labs/f1-racing/src/vehicle.js
+++ b/labs/f1-racing/src/vehicle.js
@@ -197,9 +197,10 @@ export class Vehicle {
         const steerTarget = clamp(input.steer, -1, 1);
 
         // Speed-sensitive steering keeps the car drivable at 300 km/h.
+        // Convention: positive steerTarget / steer = turn right (yaw increases).
         const speedFactor = clamp(1 - Math.abs(this.vx) / 135, 0.26, 1);
         const maxSteer = SPEC.maxSteer * speedFactor;
-        const steerRate = input.assists ? 5.2 : 8.5;
+        const steerRate = input.assists ? 6.8 : 9.5;
         this.steer += (steerTarget * maxSteer - this.steer) * Math.min(1, steerRate * dt);
 
         this.autoShift(dt);


### PR DESCRIPTION
## Summary
- Corrige steering invertido na chase cam (teclado, touch e gamepad): A/← passam a virar para a esquerda da tela
- Evita gaps absurdos tipo `+1000s` na torre de tempo (mostra voltas ou usa velocidade estável)
- Touch com `setPointerCapture` e gamepad que não engole o teclado com drift
- Direção um pouco mais responsiva com assistências; cache-bust do `main.js`

## Test plan
- [ ] Abrir `/labs/f1-racing/`, ir ao grid e acelerar
- [ ] Segurar A/←: nariz deve ir para a **esquerda** da tela (chase e cockpit)
- [ ] Segurar D/→: nariz para a **direita**
- [ ] Em mobile, segurar ◀/▶ sem soltar ao deslizar o dedo levemente
- [ ] Ficar parado enquanto a IA anda: torre não deve mostrar `+1000s` (idealmente `+N VOLTA(S)`)
- [ ] Com gamepad conectado em repouso, teclado A/D ainda deve responder


Made with [Cursor](https://cursor.com)