### PR TITLE
feat(f1-racing): realismo estilo Crazy Grand Prix

### DIFF
--- a/labs/f1-racing/index.html
+++ b/labs/f1-racing/index.html
@@ -7,14 +7,14 @@
         content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover">
     <meta name="theme-color" content="#07080c">
     <meta name="description"
-        content="Simulador de Fórmula 1 em 3D com Three.js e WebGPU: circuitos reais, física de pneus, DRS, ERS, IA e telemetria ao vivo no navegador.">
-    <title>F1 Grand Prix — Simulador 3D WebGPU</title>
+        content="F1 Grand Prix — corrida 3D hiper-realista no navegador: física Pacejka, carga aerodinâmica, DRS, ERS, circuitos detalhados e telemetria ao vivo.">
+    <title>F1 Grand Prix — Crazy Realism</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link rel="stylesheet" href="/labs/shared.css?v=4">
-    <link rel="stylesheet" href="style.css?v=10">
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Orbitron:wght@500;600;700;800;900&display=swap"
+    <link rel="stylesheet" href="style.css?v=11">
+    <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700&family=Orbitron:wght@500;600;700;800;900&display=swap"
         rel="stylesheet">
     <script type="importmap">
     {
@@ -84,9 +84,15 @@
                 <div class="hud-bottom">
                     <div class="panel systems-panel">
                         <div class="system-block">
-                            <span class="stat-label">NITRO</span>
+                            <span class="stat-label">ERS <b id="ersValue">4.0</b></span>
                             <div class="meter ers"><i id="ersFill"></i></div>
                         </div>
+                        <div class="system-block">
+                            <span class="stat-label">Pneu <b id="tyreLabel">M</b></span>
+                            <div class="meter tyre"><i id="tyreWear"></i></div>
+                            <span class="small" id="tyreTemp">80°C</span>
+                        </div>
+                        <span id="drsBadge" class="drs-badge" data-state="off">DRS</span>
                     </div>
 
                     <div class="cluster">
@@ -106,8 +112,8 @@
                     </div>
 
                     <div class="hud-actions">
-                        <button id="cameraButton" class="icon-button" type="button" title="Câmera (C)" aria-label="Trocar câmera">🎥</button>
-                        <button id="pauseButton" class="icon-button" type="button" title="Pausar (P)" aria-label="Pausar">⏸</button>
+                        <button id="cameraButton" class="icon-button" type="button" title="Câmera (C)" aria-label="Trocar câmera">Cam</button>
+                        <button id="pauseButton" class="icon-button" type="button" title="Pausar (P)" aria-label="Pausar">II</button>
                         <span id="fpsCounter" class="fps mono">—</span>
                     </div>
                 </div>
@@ -126,7 +132,8 @@
                     <button type="button" class="pad" data-control="right" aria-label="Direita">▶</button>
                 </div>
                 <div class="pad-group pad-right">
-                    <button type="button" class="pad pad-small" data-control="ers" aria-label="Nitro">NITRO</button>
+                    <button type="button" class="pad pad-small" data-control="drs" aria-label="DRS">DRS</button>
+                    <button type="button" class="pad pad-small" data-control="ers" aria-label="ERS">ERS</button>
                     <button type="button" class="pad pad-brake" data-control="brake" aria-label="Freio">FREIO</button>
                     <button type="button" class="pad pad-throttle" data-control="throttle" aria-label="Acelerar">GÁS</button>
                 </div>
@@ -136,10 +143,10 @@
             <div id="menuOverlay" class="overlay menu-overlay">
                 <div class="overlay-card menu-card">
                     <header class="menu-head">
-                        <p class="eyebrow"><i></i> Three.js · WebGPU · TSL</p>
+                        <p class="eyebrow"><i></i> WebGPU · Pacejka · Aero</p>
                         <h1>F1 <span>Grand Prix</span></h1>
-                        <p class="lede">Quatro circuitos modelados a partir da geometria real, física de pneus com carga
-                            aerodinâmica, ERS, DRS e um grid de IA que briga de verdade.</p>
+                        <p class="lede">Corrida estilo Grand Prix com pista PBR, carro detalhado, física de pneus com
+                            carga aerodinâmica, DRS, ERS e IA agressiva — no navegador.</p>
                     </header>
 
                     <div class="menu-grid">
@@ -155,6 +162,8 @@
                         </section>
 
                         <section class="menu-section">
+                            <h2>Composto</h2>
+                            <div id="compoundOptions" class="chip-row"></div>
 
                             <h2>Clima</h2>
                             <div id="weatherOptions" class="chip-row"></div>
@@ -200,7 +209,9 @@
                         <div class="keys">
                             <span><kbd>W</kbd><kbd>S</kbd> acelerar / frear</span>
                             <span><kbd>A</kbd><kbd>D</kbd> direção</span>
-                            <span><kbd>E</kbd><kbd>Espaço</kbd> Nitro</span>
+                            <span><kbd>Espaço</kbd> ERS</span>
+                            <span><kbd>E</kbd> DRS</span>
+                            <span><kbd>B</kbd> olhar atrás</span>
                             <span><kbd>C</kbd> câmera</span>
                             <span><kbd>P</kbd> pausa</span>
                         </div>
@@ -255,7 +266,7 @@
     </main>
 
     <script src="/labs/shared.js?v=5" defer></script>
-    <script type="module" src="src/main.js?v=2"></script>
+    <script type="module" src="src/main.js?v=3"></script>
 </body>
 
 </html>

--- a/labs/f1-racing/index.html
+++ b/labs/f1-racing/index.html
@@ -13,7 +13,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link rel="stylesheet" href="/labs/shared.css?v=4">
-    <link rel="stylesheet" href="style.css?v=12">
+    <link rel="stylesheet" href="style.css?v=13">
     <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700&family=Orbitron:wght@500;600;700;800;900&display=swap"
         rel="stylesheet">
     <script type="importmap">
@@ -266,7 +266,7 @@
     </main>
 
     <script src="/labs/shared.js?v=5" defer></script>
-    <script type="module" src="src/main.js?v=3"></script>
+    <script type="module" src="src/main.js?v=4"></script>
 </body>
 
 </html>

--- a/labs/f1-racing/index.html
+++ b/labs/f1-racing/index.html
@@ -13,7 +13,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link rel="stylesheet" href="/labs/shared.css?v=4">
-    <link rel="stylesheet" href="style.css?v=11">
+    <link rel="stylesheet" href="style.css?v=12">
     <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700&family=Orbitron:wght@500;600;700;800;900&display=swap"
         rel="stylesheet">
     <script type="importmap">

--- a/labs/f1-racing/src/ai.js
+++ b/labs/f1-racing/src/ai.js
@@ -4,8 +4,6 @@
  * search, and adds a lateral offset to defend or overtake.
  */
 
-import { AERO_REFERENCE } from './circuits.js';
-
 const LOOKAHEAD_MIN = 14;
 const LOOKAHEAD_MAX = 52;
 
@@ -117,35 +115,38 @@ export class AIDriver {
 
         /* --- braking / throttle -------------------------------------- */
         let targetSpeed = Infinity;
-        // Braking capability rises with downforce, so the usable deceleration at the
-        // end of a straight is several times what it is at hairpin speed.
-        const brakeCapacity = 55 * this.personality.bravery * me.weather.grip; // Arcade brakes
-        for (let k = 0; k < 110; k++) {
-            const idx = circuit.indexAt(me.lapDistance + k * circuit.spacing * 1.5);
-            const distance = Math.max(1, k * circuit.spacing * 1.5);
+        // Braking capability rises with downforce at speed.
+        const aeroBoost = clamp(Math.abs(me.vx) / 90, 0, 1.35);
+        const brakeCapacity = (28 + aeroBoost * 22) * this.personality.bravery * me.weather.grip;
+        for (let k = 0; k < 130; k++) {
+            const idx = circuit.indexAt(me.lapDistance + k * circuit.spacing * 1.4);
+            const distance = Math.max(1, k * circuit.spacing * 1.4);
             const limit = circuit.speedProfile[idx];
             const reachable = Math.sqrt(limit * limit + 2 * brakeCapacity * distance);
             if (reachable < targetSpeed) targetSpeed = reachable;
         }
-        targetSpeed *= diff.pace * this.personality.pace * 1.35; // Arcade boost for AI
+        targetSpeed *= diff.pace * this.personality.pace * 1.12;
         if (raceState?.safety) targetSpeed = Math.min(targetSpeed, 24);
 
         // Slipstream: tuck in and use the tow on straights.
-        if (ahead.car && ahead.gap < 25 && Math.abs(circuit.curvature[me.trackIndex]) < 0.004) {
-            targetSpeed *= 1.03;
+        if (ahead.car && ahead.gap < 22 && Math.abs(circuit.curvature[me.trackIndex]) < 0.004) {
+            targetSpeed *= 1.045;
         }
 
         const error = targetSpeed - speed;
-        let throttle = clamp(error * 0.35, 0, 1);
-        let brake = clamp(-error * 0.22, 0, 1);
+        let throttle = clamp(error * 0.32, 0, 1);
+        let brake = clamp(-error * 0.2, 0, 1);
 
-        // Do not brake and accelerate at once; feather off the kerbs.
         if (brake > 0.05) throttle = 0;
-        if (me.surface === 1) throttle *= 0.9;
+        if (me.surface === 1) throttle *= 0.88;
 
-        // Traction-limited exit.
-        if (speed < 26 && throttle > 0.6 && Math.abs(circuit.curvature[me.trackIndex]) > 0.012) {
-            throttle *= 0.82 + diff.reaction * 0.16;
+        // Traction-limited exit — respect tyre grip.
+        if (speed < 28 && throttle > 0.55 && Math.abs(circuit.curvature[me.trackIndex]) > 0.01) {
+            throttle *= 0.78 + diff.reaction * 0.18;
+        }
+        if (me.slip > 0.85) {
+            throttle *= 0.7;
+            steer *= 0.85;
         }
 
         /* --- ERS + DRS ------------------------------------------------ */

--- a/labs/f1-racing/src/carModel.js
+++ b/labs/f1-racing/src/carModel.js
@@ -1,17 +1,15 @@
 /**
- * Procedural Formula 1 car. The monocoque is lofted through a series of superellipse
- * cross-sections, everything else (wings, halo, suspension, wheels) is assembled from
- * primitives and merged per material so a full grid stays cheap to draw.
- *
+ * Procedural Formula 1 car — lofted monocoque, multi-element wings, halo,
+ * driver helmet, carbon accents, compound-coloured tyre sidewalls and animated DRS.
  * Local axes: +Z forward, +Y up, +X to the car's right.
  */
 
 import * as THREE from 'three';
 import { mergeGeometries } from 'three/addons/utils/BufferGeometryUtils.js';
+import { carbonTexture, liveryTexture } from './textures.js';
 
-const RADIAL = 14;
+const RADIAL = 16;
 
-/** Superellipse ring — squarish at the bottom, rounded on top, like a real tub. */
 function ring(halfWidth, bottom, top, squareness = 3.2) {
     const points = [];
     const cy = (bottom + top) / 2;
@@ -52,7 +50,6 @@ function loft(sections) {
         }
     }
 
-    // Cap the two ends.
     const capStart = positions.length / 3;
     const first = sections[0];
     const last = sections[sections.length - 1];
@@ -87,14 +84,14 @@ function tint(geometry, hex) {
     return geometry;
 }
 
-function box(w, h, d, x, y, z, hex, rot = null) {
+function box(w, h, d, x, y, z, hex, rotX = 0) {
     const g = new THREE.BoxGeometry(w, h, d);
-    if (rot) g.rotateX(rot);
+    if (rotX) g.rotateX(rotX);
     g.translate(x, y, z);
     return tint(g, hex);
 }
 
-function cylinder(rTop, rBottom, height, x, y, z, hex, axis = 'y', segments = 10) {
+function cylinder(rTop, rBottom, height, x, y, z, hex, axis = 'y', segments = 12) {
     const g = new THREE.CylinderGeometry(rTop, rBottom, height, segments);
     if (axis === 'x') g.rotateZ(Math.PI / 2);
     if (axis === 'z') g.rotateX(Math.PI / 2);
@@ -102,226 +99,364 @@ function cylinder(rTop, rBottom, height, x, y, z, hex, axis = 'y', segments = 10
     return tint(g, hex);
 }
 
-/** Front or rear wing: stacked aerofoil elements plus endplates. */
 function wing({ z, halfSpan, chord, elements, y, colorMain, colorFlap, endplateHeight, endplateColor }) {
     const parts = [];
     for (let e = 0; e < elements; e++) {
         const f = e / Math.max(1, elements - 1);
-        const g = new THREE.BoxGeometry(halfSpan * 2 * (1 - f * 0.06), 0.035, chord * (1 - f * 0.25));
-        g.rotateX(-0.16 - f * 0.22);
-        g.translate(0, y + f * 0.11, z + f * 0.1);
+        const g = new THREE.BoxGeometry(halfSpan * 2 * (1 - f * 0.05), 0.028, chord * (1 - f * 0.22));
+        g.rotateX(-0.14 - f * 0.2);
+        g.translate(0, y + f * 0.1, z + f * 0.09);
         parts.push(tint(g, e === 0 ? colorMain : colorFlap));
     }
+    // Slot gaps / cascade fences
+    for (let e = 0; e < elements - 1; e++) {
+        for (const side of [-0.55, -0.2, 0.2, 0.55]) {
+            parts.push(box(0.02, 0.08, 0.12, side * halfSpan, y + 0.06 + e * 0.08, z + 0.05 + e * 0.08, endplateColor));
+        }
+    }
     for (const side of [-1, 1]) {
-        const plate = new THREE.BoxGeometry(0.035, endplateHeight, chord * 1.25);
-        plate.translate(side * halfSpan, y + endplateHeight / 2 - 0.05, z + 0.05);
+        const plate = new THREE.BoxGeometry(0.032, endplateHeight, chord * 1.3);
+        plate.translate(side * halfSpan, y + endplateHeight / 2 - 0.04, z + 0.04);
         parts.push(tint(plate, endplateColor));
+        // Footplate
+        parts.push(box(0.22, 0.02, chord * 0.9, side * (halfSpan - 0.08), y + 0.02, z, endplateColor));
     }
     return parts;
 }
 
-function buildWheel(radius, width, rimColor) {
+function buildWheel(radius, width, rimColor, compoundColor) {
     const parts = [];
-    const tyre = new THREE.CylinderGeometry(radius, radius, width, 22, 1, false);
+    const tyre = new THREE.CylinderGeometry(radius, radius, width, 28, 1, false);
     tyre.rotateZ(Math.PI / 2);
-    parts.push(tint(tyre, 0x14151a));
+    parts.push(tint(tyre, 0x111218));
 
-    // Shoulder chamfer so tyres are not perfect cylinders.
     for (const side of [-1, 1]) {
-        const shoulder = new THREE.CylinderGeometry(radius * 0.97, radius * 0.86, width * 0.12, 22);
+        const shoulder = new THREE.CylinderGeometry(radius * 0.985, radius * 0.88, width * 0.1, 28);
         shoulder.rotateZ(Math.PI / 2);
-        shoulder.translate(side * width * 0.53, 0, 0);
-        parts.push(tint(shoulder, 0x0f1013));
+        shoulder.translate(side * width * 0.52, 0, 0);
+        parts.push(tint(shoulder, 0x0c0d10));
+
+        // Sidewall compound stripe
+        const stripe = new THREE.CylinderGeometry(radius * 0.9, radius * 0.9, 0.018, 28);
+        stripe.rotateZ(Math.PI / 2);
+        stripe.translate(side * width * 0.48, 0, 0);
+        parts.push(tint(stripe, new THREE.Color(compoundColor).getHex()));
     }
 
-    const rim = new THREE.CylinderGeometry(radius * 0.68, radius * 0.68, width * 0.86, 20);
+    const rim = new THREE.CylinderGeometry(radius * 0.66, radius * 0.66, width * 0.82, 24);
     rim.rotateZ(Math.PI / 2);
     parts.push(tint(rim, rimColor));
 
-    for (let i = 0; i < 7; i++) {
-        const a = (i / 7) * Math.PI * 2;
-        const spoke = new THREE.BoxGeometry(width * 0.9, radius * 0.62, 0.035);
+    // Hub
+    parts.push(cylinder(radius * 0.18, radius * 0.18, width * 0.7, 0, 0, 0, 0x2a2e36, 'x', 16));
+
+    for (let i = 0; i < 8; i++) {
+        const a = (i / 8) * Math.PI * 2;
+        const spoke = new THREE.BoxGeometry(width * 0.72, radius * 0.55, 0.028);
         spoke.rotateX(a);
         parts.push(tint(spoke, rimColor));
     }
+
+    // Valve stem detail
+    parts.push(cylinder(0.012, 0.012, 0.04, width * 0.35, radius * 0.55, 0, 0x888c94, 'y', 6));
+
     return mergeGeometries(parts, false);
 }
 
+function buildDriver(helmetColor, suitColor) {
+    const parts = [];
+    // Helmet shell
+    const helmet = new THREE.SphereGeometry(0.18, 16, 12);
+    helmet.scale(1.05, 0.95, 1.15);
+    helmet.translate(0, 0.92, 0.22);
+    parts.push(tint(helmet, helmetColor));
+
+    // Visor
+    const visor = new THREE.SphereGeometry(0.155, 12, 8, 0, Math.PI * 2, 0, Math.PI * 0.45);
+    visor.scale(1.02, 0.7, 1.1);
+    visor.translate(0, 0.9, 0.28);
+    parts.push(tint(visor, 0x0a1018));
+
+    // HANS / collar
+    parts.push(box(0.32, 0.08, 0.28, 0, 0.78, 0.18, 0x1a1c22));
+
+    // Shoulders / suit
+    parts.push(box(0.42, 0.16, 0.35, 0, 0.62, 0.15, suitColor));
+    parts.push(box(0.28, 0.2, 0.22, 0, 0.55, 0.05, suitColor));
+
+    // Steering wheel rim
+    const wheel = new THREE.TorusGeometry(0.12, 0.018, 8, 20);
+    wheel.rotateX(Math.PI / 2);
+    wheel.translate(0, 0.58, 0.48);
+    parts.push(tint(wheel, 0x111318));
+    parts.push(box(0.1, 0.04, 0.08, 0, 0.58, 0.48, 0x22262e));
+
+    return parts;
+}
+
 /**
- * @param {object} team  entry from TEAMS
+ * @param {object} team
  * @returns {{group: THREE.Group, api: object}}
  */
-export function buildCar(team, { quality, isPlayer = false } = {}) {
+export function buildCar(team, { quality, isPlayer = false, compoundColor = '#e8404a' } = {}) {
     const primary = team.primary;
     const secondary = team.secondary;
     const accent = team.accent;
 
-    /* --- monocoque ------------------------------------------------ */
     const bodySections = [
-        { z: 2.72, w: 0.10, b: 0.14, t: 0.24, sq: 2.4 },
-        { z: 2.35, w: 0.16, b: 0.12, t: 0.32 },
-        { z: 1.75, w: 0.24, b: 0.10, t: 0.42 },
-        { z: 1.10, w: 0.33, b: 0.09, t: 0.52 },
-        { z: 0.45, w: 0.42, b: 0.08, t: 0.64 },
-        { z: 0.00, w: 0.50, b: 0.08, t: 0.68, sq: 3.6 },
-        { z: -0.55, w: 0.62, b: 0.08, t: 0.72, sq: 4.0 },
-        { z: -1.20, w: 0.58, b: 0.09, t: 0.80, sq: 3.6 },
-        { z: -1.85, w: 0.40, b: 0.11, t: 0.72 },
-        { z: -2.45, w: 0.26, b: 0.13, t: 0.56 },
-        { z: -2.80, w: 0.17, b: 0.15, t: 0.44, sq: 2.6 }
+        { z: 2.78, w: 0.09, b: 0.13, t: 0.22, sq: 2.3 },
+        { z: 2.4, w: 0.15, b: 0.11, t: 0.30 },
+        { z: 1.85, w: 0.22, b: 0.10, t: 0.40 },
+        { z: 1.15, w: 0.32, b: 0.09, t: 0.50 },
+        { z: 0.5, w: 0.42, b: 0.08, t: 0.62 },
+        { z: 0.0, w: 0.50, b: 0.08, t: 0.68, sq: 3.6 },
+        { z: -0.55, w: 0.64, b: 0.08, t: 0.74, sq: 4.0 },
+        { z: -1.15, w: 0.60, b: 0.09, t: 0.82, sq: 3.6 },
+        { z: -1.8, w: 0.42, b: 0.11, t: 0.74 },
+        { z: -2.4, w: 0.26, b: 0.13, t: 0.56 },
+        { z: -2.82, w: 0.16, b: 0.15, t: 0.42, sq: 2.5 }
     ];
 
     const paintParts = [tint(loft(bodySections), primary)];
     const darkParts = [];
+    const carbonParts = [];
 
-    // Floor, plank and diffuser.
-    darkParts.push(box(1.9, 0.05, 4.6, 0, 0.055, -0.35, 0x101216));
-    darkParts.push(box(1.5, 0.28, 0.7, 0, 0.17, -2.55, 0x0d0f13, -0.28));
-    // Complex Diffuser strakes
-    for (const side of [-1, -0.5, 0.5, 1]) {
-        darkParts.push(box(0.02, 0.26, 0.65, side * 0.6, 0.15, -2.55, 0x0c0e12, -0.28));
+    // Floor, plank, diffuser.
+    carbonParts.push(box(1.95, 0.045, 4.7, 0, 0.05, -0.35, 0x0e1014));
+    carbonParts.push(box(1.05, 0.02, 3.2, 0, 0.028, -0.2, 0x2a1808)); // skid plank wood
+    carbonParts.push(box(1.55, 0.3, 0.72, 0, 0.18, -2.58, 0x0a0c10, -0.3));
+    for (const side of [-1, -0.55, -0.2, 0.2, 0.55, 1]) {
+        carbonParts.push(box(0.018, 0.28, 0.68, side * 0.55, 0.16, -2.58, 0x0c0e12, -0.3));
     }
-    // Floor edges (bargeboard/edge extensions)
+
+    // Floor edge + bargeboards.
     for (const side of [-1, 1]) {
-        darkParts.push(box(0.05, 0.24, 3.2, side * 0.95, 0.15, -0.2, 0x0c0e12));
-        darkParts.push(box(0.18, 0.35, 0.8, side * 0.85, 0.25, 0.8, 0x0c0e12, -0.15)); // Bargeboards
-        darkParts.push(cylinder(0.02, 0.02, 0.4, side * 0.8, 0.45, 0.6, 0x0c0e12, 'z'));
+        carbonParts.push(box(0.045, 0.22, 3.4, side * 0.98, 0.14, -0.15, 0x0c0e12));
+        carbonParts.push(box(0.2, 0.38, 0.85, side * 0.88, 0.26, 0.85, 0x0c0e12, -0.12));
+        carbonParts.push(cylinder(0.018, 0.018, 0.42, side * 0.82, 0.48, 0.65, 0x1a1e26, 'z'));
+        // Sidepod undercut scoop
+        carbonParts.push(box(0.35, 0.14, 0.9, side * 0.7, 0.2, -0.4, 0x080a0e));
     }
 
-    // Sidepod inlets + cooling louvres.
+    // Sidepod inlets + cooling louvres + paint accents.
     for (const side of [-1, 1]) {
-        darkParts.push(box(0.42, 0.30, 0.14, side * 0.62, 0.36, 0.05, 0x090b0f));
-        paintParts.push(box(0.10, 0.22, 1.1, side * 0.66, 0.62, -1.0, accent));
+        darkParts.push(box(0.45, 0.32, 0.12, side * 0.64, 0.38, 0.08, 0x06080c));
+        paintParts.push(box(0.09, 0.24, 1.15, side * 0.68, 0.64, -1.0, accent));
+        for (let i = 0; i < 5; i++) {
+            carbonParts.push(box(0.28, 0.012, 0.08, side * 0.55, 0.72, -0.6 - i * 0.14, 0x101318));
+        }
     }
 
-    // Cockpit opening + headrest.
-    darkParts.push(box(0.52, 0.10, 0.95, 0, 0.66, 0.30, 0x08090c));
-    paintParts.push(box(0.60, 0.20, 0.30, 0, 0.74, -0.16, secondary));
+    // Cockpit opening + halo surround.
+    darkParts.push(box(0.55, 0.08, 1.0, 0, 0.68, 0.28, 0x06070a));
+    paintParts.push(box(0.62, 0.18, 0.32, 0, 0.76, -0.18, secondary));
+
+    // Driver
+    paintParts.push(...buildDriver(accent, secondary));
 
     // Airbox + engine cover fin.
-    const airbox = new THREE.SphereGeometry(0.28, 12, 10);
-    airbox.scale(1, 0.9, 1.5);
-    airbox.translate(0, 0.86, -0.62);
+    const airbox = new THREE.SphereGeometry(0.3, 14, 12);
+    airbox.scale(1, 0.92, 1.55);
+    airbox.translate(0, 0.88, -0.65);
     paintParts.push(tint(airbox, primary));
-    darkParts.push(box(0.16, 0.2, 0.28, 0, 0.9, -0.5, 0x05060a));
-    paintParts.push(box(0.035, 0.32, 1.15, 0, 0.86, -1.55, accent));
+    darkParts.push(box(0.18, 0.22, 0.3, 0, 0.92, -0.52, 0x040508));
+    paintParts.push(box(0.032, 0.34, 1.2, 0, 0.88, -1.58, accent));
+
+    // Shark fin tip light housing
+    paintParts.push(box(0.04, 0.06, 0.12, 0, 1.02, -2.1, accent));
 
     // Halo.
-    const halo = new THREE.TorusGeometry(0.44, 0.045, 8, 22, Math.PI * 1.15);
+    const halo = new THREE.TorusGeometry(0.46, 0.042, 10, 28, Math.PI * 1.15);
     halo.rotateY(Math.PI / 2);
     halo.rotateZ(Math.PI * 0.42);
-    halo.translate(0, 0.72, 0.34);
-    darkParts.push(tint(halo, 0x15171c));
-    darkParts.push(cylinder(0.05, 0.05, 0.34, 0, 0.78, 0.76, 0x15171c, 'y'));
+    halo.translate(0, 0.74, 0.32);
+    carbonParts.push(tint(halo, 0x16181e));
+    carbonParts.push(cylinder(0.048, 0.048, 0.36, 0, 0.8, 0.78, 0x16181e, 'y'));
 
-    // Mirrors.
+    // Mirrors + camera.
     for (const side of [-1, 1]) {
-        darkParts.push(box(0.16, 0.09, 0.06, side * 0.5, 0.68, 0.5, 0x1a1d22));
-        darkParts.push(cylinder(0.02, 0.02, 0.2, side * 0.4, 0.68, 0.5, 0x1a1d22, 'x'));
+        darkParts.push(box(0.17, 0.09, 0.07, side * 0.52, 0.7, 0.52, 0x1c1f25));
+        carbonParts.push(cylinder(0.018, 0.018, 0.22, side * 0.42, 0.7, 0.52, 0x1c1f25, 'x'));
     }
+    darkParts.push(box(0.08, 0.06, 0.1, 0, 0.95, 0.55, 0x111318)); // T-cam
+
+    // Nose tip camera / number plate area
+    paintParts.push(box(0.22, 0.08, 0.18, 0, 0.22, 2.55, secondary));
 
     // Wings.
     paintParts.push(...wing({
-        z: 2.52, halfSpan: 1.0, chord: 0.42, elements: 3, y: 0.14,
-        colorMain: primary, colorFlap: accent, endplateHeight: 0.34, endplateColor: secondary
+        z: 2.55, halfSpan: 1.02, chord: 0.44, elements: 4, y: 0.13,
+        colorMain: primary, colorFlap: accent, endplateHeight: 0.38, endplateColor: secondary
     }));
     paintParts.push(...wing({
-        z: -2.72, halfSpan: 0.53, chord: 0.34, elements: 1, y: 0.78,
-        colorMain: primary, colorFlap: accent, endplateHeight: 0.52, endplateColor: secondary
+        z: -2.74, halfSpan: 0.54, chord: 0.36, elements: 2, y: 0.8,
+        colorMain: primary, colorFlap: accent, endplateHeight: 0.55, endplateColor: secondary
     }));
-    paintParts.push(box(1.0, 0.05, 0.26, 0, 0.34, -2.66, secondary, -0.2));  // beam wing
+    paintParts.push(box(1.05, 0.045, 0.28, 0, 0.35, -2.68, secondary, -0.18));
 
-    // Suspension wishbones.
+    // Suspension wishbones + pushrods.
     for (const zAxle of [1.72, -1.72]) {
         for (const side of [-1, 1]) {
-            for (const dz of [0.22, -0.22]) {
-                const arm = new THREE.CylinderGeometry(0.028, 0.028, 0.66, 6);
+            for (const dz of [0.24, -0.24]) {
+                const arm = new THREE.CylinderGeometry(0.022, 0.022, 0.7, 6);
                 arm.rotateZ(Math.PI / 2);
-                arm.translate(side * 0.44, zAxle > 0 ? 0.26 : 0.3, zAxle + dz);
-                darkParts.push(tint(arm, 0x1c1f25));
+                arm.translate(side * 0.42, zAxle > 0 ? 0.26 : 0.3, zAxle + dz);
+                carbonParts.push(tint(arm, 0x1e222a));
             }
+            // Pushrod
+            const push = new THREE.CylinderGeometry(0.016, 0.016, 0.55, 6);
+            push.rotateZ(side * 0.55);
+            push.rotateX(zAxle > 0 ? -0.4 : 0.35);
+            push.translate(side * 0.35, 0.45, zAxle);
+            carbonParts.push(tint(push, 0xc8ccd2));
+        }
+    }
+
+    // Brake ducts
+    for (const zAxle of [1.72, -1.72]) {
+        for (const side of [-1, 1]) {
+            carbonParts.push(box(0.14, 0.16, 0.22, side * 0.62, 0.32, zAxle + 0.15, 0x0a0c10));
         }
     }
 
     const paintMaterial = new THREE.MeshPhysicalMaterial({
         vertexColors: true,
-        roughness: 0.12,         // Shinier for realism
-        metalness: 0.35,         // Metallic flake paint look
+        roughness: 0.18,
+        metalness: 0.42,
         clearcoat: 1.0,
-        clearcoatRoughness: 0.04,
-        envMapIntensity: 1.8     // High reflection
+        clearcoatRoughness: 0.06,
+        envMapIntensity: 2.0,
+        sheen: 0.35,
+        sheenRoughness: 0.4,
+        sheenColor: new THREE.Color(primary)
     });
     const darkMaterial = new THREE.MeshStandardMaterial({
         vertexColors: true,
-        roughness: 0.85,
-        metalness: 0.15          // Matte Carbon Fiber look
+        roughness: 0.72,
+        metalness: 0.25,
+        envMapIntensity: 0.8
+    });
+    const carbonMaterial = new THREE.MeshPhysicalMaterial({
+        vertexColors: true,
+        map: carbonTexture(),
+        roughness: 0.45,
+        metalness: 0.55,
+        clearcoat: 0.6,
+        clearcoatRoughness: 0.2,
+        envMapIntensity: 1.4
     });
 
     const group = new THREE.Group();
 
     const bodyMesh = new THREE.Mesh(mergeGeometries(paintParts, false), paintMaterial);
     const trimMesh = new THREE.Mesh(mergeGeometries(darkParts, false), darkMaterial);
-    for (const mesh of [bodyMesh, trimMesh]) {
+    const carbonMesh = new THREE.Mesh(mergeGeometries(carbonParts, false), carbonMaterial);
+    for (const mesh of [bodyMesh, trimMesh, carbonMesh]) {
         mesh.castShadow = quality.shadows;
         mesh.receiveShadow = false;
         group.add(mesh);
     }
 
-    /* --- DRS flap (animated) -------------------------------------- */
+    // Livery decal on engine cover.
+    const livery = liveryTexture(team);
+    const decalMat = new THREE.MeshStandardMaterial({
+        map: livery,
+        transparent: true,
+        roughness: 0.35,
+        metalness: 0.2,
+        polygonOffset: true,
+        polygonOffsetFactor: -2
+    });
+    const noseDecal = new THREE.Mesh(new THREE.PlaneGeometry(0.45, 0.35), decalMat);
+    noseDecal.position.set(0, 0.38, 2.15);
+    noseDecal.rotation.x = -0.55;
+    group.add(noseDecal);
+
+    const coverDecal = new THREE.Mesh(new THREE.PlaneGeometry(0.5, 0.4), decalMat);
+    coverDecal.position.set(0, 0.95, -1.2);
+    coverDecal.rotation.x = -1.15;
+    group.add(coverDecal);
+
+    /* --- DRS flap ------------------------------------------------- */
     const drsPivot = new THREE.Group();
-    drsPivot.position.set(0, 0.94, -2.74);
+    drsPivot.position.set(0, 0.96, -2.76);
     const drsFlap = new THREE.Mesh(
-        tint(new THREE.BoxGeometry(1.02, 0.04, 0.26), accent),
+        tint(new THREE.BoxGeometry(1.05, 0.035, 0.28), accent),
         paintMaterial
     );
     drsFlap.castShadow = quality.shadows;
     drsPivot.add(drsFlap);
+    // Endplate tips on flap
+    for (const side of [-1, 1]) {
+        const tip = new THREE.Mesh(tint(new THREE.BoxGeometry(0.03, 0.12, 0.28), secondary), paintMaterial);
+        tip.position.set(side * 0.52, 0.04, 0);
+        drsPivot.add(tip);
+    }
     group.add(drsPivot);
 
-    /* --- wheels ---------------------------------------------------- */
+    /* --- wheels --------------------------------------------------- */
     const wheelMaterial = new THREE.MeshStandardMaterial({
-        vertexColors: true, roughness: 0.78, metalness: 0.3
+        vertexColors: true, roughness: 0.82, metalness: 0.28, envMapIntensity: 0.6
     });
     const discMaterial = new THREE.MeshStandardMaterial({
-        color: 0x2a1a14, emissive: 0xff3a08, emissiveIntensity: 0, roughness: 0.5
+        color: 0x2a1810, emissive: 0xff3a08, emissiveIntensity: 0, roughness: 0.45, metalness: 0.5
     });
 
     const wheels = [];
     const discs = [];
     const layout = [
-        { x: 0.78, z: 1.72, r: 0.355, w: 0.32, steer: true },
-        { x: -0.78, z: 1.72, r: 0.355, w: 0.32, steer: true },
-        { x: 0.82, z: -1.72, r: 0.375, w: 0.42, steer: false },
-        { x: -0.82, z: -1.72, r: 0.375, w: 0.42, steer: false }
+        { x: 0.8, z: 1.72, r: 0.355, w: 0.305, steer: true },
+        { x: -0.8, z: 1.72, r: 0.355, w: 0.305, steer: true },
+        { x: 0.84, z: -1.72, r: 0.375, w: 0.405, steer: false },
+        { x: -0.84, z: -1.72, r: 0.375, w: 0.405, steer: false }
     ];
 
     for (const spec of layout) {
         const pivot = new THREE.Group();
         pivot.position.set(spec.x, spec.r, spec.z);
         const spin = new THREE.Group();
-        const mesh = new THREE.Mesh(buildWheel(spec.r, spec.w, accent), wheelMaterial);
+        const mesh = new THREE.Mesh(buildWheel(spec.r, spec.w, accent, compoundColor), wheelMaterial);
         mesh.castShadow = quality.shadows;
         spin.add(mesh);
 
         const disc = new THREE.Mesh(
-            new THREE.CylinderGeometry(spec.r * 0.55, spec.r * 0.55, spec.w * 0.5, 16),
+            new THREE.CylinderGeometry(spec.r * 0.52, spec.r * 0.52, spec.w * 0.45, 20),
             discMaterial
         );
         disc.rotation.z = Math.PI / 2;
         spin.add(disc);
         discs.push(disc);
 
+        // Caliper
+        const caliper = new THREE.Mesh(
+            tint(new THREE.BoxGeometry(0.08, 0.1, 0.14), accent),
+            darkMaterial
+        );
+        caliper.position.set(0, spec.r * 0.15, 0.08);
+        pivot.add(caliper);
+
         pivot.add(spin);
         group.add(pivot);
         wheels.push({ pivot, spin, spec });
     }
 
-    /* --- rain light ------------------------------------------------ */
+    // Exhaust tips
+    for (const side of [-0.08, 0.08]) {
+        const tip = new THREE.Mesh(
+            new THREE.CylinderGeometry(0.035, 0.04, 0.12, 10),
+            new THREE.MeshStandardMaterial({ color: 0x1a1a1c, roughness: 0.4, metalness: 0.8, emissive: 0x331100, emissiveIntensity: 0.3 })
+        );
+        tip.rotation.x = Math.PI / 2;
+        tip.position.set(side, 0.55, -2.7);
+        group.add(tip);
+    }
+
+    /* --- rain light ----------------------------------------------- */
     const rainLight = new THREE.Mesh(
-        new THREE.BoxGeometry(0.14, 0.14, 0.06),
+        new THREE.BoxGeometry(0.16, 0.14, 0.06),
         new THREE.MeshStandardMaterial({ color: 0x2a0505, emissive: 0xff1a1a, emissiveIntensity: 0 })
     );
-    rainLight.position.set(0, 0.42, -2.82);
+    rainLight.position.set(0, 0.44, -2.85);
     group.add(rainLight);
 
     if (isPlayer) group.userData.isPlayer = true;
@@ -331,8 +466,7 @@ export function buildCar(team, { quality, isPlayer = false } = {}) {
         wheels,
         discs,
         rainLight,
-        materials: { paintMaterial, darkMaterial, wheelMaterial, discMaterial },
-        /** @param {number} steer radians @param {number} spin radians */
+        materials: { paintMaterial, darkMaterial, carbonMaterial, wheelMaterial, discMaterial, decalMat },
         updateWheels(steer, spinDelta, suspension = 0) {
             for (const wheel of wheels) {
                 if (wheel.spec.steer) wheel.pivot.rotation.y = steer;
@@ -341,20 +475,22 @@ export function buildCar(team, { quality, isPlayer = false } = {}) {
             }
         },
         setBrakeGlow(amount) {
-            discMaterial.emissiveIntensity = amount * 3.4;
+            discMaterial.emissiveIntensity = amount * 4.2;
         },
         setDrs(open) {
-            drsPivot.rotation.x = open * -0.72;
+            drsPivot.rotation.x = open * -0.78;
         },
         setRainLight(on) {
-            rainLight.material.emissiveIntensity = on ? 4 : 0;
+            rainLight.material.emissiveIntensity = on ? 5 : 0;
         },
         dispose() {
             group.traverse((obj) => obj.geometry?.dispose());
             paintMaterial.dispose();
             darkMaterial.dispose();
+            carbonMaterial.dispose();
             wheelMaterial.dispose();
             discMaterial.dispose();
+            decalMat.dispose();
         }
     };
 

--- a/labs/f1-racing/src/carModel.js
+++ b/labs/f1-racing/src/carModel.js
@@ -321,14 +321,12 @@ export function buildCar(team, { quality, isPlayer = false, compoundColor = '#e8
 
     const paintMaterial = new THREE.MeshPhysicalMaterial({
         vertexColors: true,
-        roughness: 0.18,
-        metalness: 0.42,
+        roughness: 0.14,
+        metalness: 0.55,
         clearcoat: 1.0,
-        clearcoatRoughness: 0.06,
-        envMapIntensity: 2.0,
-        sheen: 0.35,
-        sheenRoughness: 0.4,
-        sheenColor: new THREE.Color(primary)
+        clearcoatRoughness: 0.05,
+        envMapIntensity: 2.6,
+        reflectivity: 0.9
     });
     const darkMaterial = new THREE.MeshStandardMaterial({
         vertexColors: true,

--- a/labs/f1-racing/src/config.js
+++ b/labs/f1-racing/src/config.js
@@ -239,9 +239,11 @@ export function detectQuality() {
     const mobile = matchMedia('(pointer: coarse)').matches;
     const cores = navigator.hardwareConcurrency || 4;
     const memory = navigator.deviceMemory || 4;
-    if (mobile || cores <= 4 || memory <= 4) return mobile && cores >= 6 ? 'medium' : 'low';
-    if (cores >= 8 && memory >= 8) return 'high';
-    return 'medium';
+    if (mobile) return cores >= 6 && memory >= 4 ? 'medium' : 'low';
+    // Desktop browsers: prefer medium+ so shadows/PBR read correctly.
+    if (cores >= 6 && memory >= 4) return 'high';
+    if (cores >= 4) return 'medium';
+    return 'low';
 }
 
 export function formatTime(seconds) {

--- a/labs/f1-racing/src/hud.js
+++ b/labs/f1-racing/src/hud.js
@@ -248,7 +248,8 @@ export class Hud {
         if (el.ersValue) el.ersValue.textContent = car.ers.toFixed(1);
 
         if (el.tyreLabel) {
-            el.tyreLabel.textContent = car.compound?.label?.[0] || 'M';
+            const map = { soft: 'S', medium: 'M', hard: 'H' };
+            el.tyreLabel.textContent = map[car.compound?.id] || 'M';
             el.tyreLabel.style.color = car.compound?.color || '#f0c419';
         }
         if (el.tyreWear) el.tyreWear.style.setProperty('--fill', (1 - (car.tyreWear || 0)).toFixed(3));

--- a/labs/f1-racing/src/hud.js
+++ b/labs/f1-racing/src/hud.js
@@ -245,6 +245,24 @@ export class Hud {
 
         const ersPct = (car.ers / 4) * 100;
         if (el.ersFill) el.ersFill.style.setProperty('--fill', (ersPct / 100).toFixed(3));
+        if (el.ersValue) el.ersValue.textContent = car.ers.toFixed(1);
+
+        if (el.tyreLabel) {
+            el.tyreLabel.textContent = car.compound?.label?.[0] || 'M';
+            el.tyreLabel.style.color = car.compound?.color || '#f0c419';
+        }
+        if (el.tyreWear) el.tyreWear.style.setProperty('--fill', (1 - (car.tyreWear || 0)).toFixed(3));
+        if (el.tyreTemp) {
+            const temp = Math.round(car.tyreTemp || 80);
+            el.tyreTemp.textContent = `${temp}°C`;
+            el.tyreTemp.dataset.state = temp < 55 ? 'cold' : temp > 105 ? 'hot' : 'ok';
+        }
+
+        if (el.drsBadge) {
+            const state = drsState || 'off';
+            el.drsBadge.dataset.state = state;
+            el.drsBadge.textContent = state === 'open' ? 'DRS OPEN' : state === 'ready' ? 'DRS READY' : 'DRS';
+        }
 
         if (el.sector && sector) el.sector.textContent = sector;
 

--- a/labs/f1-racing/src/input.js
+++ b/labs/f1-racing/src/input.js
@@ -6,14 +6,15 @@ const KEY_MAP = {
     ArrowLeft: 'left', KeyA: 'left',
     ArrowRight: 'right', KeyD: 'right',
     Space: 'ers', ShiftLeft: 'ers', ShiftRight: 'ers',
-    KeyE: 'drs'
+    KeyE: 'drs',
+    KeyB: 'lookBack'
 };
 
 export class InputManager {
     constructor({ root, actions = {} }) {
-        this.raw = { throttle: false, brake: false, left: false, right: false, ers: false, drs: false };
+        this.raw = { throttle: false, brake: false, left: false, right: false, ers: false, drs: false, lookBack: false };
         this.touch = { throttle: 0, brake: 0, left: 0, right: 0, ers: false, drs: false };
-        this.state = { throttle: 0, brake: 0, steer: 0, ers: false, drs: false };
+        this.state = { throttle: 0, brake: 0, steer: 0, ers: false, drs: false, lookBack: false };
         this.actions = actions;
         this.gamepadIndex = null;
         this.abort = new AbortController();
@@ -101,7 +102,8 @@ export class InputManager {
             throttle: Math.max(pad.buttons[7]?.value ?? 0, pad.buttons[0]?.pressed ? 1 : 0),
             brake: Math.max(pad.buttons[6]?.value ?? 0, pad.buttons[1]?.pressed ? 1 : 0),
             ers: pad.buttons[2]?.pressed ?? false,
-            drs: pad.buttons[3]?.pressed ?? false
+            drs: pad.buttons[3]?.pressed ?? false,
+            lookBack: pad.buttons[5]?.pressed ?? false
         };
     }
 
@@ -143,6 +145,7 @@ export class InputManager {
         this.state.steer = ramp(this.state.steer, steerTarget, returning ? 11 : 6.5, 12);
 
         this.state.ers = this.raw.ers || this.touch.ers || (pad?.ers ?? false);
+        this.state.lookBack = this.raw.lookBack || (pad?.lookBack ?? false);
 
         const drsHeld = this.raw.drs || (pad?.drs ?? false);
         if (drsHeld && !this.drsWasHeld) this.actions.toggleDrs?.();

--- a/labs/f1-racing/src/main.js
+++ b/labs/f1-racing/src/main.js
@@ -883,40 +883,41 @@ class Game {
 
     emitEffects(dt) {
         const car = this.player;
-        if (!car) return;
+        if (!car || this.state === 'countdown') return;
         const density = this.quality.particles;
 
         for (const other of this.cars) {
             const isPlayer = other === car;
             const distance = Math.hypot(other.position.x - car.position.x, other.position.z - car.position.z);
             if (!isPlayer && distance > 140) continue;
+            if (Math.abs(other.vx) < 8) continue;
 
             const forward = { x: Math.sin(other.yaw), z: Math.cos(other.yaw) };
             const rearX = other.position.x - forward.x * 1.9;
             const rearZ = other.position.z - forward.z * 1.9;
 
             // Tyre smoke from sliding or wheelspin.
-            const slide = Math.max(other.slip - 0.55, other.wheelSpin * 0.8, other.lockUp || 0);
-            if (slide > 0.05 && Math.random() < slide * density * 1.4) {
+            const slide = Math.max(other.slip - 0.7, other.wheelSpin * 0.75, (other.lockUp || 0) * 0.9);
+            if (slide > 0.08 && Math.random() < slide * density * 1.1) {
                 for (const side of [-0.8, 0.8]) {
                     this.smoke.spawn(
                         rearX + Math.cos(other.yaw) * side,
-                        other.position.y + 0.2,
+                        other.position.y + 0.22,
                         rearZ - Math.sin(other.yaw) * side,
-                        (Math.random() - 0.5) * 2.4,
-                        0.8 + Math.random(),
-                        (Math.random() - 0.5) * 2.4,
-                        { size: 0.9, life: 0.85 + Math.random() * 0.6, color: 0xb9bdc4, growth: 3.2 }
+                        (Math.random() - 0.5) * 2.0,
+                        0.6 + Math.random() * 0.8,
+                        (Math.random() - 0.5) * 2.0,
+                        { size: 0.55 + slide * 0.35, life: 0.7 + Math.random() * 0.5, color: 0xb9bdc4, growth: 2.4 }
                     );
                 }
             }
 
             // Dust when running wide.
-            if (other.offTrack && Math.abs(other.vx) > 12 && Math.random() < 0.6 * density) {
+            if (other.offTrack && Math.abs(other.vx) > 12 && Math.random() < 0.55 * density) {
                 this.smoke.spawn(
                     rearX, other.position.y + 0.1, rearZ,
-                    (Math.random() - 0.5) * 3, 1.4 + Math.random(), (Math.random() - 0.5) * 3,
-                    { size: 1.3, life: 1.1, color: 0x9c8a6b, growth: 3.6 }
+                    (Math.random() - 0.5) * 3, 1.2 + Math.random(), (Math.random() - 0.5) * 3,
+                    { size: 1.0, life: 1.0, color: 0x9c8a6b, growth: 3.0 }
                 );
             }
 
@@ -938,13 +939,15 @@ class Game {
                     -forward.x * 5 + (Math.random() - 0.5) * 3,
                     2.4 + Math.random() * 2,
                     -forward.z * 5 + (Math.random() - 0.5) * 3,
-                    { size: 1.1, life: 0.75, color: 0xd8e2ee, growth: 3.8 }
+                    { size: 0.95, life: 0.7, color: 0xd8e2ee, growth: 3.2 }
                 );
             }
         }
 
-        const slideIntensity = Math.max(car.slip - 0.6, car.lockUp || 0, car.wheelSpin * 0.7);
-        this.trails.push(car.position, car.yaw, 0.82, car.surface <= 1 ? slideIntensity : 0);
+        const slideIntensity = Math.max(car.slip - 0.7, car.lockUp || 0, car.wheelSpin * 0.7);
+        if (Math.abs(car.vx) > 10) {
+            this.trails.push(car.position, car.yaw, 0.82, car.surface <= 1 ? slideIntensity : 0);
+        }
         void dt;
     }
 

--- a/labs/f1-racing/src/main.js
+++ b/labs/f1-racing/src/main.js
@@ -99,7 +99,7 @@ class Game {
         renderer.setPixelRatio(Math.min(devicePixelRatio || 1, this.quality.pixelRatio));
         renderer.setSize(innerWidth, innerHeight, false);
         renderer.toneMapping = THREE.ACESFilmicToneMapping;
-        renderer.toneMappingExposure = 1.05;
+        renderer.toneMappingExposure = 1.12;
         renderer.shadowMap.enabled = this.quality.shadows;
         renderer.shadowMap.type = THREE.PCFSoftShadowMap;
 
@@ -370,7 +370,11 @@ class Game {
                 this.player = vehicle;
             }
 
-            const model = buildCar(team, { quality: this.quality, isPlayer });
+            const model = buildCar(team, {
+                quality: this.quality,
+                isPlayer,
+                compoundColor: (COMPOUNDS[compound] || COMPOUNDS.medium).color
+            });
             this.scene.add(model.group);
             this.models.set(vehicle, model);
         }
@@ -674,13 +678,16 @@ class Game {
                 }
             }
 
-            // DRS: enabled from lap 2, inside a zone, within one second of the car ahead.
+            // DRS: detection + activation zone, lap 2+, within 1s of car ahead.
             const zone = circuit.drsZoneAt(car.lapDistance / circuit.length);
             const ahead = this.carAhead(car);
             const withinRange = ahead && ahead.gapSeconds < 1.0;
-            car.drsAvailable = Boolean(zone) && car.lap >= 1 && Boolean(withinRange) && !car.offTrack;
-            if (!car.drsAvailable || car.brake > 0.25) car.drsOpen = false;
-            if (car !== this.player && car.drsAvailable && car.throttle > 0.8) car.drsOpen = true;
+            const inActivation = zone && (car.lapDistance / circuit.length) >= zone.start
+                && (car.lapDistance / circuit.length) <= zone.end;
+            car.drsAvailable = Boolean(inActivation) && car.lap >= 1 && Boolean(withinRange)
+                && !car.offTrack && car.surface <= 1;
+            if (!car.drsAvailable || car.brake > 0.2) car.drsOpen = false;
+            if (car !== this.player && car.drsAvailable && car.throttle > 0.75) car.drsOpen = true;
         }
 
         this.order = [...this.cars].sort((a, b) => {
@@ -787,27 +794,37 @@ class Game {
         RIGHT.set(Math.cos(car.yaw), 0, -Math.sin(car.yaw));
         CAR_POS.set(car.position.x, car.position.y, car.position.z);
         const speedNorm = Math.min(1, Math.abs(car.vx) / 90);
-        let fov = 62;
+        const lookBack = this.input?.state?.lookBack;
+        let targetFov = 62;
 
-        switch (this.cameraMode) {
+        if (lookBack) {
+            DESIRED.copy(CAR_POS).addScaledVector(FORWARD, 7.5);
+            DESIRED.y += 2.4;
+            const follow = 1 - Math.exp(-dt * 10);
+            this.camera.position.lerp(DESIRED, follow);
+            LOOK_AT.copy(CAR_POS).addScaledVector(FORWARD, -18);
+            LOOK_AT.y += 1.0;
+            this.cameraLook.lerp(LOOK_AT, Math.min(1, dt * 12));
+            targetFov = 58;
+        } else switch (this.cameraMode) {
             case 'cockpit': {
-                this.camera.position.copy(CAR_POS).addScaledVector(FORWARD, 0.25);
-                this.camera.position.y += 1.02;
+                this.camera.position.copy(CAR_POS).addScaledVector(FORWARD, 0.22);
+                this.camera.position.y += 1.05;
                 LOOK_AT.copy(CAR_POS)
-                    .addScaledVector(FORWARD, 26)
-                    .addScaledVector(RIGHT, car.steer * 22);
-                LOOK_AT.y += 1.1;
+                    .addScaledVector(FORWARD, 28)
+                    .addScaledVector(RIGHT, car.steer * 18);
+                LOOK_AT.y += 1.05;
                 this.cameraLook.copy(LOOK_AT);
-                fov = 74 + speedNorm * 10;
+                targetFov = 72 + speedNorm * 12;
                 break;
             }
             case 'bonnet': {
-                this.camera.position.copy(CAR_POS).addScaledVector(FORWARD, 1.7);
-                this.camera.position.y += 0.78;
-                LOOK_AT.copy(CAR_POS).addScaledVector(FORWARD, 32);
-                LOOK_AT.y += 0.9;
+                this.camera.position.copy(CAR_POS).addScaledVector(FORWARD, 1.75);
+                this.camera.position.y += 0.8;
+                LOOK_AT.copy(CAR_POS).addScaledVector(FORWARD, 34);
+                LOOK_AT.y += 0.85;
                 this.cameraLook.copy(LOOK_AT);
-                fov = 70 + speedNorm * 12;
+                targetFov = 68 + speedNorm * 14;
                 break;
             }
             case 'broadcast': {
@@ -821,47 +838,46 @@ class Game {
                 }
                 this.camera.position.lerp(best, Math.min(1, dt * 6));
                 this.cameraLook.lerp(CAR_POS, Math.min(1, dt * 9));
-                fov = 32 + Math.min(28, best.distanceTo(CAR_POS) * 0.16);
+                targetFov = 32 + Math.min(28, best.distanceTo(CAR_POS) * 0.16);
                 break;
             }
             default: {
-                const back = 8.4 + speedNorm * 2.2;
-                const height = 3.1 + speedNorm * 0.5;
+                const back = 8.8 + speedNorm * 2.4;
+                const height = 3.2 + speedNorm * 0.55;
                 DESIRED.copy(CAR_POS)
                     .addScaledVector(FORWARD, -back)
-                    // Swing wide through corners so the apex stays in shot.
-                    .addScaledVector(RIGHT, -car.yawRate * 3.2);
+                    .addScaledVector(RIGHT, -car.yawRate * 2.8);
                 DESIRED.y += height;
-                const follow = 1 - Math.exp(-dt * (6 + speedNorm * 4));
+                const follow = 1 - Math.exp(-dt * (5.5 + speedNorm * 3.5));
                 this.camera.position.lerp(DESIRED, follow);
 
-                LOOK_AT.copy(CAR_POS).addScaledVector(FORWARD, 12);
-                LOOK_AT.y += 1.2;
+                LOOK_AT.copy(CAR_POS).addScaledVector(FORWARD, 14);
+                LOOK_AT.y += 1.15;
                 this.cameraLook.lerp(LOOK_AT, Math.min(1, dt * 8));
-                fov = 62 + speedNorm * 14;
+                targetFov = 60 + speedNorm * 16;
                 break;
             }
         }
-        
-        const groundClearance = this.circuit ? this.circuit.heightAt(this.circuit.nearest(this.camera.position.x, this.camera.position.z), 0) + 0.5 : -999;
+
+        const groundClearance = this.circuit
+            ? this.circuit.heightAt(this.circuit.nearest(this.camera.position.x, this.camera.position.z), 0) + 0.5
+            : -999;
         if (this.camera.position.y < groundClearance) {
             this.camera.position.y = groundClearance;
         }
 
-        // Camera Shake / Force Feedback effect at high speeds
-        if (speedNorm > 0.5 && this.cameraMode !== 'broadcast') {
-            const shakeFactor = Math.pow((speedNorm - 0.5) * 2, 2) * 0.05;
+        if (speedNorm > 0.55 && this.cameraMode !== 'broadcast' && !lookBack) {
+            const shakeFactor = Math.pow((speedNorm - 0.55) * 2.2, 2) * 0.04;
             this.cameraLook.x += (Math.random() - 0.5) * shakeFactor;
-            this.cameraLook.y += (Math.random() - 0.5) * shakeFactor;
+            this.cameraLook.y += (Math.random() - 0.5) * shakeFactor * 0.7;
         }
 
         this.camera.lookAt(this.cameraLook);
-        this.camera.fov = fov;
-        this.camera.updateProjectionMatrix();
-        // A touch of head tilt in the cockpit sells the lateral load.
-        if (this.cameraMode === 'cockpit') this.camera.rotateZ(-car.roll * 0.8 - car.steer * 0.12);
+        if (this.cameraMode === 'cockpit' && !lookBack) {
+            this.camera.rotateZ(-car.roll * 0.85 - car.steer * 0.1);
+        }
 
-        this.camera.fov += (fov - this.camera.fov) * Math.min(1, dt * 4);
+        this.camera.fov += (targetFov - this.camera.fov) * Math.min(1, dt * 5);
         this.camera.updateProjectionMatrix();
     }
 

--- a/labs/f1-racing/src/textures.js
+++ b/labs/f1-racing/src/textures.js
@@ -1,4 +1,4 @@
-/** Procedurally generated textures — nothing is loaded over the network. */
+/** Procedural PBR textures — albedo, normal and roughness from canvas, no network assets. */
 
 import * as THREE from 'three';
 
@@ -25,10 +25,15 @@ function makeTexture(key, w, h, draw, { repeat = [1, 1], srgb = true, aniso = 8 
     return texture;
 }
 
+/** Seeded PRNG for repeatable surfaces. */
+function rng(seed = 1) {
+    let s = seed >>> 0;
+    return () => (s = (s * 1664525 + 1013904223) >>> 0) / 4294967296;
+}
+
 /** Value noise, tiled so the texture repeats seamlessly. */
 function noiseField(ctx, w, h, { cells = 32, alpha = 0.25, light = 255, dark = 0, seed = 1 } = {}) {
-    let s = seed;
-    const rand = () => (s = (s * 1664525 + 1013904223) >>> 0) / 4294967296;
+    const rand = rng(seed);
     const grid = new Float32Array((cells + 1) * (cells + 1));
     for (let y = 0; y <= cells; y++) {
         for (let x = 0; x <= cells; x++) {
@@ -63,8 +68,7 @@ function noiseField(ctx, w, h, { cells = 32, alpha = 0.25, light = 255, dark = 0
 }
 
 function speckle(ctx, w, h, count, colors, size = 2, seed = 7) {
-    let s = seed;
-    const rand = () => (s = (s * 1103515245 + 12345) >>> 0) / 4294967296;
+    const rand = rng(seed);
     for (let i = 0; i < count; i++) {
         ctx.fillStyle = colors[Math.floor(rand() * colors.length)];
         const r = size * (0.4 + rand());
@@ -72,144 +76,309 @@ function speckle(ctx, w, h, count, colors, size = 2, seed = 7) {
     }
 }
 
-/**
- * Road surface. `u` runs across the track, so the white edge lines and the darker
- * rubbered-in racing line are baked straight into the texture.
- */
-export function roadTexture(base = 0x22242a) { // Darker realistic asphalt base
-    const key = `road-${base}`;
-    return makeTexture(key, 1024, 1024, (ctx, w, h) => { // Higher resolution
-        const col = new THREE.Color(base);
-        ctx.fillStyle = `#${col.getHexString()}`;
-        ctx.fillRect(0, 0, w, h);
-        noiseField(ctx, w, h, { cells: 60, alpha: 0.15, light: 180, dark: 30, seed: 12 });
-        noiseField(ctx, w, h, { cells: 200, alpha: 0.1, light: 200, dark: 50, seed: 88 });
-        speckle(ctx, w, h, 15000, ['#00000044', '#ffffff11', '#00000066'], 2, 33); // More speckles for macro texture
-
-        // Asphalt seam down the middle of the lane.
-        ctx.globalAlpha = 0.25;
-        ctx.fillStyle = '#000';
-        ctx.fillRect(w * 0.5 - 2, 0, 4, h);
-        ctx.globalAlpha = 1;
-
-        // Painted edge lines.
-        ctx.fillStyle = '#e9ecef';
-        ctx.fillRect(w * 0.022, 0, w * 0.028, h);
-        ctx.fillRect(w * 0.95, 0, w * 0.028, h);
-        
-        // Add subtle tyre grooves / rubbering near edges
-        ctx.globalAlpha = 0.1;
-        ctx.fillStyle = '#000';
-        ctx.fillRect(w * 0.1, 0, w * 0.15, h);
-        ctx.fillRect(w * 0.75, 0, w * 0.15, h);
-        
-        ctx.globalAlpha = 0.35;
-        speckle(ctx, w, h, 1200, ['#0008'], 3, 5);
-        ctx.globalAlpha = 1;
-    }, { repeat: [1, 1], aniso: 16 });
-}
-
-/** Rubber build-up on the racing line, blended over the road with a second pass. */
-export function kerbTexture() {
-    return makeTexture('kerb', 64, 128, (ctx, w, h) => {
-        const bands = 4;
-        for (let i = 0; i < bands; i++) {
-            ctx.fillStyle = i % 2 === 0 ? '#d93b32' : '#f2f3f5';
-            ctx.fillRect(0, (i * h) / bands, w, h / bands);
+/** Derive a tangent-space normal map from luminance of an albedo canvas. */
+function heightToNormal(srcCtx, w, h, strength = 2.4) {
+    const src = srcCtx.getImageData(0, 0, w, h).data;
+    const out = canvas(w, h);
+    const ctx = out.getContext('2d');
+    const img = ctx.createImageData(w, h);
+    const d = img.data;
+    const lum = (x, y) => {
+        const i = (((y + h) % h) * w + ((x + w) % w)) * 4;
+        return (src[i] * 0.299 + src[i + 1] * 0.587 + src[i + 2] * 0.114) / 255;
+    };
+    for (let y = 0; y < h; y++) {
+        for (let x = 0; x < w; x++) {
+            const dx = (lum(x + 1, y) - lum(x - 1, y)) * strength;
+            const dy = (lum(x, y + 1) - lum(x, y - 1)) * strength;
+            const len = Math.hypot(dx, dy, 1) || 1;
+            const i = (y * w + x) * 4;
+            d[i] = ((-dx / len) * 0.5 + 0.5) * 255;
+            d[i + 1] = ((-dy / len) * 0.5 + 0.5) * 255;
+            d[i + 2] = (1 / len) * 0.5 * 255 + 128;
+            d[i + 3] = 255;
         }
-        noiseField(ctx, w, h, { cells: 20, alpha: 0.16, light: 255, dark: 90, seed: 4 });
-        ctx.globalAlpha = 0.25;
-        speckle(ctx, w, h, 400, ['#0007'], 2, 19);
-        ctx.globalAlpha = 1;
-    }, { repeat: [1, 1] });
+    }
+    ctx.putImageData(img, 0, 0);
+    return out;
 }
 
-export function grassTexture(tint = 0x223618) { // Darker grass tint
-    return makeTexture(`grass-${tint}`, 1024, 1024, (ctx, w, h) => { // Higher res
-        const col = new THREE.Color(tint);
-        ctx.fillStyle = `#${col.getHexString()}`;
-        ctx.fillRect(0, 0, w, h);
-        noiseField(ctx, w, h, { cells: 35, alpha: 0.45, light: 130, dark: 10, seed: 21 });
-        noiseField(ctx, w, h, { cells: 150, alpha: 0.25, light: 160, dark: 20, seed: 55 });
-        speckle(ctx, w, h, 18000, ['#00000033', '#7fa04a22', '#4c6b2a44'], 3, 91);
-    }, { repeat: [1, 1], aniso: 8 });
+function roughnessFromAlbedo(srcCtx, w, h, { base = 0.82, contrast = 0.22, invert = false } = {}) {
+    const src = srcCtx.getImageData(0, 0, w, h).data;
+    const out = canvas(w, h);
+    const ctx = out.getContext('2d');
+    const img = ctx.createImageData(w, h);
+    const d = img.data;
+    for (let i = 0; i < src.length; i += 4) {
+        let v = (src[i] + src[i + 1] + src[i + 2]) / (3 * 255);
+        if (invert) v = 1 - v;
+        const r = Math.max(0, Math.min(1, base + (v - 0.5) * contrast));
+        const g = Math.round(r * 255);
+        d[i] = d[i + 1] = d[i + 2] = g;
+        d[i + 3] = 255;
+    }
+    ctx.putImageData(img, 0, 0);
+    return out;
 }
 
-/** Asphalt run-off apron: like the track but lighter, unmarked and coarser. */
+function packMaps(key, albedoCanvas, { strength = 2.2, roughBase = 0.84, roughContrast = 0.2, aniso = 8, repeat = [1, 1] } = {}) {
+    const mapKey = `${key}-pack`;
+    if (cache.has(mapKey)) return cache.get(mapKey);
+
+    const w = albedoCanvas.width;
+    const h = albedoCanvas.height;
+    const aCtx = albedoCanvas.getContext('2d');
+
+    const map = new THREE.CanvasTexture(albedoCanvas);
+    map.wrapS = map.wrapT = THREE.RepeatWrapping;
+    map.repeat.set(repeat[0], repeat[1]);
+    map.anisotropy = aniso;
+    map.colorSpace = THREE.SRGBColorSpace;
+
+    const normal = new THREE.CanvasTexture(heightToNormal(aCtx, w, h, strength));
+    normal.wrapS = normal.wrapT = THREE.RepeatWrapping;
+    normal.repeat.set(repeat[0], repeat[1]);
+    normal.anisotropy = aniso;
+    normal.colorSpace = THREE.NoColorSpace;
+
+    const rough = new THREE.CanvasTexture(roughnessFromAlbedo(aCtx, w, h, { base: roughBase, contrast: roughContrast }));
+    rough.wrapS = rough.wrapT = THREE.RepeatWrapping;
+    rough.repeat.set(repeat[0], repeat[1]);
+    rough.anisotropy = Math.min(4, aniso);
+    rough.colorSpace = THREE.NoColorSpace;
+
+    const pack = { map, normalMap: normal, roughnessMap: rough };
+    cache.set(mapKey, pack);
+    return pack;
+}
+
+/**
+ * Road surface. `u` runs across the track — white edge lines and darker rubbered
+ * racing line are baked into the albedo for a Grand Prix look.
+ */
+export function roadTexture(base = 0x1e2026) {
+    const key = `road-${base}`;
+    if (cache.has(`${key}-pack`)) return cache.get(`${key}-pack`).map;
+
+    const el = canvas(1024, 1024);
+    const ctx = el.getContext('2d');
+    const col = new THREE.Color(base);
+    ctx.fillStyle = `#${col.getHexString()}`;
+    ctx.fillRect(0, 0, 1024, 1024);
+
+    noiseField(ctx, 1024, 1024, { cells: 48, alpha: 0.18, light: 170, dark: 28, seed: 12 });
+    noiseField(ctx, 1024, 1024, { cells: 180, alpha: 0.12, light: 195, dark: 40, seed: 88 });
+    noiseField(ctx, 1024, 1024, { cells: 320, alpha: 0.08, light: 210, dark: 55, seed: 201 });
+    speckle(ctx, 1024, 1024, 22000, ['#00000055', '#ffffff14', '#00000077', '#3a3c4222'], 2, 33);
+
+    // Aggregate chips — small bright/dark stones in the asphalt matrix.
+    const rand = rng(404);
+    for (let i = 0; i < 9000; i++) {
+        ctx.fillStyle = rand() > 0.55 ? '#2a2c3288' : '#6a6e7688';
+        ctx.fillRect(rand() * 1024, rand() * 1024, 1 + rand() * 2, 1 + rand());
+    }
+
+    // Longitudinal rubber build-up (racing line).
+    ctx.globalAlpha = 0.22;
+    ctx.fillStyle = '#0a0a0c';
+    ctx.fillRect(1024 * 0.28, 0, 1024 * 0.18, 1024);
+    ctx.fillRect(1024 * 0.54, 0, 1024 * 0.18, 1024);
+    ctx.globalAlpha = 0.12;
+    ctx.fillRect(1024 * 0.12, 0, 1024 * 0.12, 1024);
+    ctx.fillRect(1024 * 0.76, 0, 1024 * 0.12, 1024);
+
+    // Asphalt seam / expansion joint.
+    ctx.globalAlpha = 0.35;
+    ctx.fillStyle = '#000';
+    ctx.fillRect(1024 * 0.5 - 1.5, 0, 3, 1024);
+
+    // Painted edge lines with slight wear.
+    ctx.globalAlpha = 1;
+    ctx.fillStyle = '#e8ebf0';
+    ctx.fillRect(1024 * 0.018, 0, 1024 * 0.032, 1024);
+    ctx.fillRect(1024 * 0.95, 0, 1024 * 0.032, 1024);
+    ctx.globalAlpha = 0.35;
+    speckle(ctx, 1024, 1024, 800, ['#0009'], 2, 5);
+    ctx.globalAlpha = 1;
+
+    // Dashed centre guideline (subtle).
+    ctx.globalAlpha = 0.18;
+    ctx.fillStyle = '#d0d4da';
+    for (let y = 0; y < 1024; y += 48) ctx.fillRect(1024 * 0.5 - 2, y, 4, 22);
+    ctx.globalAlpha = 1;
+
+    const pack = packMaps(key, el, { strength: 3.2, roughBase: 0.88, roughContrast: 0.18, aniso: 16 });
+    return pack.map;
+}
+
+export function roadMaps(base = 0x1e2026) {
+    roadTexture(base);
+    return cache.get(`road-${base}-pack`);
+}
+
+export function kerbTexture() {
+    const key = 'kerb';
+    if (cache.has(`${key}-pack`)) return cache.get(`${key}-pack`).map;
+
+    const el = canvas(128, 256);
+    const ctx = el.getContext('2d');
+    const bands = 8;
+    for (let i = 0; i < bands; i++) {
+        ctx.fillStyle = i % 2 === 0 ? '#c92e28' : '#f4f5f7';
+        ctx.fillRect(0, (i * 256) / bands, 128, 256 / bands);
+    }
+    // Raised serration ridges.
+    ctx.globalAlpha = 0.28;
+    for (let i = 0; i < bands; i++) {
+        ctx.fillStyle = '#000';
+        ctx.fillRect(0, (i * 256) / bands, 128, 3);
+        ctx.fillStyle = '#fff';
+        ctx.fillRect(0, (i * 256) / bands + 3, 128, 2);
+    }
+    ctx.globalAlpha = 1;
+    noiseField(ctx, 128, 256, { cells: 24, alpha: 0.18, light: 255, dark: 80, seed: 4 });
+    speckle(ctx, 128, 256, 600, ['#0008', '#fff3'], 2, 19);
+
+    packMaps(key, el, { strength: 4.5, roughBase: 0.55, roughContrast: 0.3, aniso: 8 });
+    return cache.get(`${key}-pack`).map;
+}
+
+export function kerbMaps() {
+    kerbTexture();
+    return cache.get('kerb-pack');
+}
+
+export function grassTexture(tint = 0x1f3518) {
+    const key = `grass-${tint}`;
+    if (cache.has(`${key}-pack`)) return cache.get(`${key}-pack`).map;
+
+    const el = canvas(1024, 1024);
+    const ctx = el.getContext('2d');
+    const col = new THREE.Color(tint);
+    ctx.fillStyle = `#${col.getHexString()}`;
+    ctx.fillRect(0, 0, 1024, 1024);
+    noiseField(ctx, 1024, 1024, { cells: 28, alpha: 0.42, light: 120, dark: 8, seed: 21 });
+    noiseField(ctx, 1024, 1024, { cells: 140, alpha: 0.28, light: 150, dark: 18, seed: 55 });
+    noiseField(ctx, 1024, 1024, { cells: 280, alpha: 0.15, light: 170, dark: 30, seed: 99 });
+
+    // Blade streaks.
+    const rand = rng(77);
+    ctx.globalAlpha = 0.2;
+    for (let i = 0; i < 6000; i++) {
+        const x = rand() * 1024;
+        const y = rand() * 1024;
+        ctx.strokeStyle = rand() > 0.5 ? '#6a9a3a' : '#14280e';
+        ctx.beginPath();
+        ctx.moveTo(x, y);
+        ctx.lineTo(x + (rand() - 0.5) * 4, y - 6 - rand() * 10);
+        ctx.stroke();
+    }
+    ctx.globalAlpha = 1;
+    speckle(ctx, 1024, 1024, 14000, ['#00000044', '#7fa04a33', '#4c6b2a55'], 2, 91);
+
+    packMaps(key, el, { strength: 2.8, roughBase: 0.95, roughContrast: 0.12, aniso: 8 });
+    return cache.get(`${key}-pack`).map;
+}
+
+export function grassMaps(tint = 0x1f3518) {
+    grassTexture(tint);
+    return cache.get(`grass-${tint}-pack`);
+}
+
 export function runoffTexture() {
-    return makeTexture('runoff', 256, 256, (ctx, w, h) => {
-        ctx.fillStyle = '#4c5057';
-        ctx.fillRect(0, 0, w, h);
-        noiseField(ctx, w, h, { cells: 30, alpha: 0.24, light: 200, dark: 60, seed: 71 });
-        noiseField(ctx, w, h, { cells: 110, alpha: 0.14, light: 180, dark: 70, seed: 19 });
-        speckle(ctx, w, h, 3000, ['#0005', '#fff1'], 2, 12);
-    }, { repeat: [1, 1] });
+    const key = 'runoff';
+    if (cache.has(`${key}-pack`)) return cache.get(`${key}-pack`).map;
+    const el = canvas(512, 512);
+    const ctx = el.getContext('2d');
+    ctx.fillStyle = '#4a4e55';
+    ctx.fillRect(0, 0, 512, 512);
+    noiseField(ctx, 512, 512, { cells: 36, alpha: 0.26, light: 200, dark: 55, seed: 71 });
+    noiseField(ctx, 512, 512, { cells: 140, alpha: 0.16, light: 180, dark: 65, seed: 19 });
+    speckle(ctx, 512, 512, 8000, ['#0006', '#fff2', '#2a2c30aa'], 2, 12);
+    packMaps(key, el, { strength: 2.6, roughBase: 0.9, roughContrast: 0.15 });
+    return cache.get(`${key}-pack`).map;
+}
+
+export function runoffMaps() {
+    runoffTexture();
+    return cache.get('runoff-pack');
 }
 
 export function gravelTexture() {
-    return makeTexture('gravel', 512, 512, (ctx, w, h) => {
-        ctx.fillStyle = '#8d7a5c';
-        ctx.fillRect(0, 0, w, h);
-        noiseField(ctx, w, h, { cells: 60, alpha: 0.35, light: 225, dark: 90, seed: 6 });
-        speckle(ctx, w, h, 14000, ['#00000033', '#ffffff33', '#6b5c42aa'], 3, 41);
-    }, { repeat: [1, 1] });
+    const key = 'gravel';
+    if (cache.has(`${key}-pack`)) return cache.get(`${key}-pack`).map;
+    const el = canvas(512, 512);
+    const ctx = el.getContext('2d');
+    ctx.fillStyle = '#8a7658';
+    ctx.fillRect(0, 0, 512, 512);
+    noiseField(ctx, 512, 512, { cells: 70, alpha: 0.38, light: 230, dark: 85, seed: 6 });
+    const rand = rng(41);
+    for (let i = 0; i < 18000; i++) {
+        const r = 1 + rand() * 3;
+        ctx.fillStyle = rand() > 0.5 ? '#c4b089' : '#5a4a32';
+        ctx.beginPath();
+        ctx.arc(rand() * 512, rand() * 512, r, 0, Math.PI * 2);
+        ctx.fill();
+    }
+    packMaps(key, el, { strength: 4.0, roughBase: 0.98, roughContrast: 0.1 });
+    return cache.get(`${key}-pack`).map;
+}
+
+export function gravelMaps() {
+    gravelTexture();
+    return cache.get('gravel-pack');
 }
 
 export function concreteTexture() {
-    return makeTexture('concrete', 256, 256, (ctx, w, h) => {
-        ctx.fillStyle = '#9aa0a6';
-        ctx.fillRect(0, 0, w, h);
-        noiseField(ctx, w, h, { cells: 24, alpha: 0.25, light: 230, dark: 120, seed: 17 });
-        ctx.strokeStyle = '#00000033';
-        ctx.lineWidth = 2;
-        for (let i = 0; i <= 4; i++) {
-            ctx.beginPath();
-            ctx.moveTo(0, (i * h) / 4);
-            ctx.lineTo(w, (i * h) / 4);
-            ctx.stroke();
-        }
-    }, { repeat: [1, 1] });
+    const key = 'concrete';
+    if (cache.has(`${key}-pack`)) return cache.get(`${key}-pack`).map;
+    const el = canvas(512, 512);
+    const ctx = el.getContext('2d');
+    ctx.fillStyle = '#949aa0';
+    ctx.fillRect(0, 0, 512, 512);
+    noiseField(ctx, 512, 512, { cells: 28, alpha: 0.28, light: 230, dark: 110, seed: 17 });
+    noiseField(ctx, 512, 512, { cells: 120, alpha: 0.12, light: 200, dark: 90, seed: 44 });
+    ctx.strokeStyle = '#00000040';
+    ctx.lineWidth = 2;
+    for (let i = 0; i <= 6; i++) {
+        ctx.beginPath();
+        ctx.moveTo(0, (i * 512) / 6);
+        ctx.lineTo(512, (i * 512) / 6);
+        ctx.stroke();
+    }
+    for (let i = 0; i <= 4; i++) {
+        ctx.beginPath();
+        ctx.moveTo((i * 512) / 4, 0);
+        ctx.lineTo((i * 512) / 4, 512);
+        ctx.stroke();
+    }
+    speckle(ctx, 512, 512, 4000, ['#0004', '#fff2'], 2, 9);
+    packMaps(key, el, { strength: 2.0, roughBase: 0.78, roughContrast: 0.16 });
+    return cache.get(`${key}-pack`).map;
 }
 
-/** Grandstand crowd: coloured dots that read as people from a distance. */
-export function crowdTexture() {
-    return makeTexture('crowd', 256, 128, (ctx, w, h) => {
-        ctx.fillStyle = '#15181d';
-        ctx.fillRect(0, 0, w, h);
-        const palette = ['#e8e8e8', '#d94f4f', '#4f7fd9', '#e0c65a', '#54b06a', '#c96ad0', '#f0a04b', '#2a2f38'];
-        let s = 99;
-        const rand = () => (s = (s * 1664525 + 1013904223) >>> 0) / 4294967296;
-        for (let row = 0; row < 16; row++) {
-            for (let i = 0; i < 46; i++) {
-                const x = (i / 46) * w + (rand() - 0.5) * 4;
-                const y = (row / 16) * h + 3;
-                ctx.fillStyle = palette[Math.floor(rand() * palette.length)];
-                ctx.beginPath();
-                ctx.arc(x, y, 2 + rand() * 1.4, 0, Math.PI * 2);
-                ctx.fill();
-            }
-        }
-        ctx.globalAlpha = 0.25;
-        ctx.fillStyle = '#000';
-        ctx.fillRect(0, 0, w, h);
-        ctx.globalAlpha = 1;
-    }, { repeat: [1, 1] });
+export function concreteMaps() {
+    concreteTexture();
+    return cache.get('concrete-pack');
 }
 
-/** Start/finish grid: the painted chequered band across the track. */
-export function startLineTexture() {
-    return makeTexture('startline', 256, 64, (ctx, w, h) => {
-        ctx.fillStyle = '#e9ecef';
+/** Carbon-fibre weave for monocoque accents. */
+export function carbonTexture() {
+    return makeTexture('carbon', 256, 256, (ctx, w, h) => {
+        ctx.fillStyle = '#0c0e12';
         ctx.fillRect(0, 0, w, h);
-        ctx.fillStyle = '#15171c';
-        const cols = 16, rows = 4;
-        for (let y = 0; y < rows; y++) {
-            for (let x = 0; x < cols; x++) {
-                if ((x + y) % 2 === 0) continue;
-                ctx.fillRect((x * w) / cols, (y * h) / rows, w / cols, h / rows);
+        const cell = 8;
+        for (let y = 0; y < h; y += cell) {
+            for (let x = 0; x < w; x += cell) {
+                const dark = ((x / cell) + (y / cell)) % 2 === 0;
+                ctx.fillStyle = dark ? '#12151b' : '#1a1e26';
+                ctx.fillRect(x, y, cell, cell);
+                ctx.fillStyle = dark ? '#2a303a22' : '#080a0e44';
+                ctx.fillRect(x + 1, y + 1, cell - 2, cell - 2);
             }
         }
-    }, { repeat: [1, 1] });
+        noiseField(ctx, w, h, { cells: 40, alpha: 0.12, light: 180, dark: 20, seed: 3 });
+    }, { aniso: 4 });
 }
 
 /** Soft radial sprite reused by smoke, spray and dust. */
@@ -224,28 +393,162 @@ export function smokeTexture() {
     }, { srgb: false });
 }
 
-/** Car number + team stripe used on the nose and the engine cover. */
-export function liveryTexture(team) {
-    const key = `livery-${team.id}`;
-    return makeTexture(key, 256, 256, (ctx, w, h) => {
+/** Grandstand crowd: denser coloured silhouettes. */
+export function crowdTexture() {
+    return makeTexture('crowd', 512, 256, (ctx, w, h) => {
+        ctx.fillStyle = '#12151a';
+        ctx.fillRect(0, 0, w, h);
+        const palette = ['#e8e8e8', '#d94f4f', '#4f7fd9', '#e0c65a', '#54b06a', '#c96ad0', '#f0a04b', '#2a2f38', '#f5f5f5', '#1a6bb5'];
+        const rand = rng(99);
+        for (let row = 0; row < 22; row++) {
+            for (let i = 0; i < 72; i++) {
+                const x = (i / 72) * w + (rand() - 0.5) * 5;
+                const y = (row / 22) * h + 4;
+                ctx.fillStyle = palette[Math.floor(rand() * palette.length)];
+                // Body
+                ctx.fillRect(x - 1.2, y, 2.4, 5 + rand() * 3);
+                // Head
+                ctx.beginPath();
+                ctx.arc(x, y - 1.2, 1.4 + rand() * 0.6, 0, Math.PI * 2);
+                ctx.fill();
+            }
+        }
+        ctx.globalAlpha = 0.22;
+        ctx.fillStyle = '#000';
+        ctx.fillRect(0, 0, w, h);
+        ctx.globalAlpha = 1;
+    }, { repeat: [1, 1] });
+}
+
+export function startLineTexture() {
+    return makeTexture('startline', 512, 128, (ctx, w, h) => {
+        ctx.fillStyle = '#f0f2f6';
+        ctx.fillRect(0, 0, w, h);
+        ctx.fillStyle = '#101218';
+        const cols = 20, rows = 5;
+        for (let y = 0; y < rows; y++) {
+            for (let x = 0; x < cols; x++) {
+                if ((x + y) % 2 === 0) continue;
+                ctx.fillRect((x * w) / cols, (y * h) / rows, w / cols, h / rows);
+            }
+        }
+        noiseField(ctx, w, h, { cells: 20, alpha: 0.1, light: 255, dark: 40, seed: 2 });
+    }, { repeat: [1, 1] });
+}
+
+/** Team ad board with logo-like typography. */
+export function bannerTexture(team) {
+    const key = `banner-${team.id}`;
+    return makeTexture(key, 512, 128, (ctx, w, h) => {
         const primary = new THREE.Color(team.primary);
         const accent = new THREE.Color(team.accent);
-        ctx.fillStyle = `#${primary.getHexString()}`;
+        const secondary = new THREE.Color(team.secondary);
+        const g = ctx.createLinearGradient(0, 0, w, 0);
+        g.addColorStop(0, `#${secondary.getHexString()}`);
+        g.addColorStop(0.35, `#${primary.getHexString()}`);
+        g.addColorStop(1, `#${accent.getHexString()}`);
+        ctx.fillStyle = g;
         ctx.fillRect(0, 0, w, h);
-        ctx.fillStyle = `#${accent.getHexString()}`;
-        ctx.fillRect(0, h * 0.68, w, h * 0.06);
-        ctx.fillStyle = 'rgba(255,255,255,0.9)';
-        ctx.font = 'bold 150px Inter, Helvetica, Arial, sans-serif';
+        ctx.fillStyle = 'rgba(0,0,0,0.25)';
+        ctx.fillRect(0, h * 0.78, w, h * 0.22);
+        ctx.fillStyle = '#fff';
+        ctx.font = 'bold 48px Orbitron, Helvetica, Arial, sans-serif';
         ctx.textAlign = 'center';
         ctx.textBaseline = 'middle';
-        ctx.fillText(String(team.number), w / 2, h * 0.4);
-        ctx.font = 'bold 34px Inter, Helvetica, Arial, sans-serif';
+        ctx.fillText(team.short, w * 0.5, h * 0.42);
+        ctx.font = '600 18px Inter, Helvetica, Arial, sans-serif';
         ctx.fillStyle = 'rgba(255,255,255,0.75)';
+        ctx.fillText(team.name.toUpperCase(), w * 0.5, h * 0.88);
+    }, { aniso: 4 });
+}
+
+/** Catch-fence mesh pattern. */
+export function fenceTexture() {
+    return makeTexture('fence', 128, 128, (ctx, w, h) => {
+        ctx.clearRect(0, 0, w, h);
+        ctx.strokeStyle = 'rgba(200,205,215,0.55)';
+        ctx.lineWidth = 1.5;
+        const step = 10;
+        for (let x = 0; x <= w; x += step) {
+            ctx.beginPath();
+            ctx.moveTo(x, 0);
+            ctx.lineTo(x, h);
+            ctx.stroke();
+        }
+        for (let y = 0; y <= h; y += step) {
+            ctx.beginPath();
+            ctx.moveTo(0, y);
+            ctx.lineTo(w, y);
+            ctx.stroke();
+        }
+    }, { srgb: true, aniso: 2 });
+}
+
+/** Car number + team stripe for nose / engine cover. */
+export function liveryTexture(team) {
+    const key = `livery-${team.id}`;
+    return makeTexture(key, 512, 512, (ctx, w, h) => {
+        const primary = new THREE.Color(team.primary);
+        const accent = new THREE.Color(team.accent);
+        const secondary = new THREE.Color(team.secondary);
+        ctx.fillStyle = `#${primary.getHexString()}`;
+        ctx.fillRect(0, 0, w, h);
+
+        // Metallic flake noise.
+        noiseField(ctx, w, h, { cells: 80, alpha: 0.08, light: 255, dark: 0, seed: team.number * 13 });
+
+        // Accent chevron / stripe.
+        ctx.fillStyle = `#${accent.getHexString()}`;
+        ctx.beginPath();
+        ctx.moveTo(0, h * 0.55);
+        ctx.lineTo(w, h * 0.42);
+        ctx.lineTo(w, h * 0.52);
+        ctx.lineTo(0, h * 0.65);
+        ctx.closePath();
+        ctx.fill();
+
+        ctx.fillStyle = `#${secondary.getHexString()}`;
+        ctx.fillRect(0, h * 0.72, w, h * 0.08);
+
+        ctx.fillStyle = 'rgba(255,255,255,0.92)';
+        ctx.font = 'bold 220px Orbitron, Helvetica, Arial, sans-serif';
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'middle';
+        ctx.fillText(String(team.number), w / 2, h * 0.34);
+
+        ctx.font = 'bold 42px Orbitron, Helvetica, Arial, sans-serif';
+        ctx.fillStyle = 'rgba(255,255,255,0.8)';
         ctx.fillText(team.short, w / 2, h * 0.86);
-    }, { repeat: [1, 1], aniso: 4 });
+    }, { repeat: [1, 1], aniso: 8 });
+}
+
+/** Tyre sidewall with compound-style ring colour. */
+export function tyreSidewallTexture(compoundColor = '#e8404a') {
+    const key = `tyre-side-${compoundColor}`;
+    return makeTexture(key, 256, 64, (ctx, w, h) => {
+        ctx.fillStyle = '#0e0f12';
+        ctx.fillRect(0, 0, w, h);
+        ctx.fillStyle = compoundColor;
+        ctx.fillRect(0, h * 0.35, w, h * 0.28);
+        ctx.fillStyle = 'rgba(255,255,255,0.35)';
+        ctx.font = 'bold 14px Inter, Helvetica, Arial, sans-serif';
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'middle';
+        for (let i = 0; i < 4; i++) {
+            ctx.fillText('GP SLICK  ·  305/660-R13', (i + 0.5) * (w / 4), h * 0.5);
+        }
+        noiseField(ctx, w, h, { cells: 20, alpha: 0.15, light: 80, dark: 0, seed: 8 });
+    }, { aniso: 4 });
 }
 
 export function disposeTextures() {
-    for (const texture of cache.values()) texture.dispose();
+    for (const value of cache.values()) {
+        if (value.dispose) value.dispose();
+        else if (value.map) {
+            value.map.dispose();
+            value.normalMap?.dispose();
+            value.roughnessMap?.dispose();
+        }
+    }
     cache.clear();
 }

--- a/labs/f1-racing/src/textures.js
+++ b/labs/f1-racing/src/textures.js
@@ -11,10 +11,14 @@ function canvas(w, h) {
     return el;
 }
 
+function ctx2d(el) {
+    return el.getContext('2d', { willReadFrequently: true });
+}
+
 function makeTexture(key, w, h, draw, { repeat = [1, 1], srgb = true, aniso = 8 } = {}) {
     if (cache.has(key)) return cache.get(key);
     const el = canvas(w, h);
-    draw(el.getContext('2d'), w, h);
+    draw(ctx2d(el), w, h);
     const texture = new THREE.CanvasTexture(el);
     texture.wrapS = texture.wrapT = THREE.RepeatWrapping;
     texture.repeat.set(repeat[0], repeat[1]);
@@ -80,7 +84,7 @@ function speckle(ctx, w, h, count, colors, size = 2, seed = 7) {
 function heightToNormal(srcCtx, w, h, strength = 2.4) {
     const src = srcCtx.getImageData(0, 0, w, h).data;
     const out = canvas(w, h);
-    const ctx = out.getContext('2d');
+    const ctx = out.getContext('2d', { willReadFrequently: true });
     const img = ctx.createImageData(w, h);
     const d = img.data;
     const lum = (x, y) => {
@@ -106,7 +110,7 @@ function heightToNormal(srcCtx, w, h, strength = 2.4) {
 function roughnessFromAlbedo(srcCtx, w, h, { base = 0.82, contrast = 0.22, invert = false } = {}) {
     const src = srcCtx.getImageData(0, 0, w, h).data;
     const out = canvas(w, h);
-    const ctx = out.getContext('2d');
+    const ctx = out.getContext('2d', { willReadFrequently: true });
     const img = ctx.createImageData(w, h);
     const d = img.data;
     for (let i = 0; i < src.length; i += 4) {
@@ -127,7 +131,7 @@ function packMaps(key, albedoCanvas, { strength = 2.2, roughBase = 0.84, roughCo
 
     const w = albedoCanvas.width;
     const h = albedoCanvas.height;
-    const aCtx = albedoCanvas.getContext('2d');
+    const aCtx = albedoCanvas.getContext('2d', { willReadFrequently: true });
 
     const map = new THREE.CanvasTexture(albedoCanvas);
     map.wrapS = map.wrapT = THREE.RepeatWrapping;
@@ -161,7 +165,7 @@ export function roadTexture(base = 0x1e2026) {
     if (cache.has(`${key}-pack`)) return cache.get(`${key}-pack`).map;
 
     const el = canvas(1024, 1024);
-    const ctx = el.getContext('2d');
+    const ctx = ctx2d(el);
     const col = new THREE.Color(base);
     ctx.fillStyle = `#${col.getHexString()}`;
     ctx.fillRect(0, 0, 1024, 1024);
@@ -221,7 +225,7 @@ export function kerbTexture() {
     if (cache.has(`${key}-pack`)) return cache.get(`${key}-pack`).map;
 
     const el = canvas(128, 256);
-    const ctx = el.getContext('2d');
+    const ctx = el.getContext('2d', { willReadFrequently: true });
     const bands = 8;
     for (let i = 0; i < bands; i++) {
         ctx.fillStyle = i % 2 === 0 ? '#c92e28' : '#f4f5f7';
@@ -253,7 +257,7 @@ export function grassTexture(tint = 0x1f3518) {
     if (cache.has(`${key}-pack`)) return cache.get(`${key}-pack`).map;
 
     const el = canvas(1024, 1024);
-    const ctx = el.getContext('2d');
+    const ctx = ctx2d(el);
     const col = new THREE.Color(tint);
     ctx.fillStyle = `#${col.getHexString()}`;
     ctx.fillRect(0, 0, 1024, 1024);
@@ -289,7 +293,7 @@ export function runoffTexture() {
     const key = 'runoff';
     if (cache.has(`${key}-pack`)) return cache.get(`${key}-pack`).map;
     const el = canvas(512, 512);
-    const ctx = el.getContext('2d');
+    const ctx = el.getContext('2d', { willReadFrequently: true });
     ctx.fillStyle = '#4a4e55';
     ctx.fillRect(0, 0, 512, 512);
     noiseField(ctx, 512, 512, { cells: 36, alpha: 0.26, light: 200, dark: 55, seed: 71 });
@@ -308,7 +312,7 @@ export function gravelTexture() {
     const key = 'gravel';
     if (cache.has(`${key}-pack`)) return cache.get(`${key}-pack`).map;
     const el = canvas(512, 512);
-    const ctx = el.getContext('2d');
+    const ctx = el.getContext('2d', { willReadFrequently: true });
     ctx.fillStyle = '#8a7658';
     ctx.fillRect(0, 0, 512, 512);
     noiseField(ctx, 512, 512, { cells: 70, alpha: 0.38, light: 230, dark: 85, seed: 6 });
@@ -333,7 +337,7 @@ export function concreteTexture() {
     const key = 'concrete';
     if (cache.has(`${key}-pack`)) return cache.get(`${key}-pack`).map;
     const el = canvas(512, 512);
-    const ctx = el.getContext('2d');
+    const ctx = el.getContext('2d', { willReadFrequently: true });
     ctx.fillStyle = '#949aa0';
     ctx.fillRect(0, 0, 512, 512);
     noiseField(ctx, 512, 512, { cells: 28, alpha: 0.28, light: 230, dark: 110, seed: 17 });

--- a/labs/f1-racing/src/vehicle.js
+++ b/labs/f1-racing/src/vehicle.js
@@ -386,17 +386,23 @@ export class Vehicle {
         /* --- wheels + tyre state ------------------------------------ */
         this.wheelAngle += (this.vx / SPEC.wheelRadius) * dt;
 
-        // Thermal: warm with slip/load, cool when coasting.
-        const heat = (this.slip * 38 + Math.abs(this.throttle) * 6 + Math.abs(this.brake) * 10)
-            * this.compound.warmup;
-        const cool = 4.5 + (this.weather.id === 'wet' ? 3 : 0);
-        this.tyreTemp += (heat - cool) * dt;
-        this.tyreTemp = clamp(this.tyreTemp, 30, 128);
+        // Thermal: warm with slip/load while moving, cool when coasting/stopped.
+        if (Math.abs(this.vx) > 4) {
+            const heat = (this.slip * 28 + Math.abs(this.throttle) * 5 + Math.abs(this.brake) * 8)
+                * this.compound.warmup;
+            const cool = 5.5 + (this.weather.id === 'wet' ? 3.5 : 0);
+            this.tyreTemp += (heat - cool) * dt;
+        } else {
+            this.tyreTemp += (55 - this.tyreTemp) * Math.min(1, 0.35 * dt);
+        }
+        this.tyreTemp = clamp(this.tyreTemp, 30, 125);
 
         // Wear accumulates with slip energy and compound aggressiveness.
-        const wearRate = (0.0009 + this.slip * 0.0045) * this.compound.wear
-            * (this.offTrack ? 2.2 : 1);
-        this.tyreWear = clamp(this.tyreWear + wearRate * dt, 0, 1);
+        if (Math.abs(this.vx) > 6) {
+            const wearRate = (0.0007 + this.slip * 0.0038) * this.compound.wear
+                * (this.offTrack ? 2.2 : 1);
+            this.tyreWear = clamp(this.tyreWear + wearRate * dt, 0, 1);
+        }
 
         return delta;
     }

--- a/labs/f1-racing/src/vehicle.js
+++ b/labs/f1-racing/src/vehicle.js
@@ -1,8 +1,8 @@
 /**
- * Vehicle dynamics: a single-track (bicycle) model with a simplified Pacejka tyre,
- * speed-dependent downforce, longitudinal weight transfer, an 8-speed gearbox and
- * ERS/DRS. The same class drives both the player and the AI — only the input source
- * differs.
+ * Vehicle dynamics — single-track bicycle model with simplified Pacejka tyres,
+ * speed-dependent downforce, longitudinal weight transfer, 8-speed gearbox and
+ * ERS/DRS. Tuned for arcade-satisfying feel with real grip/weight feedback
+ * (Crazy Grand Prix style: accessible, weighty, not a hardcore sim).
  */
 
 import { COMPOUNDS } from './config.js';
@@ -13,20 +13,20 @@ const RHO = 1.225;
 const SPEC = {
     mass: 798,
     wheelbase: 3.6,
-    frontAxle: 1.62,        // distance CoG -> front axle
+    frontAxle: 1.62,
     rearAxle: 1.98,
     cgHeight: 0.32,
     yawInertia: 1150,
     wheelRadius: 0.36,
-    clA: 4.6,               // downforce coefficient x area
-    cdA: 1.28,
-    maxPower: 580000,       // W (ICE + deployment)
-    maxTorqueForce: 21000,  // N at the contact patch in first gear
-    brakeForce: 38000,      // N total at full pedal
-    maxSteer: 0.34,
-    ersCapacity: 4.0,       // MJ
-    ersDeployRate: 0.36,    // MJ/s
-    ersHarvestRate: 0.55,
+    clA: 4.8,
+    cdA: 1.22,
+    maxPower: 620000,
+    maxTorqueForce: 22000,
+    brakeForce: 42000,
+    maxSteer: 0.36,
+    ersCapacity: 4.0,
+    ersDeployRate: 0.42,
+    ersHarvestRate: 0.58,
     gears: [24, 18, 14.5, 12, 10.2, 8.8, 7.6, 6.4],
     idleRpm: 4200,
     redline: 15000,
@@ -34,20 +34,24 @@ const SPEC = {
     shiftDownRpm: 8200
 };
 
-const SURFACE_GRIP = [1, 0.94, 0.88, 0.5, 0.42];
-const SURFACE_DRAG = [0, 220, 380, 4400, 2600];
+/** Surface grip multipliers: asphalt, kerb, runoff, gravel, grass. */
+const SURFACE_GRIP = [1.0, 0.92, 0.82, 0.48, 0.38];
+const SURFACE_DRAG = [0, 280, 520, 5200, 3100];
 
-/** Peak friction coefficient of a slick at operating temperature. */
-const BASE_MU = 1.85;
-const ROLLING_COEFF = 0.014;
+const BASE_MU = 1.78;
+const ROLLING_COEFF = 0.0135;
 
-/** Simplified magic formula: normalised lateral force for a slip angle. */
-function tyreCurve(slip, sharpness = 9.2, shape = 1.55, peak = 1) {
+/** Simplified Pacejka: lateral force coefficient for a slip angle (radians). */
+function tyreCurve(slip, sharpness = 10.5, shape = 1.48, peak = 1) {
     return peak * Math.sin(shape * Math.atan(sharpness * slip));
 }
 
 function clamp(v, lo, hi) {
     return v < lo ? lo : v > hi ? hi : v;
+}
+
+function sign(v) {
+    return v < 0 ? -1 : 1;
 }
 
 export class Vehicle {
@@ -64,8 +68,8 @@ export class Vehicle {
         this.yaw = 0;
         this.pitch = 0;
         this.roll = 0;
-        this.vx = 0;              // body-frame longitudinal velocity
-        this.vz = 0;              // body-frame lateral velocity
+        this.vx = 0;
+        this.vz = 0;
         this.yawRate = 0;
 
         this.steer = 0;
@@ -89,6 +93,7 @@ export class Vehicle {
         this.offTrack = false;
         this.slip = 0;
         this.wheelSpin = 0;
+        this.lockUp = 0;
         this.wheelAngle = 0;
         this.suspension = 0;
         this.airborne = 0;
@@ -103,9 +108,11 @@ export class Vehicle {
         this.finishTime = 0;
         this.position_ = 1;
         this.impulse = { x: 0, z: 0 };
+        this.shiftCooldown = 0;
+        this.lastAccel = 0;
+        this.verticalSpeed = 0;
     }
 
-    /** Places the car on the grid (staggered, alternating sides, behind the line). */
     placeOnGrid(slot) {
         const circuit = this.circuit;
         const back = 12 + slot * 9;
@@ -128,9 +135,11 @@ export class Vehicle {
         this.lap = 0;
         this.totalDistance = -back;
         this.gridSlot = slot;
+        this.tyreTemp = 55;
+        this.tyreWear = 0;
+        this.ers = SPEC.ersCapacity;
     }
 
-    /** Puts a beached car back on the racing line facing the right way. */
     recover() {
         const circuit = this.circuit;
         const i = this.trackIndex;
@@ -145,15 +154,17 @@ export class Vehicle {
     }
 
     get downforce() {
-        const drsLoss = this.drsOpen ? 0.82 : 1;
+        const drsLoss = this.drsOpen ? 0.78 : 1;
         return 0.5 * RHO * SPEC.clA * drsLoss * this.vx * this.vx;
     }
 
-    /** Effective friction coefficient: compound, wear, temperature, weather and track. */
+    /** Effective friction: compound, wear, temperature, weather, surface, track bias. */
     get gripLevel() {
-        const wear = 1 - this.tyreWear * 0.28;
-        const temp = 0.82 + 0.18 * clamp((this.tyreTemp - 40) / 55, 0, 1.05);
-        return BASE_MU * this.compound.grip * wear * temp * this.weather.grip * (this.circuit.def.gripBias || 1);
+        const wear = 1 - this.tyreWear * 0.32;
+        const temp = 0.78 + 0.22 * clamp((this.tyreTemp - 35) / 55, 0, 1.1);
+        const surface = SURFACE_GRIP[this.surface] ?? 1;
+        return BASE_MU * this.compound.grip * wear * temp * this.weather.grip
+            * surface * (this.circuit.def.gripBias || 1);
     }
 
     engineForce() {
@@ -162,10 +173,9 @@ export class Vehicle {
         const rpm = clamp(wheelRpm * ratio, SPEC.idleRpm, SPEC.redline);
         this.rpm = rpm;
 
-        // Torque curve: soft below 7k, plateau to the limiter, cut at the redline.
         const norm = rpm / SPEC.redline;
-        const curve = clamp(0.42 + 1.35 * norm - 0.72 * norm * norm, 0, 1.05);
-        const limiter = rpm >= SPEC.redline - 60 ? 0.25 : 1;
+        const curve = clamp(0.38 + 1.42 * norm - 0.78 * norm * norm, 0, 1.08);
+        const limiter = rpm >= SPEC.redline - 60 ? 0.2 : 1;
 
         const force = (SPEC.maxTorqueForce / (SPEC.gears[0] / ratio)) * curve * limiter;
         const powerCap = this.vx > 1 ? SPEC.maxPower / Math.abs(this.vx) : Infinity;
@@ -173,37 +183,39 @@ export class Vehicle {
     }
 
     autoShift(dt) {
-        this.shiftCooldown = Math.max(0, (this.shiftCooldown || 0) - dt);
+        this.shiftCooldown = Math.max(0, this.shiftCooldown - dt);
         if (this.shiftCooldown > 0) return;
         if (this.rpm > SPEC.shiftUpRpm && this.gear < SPEC.gears.length && this.throttle > 0.2) {
             this.gear++;
-            this.shiftCooldown = 0.12;
+            this.shiftCooldown = 0.11;
             this.justShifted = 1;
         } else if (this.rpm < SPEC.shiftDownRpm && this.gear > 1) {
             this.gear--;
-            this.shiftCooldown = 0.12;
+            this.shiftCooldown = 0.11;
         }
     }
 
     /**
      * @param {number} dt seconds
-     * @param {{throttle:number, brake:number, steer:number, ers:boolean}} input
+     * @param {{throttle:number, brake:number, steer:number, ers:boolean, assists?:boolean}} input
      */
     update(dt, input) {
         const circuit = this.circuit;
+        const assists = input.assists !== false;
 
         this.throttle = clamp(input.throttle, 0, 1);
         this.brake = clamp(input.brake, 0, 1);
         const steerTarget = clamp(input.steer, -1, 1);
 
-        const speedFactor = clamp(1 - Math.abs(this.vx) / 135, 0.4, 1);
+        // Speed-sensitive steering lock — high-speed stability like a real F1 rack.
+        const speedFactor = clamp(1 - Math.abs(this.vx) / 145, 0.28, 1);
         const maxSteer = SPEC.maxSteer * speedFactor;
-        const steerRate = 12.0;
+        const steerRate = assists ? 10.5 : 14.5;
         this.steer += (steerTarget * maxSteer - this.steer) * Math.min(1, steerRate * dt);
 
         this.autoShift(dt);
 
-        /* --- surface ------------------------------------------------ */
+        /* --- track location ----------------------------------------- */
         const located = circuit.locate(this.position.x, this.position.z, this.trackIndex);
         this.trackIndex = located.index;
         this.lateral = located.lateral;
@@ -215,48 +227,131 @@ export class Vehicle {
         this.totalDistance += delta;
 
         this.surface = circuit.surfaceAt(this.lateral, this.trackIndex);
-        this.wide = this.surface >= 2;          // beyond the white line
-        this.offTrack = this.surface >= 3;      // gravel or grass
+        this.wide = this.surface >= 2;
+        this.offTrack = this.surface >= 3;
 
-        /* --- arcade longitudinal forces ----------------------------- */
+        /* --- aero + normal load ------------------------------------- */
+        const aeroDown = this.downforce;
+        const staticLoad = SPEC.mass * G;
+        const normalLoad = staticLoad + aeroDown;
+
+        // Longitudinal weight transfer for braking dive / accel squat.
+        const axGuess = this.lastAccel || 0;
+        const transfer = clamp((SPEC.cgHeight / SPEC.wheelbase) * SPEC.mass * axGuess, -0.35 * staticLoad, 0.35 * staticLoad);
+        const frontLoad = normalLoad * (SPEC.rearAxle / SPEC.wheelbase) - transfer;
+        const rearLoad = normalLoad * (SPEC.frontAxle / SPEC.wheelbase) + transfer;
+
+        const mu = this.gripLevel;
+        const frontGrip = Math.max(400, frontLoad * mu);
+        const rearGrip = Math.max(400, rearLoad * mu);
+        const totalGrip = frontGrip + rearGrip;
+
+        /* --- longitudinal forces ------------------------------------ */
         let drive = 0;
+        this.wheelSpin = 0;
+        this.lockUp = 0;
+
         if (this.throttle > 0) {
             drive = this.engineForce() * this.throttle;
+            // ERS: ~120 kW hybrid boost — strong but not pure nitro.
             if (this.ersActive && this.ers > 0) {
-                drive *= 1.5; // Arcade Nitro Boost
-                this.ers = Math.max(0, this.ers - SPEC.ersDeployRate * dt * 2);
+                const boost = Math.min(120000 / Math.max(8, Math.abs(this.vx)), 8500);
+                drive += boost;
+                this.ers = Math.max(0, this.ers - SPEC.ersDeployRate * dt);
+                if (this.ers <= 0) this.ersActive = false;
             }
-        } else if (this.brake > 0) {
-            // Braking recharges boost
-            this.ers = Math.min(SPEC.ersCapacity, this.ers + SPEC.ersHarvestRate * dt * 1.5);
+
+            // Traction limit at the driven (rear) axle.
+            if (drive > rearGrip) {
+                this.wheelSpin = clamp((drive - rearGrip) / rearGrip, 0, 1.4);
+                drive = rearGrip * (assists ? 0.96 : 0.88);
+            }
+        } else if (this.brake > 0.05) {
+            this.ers = Math.min(SPEC.ersCapacity, this.ers + SPEC.ersHarvestRate * this.brake * dt);
         }
 
-        let braking = this.brake * SPEC.brakeForce; // Removed arcade 1.5x multiplier for more realistic braking distance
+        let braking = this.brake * SPEC.brakeForce;
+        // Brake force also scales with aero load (more downforce = shorter stopping).
+        braking *= 0.72 + 0.28 * clamp(normalLoad / (staticLoad * 3.2), 0, 1.4);
+        if (braking > totalGrip * 1.05) {
+            this.lockUp = clamp((braking - totalGrip) / totalGrip, 0, 1);
+            braking = totalGrip * (assists ? 0.98 : 0.9);
+        }
 
-        const drag = 0.5 * RHO * SPEC.cdA * (this.drsOpen ? 0.5 : 1) * this.vx * Math.abs(this.vx);
-        const rolling = ROLLING_COEFF * SPEC.mass * G * Math.sign(this.vx || 1)
-            + (this.offTrack ? 12000 : 0) * Math.sign(this.vx); // Heavy penalty off-track
+        const dragCd = SPEC.cdA * (this.drsOpen ? 0.52 : 1);
+        const drag = 0.5 * RHO * dragCd * this.vx * Math.abs(this.vx);
+        const surfaceDrag = SURFACE_DRAG[this.surface] ?? 0;
+        const rolling = ROLLING_COEFF * normalLoad * sign(this.vx || 1)
+            + surfaceDrag * sign(this.vx || 1) * clamp(Math.abs(this.vx) / 40, 0.2, 1.5);
+
         const slope = circuit.slope[this.trackIndex];
         const gravityPull = SPEC.mass * G * -slope;
 
-        let fx = drive - braking * Math.sign(this.vx || 1) - drag - rolling + gravityPull;
+        // Apply pending collision impulse in body frame.
+        if (this.impulse.x || this.impulse.z) {
+            const sinYaw = Math.sin(this.yaw);
+            const cosYaw = Math.cos(this.yaw);
+            this.vx += this.impulse.x * sinYaw + this.impulse.z * cosYaw;
+            this.vz += this.impulse.x * cosYaw - this.impulse.z * sinYaw;
+            this.impulse.x = 0;
+            this.impulse.z = 0;
+        }
+
+        let fx = drive - braking * sign(this.vx || 1) - drag - rolling + gravityPull;
         this.lastAccel = fx / SPEC.mass;
 
-        /* --- arcade lateral kinematics ------------------------------ */
         this.vx += (fx / SPEC.mass) * dt;
-        if (this.brake > 0.1 && this.vx < 0.6) this.vx = Math.max(0, this.vx - 12 * dt);
-        this.vx = clamp(this.vx, -12, 95); // Capped max speed to ~342 km/h (realistic F1)
+        if (this.brake > 0.15 && this.vx < 0.8 && this.vx > -0.5) {
+            this.vx = Math.max(0, this.vx - 18 * dt);
+        }
+        this.vx = clamp(this.vx, -14, 98);
 
-        // Simple kinematic steering with drift
-        const turnRadius = SPEC.wheelbase / Math.tan(this.steer || 0.001);
-        this.yawRate = this.vx / turnRadius;
-        
-        // Refined drift/slip (more grip, less slide)
-        this.vz = this.steer * this.vx * 0.06; 
-        this.slip = Math.abs(this.steer) * (this.vx / 45);
+        /* --- lateral bicycle / Pacejka ------------------------------ */
+        const speed = Math.max(1.2, Math.abs(this.vx));
+        // Slip angles at each axle.
+        const beta = Math.atan2(this.vz, speed);
+        const yawTerm = this.yawRate;
+        const frontSlip = this.steer - beta - (SPEC.frontAxle * yawTerm) / speed;
+        const rearSlip = -beta + (SPEC.rearAxle * yawTerm) / speed;
+
+        const frontLat = frontGrip * tyreCurve(frontSlip);
+        const rearLat = rearGrip * tyreCurve(rearSlip);
+
+        // Combined-slip ellipse: reduce lateral when using lots of long. force.
+        const longDemand = Math.abs(drive - braking * sign(this.vx || 1)) / Math.max(1, totalGrip);
+        const latScale = Math.sqrt(Math.max(0.2, 1 - clamp(longDemand, 0, 0.95) ** 2));
+        const FyF = frontLat * latScale;
+        const FyR = rearLat * latScale;
+
+        // Assist: gently bleed lateral velocity when near the limit.
+        if (assists && Math.abs(this.vz) > 4.5) {
+            this.vz *= Math.exp(-dt * 1.8);
+        }
+
+        const Fy = FyF + FyR;
+        this.vz += (Fy / SPEC.mass - this.vx * this.yawRate) * dt;
+
+        const yawMoment = SPEC.frontAxle * FyF - SPEC.rearAxle * FyR;
+        this.yawRate += (yawMoment / SPEC.yawInertia) * dt;
+
+        // Soft kinematic blend at very low speed so parking doesn't spin forever.
+        if (Math.abs(this.vx) < 3.5) {
+            const turnRadius = SPEC.wheelbase / Math.tan(this.steer || 0.001);
+            const kinYaw = this.vx / turnRadius;
+            this.yawRate += (kinYaw - this.yawRate) * Math.min(1, 8 * dt);
+            this.vz *= Math.exp(-dt * 6);
+        }
+
+        // Damp residual yaw / lateral for arcade composure.
+        this.yawRate *= Math.exp(-dt * (assists ? 1.15 : 0.55));
+        this.vz *= Math.exp(-dt * (assists ? 0.85 : 0.35));
 
         this.yaw += this.yawRate * dt;
         this.speed = Math.hypot(this.vx, this.vz);
+
+        // Slip metric for HUD / FX / audio (0 = glued, 1+ = sliding).
+        const peakSlip = Math.max(Math.abs(frontSlip), Math.abs(rearSlip));
+        this.slip = clamp(peakSlip / 0.18 + this.wheelSpin * 0.45 + this.lockUp * 0.55, 0, 2.2);
 
         /* --- integrate position ------------------------------------- */
         const sinYaw = Math.sin(this.yaw);
@@ -264,52 +359,59 @@ export class Vehicle {
         this.position.x += (this.vx * sinYaw + this.vz * cosYaw) * dt;
         this.position.z += (this.vx * cosYaw - this.vz * sinYaw) * dt;
 
-        // Ground tracking
         const groundY = circuit.heightAt(this.trackIndex, clamp(this.lateral, -60, 60));
         const drop = this.position.y - groundY;
-        if (drop > 0.05) {
-            this.airborne = Math.min(1, this.airborne + dt * 2);
-            this.verticalSpeed = (this.verticalSpeed || 0) - G * dt;
+        if (drop > 0.06) {
+            this.airborne = Math.min(1, this.airborne + dt * 2.2);
+            this.verticalSpeed -= G * dt;
         } else {
             this.airborne *= Math.exp(-dt * 5);
             this.verticalSpeed = 0;
         }
-        this.position.y += (this.verticalSpeed || 0) * dt;
-        this.position.y += (groundY - this.position.y) * Math.min(1, 14 * dt);
-        this.suspension = clamp(-drop * 0.4, -0.05, 0.05);
+        this.position.y += this.verticalSpeed * dt;
+        this.position.y += (groundY - this.position.y) * Math.min(1, 16 * dt);
+        this.suspension = clamp(-drop * 0.45, -0.06, 0.05);
 
-        // Kerb rattle
         if (this.surface === 1) {
-            this.suspension += Math.sin(this.totalDistance * 6) * 0.022;
+            this.suspension += Math.sin(this.totalDistance * 7.5) * 0.028;
         }
 
-        /* --- attitude ------------------------------------------------ */
-        const targetPitch = clamp(-slope * 0.9 - (fx / SPEC.mass) * 0.006, -0.3, 0.3);
-        this.pitch += (targetPitch - this.pitch) * Math.min(1, 6 * dt);
-        const targetRoll = clamp(circuit.bank[this.trackIndex] + (this.vz * this.yawRate) * 0.004, -0.2, 0.2);
-        this.roll += (targetRoll - this.roll) * Math.min(1, 6 * dt);
+        /* --- attitude ----------------------------------------------- */
+        const targetPitch = clamp(-slope * 0.95 - (fx / SPEC.mass) * 0.007, -0.32, 0.32);
+        this.pitch += (targetPitch - this.pitch) * Math.min(1, 7 * dt);
+        const latLoad = clamp(this.vz * 0.012 + this.yawRate * this.vx * 0.0008, -0.18, 0.18);
+        const targetRoll = clamp(circuit.bank[this.trackIndex] + latLoad, -0.22, 0.22);
+        this.roll += (targetRoll - this.roll) * Math.min(1, 7 * dt);
 
-        /* --- wheels & HUD fakes -------------------------------------- */
+        /* --- wheels + tyre state ------------------------------------ */
         this.wheelAngle += (this.vx / SPEC.wheelRadius) * dt;
 
-        // Keep HUD/Audio happy but no actual wear
-        this.tyreWear = 0;
-        this.tyreTemp = 80;
+        // Thermal: warm with slip/load, cool when coasting.
+        const heat = (this.slip * 38 + Math.abs(this.throttle) * 6 + Math.abs(this.brake) * 10)
+            * this.compound.warmup;
+        const cool = 4.5 + (this.weather.id === 'wet' ? 3 : 0);
+        this.tyreTemp += (heat - cool) * dt;
+        this.tyreTemp = clamp(this.tyreTemp, 30, 128);
+
+        // Wear accumulates with slip energy and compound aggressiveness.
+        const wearRate = (0.0009 + this.slip * 0.0045) * this.compound.wear
+            * (this.offTrack ? 2.2 : 1);
+        this.tyreWear = clamp(this.tyreWear + wearRate * dt, 0, 1);
 
         return delta;
     }
 
-    /** Contact response: split the closing velocity and nudge the cars apart. */
+    /** Contact response with momentum exchange. */
     static resolveContact(a, b) {
         const dx = b.position.x - a.position.x;
         const dz = b.position.z - a.position.z;
         const distance = Math.hypot(dx, dz);
-        const minDistance = 3.4;
+        const minDistance = 3.35;
         if (distance > minDistance || distance < 1e-4) return 0;
 
         const nx = dx / distance;
         const nz = dz / distance;
-        const overlap = (minDistance - distance) * 0.5;
+        const overlap = (minDistance - distance) * 0.55;
 
         a.position.x -= nx * overlap;
         a.position.z -= nz * overlap;
@@ -319,13 +421,24 @@ export class Vehicle {
         const av = a.worldVelocity();
         const bv = b.worldVelocity();
         const closing = (bv.x - av.x) * nx + (bv.z - av.z) * nz;
-        if (closing > 0) return 0;
+        if (closing >= 0) return 0;
 
-        const impulse = -closing * 0.55;
+        // Elastic-ish impulse shared between both cars.
+        const restitution = 0.35;
+        const impulse = -(1 + restitution) * closing * 0.5;
         a.impulse.x -= nx * impulse;
         a.impulse.z -= nz * impulse;
         b.impulse.x += nx * impulse;
         b.impulse.z += nz * impulse;
+
+        // Immediate body-frame scrub so contact feels snappy this frame.
+        const aSin = Math.sin(a.yaw), aCos = Math.cos(a.yaw);
+        const bSin = Math.sin(b.yaw), bCos = Math.cos(b.yaw);
+        a.vx -= (nx * impulse) * aSin + (nz * impulse) * aCos;
+        a.vz -= (nx * impulse) * aCos - (nz * impulse) * aSin;
+        b.vx += (nx * impulse) * bSin + (nz * impulse) * bCos;
+        b.vz += (nx * impulse) * bCos - (nz * impulse) * bSin;
+
         return Math.abs(closing);
     }
 
@@ -338,23 +451,22 @@ export class Vehicle {
         };
     }
 
-    /** Pushes the car back inside the barriers and scrubs speed. */
     clampToTrack() {
         const circuit = this.circuit;
         const limit = circuit.halfWidth * circuit.widthScale[this.trackIndex] + 14.6;
         if (Math.abs(this.lateral) <= limit) return 0;
 
         const i = this.trackIndex;
-        const sign = Math.sign(this.lateral);
-        const clamped = sign * limit;
+        const side = Math.sign(this.lateral);
+        const clamped = side * limit;
         this.position.x = circuit.cx[i] + circuit.nx[i] * clamped;
         this.position.z = circuit.cz[i] + circuit.nz[i] * clamped;
         this.lateral = clamped;
 
-        const hit = Math.abs(this.vz) + Math.abs(this.vx) * 0.25;
-        this.vx *= 0.55;
-        this.vz *= -0.25;
-        this.yawRate *= 0.3;
+        const hit = Math.abs(this.vz) + Math.abs(this.vx) * 0.28;
+        this.vx *= 0.52;
+        this.vz *= -0.35;
+        this.yawRate *= 0.25;
         return hit;
     }
 }

--- a/labs/f1-racing/src/vehicle.js
+++ b/labs/f1-racing/src/vehicle.js
@@ -387,15 +387,15 @@ export class Vehicle {
         this.wheelAngle += (this.vx / SPEC.wheelRadius) * dt;
 
         // Thermal: warm with slip/load while moving, cool when coasting/stopped.
-        if (Math.abs(this.vx) > 4) {
-            const heat = (this.slip * 28 + Math.abs(this.throttle) * 5 + Math.abs(this.brake) * 8)
+        if (Math.abs(this.vx) > 8) {
+            const heat = (this.slip * 18 + Math.abs(this.throttle) * 3.5 + Math.abs(this.brake) * 5)
                 * this.compound.warmup;
-            const cool = 5.5 + (this.weather.id === 'wet' ? 3.5 : 0);
+            const cool = 7 + (this.weather.id === 'wet' ? 4 : 0) + Math.abs(this.vx) * 0.04;
             this.tyreTemp += (heat - cool) * dt;
         } else {
-            this.tyreTemp += (55 - this.tyreTemp) * Math.min(1, 0.35 * dt);
+            this.tyreTemp += (62 - this.tyreTemp) * Math.min(1, 0.55 * dt);
         }
-        this.tyreTemp = clamp(this.tyreTemp, 30, 125);
+        this.tyreTemp = clamp(this.tyreTemp, 35, 118);
 
         // Wear accumulates with slip energy and compound aggressiveness.
         if (Math.abs(this.vx) > 6) {

--- a/labs/f1-racing/src/world.js
+++ b/labs/f1-racing/src/world.js
@@ -8,8 +8,8 @@ import * as THREE from 'three';
 import { mergeGeometries } from 'three/addons/utils/BufferGeometryUtils.js';
 import { SkyMesh } from 'three/addons/objects/SkyMesh.js';
 import {
-    roadTexture, kerbTexture, grassTexture, gravelTexture, runoffTexture, concreteTexture,
-    crowdTexture, startLineTexture, liveryTexture
+    roadMaps, kerbMaps, grassMaps, gravelMaps, runoffMaps, concreteMaps,
+    crowdTexture, startLineTexture, liveryTexture, bannerTexture, fenceTexture
 } from './textures.js';
 import { TEAMS } from './config.js';
 
@@ -202,25 +202,75 @@ function buildStartLine(circuit) {
  * ------------------------------------------------------------------ */
 
 function treeGeometry() {
-    const trunk = new THREE.CylinderGeometry(0.3, 0.45, 3.5, 6);
-    trunk.translate(0, 1.75, 0);
+    const trunk = new THREE.CylinderGeometry(0.28, 0.48, 4.2, 7);
+    trunk.translate(0, 2.1, 0);
     paint(trunk, 0x4a3a2a);
-    
-    // Pine tree layers (multiple overlapping cones)
+
     const layers = [];
-    for(let i = 0; i < 4; i++) {
-        const r = 3.2 - i * 0.6;
-        const h = 4.5;
-        const cone = new THREE.ConeGeometry(r, h, 8);
-        cone.translate(0, 3.5 + i * 2.2, 0);
-        // Add some random tilt for organic look
-        cone.rotateX((Math.random() - 0.5) * 0.1);
-        cone.rotateZ((Math.random() - 0.5) * 0.1);
-        paint(cone, i % 2 === 0 ? 0x2c4a22 : 0x35592a);
+    for (let i = 0; i < 5; i++) {
+        const r = 3.4 - i * 0.55;
+        const h = 4.2;
+        const cone = new THREE.ConeGeometry(r, h, 9);
+        cone.translate(0, 3.8 + i * 2.05, 0);
+        cone.rotateX(((i * 17) % 7 - 3) * 0.015);
+        cone.rotateZ(((i * 29) % 7 - 3) * 0.015);
+        paint(cone, i % 2 === 0 ? 0x254820 : 0x2f5a28);
         layers.push(cone);
     }
-    
+
     return mergeGeometries([trunk, ...layers], false);
+}
+
+function lightPoleGeometry() {
+    const pole = new THREE.CylinderGeometry(0.12, 0.16, 12, 8);
+    pole.translate(0, 6, 0);
+    paint(pole, 0x3a4048);
+    const arm = new THREE.BoxGeometry(0.15, 0.12, 3.2);
+    arm.translate(0, 11.6, 1.4);
+    paint(arm, 0x2e343c);
+    const lamp = new THREE.BoxGeometry(0.5, 0.25, 0.7);
+    lamp.translate(0, 11.4, 2.6);
+    paint(lamp, 0x1a1e24);
+    return mergeGeometries([pole, arm, lamp], false);
+}
+
+function pitBuilding(length = 90) {
+    const group = new THREE.Group();
+    const wall = new THREE.MeshStandardMaterial({ color: 0x2a2f38, roughness: 0.7, metalness: 0.25 });
+    const glass = new THREE.MeshPhysicalMaterial({
+        color: 0x6a90b8, roughness: 0.15, metalness: 0.4, transmission: 0.35, transparent: true, opacity: 0.85
+    });
+
+    const garage = new THREE.Mesh(new THREE.BoxGeometry(length, 5.5, 14), wall);
+    garage.position.set(0, 2.75, 8);
+    group.add(garage);
+
+    const upper = new THREE.Mesh(new THREE.BoxGeometry(length * 0.92, 3.2, 10), glass);
+    upper.position.set(0, 7.2, 7);
+    group.add(upper);
+
+    const roof = new THREE.Mesh(
+        new THREE.BoxGeometry(length + 4, 0.4, 16),
+        new THREE.MeshStandardMaterial({ color: 0xd8261f, roughness: 0.55, metalness: 0.3, emissive: 0x3b0906, emissiveIntensity: 0.35 })
+    );
+    roof.position.set(0, 9.0, 7.5);
+    group.add(roof);
+
+    // Garage doors
+    const doorMat = new THREE.MeshStandardMaterial({ color: 0x15181e, roughness: 0.8 });
+    const doorCount = Math.floor(length / 10);
+    for (let i = 0; i < doorCount; i++) {
+        const door = new THREE.Mesh(new THREE.BoxGeometry(7.5, 3.8, 0.2), doorMat);
+        door.position.set(-length / 2 + 5 + i * 10, 1.9, 0.9);
+        group.add(door);
+    }
+
+    // Pit wall
+    const pitWall = new THREE.Mesh(new THREE.BoxGeometry(length * 0.85, 1.1, 0.45), wall);
+    pitWall.position.set(0, 0.55, -2.5);
+    group.add(pitWall);
+
+    return group;
 }
 
 function paint(geometry, hex) {
@@ -324,16 +374,24 @@ function buildGantry(circuit) {
 
 function environmentTexture(sunColor, skyColor, groundColor) {
     const el = document.createElement('canvas');
-    el.width = 128;
-    el.height = 64;
+    el.width = 256;
+    el.height = 128;
     const ctx = el.getContext('2d');
-    const grad = ctx.createLinearGradient(0, 0, 0, 64);
-    grad.addColorStop(0, `#${new THREE.Color(skyColor).getHexString()}`);
-    grad.addColorStop(0.48, `#${new THREE.Color(sunColor).getHexString()}`);
-    grad.addColorStop(0.52, `#${new THREE.Color(groundColor).getHexString()}`);
-    grad.addColorStop(1, '#14170f');
+    const grad = ctx.createLinearGradient(0, 0, 0, 128);
+    grad.addColorStop(0, `#${new THREE.Color(skyColor).clone().multiplyScalar(1.15).getHexString()}`);
+    grad.addColorStop(0.42, `#${new THREE.Color(sunColor).getHexString()}`);
+    grad.addColorStop(0.52, `#${new THREE.Color(skyColor).getHexString()}`);
+    grad.addColorStop(0.58, `#${new THREE.Color(groundColor).getHexString()}`);
+    grad.addColorStop(1, '#0e120c');
     ctx.fillStyle = grad;
-    ctx.fillRect(0, 0, 128, 64);
+    ctx.fillRect(0, 0, 256, 128);
+    // Soft sun disc
+    const sun = ctx.createRadialGradient(190, 48, 2, 190, 48, 28);
+    sun.addColorStop(0, 'rgba(255,248,220,0.95)');
+    sun.addColorStop(0.4, 'rgba(255,210,140,0.35)');
+    sun.addColorStop(1, 'rgba(255,200,120,0)');
+    ctx.fillStyle = sun;
+    ctx.fillRect(0, 0, 256, 128);
     const texture = new THREE.CanvasTexture(el);
     texture.mapping = THREE.EquirectangularReflectionMapping;
     texture.colorSpace = THREE.SRGBColorSpace;
@@ -368,54 +426,59 @@ export function buildWorld(circuit, { quality, weather }) {
     sky.material.fog = false;   // the dome sits far beyond the fog range
     scene.add(sky);
 
-    const sunTint = wet ? 0xbfc9d6 : 0xfff2dd;
-    const sun = new THREE.DirectionalLight(sunTint, wet ? 1.6 : 3.6);
+    const sunTint = wet ? 0xbfc9d6 : 0xfff1dc;
+    const sun = new THREE.DirectionalLight(sunTint, wet ? 1.85 : 4.1);
     sun.position.copy(sunDirection).multiplyScalar(320);
     sun.castShadow = quality.shadows;
     if (quality.shadows) {
         sun.shadow.mapSize.set(quality.shadowSize, quality.shadowSize);
         sun.shadow.camera.near = 1;
-        sun.shadow.camera.far = 520;
-        const extent = 90;
+        sun.shadow.camera.far = 560;
+        const extent = 110;
         sun.shadow.camera.left = -extent;
         sun.shadow.camera.right = extent;
         sun.shadow.camera.top = extent;
         sun.shadow.camera.bottom = -extent;
-        sun.shadow.bias = -0.0008;
-        sun.shadow.normalBias = 0.05;
+        sun.shadow.bias = -0.0006;
+        sun.shadow.normalBias = 0.04;
     }
     scene.add(sun);
     scene.add(sun.target);
 
-    // Kept deliberately low: too much sky light and the sun's shadows stop reading.
     const hemi = new THREE.HemisphereLight(
-        wet ? 0x7f8b9c : 0x9fc4ff,
+        wet ? 0x7f8b9c : 0xa8cfff,
         circuit.def.scenery === 'city' ? 0x2a2c30 : 0x2d3a22,
-        wet ? 1.15 : 0.42
+        wet ? 1.25 : 0.48
     );
     scene.add(hemi);
+
+    // Soft fill to lift shadowed asphalt without killing contrast.
+    const fill = new THREE.DirectionalLight(wet ? 0x8a9aab : 0xb8d0f0, wet ? 0.35 : 0.55);
+    fill.position.set(-sunDirection.x * 80, 40, -sunDirection.z * 80);
+    scene.add(fill);
 
     scene.environment = environmentTexture(
         wet ? 0x9aa6b4 : 0xffd9a0,
         wet ? 0x6d7887 : 0x5f8fd0,
         circuit.def.scenery === 'city' ? 0x3a3d42 : 0x39492a
     );
-    scene.environmentIntensity = wet ? 0.55 : 0.3;
+    scene.environmentIntensity = wet ? 0.85 : 0.55;
 
     const fogColor = new THREE.Color(wet ? 0x8d99a8 : 0xa8bede);
-    scene.fog = new THREE.Fog(fogColor, quality.drawDistance * 0.35, quality.drawDistance * 1.5);
+    scene.fog = new THREE.Fog(fogColor, quality.drawDistance * 0.38, quality.drawDistance * 1.55);
 
     /* --- road ----------------------------------------------------- */
-    const roadMap = roadTexture(circuit.def.surface);
-    roadMap.repeat.set(1, 1);
-    roadMap.anisotropy = quality.anisotropy;
+    const roadPack = roadMaps(circuit.def.surface);
+    roadPack.map.anisotropy = quality.anisotropy;
+    roadPack.normalMap.anisotropy = quality.anisotropy;
     const roadMaterial = new THREE.MeshStandardMaterial({
-        map: roadMap,
-        bumpMap: roadMap,
-        bumpScale: 0.015,
-        roughness: wet ? 0.28 : 0.86,
-        metalness: wet ? 0.16 : 0.02,
-        envMapIntensity: wet ? 1.5 : 0.35
+        map: roadPack.map,
+        normalMap: roadPack.normalMap,
+        normalScale: new THREE.Vector2(0.85, 0.85),
+        roughnessMap: roadPack.roughnessMap,
+        roughness: wet ? 0.22 : 0.92,
+        metalness: wet ? 0.22 : 0.04,
+        envMapIntensity: wet ? 1.85 : 0.45
     });
 
     const halfAt = (i) => circuit.halfWidth * circuit.widthScale[i];
@@ -429,34 +492,59 @@ export function buildWorld(circuit, { quality, weather }) {
 
     const startLine = new THREE.Mesh(
         buildStartLine(circuit),
-        new THREE.MeshStandardMaterial({ map: startLineTexture(), roughness: 0.7, polygonOffset: true, polygonOffsetFactor: -2 })
+        new THREE.MeshStandardMaterial({
+            map: startLineTexture(), roughness: 0.65, metalness: 0.05,
+            polygonOffset: true, polygonOffsetFactor: -2
+        })
     );
     startLine.receiveShadow = false;
     group.add(startLine);
 
     /* --- kerbs ---------------------------------------------------- */
-    const kerbMap = kerbTexture();
-    kerbMap.anisotropy = quality.anisotropy;
+    const kerbPack = kerbMaps();
+    kerbPack.map.anisotropy = quality.anisotropy;
     const kerbs = new THREE.Mesh(
         buildKerbs(circuit),
-        new THREE.MeshStandardMaterial({ map: kerbMap, bumpMap: kerbMap, bumpScale: 0.02, roughness: 0.62, metalness: 0.03 })
+        new THREE.MeshStandardMaterial({
+            map: kerbPack.map,
+            normalMap: kerbPack.normalMap,
+            normalScale: new THREE.Vector2(1.4, 1.4),
+            roughnessMap: kerbPack.roughnessMap,
+            roughness: 0.55,
+            metalness: 0.04,
+            envMapIntensity: 0.5
+        })
     );
     kerbs.receiveShadow = quality.shadows;
+    kerbs.castShadow = quality.shadows;
     group.add(kerbs);
 
     /* --- run-off + terrain ---------------------------------------- */
     const cityLike = circuit.def.scenery === 'city';
 
-    // Modern circuits: a paved apron right beside the track, then a gravel trap.
-    const apronMap = runoffTexture();
-    apronMap.repeat.set(3, 1);
-    apronMap.anisotropy = quality.anisotropy;
-    const apronMaterial = new THREE.MeshStandardMaterial({ map: apronMap, roughness: 0.92 });
+    const apronPack = runoffMaps();
+    apronPack.map.repeat.set(3, 1);
+    apronPack.normalMap.repeat.set(3, 1);
+    apronPack.map.anisotropy = quality.anisotropy;
+    const apronMaterial = new THREE.MeshStandardMaterial({
+        map: apronPack.map,
+        normalMap: apronPack.normalMap,
+        normalScale: new THREE.Vector2(0.7, 0.7),
+        roughnessMap: apronPack.roughnessMap,
+        roughness: 0.92
+    });
 
-    const gravelMap = cityLike ? concreteTexture() : gravelTexture();
-    gravelMap.repeat.set(5, 1);
-    gravelMap.anisotropy = quality.anisotropy;
-    const gravelMaterial = new THREE.MeshStandardMaterial({ map: gravelMap, roughness: 0.98 });
+    const gravelPack = cityLike ? concreteMaps() : gravelMaps();
+    gravelPack.map.repeat.set(5, 1);
+    gravelPack.normalMap.repeat.set(5, 1);
+    gravelPack.map.anisotropy = quality.anisotropy;
+    const gravelMaterial = new THREE.MeshStandardMaterial({
+        map: gravelPack.map,
+        normalMap: gravelPack.normalMap,
+        normalScale: new THREE.Vector2(1.2, 1.2),
+        roughnessMap: gravelPack.roughnessMap,
+        roughness: 0.98
+    });
 
     for (const side of [-1, 1]) {
         const apron = new THREE.Mesh(
@@ -484,10 +572,17 @@ export function buildWorld(circuit, { quality, weather }) {
         group.add(gravel);
     }
 
-    const grassMap = grassTexture(cityLike ? 0x39413a : 0x33501f);
-    grassMap.repeat.set(26, 1);
-    grassMap.anisotropy = quality.anisotropy;
-    const grassMaterial = new THREE.MeshStandardMaterial({ map: grassMap, bumpMap: grassMap, bumpScale: 0.08, roughness: 1 });
+    const grassPack = grassMaps(cityLike ? 0x39413a : 0x1f3518);
+    grassPack.map.repeat.set(26, 1);
+    grassPack.normalMap.repeat.set(26, 1);
+    grassPack.map.anisotropy = quality.anisotropy;
+    const grassMaterial = new THREE.MeshStandardMaterial({
+        map: grassPack.map,
+        normalMap: grassPack.normalMap,
+        normalScale: new THREE.Vector2(1.1, 1.1),
+        roughnessMap: grassPack.roughnessMap,
+        roughness: 1
+    });
 
     let baseY = Infinity;
     for (let i = 0; i < circuit.count; i++) baseY = Math.min(baseY, circuit.y[i]);
@@ -502,7 +597,6 @@ export function buildWorld(circuit, { quality, weather }) {
                 {
                     vScale: 1 / 55,
                     lift: -0.36,
-                    // Blend the outer edge towards the base plane so the ground meets it flat.
                     outerLift: (i) => baseY + 0.55 - (circuit.y[i] + side * (halfAt(i) + VERGE_WIDTH) * Math.tan(circuit.bank[i])),
                     step: 2
                 }
@@ -516,11 +610,18 @@ export function buildWorld(circuit, { quality, weather }) {
     const spanX = circuit.maxX - circuit.minX;
     const spanZ = circuit.maxZ - circuit.minZ;
     const groundSize = Math.max(spanX, spanZ) + 4200;
-    const groundMap = grassTexture(cityLike ? 0x3c4139 : 0x2c471c);
-    groundMap.repeat.set(groundSize / 26, groundSize / 26);
+    const groundPack = grassMaps(cityLike ? 0x3c4139 : 0x1a3014);
+    groundPack.map.repeat.set(groundSize / 26, groundSize / 26);
+    groundPack.normalMap.repeat.set(groundSize / 26, groundSize / 26);
     const ground = new THREE.Mesh(
         new THREE.PlaneGeometry(groundSize, groundSize),
-        new THREE.MeshStandardMaterial({ map: groundMap, bumpMap: groundMap, bumpScale: 0.08, roughness: 1 })
+        new THREE.MeshStandardMaterial({
+            map: groundPack.map,
+            normalMap: groundPack.normalMap,
+            normalScale: new THREE.Vector2(0.9, 0.9),
+            roughnessMap: groundPack.roughnessMap,
+            roughness: 1
+        })
     );
     ground.rotation.x = -Math.PI / 2;
     ground.position.set((circuit.minX + circuit.maxX) / 2, baseY + 0.55, (circuit.minZ + circuit.maxZ) / 2);
@@ -528,10 +629,16 @@ export function buildWorld(circuit, { quality, weather }) {
     group.add(ground);
 
     /* --- barriers ------------------------------------------------- */
-    const wallHeight = 1.05;
-    const wallGeo = new THREE.BoxGeometry(3.4, wallHeight, 0.4);
+    const concretePack = concreteMaps();
+    const wallHeight = 1.1;
+    const wallGeo = new THREE.BoxGeometry(3.5, wallHeight, 0.42);
     const wallMaterial = new THREE.MeshStandardMaterial({
-        map: concreteTexture(), roughness: 0.85, metalness: 0.05
+        map: concretePack.map,
+        normalMap: concretePack.normalMap,
+        normalScale: new THREE.Vector2(0.6, 0.6),
+        roughnessMap: concretePack.roughnessMap,
+        roughness: 0.82,
+        metalness: 0.06
     });
     const wallStep = Math.max(1, Math.round(3.6 / circuit.spacing));
     const wallCount = Math.floor(circuit.count / wallStep) * 2;
@@ -555,24 +662,54 @@ export function buildWorld(circuit, { quality, weather }) {
     walls.count = w;
     group.add(walls);
 
+    // Catch fencing above barriers on high-speed stretches.
+    const fenceMat = new THREE.MeshStandardMaterial({
+        map: fenceTexture(),
+        transparent: true,
+        opacity: 0.55,
+        side: THREE.DoubleSide,
+        roughness: 0.4,
+        metalness: 0.7,
+        depthWrite: false
+    });
+    const fenceGeo = new THREE.PlaneGeometry(3.5, 2.4);
+    const fenceCount = Math.floor(circuit.count / (wallStep * 2)) * 2;
+    const fences = new THREE.InstancedMesh(fenceGeo, fenceMat, Math.max(1, fenceCount));
+    let fi = 0;
+    for (let i = 0; i < circuit.count; i += wallStep * 2) {
+        if (Math.abs(circuit.curvature[i]) > 0.012) continue; // skip tight hairpins
+        for (const side of [-1, 1]) {
+            if (fi >= fenceCount) break;
+            const lateral = side * (halfAt(i) + RUNOFF_WIDTH + 1.35);
+            const [x, y, z] = surfacePoint(circuit, i, lateral, -0.4);
+            dummy.position.set(x, y + wallHeight + 1.2, z);
+            dummy.rotation.set(0, circuit.heading[i] + (side > 0 ? 0 : Math.PI), 0);
+            dummy.scale.set(1, 1, 1);
+            dummy.updateMatrix();
+            fences.setMatrixAt(fi++, dummy.matrix);
+        }
+    }
+    fences.count = fi;
+    group.add(fences);
+
     // Tyre stacks on the outside of the quickest corners.
-    const tyreGeo = new THREE.CylinderGeometry(0.36, 0.36, 0.55, 10);
+    const tyreGeo = new THREE.CylinderGeometry(0.36, 0.36, 0.55, 12);
     const tyreMaterial = new THREE.MeshStandardMaterial({ color: 0x1b1c20, roughness: 0.95 });
     const stackSlots = [];
     for (let i = 0; i < circuit.count; i += 3) {
         if (Math.abs(circuit.curvature[i]) < 0.008) continue;
         stackSlots.push(i);
     }
-    const tyres = new THREE.InstancedMesh(tyreGeo, tyreMaterial, Math.max(1, stackSlots.length * 3));
+    const tyres = new THREE.InstancedMesh(tyreGeo, tyreMaterial, Math.max(1, stackSlots.length * 4));
     tyres.castShadow = quality.shadows;
     let ti = 0;
     for (const i of stackSlots) {
         const side = circuit.curvature[i] > 0 ? -1 : 1;
         const lateral = side * (halfAt(i) + RUNOFF_WIDTH + 0.5);
         const [x, y, z] = surfacePoint(circuit, i, lateral, -0.4);
-        for (let level = 0; level < 3; level++) {
-            dummy.position.set(x, y + 0.28 + level * 0.55, z);
-            dummy.rotation.set(0, circuit.heading[i], 0);
+        for (let level = 0; level < 4; level++) {
+            dummy.position.set(x + (level % 2) * 0.15, y + 0.28 + level * 0.52, z);
+            dummy.rotation.set(0, circuit.heading[i] + level * 0.2, 0);
             dummy.updateMatrix();
             tyres.setMatrixAt(ti++, dummy.matrix);
         }
@@ -581,53 +718,75 @@ export function buildWorld(circuit, { quality, weather }) {
     group.add(tyres);
 
     /* --- advertising hoardings ------------------------------------ */
-    const boardCount = Math.floor(circuit.count / 14);
-    const boardGeo = new THREE.PlaneGeometry(6.5, 1.5);
-    const boards = new THREE.InstancedMesh(
-        boardGeo,
-        new THREE.MeshStandardMaterial({ roughness: 0.55, side: THREE.DoubleSide }),
-        boardCount * 2
-    );
-    const boardColor = new THREE.Color();
+    const boardStride = 12;
+    const boardCount = Math.floor(circuit.count / boardStride);
+    const boardGeo = new THREE.PlaneGeometry(7.2, 1.7);
+    const boardMats = TEAMS.map((team) => new THREE.MeshStandardMaterial({
+        map: bannerTexture(team),
+        roughness: 0.45,
+        metalness: 0.15,
+        side: THREE.DoubleSide,
+        envMapIntensity: 0.8
+    }));
     let bi = 0;
-    for (let i = 0; i < circuit.count; i += 14) {
+    for (let i = 0; i < circuit.count; i += boardStride) {
         for (const side of [-1, 1]) {
-            if (bi >= boardCount * 2) break;
+            const teamIdx = (Math.floor(i / boardStride) + (side > 0 ? 3 : 0)) % TEAMS.length;
+            const board = new THREE.Mesh(boardGeo, boardMats[teamIdx]);
             const lateral = side * (halfAt(i) + RUNOFF_WIDTH + 1.05);
             const [x, y, z] = surfacePoint(circuit, i, lateral, -0.4);
-            dummy.position.set(x, y + 1.5, z);
-            dummy.rotation.set(0, circuit.heading[i] + (side > 0 ? Math.PI : 0), 0);
-            dummy.updateMatrix();
-            boards.setMatrixAt(bi, dummy.matrix);
-            const team = TEAMS[(i / 14 + (side > 0 ? 3 : 0)) % TEAMS.length | 0];
-            boards.setColorAt(bi, boardColor.setHex(team.primary).multiplyScalar(0.85));
+            board.position.set(x, y + 1.6, z);
+            board.rotation.y = circuit.heading[i] + (side > 0 ? Math.PI : 0);
+            group.add(board);
             bi++;
+            if (bi > boardCount * 2) break;
         }
     }
-    boards.count = bi;
-    if (boards.instanceColor) boards.instanceColor.needsUpdate = true;
-    group.add(boards);
+    void bi;
+
+    /* --- light poles ---------------------------------------------- */
+    if (quality.scenery > 0.2) {
+        const poleGeo = lightPoleGeometry();
+        const poleMat = new THREE.MeshStandardMaterial({ vertexColors: true, roughness: 0.55, metalness: 0.65 });
+        const poleStep = Math.max(8, Math.round(28 / quality.scenery));
+        const poleSlots = Math.floor(circuit.count / poleStep);
+        const poles = new THREE.InstancedMesh(poleGeo, poleMat, poleSlots);
+        poles.castShadow = quality.shadows;
+        let pi = 0;
+        for (let i = 0; i < circuit.count && pi < poleSlots; i += poleStep) {
+            const side = (Math.floor(i / poleStep) % 2 === 0) ? 1 : -1;
+            const lateral = side * (halfAt(i) + RUNOFF_WIDTH + 4.5);
+            const [x, y, z] = surfacePoint(circuit, i, lateral, -0.4);
+            dummy.position.set(x, y, z);
+            dummy.rotation.set(0, circuit.heading[i] + (side > 0 ? Math.PI / 2 : -Math.PI / 2), 0);
+            dummy.scale.setScalar(1);
+            dummy.updateMatrix();
+            poles.setMatrixAt(pi++, dummy.matrix);
+        }
+        poles.count = pi;
+        group.add(poles);
+    }
 
     /* --- scenery -------------------------------------------------- */
     if (quality.scenery > 0.1 && !cityLike) {
         const trees = new THREE.InstancedMesh(
             treeGeometry(),
-            new THREE.MeshStandardMaterial({ vertexColors: true, roughness: 0.9, metalness: 0.0 }),
-            Math.floor(circuit.count * 1.8 * quality.scenery) // Increased density
+            new THREE.MeshStandardMaterial({ vertexColors: true, roughness: 0.88, metalness: 0.0 }),
+            Math.floor(circuit.count * 2.1 * quality.scenery)
         );
-        trees.castShadow = true; // Enabled shadows for hyper-realism
-        trees.receiveShadow = true;
+        trees.castShadow = quality.shadows;
+        trees.receiveShadow = quality.shadows;
         let seed = 1337;
         const rand = () => (seed = (seed * 1664525 + 1013904223) >>> 0) / 4294967296;
         let idx = 0;
-        const step = Math.max(2, Math.round(6 / quality.scenery));
+        const step = Math.max(2, Math.round(5 / quality.scenery));
         for (let i = 0; i < circuit.count && idx < trees.count; i += step) {
-            const clusters = rand() < 0.55 ? 2 : 1;
+            const clusters = rand() < 0.6 ? 2 : 1;
             for (let c = 0; c < clusters && idx < trees.count; c++) {
                 const side = rand() < 0.5 ? -1 : 1;
                 const lateral = side * (halfAt(i) + RUNOFF_WIDTH + 14 + rand() * 78);
-                const [x, _, z] = surfacePoint(circuit, i, lateral, -0.4);
-                const scale = 0.75 + rand() * 0.9;
+                const [x, , z] = surfacePoint(circuit, i, lateral, -0.4);
+                const scale = 0.7 + rand() * 1.05;
                 dummy.position.set(x + (rand() - 0.5) * 12, baseY + 0.55, z + (rand() - 0.5) * 12);
                 dummy.rotation.set(0, rand() * Math.PI * 2, 0);
                 dummy.scale.setScalar(scale);
@@ -640,20 +799,28 @@ export function buildWorld(circuit, { quality, weather }) {
         group.add(trees);
     }
 
-    // Grandstands: one at the line, the rest at the slowest corners (best viewing).
+    // Grandstands + pit complex at the start/finish.
     const standSpots = [0];
     const sorted = [...circuit.corners].sort((a, b) => a.radius - b.radius).slice(0, 4);
     for (const corner of sorted) standSpots.push(corner.index);
     for (const spotIndex of standSpots) {
-        const stand = buildGrandstand(spotIndex === 0 ? 120 : 70, spotIndex === 0 ? 12 : 8);
+        const stand = buildGrandstand(spotIndex === 0 ? 130 : 75, spotIndex === 0 ? 13 : 8.5);
         const side = spotIndex === 0 ? 1 : (circuit.curvature[spotIndex] > 0 ? -1 : 1);
         const lateral = side * (halfAt(spotIndex) + RUNOFF_WIDTH + 3.5);
         const [x, y, z] = surfacePoint(circuit, spotIndex, lateral, -0.4);
         stand.position.set(x, y, z);
-        // The stand is built facing local -Z with its length on X, so it has to be
-        // turned a quarter turn to run alongside the track and face the racing line.
         stand.rotation.y = circuit.heading[spotIndex] + (side > 0 ? Math.PI / 2 : -Math.PI / 2);
         group.add(stand);
+    }
+
+    {
+        const pits = pitBuilding(110);
+        const side = -1;
+        const lateral = side * (halfAt(0) + RUNOFF_WIDTH + 18);
+        const [x, y, z] = surfacePoint(circuit, 0, lateral, -0.4);
+        pits.position.set(x, y, z);
+        pits.rotation.y = circuit.heading[0] + (side > 0 ? Math.PI / 2 : -Math.PI / 2);
+        group.add(pits);
     }
 
     const gantry = buildGantry(circuit);
@@ -666,15 +833,15 @@ export function buildWorld(circuit, { quality, weather }) {
 
     /* --- DRS zone markers ----------------------------------------- */
     const drsMaterial = new THREE.MeshStandardMaterial({
-        color: 0x0a2e1c, emissive: 0x18f08a, emissiveIntensity: 1.4, roughness: 0.4
+        color: 0x0a2e1c, emissive: 0x18f08a, emissiveIntensity: 1.6, roughness: 0.35, metalness: 0.2
     });
     for (const zone of circuit.drs) {
         const i = circuit.indexAt(zone.start * circuit.length);
         for (const side of [-1, 1]) {
-            const sign = new THREE.Mesh(new THREE.BoxGeometry(2.6, 1.1, 0.2), drsMaterial);
+            const sign = new THREE.Mesh(new THREE.BoxGeometry(2.8, 1.2, 0.22), drsMaterial);
             const lateral = side * (halfAt(i) + 3.2);
             const [x, y, z] = surfacePoint(circuit, i, lateral, 0);
-            sign.position.set(x, y + 2.2, z);
+            sign.position.set(x, y + 2.3, z);
             sign.rotation.y = circuit.heading[i];
             group.add(sign);
         }
@@ -689,10 +856,9 @@ export function buildWorld(circuit, { quality, weather }) {
         gantry,
         baseY,
         roadMaterial,
-        /** Keeps the shadow frustum tight around the player. */
         update(target) {
             sun.target.position.copy(target);
-            sun.position.copy(target).addScaledVector(sunDirection, 260);
+            sun.position.copy(target).addScaledVector(sunDirection, 280);
             sun.target.updateMatrixWorld();
         },
         dispose() {

--- a/labs/f1-racing/src/world.js
+++ b/labs/f1-racing/src/world.js
@@ -462,7 +462,7 @@ export function buildWorld(circuit, { quality, weather }) {
         wet ? 0x6d7887 : 0x5f8fd0,
         circuit.def.scenery === 'city' ? 0x3a3d42 : 0x39492a
     );
-    scene.environmentIntensity = wet ? 0.85 : 0.55;
+    scene.environmentIntensity = wet ? 1.05 : 0.85;
 
     const fogColor = new THREE.Color(wet ? 0x8d99a8 : 0xa8bede);
     scene.fog = new THREE.Fog(fogColor, quality.drawDistance * 0.38, quality.drawDistance * 1.55);
@@ -474,16 +474,16 @@ export function buildWorld(circuit, { quality, weather }) {
     const roadMaterial = new THREE.MeshStandardMaterial({
         map: roadPack.map,
         normalMap: roadPack.normalMap,
-        normalScale: new THREE.Vector2(0.85, 0.85),
+        normalScale: new THREE.Vector2(1.35, 1.35),
         roughnessMap: roadPack.roughnessMap,
-        roughness: wet ? 0.22 : 0.92,
-        metalness: wet ? 0.22 : 0.04,
-        envMapIntensity: wet ? 1.85 : 0.45
+        roughness: wet ? 0.22 : 0.9,
+        metalness: wet ? 0.22 : 0.06,
+        envMapIntensity: wet ? 2.1 : 0.7
     });
 
     const halfAt = (i) => circuit.halfWidth * circuit.widthScale[i];
     const road = new THREE.Mesh(
-        buildRibbon(circuit, (i) => -halfAt(i), (i) => halfAt(i), { vScale: 1 / 14 }),
+        buildRibbon(circuit, (i) => -halfAt(i), (i) => halfAt(i), { vScale: 1 / 8 }),
         roadMaterial
     );
     road.receiveShadow = quality.shadows;

--- a/labs/f1-racing/style.css
+++ b/labs/f1-racing/style.css
@@ -47,7 +47,7 @@ body {
     min-height: 100dvh;
     padding: 0;
     color: var(--text);
-    font-family: Inter, system-ui, -apple-system, 'Segoe UI', sans-serif;
+    font-family: 'DM Sans', system-ui, -apple-system, 'Segoe UI', sans-serif;
     font-synthesis-weight: none;
     user-select: none;
     -webkit-user-select: none;
@@ -121,7 +121,7 @@ button {
 }
 
 .f1-mark {
-    font-family: Orbitron, Inter, sans-serif;
+    font-family: Orbitron, 'DM Sans', sans-serif;
     font-weight: 900;
     font-style: italic;
     letter-spacing: -0.06em;
@@ -208,7 +208,7 @@ button {
 }
 
 .stat-value strong {
-    font-family: Orbitron, Inter, sans-serif;
+    font-family: Orbitron, 'DM Sans', sans-serif;
     font-size: 1.75rem;
     font-weight: 800;
 }
@@ -399,7 +399,7 @@ button {
 .speedo { display: flex; align-items: baseline; gap: 0.3rem; }
 
 .speedo strong {
-    font-family: Orbitron, Inter, sans-serif;
+    font-family: Orbitron, 'DM Sans', sans-serif;
     font-size: clamp(2.4rem, 6vw, 3.4rem);
     font-weight: 800;
     line-height: 0.9;
@@ -425,7 +425,7 @@ button {
 }
 
 .gear strong {
-    font-family: Orbitron, Inter, sans-serif;
+    font-family: Orbitron, 'DM Sans', sans-serif;
     font-size: 1.9rem;
     font-weight: 800;
     line-height: 1;
@@ -485,7 +485,7 @@ button {
     background: var(--panel-strong);
     border: 1px solid var(--line);
     backdrop-filter: blur(var(--blur));
-    font-family: Orbitron, Inter, sans-serif;
+    font-family: Orbitron, 'DM Sans', sans-serif;
     font-size: clamp(1rem, 2.6vw, 1.5rem);
     font-weight: 700;
     letter-spacing: 0.04em;
@@ -594,7 +594,7 @@ button {
 
 .menu-head h1 {
     margin: 0.4rem 0 0.5rem;
-    font-family: Orbitron, Inter, sans-serif;
+    font-family: Orbitron, 'DM Sans', sans-serif;
     font-size: clamp(2rem, 6vw, 3.4rem);
     font-weight: 900;
     font-style: italic;
@@ -679,7 +679,7 @@ button {
 }
 
 .team-number {
-    font-family: Orbitron, Inter, sans-serif;
+    font-family: Orbitron, 'DM Sans', sans-serif;
     font-size: 1.15rem;
     font-weight: 800;
     min-width: 2ch;
@@ -825,7 +825,7 @@ kbd {
 
 .compact-card h2, .results-card h2 {
     margin: 0;
-    font-family: Orbitron, Inter, sans-serif;
+    font-family: Orbitron, 'DM Sans', sans-serif;
     font-size: clamp(1.4rem, 4vw, 2.2rem);
     font-weight: 800;
     letter-spacing: -0.02em;
@@ -851,7 +851,7 @@ kbd {
 }
 
 .result-highlights span { font-size: 0.62rem; letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-dim); }
-.result-highlights strong { font-size: 1.15rem; font-family: Orbitron, Inter, sans-serif; }
+.result-highlights strong { font-size: 1.15rem; font-family: Orbitron, 'DM Sans', sans-serif; }
 .result-highlights div:first-child strong { color: var(--f1-red-soft); }
 
 .result-board {

--- a/labs/f1-racing/style.css
+++ b/labs/f1-racing/style.css
@@ -545,10 +545,15 @@ button {
     z-index: 10;
     opacity: 0;
     visibility: hidden;
+    pointer-events: none;
     transition: opacity 0.35s var(--ease), visibility 0.35s;
 }
 
-.overlay.is-visible { opacity: 1; visibility: visible; }
+.overlay.is-visible {
+    opacity: 1;
+    visibility: visible;
+    pointer-events: auto;
+}
 
 .overlay-card {
     width: min(1080px, 100%);

--- a/labs/f1-racing/style.css
+++ b/labs/f1-racing/style.css
@@ -537,22 +537,26 @@ button {
 .overlay {
     position: absolute;
     inset: 0;
-    display: grid;
+    display: none;
     place-items: center;
     padding: calc(var(--safe-top) + 4.2rem) 1rem calc(var(--safe-bottom) + 1rem);
     background: color-mix(in oklab, var(--ink-deep) 78%, transparent);
     backdrop-filter: blur(12px);
     z-index: 10;
     opacity: 0;
-    visibility: hidden;
     pointer-events: none;
-    transition: opacity 0.35s var(--ease), visibility 0.35s;
 }
 
 .overlay.is-visible {
+    display: grid;
     opacity: 1;
-    visibility: visible;
     pointer-events: auto;
+    animation: overlayIn 0.28s var(--ease);
+}
+
+@keyframes overlayIn {
+    from { opacity: 0; }
+    to { opacity: 1; }
 }
 
 .overlay-card {
@@ -769,6 +773,8 @@ select {
     gap: 1rem;
     padding-top: 1rem;
     border-top: 1px solid var(--line-soft);
+    position: relative;
+    z-index: 2;
 }
 
 .keys { display: flex; flex-wrap: wrap; gap: 0.4rem 0.9rem; font-size: 0.7rem; color: var(--text-dim); }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Overhaul do lab `f1-racing` mirando o nível visual/jogabilidade de [Crazy Grand Prix](https://www.crazygames.com/game/crazy-grand-prix): pista e materiais PBR, carro F1 bem mais detalhado, ambiente de paddock, física com peso/grip real (ainda arcade-acessível) e HUD/controles completos.

### Visual
- Texturas procedurais PBR com **albedo + normal + roughness** (asfalto, zebra, grama, gravel, concreto)
- Carro com piloto/capacete, volante, carbon weave, livery com número, DRS animado, sidewall de composto
- Mundo: boxes no grid, catch fencing, postes de iluminação, banners de equipe, árvores densas, lighting/HDRI melhorados
- Paint com clearcoat/env mais forte; asfalto com UV mais denso

### Jogabilidade
- Física **bicycle + Pacejka** com downforce, weight transfer, grip por superfície/clima/composto, wear/temp de pneu
- ERS como boost híbrido (~120 kW), DRS por zona de ativação, colisões com impulso real
- Look-back (`B`), seletor de composto, badge DRS + telemetria de pneu no HUD
- IA com freada aero-aware e slipstream

### UI / fixes
- Menu de compostos, controles touch DRS/ERS, tipografia DM Sans + Orbitron
- Overlays ocultos com `display: none` (não bloqueiam cliques)
- Sem fumaça fantasma no grid; temperatura de pneus estável (~35–100 °C em uso)
- Qualidade auto favorece medium/high no desktop (sombras + PBR)

### Testes
- Corrida inicia, countdown, física e HUD OK em WebGL2 (fallback sem WebGPU)

[Chase camera](https://cursor.com/agents/bc-521eb0f4-ac26-4428-a6aa-cff764aa5791/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Ff1-final-chase.webp)
[Car detail](https://cursor.com/agents/bc-521eb0f4-ac26-4428-a6aa-cff764aa5791/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Ff1-final-car.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-521eb0f4-ac26-4428-a6aa-cff764aa5791?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-521eb0f4-ac26-4428-a6aa-cff764aa5791&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

