### PR TITLE
docs: add Cursor Cloud dev environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,4 +46,16 @@ Este repositório é o portfólio pessoal e *Playground* de laboratórios do Dio
 - Sempre documente o código de lógicas complexas (como fórmulas matemáticas para simulações ou regras de jogos).
 
 ---
+
+## Cursor Cloud specific instructions
+
+Site 100% estático (HTML/CSS/JS puro). **Não há build, dependências, lockfiles, nem testes/lint automatizados** — não procure por `package.json`, `npm install`, etc. O código-fonte é o próprio artefato servido no GitHub Pages.
+
+- **Rodar em desenvolvimento**: sirva a raiz do repositório por HTTP (abrir os arquivos via `file://` quebra caminhos absolutos como `/favicon.ico` e módulos ES). A partir de `/workspace`:
+  - `python3 -m http.server 8000` → site principal em `http://localhost:8000/`, playground em `http://localhost:8000/labs/`.
+- **Estrutura**: `index.html` (portfólio raiz) + `labs/<nome-do-lab>/index.html` (cada lab é autocontido). `labs/index.html` é a galeria que linka todos os labs.
+- **Caminhos**: o `manifest.json` e alguns assets usam caminhos absolutos (`/favicon.ico`, `/assets/...`), por isso é necessário servir a partir da raiz do repositório, não de uma subpasta.
+- **Verificação/"testes"**: não existe suíte automatizada. Valide manualmente carregando as páginas no navegador (o toggle de tema na home e abrir um lab da galeria são bons smoke tests).
+
+---
 *Lembre-se: O objetivo principal do projeto é criatividade, performance e experimentação tecnológica na web sem barreiras.*


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for this static portfolio + labs playground and documents how to run it for future Cloud Agents.

This repo is a 100% static site (Vanilla HTML/CSS/JS) with **no build step, no dependencies, no lockfiles, and no automated tests/lint** — it's served directly (GitHub Pages in production). The only setup needed for development is serving the repository root over HTTP.

## Changes

- Added a `## Cursor Cloud specific instructions` section to `AGENTS.md` explaining:
  - There are no dependencies/build/tests to install or run.
  - How to run the dev server: `python3 -m http.server 8000` from the repo root (main site at `/`, labs at `/labs/`).
  - Why it must be served from the repo root (absolute asset paths like `/favicon.ico`).
  - How to smoke-test manually.

## Environment

- Update script: `python3 --version` (no dependencies to install; just verifies the runtime used to serve files).

## Verification

Started `python3 -m http.server 8000` and confirmed HTTP 200 for `/`, `/labs/index.html`, an individual lab, and shared CSS. Performed a browser walkthrough: homepage loads, theme toggle works, labs gallery navigates, and the Snake game opens and responds to input.

[portfolio_dev_env_walkthrough.mp4](https://cursor.com/agents/bc-c176c1de-2d8b-4061-b609-4603d4597897/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fportfolio_dev_env_walkthrough.mp4)
[Homepage light theme](https://cursor.com/agents/bc-c176c1de-2d8b-4061-b609-4603d4597897/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2F01_homepage_light.webp)
[Homepage dark theme](https://cursor.com/agents/bc-c176c1de-2d8b-4061-b609-4603d4597897/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2F02_homepage_dark.webp)
[Labs gallery](https://cursor.com/agents/bc-c176c1de-2d8b-4061-b609-4603d4597897/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2F03_labs_gallery.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c176c1de-2d8b-4061-b609-4603d4597897?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c176c1de-2d8b-4061-b609-4603d4597897&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

