### PR TITLE
feat: standardize lab headers to use shared data-lab-header

### DIFF
--- a/labs/ravi-123/game.js
+++ b/labs/ravi-123/game.js
@@ -113,7 +113,7 @@ function bindUI() {
   });
 
   document.getElementById('btn-fs').addEventListener('click', toggleFullscreen);
-  document.getElementById('btn-back').addEventListener('click', () => {
+  const btnBack = document.getElementById('btn-back'); if (btnBack) btnBack.addEventListener('click', () => {
     window.location.href = '/labs/';
   });
 

--- a/labs/ravi-123/index.html
+++ b/labs/ravi-123/index.html
@@ -21,6 +21,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Fredoka:wght@400;600;700&family=Nunito:wght@700;900&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css?v=3">
+  <link rel="stylesheet" href="/labs/shared.css?v=5">
 </head>
 
 <body>
@@ -28,9 +29,13 @@
     <canvas id="game" width="640" height="400" aria-label="Ravi 1·2·3"></canvas>
 
     <div id="hud">
-      <button id="btn-back" class="hud-btn" type="button" title="Voltar aos labs" aria-label="Voltar">←</button>
+      
       <div id="speech-bubble" class="hidden" aria-live="polite"></div>
-      <button id="btn-fs" class="hud-btn" type="button" title="Tela cheia" aria-label="Tela cheia">⛶</button>
+      <header data-lab-header data-title="Ravi 1·2·3" class="ravi-header">
+        <template data-slot="actions">
+          <button id="btn-fs" class="hud-btn" type="button" title="Tela cheia" aria-label="Tela cheia">⛶</button>
+        </template>
+      </header>
     </div>
 
     <div id="flashcard" class="hidden" aria-hidden="true">
@@ -70,6 +75,7 @@
   </div>
 
   <script type="module" src="main.js?v=3"></script>
+  <script src="/labs/shared.js?v=5" defer></script>
 </body>
 
 </html>

--- a/labs/ravi-123/style.css
+++ b/labs/ravi-123/style.css
@@ -387,3 +387,15 @@ body.fs-fallback #app {
   inset: 0;
   z-index: 9999;
 }
+.ravi-header {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 100;
+  margin-bottom: 0;
+  padding: 1rem;
+}
+.ravi-header .app-logo {
+  display: none;
+}

--- a/labs/rock-kombat/index.html
+++ b/labs/rock-kombat/index.html
@@ -8,18 +8,20 @@
   <meta name="theme-color" content="#090a0c">
   <meta property="og:title" content="Rock Kombat — 2D Arcade Fight">
   <meta property="og:description" content="Escolha sua lenda. Leia a distância. Domine o palco.">
+  <link rel="stylesheet" href="/labs/shared.css?v=5">
   <link rel="stylesheet" href="style.css?v=5">
 </head>
 <body>
   <div class="grain" aria-hidden="true"></div>
 
-  <header class="topbar">
-    <a href="/labs/" class="back-link" aria-label="Voltar para Labs">← <span>LABS</span></a>
-    <div class="mini-brand" aria-label="Rock Kombat"><b>ROCK</b> KOMBAT</div>
-    <div class="top-actions">
+  <header data-lab-header data-title="Rock Kombat">
+    <template data-slot="logo">
+      <div class="mini-brand" aria-label="Rock Kombat"><b>ROCK</b> KOMBAT</div>
+    </template>
+    <template data-slot="actions">
       <button id="help-button" type="button">COMANDOS</button>
       <button id="sound-button" type="button" aria-label="Ativar ou desativar som">SOM ON</button>
-    </div>
+    </template>
   </header>
 
   <main id="app">
@@ -166,6 +168,7 @@
     <div><p class="overline">INTERMISSION</p><h2>PAUSADO</h2><button class="cta" id="resume-button" type="button"><b>CONTINUAR</b></button><button class="quiet-button" id="quit-button" type="button">SAIR DA LUTA</button></div>
   </div>
 
+  <script src="/labs/shared.js?v=5" defer></script>
   <script src="audio.js?v=3"></script>
   <script src="game.js?v=1"></script>
 </body>


### PR DESCRIPTION
## O que foi feito

- **Rock Kombat**: Injeção de `data-lab-header` padronizado e reaproveitamento dos botões do HUD original no `data-slot=\actions\`.
- **Ravi 1·2·3**: Injeção de `data-lab-header` em modo overlay usando uma classe especial para suportar a arquitetura fullscreen sem quebrar proporções. Correção leve de eventListeners no `game.js`.
- Inclusão dos imports globais `shared.js` e `shared.css` nos aplicativos adaptados.