### PR TITLE
feat(labs): River Knight — aventura medieval 3D em three.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Um laboratório aberto onde guardo os experimentos e mini-projetos que fui crian
 
 | Projeto | O que é? |
 | :--- | :--- |
+| ⚔️ **[River Knight](https://diogopaulino.com.br/labs/river-knight/)** | Aventura medieval 3D em three.js — drakkar, machados e o resgate da princesa no castelo |
 | 🌇 **[Santos Vice Games](https://diogopaulino.com.br/labs/santos-vice-city/)** | California Games, mas caiçara — seis provas de praia 16-bit com patrocinador, medalhas e pódio |
 | 🎈 **[Ravi 1·2·3](https://diogopaulino.com.br/labs/ravi-123/)** | Festa surpresa com heróis — conte 1 a 9 estilo Mickey's 123 |
 | 🥊 **[Rock Kombat](https://diogopaulino.com.br/labs/rock-kombat/)** | Luta 2D cinematográfica com lendas do rock |

--- a/labs/index.html
+++ b/labs/index.html
@@ -567,6 +567,27 @@
           </div>
         </div>
       </a>
+      <a href="/labs/river-knight/" class="project-card" data-groups="game">
+        <div class="project-icon">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+            stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M12 2.5v9" />
+            <path d="M12 4h5.5l-1.8 2.6L17.5 9H12" />
+            <path d="M3.5 12.5h17l-2.6 4.4a3 3 0 0 1-2.6 1.5H8.7a3 3 0 0 1-2.6-1.5l-2.6-4.4z" />
+            <path d="M2 21.5c1.7 0 1.7-1.3 3.3-1.3s1.7 1.3 3.4 1.3 1.7-1.3 3.3-1.3 1.7 1.3 3.4 1.3 1.7-1.3 3.3-1.3 1.7 1.3 3.3 1.3" />
+          </svg>
+        </div>
+        <div class="project-content">
+          <h2>River Knight</h2>
+          <p>Aventura medieval 3D em three.js: leve o drakkar rio abaixo, derrube barcos e
+            torres inimigas, vença a Barcaça Negra e resgate a princesa no castelo</p>
+          <div class="project-tags">
+            <span class="tag">three.js</span>
+            <span class="tag">3D</span>
+            <span class="tag">Medieval</span>
+          </div>
+        </div>
+      </a>
       <a href="/labs/santos-vice-city/" class="project-card" data-groups="game">
         <div class="project-icon">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"

--- a/labs/river-knight/index.html
+++ b/labs/river-knight/index.html
@@ -1,0 +1,245 @@
+<!DOCTYPE html>
+<html lang="pt-br" data-theme="dark">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport"
+        content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover">
+    <meta name="theme-color" content="#0b0a12">
+    <title>River Knight — resgate a princesa no castelo | Labs</title>
+    <meta name="description"
+        content="Jogo 3D em three.js: guie o drakkar do guerreiro medieval rio abaixo, derrube barcos inimigos e torres, enfrente a barcaça negra e resgate a princesa no castelo.">
+    <link rel="canonical" href="https://diogopaulino.com.br/labs/river-knight/">
+
+    <meta property="og:type" content="website">
+    <meta property="og:site_name" content="Diogo Paulino · Labs">
+    <meta property="og:url" content="https://diogopaulino.com.br/labs/river-knight/">
+    <meta property="og:title" content="River Knight">
+    <meta property="og:description"
+        content="Aventura medieval 3D no navegador: rio com ondas de Gerstner, drakkar, machados de arremesso e um castelo à espera.">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="River Knight">
+    <meta name="twitter:description" content="Navegue, lute e resgate a princesa. Aventura medieval 3D em three.js.">
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;600;700;800&family=Outfit:wght@300;400;500;600;700&display=swap"
+        rel="stylesheet">
+    <link rel="stylesheet" href="/labs/shared.css?v=4">
+    <link rel="stylesheet" href="style.css?v=1">
+
+    <script type="importmap">
+    {
+        "imports": {
+            "three": "https://cdn.jsdelivr.net/npm/three@0.185.1/build/three.module.js",
+            "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.185.1/examples/jsm/"
+        }
+    }
+    </script>
+</head>
+
+<body>
+    <main class="game-shell">
+        <header data-lab-header data-title="River Knight" data-back-label="Labs">
+            <template data-slot="logo">
+                <div class="app-logo">
+                    <span class="brand-mark" aria-hidden="true">⚔️</span>
+                    <span>River Knight</span>
+                </div>
+            </template>
+        </header>
+
+        <canvas id="scene" aria-label="Rio medieval em 3D com o barco do guerreiro"></canvas>
+
+        <!-- ================= HUD ================= -->
+        <div id="hud" class="hud" hidden>
+            <div class="hud-top">
+                <div class="panel hull-panel">
+                    <span class="hud-label">Casco</span>
+                    <div id="hullPips" class="pips" aria-label="Integridade do casco"></div>
+                    <div class="fury">
+                        <span class="hud-label">Fúria</span>
+                        <div class="meter"><i id="furyFill"></i></div>
+                    </div>
+                </div>
+
+                <div class="panel voyage-panel">
+                    <div class="voyage-head">
+                        <span class="hud-label">Rumo ao castelo</span>
+                        <strong id="distanceValue" class="mono">4200 m</strong>
+                    </div>
+                    <div class="rail">
+                        <i id="progressFill"></i>
+                        <span id="progressBoat" class="rail-boat" aria-hidden="true">⛵</span>
+                        <span class="rail-castle" aria-hidden="true">🏰</span>
+                    </div>
+                </div>
+
+                <div class="panel score-panel">
+                    <div class="score-row">
+                        <span class="hud-label">Glória</span>
+                        <strong id="scoreValue" class="mono">0</strong>
+                    </div>
+                    <div class="score-row score-row--sub">
+                        <span id="comboBadge" class="combo" data-active="false">x1.0</span>
+                        <span id="timeValue" class="mono">0:00</span>
+                    </div>
+                </div>
+            </div>
+
+            <div id="bossPanel" class="boss-panel" hidden>
+                <span class="boss-name">Barcaça Negra de Morvain</span>
+                <div class="boss-bar"><i id="bossFill"></i></div>
+            </div>
+
+            <p id="message" class="message" role="status" aria-live="polite"></p>
+
+            <div class="hud-actions">
+                <button id="soundButton" class="icon-button" type="button" aria-pressed="true"
+                    title="Som (M)" aria-label="Alternar som">♪</button>
+                <button id="pauseButton" class="icon-button" type="button" title="Pausar (P)"
+                    aria-label="Pausar">II</button>
+                <span id="fpsCounter" class="fps mono" hidden>—</span>
+            </div>
+
+            <!-- Controles de toque -->
+            <div id="touchControls" class="touch-controls" hidden>
+                <div class="steer-zone" id="steerZone" aria-label="Arraste para navegar">
+                    <span class="steer-hint">navegar</span>
+                </div>
+                <div class="touch-buttons">
+                    <button type="button" class="pad pad-boost" data-control="boost" aria-label="Acelerar">REMAR</button>
+                    <button type="button" class="pad pad-throw" data-control="throw" aria-label="Arremessar machado">🪓</button>
+                </div>
+            </div>
+        </div>
+
+        <div id="hitFlash" class="hit-flash" aria-hidden="true"></div>
+
+        <!-- ================= Overlays ================= -->
+        <div id="loadingOverlay" class="overlay loading-overlay">
+            <div class="loading-card">
+                <span class="loading-mark" aria-hidden="true">⚔️</span>
+                <h1>River Knight</h1>
+                <p id="loadingText">Forjando o rio…</p>
+                <div class="loading-bar"><i id="loadingFill"></i></div>
+            </div>
+        </div>
+
+        <div id="menuOverlay" class="overlay menu-overlay" hidden>
+            <div class="overlay-card menu-card">
+                <header class="menu-head">
+                    <p class="eyebrow"><i></i> three.js · ondas de Gerstner · céu procedural</p>
+                    <h1>River <span>Knight</span></h1>
+                    <p class="lede">A princesa está presa na torre de Morvain. Entre o seu drakkar e o
+                        castelo há quatro quilômetros de rio, arqueiros nas margens, barcos de guerra e
+                        uma barcaça negra bloqueando o portão. Reme.</p>
+                </header>
+
+                <div class="menu-grid">
+                    <section class="menu-section">
+                        <h2>Jornada</h2>
+                        <div id="difficultyOptions" class="chip-row" role="radiogroup"
+                            aria-label="Dificuldade"></div>
+                        <p id="difficultyBlurb" class="section-note"></p>
+                    </section>
+
+                    <section class="menu-section">
+                        <h2>Comandos</h2>
+                        <div class="keys">
+                            <span><kbd>A</kbd><kbd>D</kbd> ou <kbd>←</kbd><kbd>→</kbd> navegar</span>
+                            <span><kbd>W</kbd> remar forte · <kbd>S</kbd> segurar</span>
+                            <span><kbd>Espaço</kbd> ou <kbd>clique</kbd> arremessar machado</span>
+                            <span><kbd>C</kbd> câmera · <kbd>P</kbd> pausa · <kbd>M</kbd> som</span>
+                        </div>
+                    </section>
+
+                    <section class="menu-section">
+                        <h2>Ajustes</h2>
+                        <div class="settings-grid">
+                            <label class="field">
+                                <span>Qualidade</span>
+                                <select id="qualitySelect">
+                                    <option value="auto">Automática</option>
+                                    <option value="low">Performance</option>
+                                    <option value="medium">Equilibrada</option>
+                                    <option value="high">Cinemática</option>
+                                </select>
+                            </label>
+                            <label class="field">
+                                <span>Volume <b id="volumeValue">70</b></span>
+                                <input id="volumeSlider" type="range" min="0" max="100" step="1" value="70">
+                            </label>
+                        </div>
+                        <p class="section-note">Melhor glória: <b id="bestScore" class="mono">—</b></p>
+                    </section>
+                </div>
+
+                <footer class="menu-foot">
+                    <button id="startButton" class="primary-button" type="button">
+                        <span>Zarpar</span>
+                        <i aria-hidden="true">→</i>
+                    </button>
+                </footer>
+            </div>
+        </div>
+
+        <div id="pauseOverlay" class="overlay" hidden>
+            <div class="overlay-card compact-card">
+                <p class="eyebrow"><i></i> Âncora lançada</p>
+                <h2>O rio espera.</h2>
+                <div class="card-actions">
+                    <button id="resumeButton" class="primary-button" type="button">
+                        <span>Continuar</span><i aria-hidden="true">→</i>
+                    </button>
+                    <button id="pauseMenuButton" class="ghost-button" type="button">Voltar ao porto</button>
+                </div>
+            </div>
+        </div>
+
+        <div id="gameOverOverlay" class="overlay" hidden>
+            <div class="overlay-card compact-card defeat-card">
+                <p class="eyebrow eyebrow--danger"><i></i> O casco cedeu</p>
+                <h2>O rio levou<br>o guerreiro.</h2>
+                <div id="defeatStats" class="stats"></div>
+                <div class="card-actions">
+                    <button id="retryButton" class="primary-button" type="button">
+                        <span>Tentar de novo</span><i aria-hidden="true">↻</i>
+                    </button>
+                    <button id="defeatMenuButton" class="ghost-button" type="button">Voltar ao porto</button>
+                </div>
+            </div>
+        </div>
+
+        <div id="victoryOverlay" class="overlay" hidden>
+            <div class="overlay-card compact-card victory-card">
+                <p class="eyebrow eyebrow--gold"><i></i> Portão tomado</p>
+                <h2>A princesa<br>está livre.</h2>
+                <div id="victoryStats" class="stats"></div>
+                <div class="card-actions">
+                    <button id="replayButton" class="primary-button" type="button">
+                        <span>Nova jornada</span><i aria-hidden="true">→</i>
+                    </button>
+                    <button id="victoryMenuButton" class="ghost-button" type="button">Voltar ao porto</button>
+                </div>
+            </div>
+        </div>
+
+        <div id="errorOverlay" class="overlay" hidden>
+            <div class="overlay-card compact-card">
+                <p class="eyebrow eyebrow--danger"><i></i> WebGL indisponível</p>
+                <h2>Seu navegador não<br>conseguiu abrir o rio.</h2>
+                <p class="lede" id="errorText">Este laboratório precisa de WebGL 2. Tente um navegador
+                    atualizado ou reative a aceleração de hardware.</p>
+            </div>
+        </div>
+
+        <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
+    </main>
+
+    <script src="/labs/shared.js?v=5" defer></script>
+    <script type="module" src="src/main.js?v=1"></script>
+</body>
+
+</html>

--- a/labs/river-knight/src/audio.js
+++ b/labs/river-knight/src/audio.js
@@ -1,0 +1,454 @@
+/**
+ * Áudio 100 % sintetizado com a Web Audio API — nenhum arquivo de som.
+ *
+ * A trilha é um sequenciador simples em ré menor com alaúde (osciladores com
+ * decaimento rápido), tambores de guerra e um drone de coro. As camadas entram
+ * e saem conforme o momento do jogo (menu, rio, chefe, vitória, derrota).
+ */
+
+const SCALE = [0, 2, 3, 5, 7, 8, 10]; // eólio (menor natural)
+const ROOT = 146.83; // ré2
+
+/** Frequência de um grau da escala (com oitavas). */
+function noteFreq(degree, octave = 0) {
+    const idx = ((degree % 7) + 7) % 7;
+    const oct = octave + Math.floor(degree / 7);
+    return ROOT * Math.pow(2, oct + SCALE[idx] / 12);
+}
+
+const PROGRESSION = [
+    { root: 0, chord: [0, 2, 4] },   // Dm
+    { root: 5, chord: [5, 0, 2] },   // Bb
+    { root: 2, chord: [2, 4, 6] },   // F
+    { root: 4, chord: [4, 6, 1] }    // C
+];
+
+export class GameAudio {
+    constructor() {
+        this.ctx = null;
+        this.enabled = true;
+        this.volume = 0.7;
+        this.mode = null;
+        this.step = 0;
+        this.nextNoteTime = 0;
+        this.timer = null;
+        this.tempo = 96;
+        this.intensity = 0;
+    }
+
+    /** Precisa ser chamado a partir de um gesto do usuário. */
+    init() {
+        if (this.ctx) {
+            if (this.ctx.state === 'suspended') this.ctx.resume();
+            return;
+        }
+
+        const Ctx = window.AudioContext || window.webkitAudioContext;
+        if (!Ctx) return;
+
+        const ctx = new Ctx();
+        this.ctx = ctx;
+
+        this.master = ctx.createGain();
+        this.master.gain.value = this.enabled ? this.volume : 0;
+
+        this.compressor = ctx.createDynamicsCompressor();
+        this.compressor.threshold.value = -12;
+        this.compressor.knee.value = 22;
+        this.compressor.ratio.value = 6;
+        this.compressor.attack.value = 0.004;
+        this.compressor.release.value = 0.22;
+
+        this.musicBus = ctx.createGain();
+        this.musicBus.gain.value = 0.55;
+        this.sfxBus = ctx.createGain();
+        this.sfxBus.gain.value = 0.9;
+
+        // Reverberação curta (impulso sintético) dá "sala" ao conjunto.
+        this.reverb = ctx.createConvolver();
+        this.reverb.buffer = this._impulse(2.1, 2.6);
+        this.reverbSend = ctx.createGain();
+        this.reverbSend.gain.value = 0.24;
+
+        this.musicBus.connect(this.compressor);
+        this.sfxBus.connect(this.compressor);
+        this.musicBus.connect(this.reverbSend);
+        this.sfxBus.connect(this.reverbSend);
+        this.reverbSend.connect(this.reverb);
+        this.reverb.connect(this.compressor);
+        this.compressor.connect(this.master);
+        this.master.connect(ctx.destination);
+
+        this.noiseBuffer = this._noise(2);
+    }
+
+    _impulse(duration, decay) {
+        const rate = this.ctx.sampleRate;
+        const length = Math.floor(rate * duration);
+        const buffer = this.ctx.createBuffer(2, length, rate);
+        for (let c = 0; c < 2; c++) {
+            const data = buffer.getChannelData(c);
+            for (let i = 0; i < length; i++) {
+                const t = i / length;
+                data[i] = (Math.random() * 2 - 1) * Math.pow(1 - t, decay);
+            }
+        }
+        return buffer;
+    }
+
+    _noise(seconds) {
+        const rate = this.ctx.sampleRate;
+        const buffer = this.ctx.createBuffer(1, rate * seconds, rate);
+        const data = buffer.getChannelData(0);
+        for (let i = 0; i < data.length; i++) data[i] = Math.random() * 2 - 1;
+        return buffer;
+    }
+
+    setVolume(value) {
+        this.volume = value;
+        if (this.master) {
+            this.master.gain.setTargetAtTime(this.enabled ? value : 0, this.ctx.currentTime, 0.05);
+        }
+    }
+
+    setEnabled(enabled) {
+        this.enabled = enabled;
+        if (this.master) {
+            this.master.gain.setTargetAtTime(enabled ? this.volume : 0, this.ctx.currentTime, 0.05);
+        }
+    }
+
+    /* -------------------------------------------------------------- */
+    /* Vozes                                                           */
+    /* -------------------------------------------------------------- */
+
+    _pluck(freq, time, duration = 0.5, gain = 0.25, type = 'triangle') {
+        const ctx = this.ctx;
+        const osc = ctx.createOscillator();
+        const osc2 = ctx.createOscillator();
+        const filter = ctx.createBiquadFilter();
+        const env = ctx.createGain();
+
+        osc.type = type;
+        osc.frequency.value = freq;
+        osc2.type = 'sawtooth';
+        osc2.frequency.value = freq * 1.005;
+
+        filter.type = 'lowpass';
+        filter.frequency.setValueAtTime(Math.min(7200, freq * 9), time);
+        filter.frequency.exponentialRampToValueAtTime(Math.max(220, freq * 2.2), time + duration);
+        filter.Q.value = 1.4;
+
+        env.gain.setValueAtTime(0.0001, time);
+        env.gain.exponentialRampToValueAtTime(gain, time + 0.012);
+        env.gain.exponentialRampToValueAtTime(0.0001, time + duration);
+
+        osc.connect(filter);
+        osc2.connect(filter);
+        filter.connect(env);
+        env.connect(this.musicBus);
+
+        osc.start(time);
+        osc2.start(time);
+        osc.stop(time + duration + 0.05);
+        osc2.stop(time + duration + 0.05);
+    }
+
+    _pad(freq, time, duration, gain = 0.08) {
+        const ctx = this.ctx;
+        const env = ctx.createGain();
+        env.gain.setValueAtTime(0.0001, time);
+        env.gain.exponentialRampToValueAtTime(gain, time + duration * 0.4);
+        env.gain.exponentialRampToValueAtTime(0.0001, time + duration);
+        env.connect(this.musicBus);
+
+        for (const detune of [-7, 0, 7]) {
+            const osc = ctx.createOscillator();
+            osc.type = 'triangle';
+            osc.frequency.value = freq;
+            osc.detune.value = detune;
+            osc.connect(env);
+            osc.start(time);
+            osc.stop(time + duration + 0.1);
+        }
+    }
+
+    _drum(time, kind = 'kick', gain = 0.5) {
+        const ctx = this.ctx;
+        if (kind === 'kick') {
+            const osc = ctx.createOscillator();
+            const env = ctx.createGain();
+            osc.type = 'sine';
+            osc.frequency.setValueAtTime(150, time);
+            osc.frequency.exponentialRampToValueAtTime(44, time + 0.16);
+            env.gain.setValueAtTime(gain, time);
+            env.gain.exponentialRampToValueAtTime(0.0001, time + 0.3);
+            osc.connect(env);
+            env.connect(this.musicBus);
+            osc.start(time);
+            osc.stop(time + 0.32);
+        } else {
+            const src = ctx.createBufferSource();
+            src.buffer = this.noiseBuffer;
+            const filter = ctx.createBiquadFilter();
+            filter.type = kind === 'snare' ? 'bandpass' : 'highpass';
+            filter.frequency.value = kind === 'snare' ? 1900 : 6200;
+            filter.Q.value = 1.1;
+            const env = ctx.createGain();
+            env.gain.setValueAtTime(gain * 0.55, time);
+            env.gain.exponentialRampToValueAtTime(0.0001, time + (kind === 'snare' ? 0.18 : 0.07));
+            src.connect(filter);
+            filter.connect(env);
+            env.connect(this.musicBus);
+            src.start(time, Math.random());
+            src.stop(time + 0.3);
+        }
+    }
+
+    _brass(freq, time, duration, gain = 0.16) {
+        const ctx = this.ctx;
+        const osc = ctx.createOscillator();
+        const filter = ctx.createBiquadFilter();
+        const env = ctx.createGain();
+        osc.type = 'sawtooth';
+        osc.frequency.setValueAtTime(freq * 0.98, time);
+        osc.frequency.linearRampToValueAtTime(freq, time + 0.09);
+        filter.type = 'lowpass';
+        filter.frequency.setValueAtTime(freq * 2.2, time);
+        filter.frequency.linearRampToValueAtTime(freq * 5, time + duration * 0.5);
+        env.gain.setValueAtTime(0.0001, time);
+        env.gain.exponentialRampToValueAtTime(gain, time + 0.07);
+        env.gain.setValueAtTime(gain, time + duration * 0.7);
+        env.gain.exponentialRampToValueAtTime(0.0001, time + duration);
+        osc.connect(filter);
+        filter.connect(env);
+        env.connect(this.musicBus);
+        osc.start(time);
+        osc.stop(time + duration + 0.05);
+    }
+
+    /* -------------------------------------------------------------- */
+    /* Sequenciador                                                    */
+    /* -------------------------------------------------------------- */
+
+    playMusic(mode) {
+        if (!this.ctx) return;
+        if (this.mode === mode) return;
+        this.mode = mode;
+        this.step = 0;
+        this.tempo = mode === 'boss' ? 132 : mode === 'river' ? 112 : mode === 'victory' ? 104 : 84;
+        this.nextNoteTime = this.ctx.currentTime + 0.08;
+
+        if (!this.timer) {
+            this.timer = setInterval(() => this._scheduler(), 25);
+        }
+    }
+
+    stopMusic() {
+        this.mode = null;
+        if (this.timer) {
+            clearInterval(this.timer);
+            this.timer = null;
+        }
+    }
+
+    _scheduler() {
+        if (!this.ctx || !this.mode) return;
+        const beat = 60 / this.tempo / 2; // colcheias
+        while (this.nextNoteTime < this.ctx.currentTime + 0.16) {
+            this._scheduleStep(this.step, this.nextNoteTime, beat);
+            this.nextNoteTime += beat;
+            this.step++;
+        }
+    }
+
+    _scheduleStep(step, time, beat) {
+        const bar = Math.floor(step / 8) % PROGRESSION.length;
+        const inBar = step % 8;
+        const chord = PROGRESSION[bar];
+        const mode = this.mode;
+
+        // Drone/coro no início de cada compasso.
+        if (inBar === 0) {
+            this._pad(noteFreq(chord.root, 0) / 2, time, beat * 8.6, mode === 'boss' ? 0.13 : 0.075);
+            this._pad(noteFreq(chord.root + 4, 0), time, beat * 8.6, 0.045);
+        }
+
+        if (mode === 'menu') {
+            // Arpejo lento de alaúde.
+            if (inBar % 2 === 0) {
+                const deg = chord.chord[(inBar / 2) % chord.chord.length];
+                this._pluck(noteFreq(deg, 1), time, beat * 2.4, 0.16);
+            }
+            if (inBar === 4) this._drum(time, 'kick', 0.24);
+            return;
+        }
+
+        if (mode === 'river') {
+            const deg = chord.chord[inBar % chord.chord.length];
+            this._pluck(noteFreq(deg, 1), time, beat * 1.6, 0.13);
+            if (inBar % 4 === 0) this._pluck(noteFreq(chord.root, 0), time, beat * 2.2, 0.18);
+            if (inBar === 0 || inBar === 3 || inBar === 6) this._drum(time, 'kick', 0.42);
+            if (inBar === 4) this._drum(time, 'snare', 0.34);
+            if (inBar % 2 === 1) this._drum(time, 'hat', 0.2);
+
+            // Melodia esporádica quando a ação aperta.
+            if (this.intensity > 0.4 && inBar === 2) {
+                const deg2 = chord.chord[(step * 3) % chord.chord.length] + 7;
+                this._pluck(noteFreq(deg2, 1), time + beat * 0.5, beat * 1.4, 0.1, 'square');
+            }
+            return;
+        }
+
+        if (mode === 'boss') {
+            this._drum(time, inBar % 2 === 0 ? 'kick' : 'hat', inBar % 2 === 0 ? 0.55 : 0.2);
+            if (inBar === 4 || inBar === 6) this._drum(time, 'snare', 0.4);
+            if (inBar === 0) this._brass(noteFreq(chord.root, 0), time, beat * 3.4, 0.2);
+            if (inBar === 4) this._brass(noteFreq(chord.root + 4, 0), time, beat * 2.4, 0.15);
+            const deg = chord.chord[inBar % chord.chord.length];
+            if (inBar % 2 === 1) this._pluck(noteFreq(deg, 1), time, beat * 1.1, 0.09, 'sawtooth');
+            return;
+        }
+
+        if (mode === 'victory') {
+            const major = [0, 2, 4, 7];
+            if (inBar % 2 === 0) {
+                this._brass(ROOT * Math.pow(2, (major[(inBar / 2) % 4] + 3) / 12) * 2, time, beat * 2.2, 0.18);
+            }
+            if (inBar === 0 || inBar === 4) this._drum(time, 'kick', 0.4);
+            if (inBar % 2 === 1) this._pluck(noteFreq(chord.chord[inBar % 3], 2), time, beat * 1.6, 0.12);
+            return;
+        }
+
+        if (mode === 'defeat') {
+            if (inBar === 0) this._pluck(noteFreq(chord.root, 0), time, beat * 6, 0.14);
+            if (inBar === 4) this._pluck(noteFreq(chord.root + 2, 0), time, beat * 4, 0.09);
+        }
+    }
+
+    /* -------------------------------------------------------------- */
+    /* Efeitos                                                         */
+    /* -------------------------------------------------------------- */
+
+    _noiseBurst(time, { duration = 0.3, type = 'bandpass', freq = 800, endFreq = null, q = 1, gain = 0.4 }) {
+        const ctx = this.ctx;
+        const src = ctx.createBufferSource();
+        src.buffer = this.noiseBuffer;
+        const filter = ctx.createBiquadFilter();
+        filter.type = type;
+        filter.frequency.setValueAtTime(freq, time);
+        if (endFreq) filter.frequency.exponentialRampToValueAtTime(endFreq, time + duration);
+        filter.Q.value = q;
+        const env = ctx.createGain();
+        env.gain.setValueAtTime(gain, time);
+        env.gain.exponentialRampToValueAtTime(0.0001, time + duration);
+        src.connect(filter);
+        filter.connect(env);
+        env.connect(this.sfxBus);
+        src.start(time, Math.random() * 1.5);
+        src.stop(time + duration + 0.05);
+    }
+
+    _tone(time, { freq = 440, endFreq = null, duration = 0.25, gain = 0.3, type = 'sine' }) {
+        const ctx = this.ctx;
+        const osc = ctx.createOscillator();
+        const env = ctx.createGain();
+        osc.type = type;
+        osc.frequency.setValueAtTime(freq, time);
+        if (endFreq) osc.frequency.exponentialRampToValueAtTime(Math.max(20, endFreq), time + duration);
+        env.gain.setValueAtTime(0.0001, time);
+        env.gain.exponentialRampToValueAtTime(gain, time + 0.012);
+        env.gain.exponentialRampToValueAtTime(0.0001, time + duration);
+        osc.connect(env);
+        env.connect(this.sfxBus);
+        osc.start(time);
+        osc.stop(time + duration + 0.05);
+    }
+
+    sfx(name, intensity = 1) {
+        if (!this.ctx || !this.enabled) return;
+        const t = this.ctx.currentTime + 0.001;
+
+        switch (name) {
+            case 'throw':
+                this._noiseBurst(t, { duration: 0.22, freq: 1800, endFreq: 420, q: 3, gain: 0.22 * intensity });
+                this._tone(t, { freq: 620, endFreq: 240, duration: 0.16, gain: 0.1, type: 'triangle' });
+                break;
+            case 'hitWood':
+                this._noiseBurst(t, { duration: 0.14, type: 'lowpass', freq: 1400, endFreq: 300, gain: 0.32 });
+                this._tone(t, { freq: 180, endFreq: 90, duration: 0.18, gain: 0.22, type: 'square' });
+                break;
+            case 'hitMetal':
+                this._tone(t, { freq: 1560, endFreq: 720, duration: 0.24, gain: 0.14, type: 'triangle' });
+                this._noiseBurst(t, { duration: 0.2, freq: 3400, q: 6, gain: 0.16 });
+                break;
+            case 'explosion':
+                this._noiseBurst(t, { duration: 0.85, type: 'lowpass', freq: 2400, endFreq: 120, gain: 0.6 * intensity });
+                this._tone(t, { freq: 120, endFreq: 32, duration: 0.7, gain: 0.4 * intensity, type: 'sine' });
+                break;
+            case 'splash':
+                this._noiseBurst(t, { duration: 0.5, type: 'bandpass', freq: 700, endFreq: 2600, q: 0.9, gain: 0.22 * intensity });
+                break;
+            case 'arrow':
+                this._noiseBurst(t, { duration: 0.3, freq: 2600, endFreq: 900, q: 5, gain: 0.16 });
+                break;
+            case 'damage':
+                this._tone(t, { freq: 220, endFreq: 60, duration: 0.5, gain: 0.4, type: 'sawtooth' });
+                this._noiseBurst(t, { duration: 0.35, type: 'lowpass', freq: 900, endFreq: 160, gain: 0.35 });
+                break;
+            case 'pickup':
+                this._tone(t, { freq: 880, duration: 0.18, gain: 0.16, type: 'sine' });
+                this._tone(t + 0.07, { freq: 1320, duration: 0.24, gain: 0.14, type: 'sine' });
+                break;
+            case 'coin':
+                this._tone(t, { freq: 1180, duration: 0.1, gain: 0.1, type: 'square' });
+                this._tone(t + 0.05, { freq: 1760, duration: 0.16, gain: 0.08, type: 'square' });
+                break;
+            case 'fury':
+                this._tone(t, { freq: 180, endFreq: 900, duration: 0.6, gain: 0.24, type: 'sawtooth' });
+                this._noiseBurst(t, { duration: 0.7, freq: 400, endFreq: 4200, q: 2, gain: 0.2 });
+                break;
+            case 'horn':
+                this._brassSfx(t, 196, 0.9);
+                this._brassSfx(t + 0.18, 294, 1.2);
+                break;
+            case 'gate':
+                this._tone(t, { freq: 90, endFreq: 40, duration: 1.4, gain: 0.4, type: 'sawtooth' });
+                this._noiseBurst(t, { duration: 1.6, type: 'lowpass', freq: 1200, endFreq: 90, gain: 0.4 });
+                break;
+            case 'firework':
+                this._noiseBurst(t, { duration: 0.5, type: 'highpass', freq: 1800, gain: 0.18 * intensity });
+                this._tone(t, { freq: 340, endFreq: 90, duration: 0.35, gain: 0.14, type: 'triangle' });
+                break;
+            default:
+                break;
+        }
+    }
+
+    _brassSfx(time, freq, duration) {
+        const ctx = this.ctx;
+        const osc = ctx.createOscillator();
+        const filter = ctx.createBiquadFilter();
+        const env = ctx.createGain();
+        osc.type = 'sawtooth';
+        osc.frequency.value = freq;
+        filter.type = 'lowpass';
+        filter.frequency.setValueAtTime(freq * 2, time);
+        filter.frequency.linearRampToValueAtTime(freq * 6, time + duration * 0.4);
+        env.gain.setValueAtTime(0.0001, time);
+        env.gain.exponentialRampToValueAtTime(0.3, time + 0.08);
+        env.gain.setValueAtTime(0.3, time + duration * 0.6);
+        env.gain.exponentialRampToValueAtTime(0.0001, time + duration);
+        osc.connect(filter);
+        filter.connect(env);
+        env.connect(this.sfxBus);
+        osc.start(time);
+        osc.stop(time + duration + 0.1);
+    }
+
+    dispose() {
+        this.stopMusic();
+        this.ctx?.close();
+        this.ctx = null;
+    }
+}

--- a/labs/river-knight/src/castle.js
+++ b/labs/river-knight/src/castle.js
@@ -1,0 +1,583 @@
+/**
+ * O castelo de Morvain, a princesa na torre e a barcaça negra que bloqueia
+ * o portão — todo o desfecho da jornada.
+ */
+
+import * as THREE from 'three';
+import {
+    buildLongship,
+    buildBanner,
+    stoneMaterial,
+    metalMaterial,
+    plainMaterial,
+    woodMaterial
+} from './models.js';
+import { centerX, halfWidth, terrainHeight } from './river.js';
+import { waterHeight, waterSlope } from './water.js';
+import { COLORS, CASTLE_Z, SCORE } from './config.js';
+import { clamp, damp, randRange } from './utils.js';
+
+const tmpSlope = { dx: 0, dz: 0 };
+
+/* ================================================================== */
+/* Castelo                                                             */
+/* ================================================================== */
+
+function buildTower(radius, height, { roof = true, tint = '#8a877f' } = {}) {
+    const group = new THREE.Group();
+    const stone = stoneMaterial(tint);
+
+    const body = new THREE.Mesh(new THREE.CylinderGeometry(radius, radius * 1.12, height, 14), stone);
+    body.position.y = height / 2;
+    body.castShadow = true;
+    body.receiveShadow = true;
+    group.add(body);
+
+    const ledge = new THREE.Mesh(new THREE.CylinderGeometry(radius * 1.2, radius * 1.1, 0.9, 14), stone);
+    ledge.position.y = height + 0.3;
+    ledge.castShadow = true;
+    group.add(ledge);
+
+    const merlonCount = Math.max(8, Math.round(radius * 5));
+    for (let i = 0; i < merlonCount; i++) {
+        const a = (i / merlonCount) * Math.PI * 2;
+        const merlon = new THREE.Mesh(new THREE.BoxGeometry(radius * 0.42, 1.1, radius * 0.34), stone);
+        merlon.position.set(Math.cos(a) * radius * 1.06, height + 1.2, Math.sin(a) * radius * 1.06);
+        merlon.rotation.y = -a;
+        merlon.castShadow = true;
+        group.add(merlon);
+    }
+
+    if (roof) {
+        const cone = new THREE.Mesh(
+            new THREE.ConeGeometry(radius * 1.3, radius * 2.1, 14),
+            plainMaterial(COLORS.roof, 0.75, 0.05)
+        );
+        cone.position.y = height + radius * 1.05 + 1.6;
+        cone.castShadow = true;
+        group.add(cone);
+
+        const finial = new THREE.Mesh(
+            new THREE.SphereGeometry(radius * 0.16, 8, 8),
+            metalMaterial(0xd9b45c, 0.35)
+        );
+        finial.position.y = height + radius * 2.1 + 1.8;
+        group.add(finial);
+
+        const banner = buildBanner('#5a1220', '#f3c96b', radius * 0.9, radius * 1.6);
+        banner.position.set(radius * 0.5, height + radius * 1.9, 0);
+        group.add(banner);
+    }
+
+    return group;
+}
+
+function buildTorch(color = 0xff9a3c, intensity = 9) {
+    const group = new THREE.Group();
+    const bracket = new THREE.Mesh(new THREE.CylinderGeometry(0.09, 0.12, 0.7, 6), metalMaterial(0x4a4139, 0.6));
+    group.add(bracket);
+    const flame = new THREE.Mesh(
+        new THREE.SphereGeometry(0.26, 8, 8),
+        plainMaterial(0xffc477, 0.4, 0, 0xff7a20, 3.2)
+    );
+    flame.position.y = 0.45;
+    flame.scale.y = 1.5;
+    group.add(flame);
+    const light = new THREE.PointLight(color, intensity, 26, 2);
+    light.position.y = 0.6;
+    group.add(light);
+    group.userData.flame = flame;
+    group.userData.light = light;
+    return group;
+}
+
+/** A princesa acenando na janela da torre. */
+function buildPrincess() {
+    const group = new THREE.Group();
+
+    const dress = new THREE.Mesh(new THREE.ConeGeometry(0.42, 1.1, 12), plainMaterial(COLORS.princess, 0.7, 0.03));
+    dress.position.y = 0.55;
+    group.add(dress);
+
+    const bodice = new THREE.Mesh(new THREE.CylinderGeometry(0.17, 0.24, 0.42, 10), plainMaterial(0xb85a8a, 0.7, 0.03));
+    bodice.position.y = 1.18;
+    group.add(bodice);
+
+    const head = new THREE.Mesh(new THREE.SphereGeometry(0.17, 12, 10), plainMaterial(0xf0c9a4, 0.75, 0));
+    head.position.y = 1.55;
+    group.add(head);
+
+    const hair = new THREE.Mesh(new THREE.SphereGeometry(0.2, 12, 10, 0, Math.PI * 2, 0, Math.PI * 0.7),
+        plainMaterial(0x6b3b1c, 0.8, 0));
+    hair.position.y = 1.58;
+    group.add(hair);
+
+    const braid = new THREE.Mesh(new THREE.CylinderGeometry(0.07, 0.05, 0.8, 6), plainMaterial(0x6b3b1c, 0.8, 0));
+    braid.position.set(0, 1.25, -0.18);
+    group.add(braid);
+
+    const crown = new THREE.Mesh(new THREE.CylinderGeometry(0.14, 0.14, 0.09, 10), metalMaterial(0xf0cf7a, 0.3));
+    crown.position.y = 1.7;
+    group.add(crown);
+
+    const arm = new THREE.Group();
+    arm.position.set(0.22, 1.36, 0);
+    const armMesh = new THREE.Mesh(new THREE.CylinderGeometry(0.06, 0.055, 0.5, 8), plainMaterial(0xf0c9a4, 0.75, 0));
+    armMesh.position.y = -0.22;
+    arm.add(armMesh);
+    group.add(arm);
+
+    const scarf = new THREE.Mesh(new THREE.PlaneGeometry(0.5, 0.22), new THREE.MeshStandardMaterial({
+        color: 0xffe9f2,
+        side: THREE.DoubleSide,
+        roughness: 0.9
+    }));
+    scarf.position.set(0.3, -0.42, 0);
+    arm.add(scarf);
+
+    group.traverse((c) => {
+        c.castShadow = true;
+    });
+
+    group.userData.arm = arm;
+    group.userData.scarf = scarf;
+    return group;
+}
+
+/**
+ * Monta o castelo sobre o rio: duas alas nas margens, muralha com portão
+ * levadiço sobre a água e a torre da princesa.
+ */
+export function createCastle(scene) {
+    const group = new THREE.Group();
+    const z = CASTLE_Z;
+    const cx = centerX(z);
+    const hw = halfWidth(z);
+    const stone = stoneMaterial('#8a877f');
+
+    group.position.set(cx, 0, z);
+    scene.add(group);
+
+    // ---- Muralha atravessando o rio ----
+    // A muralha é feita de dois blocos laterais e um arco: o vão central é o
+    // portão de água por onde o drakkar passa.
+    const wallWidth = hw * 2 + 44;
+    const gateWidth = hw * 1.5;
+    const gapLeft = new THREE.Mesh(new THREE.BoxGeometry((wallWidth - gateWidth) / 2, 22, 7.2), stone);
+    gapLeft.position.set(-(gateWidth + (wallWidth - gateWidth) / 2) / 2, 11, 0);
+    gapLeft.castShadow = true;
+    group.add(gapLeft);
+    const gapRight = gapLeft.clone();
+    gapRight.position.x *= -1;
+    group.add(gapRight);
+
+    const arch = new THREE.Mesh(new THREE.BoxGeometry(gateWidth + 3, 6, 7.4), stone);
+    arch.position.set(0, 19, 0);
+    arch.castShadow = true;
+    group.add(arch);
+
+    // Aduelas: dão a curva do arco sobre o vão do portão.
+    const voussoirs = 13;
+    for (let i = 0; i < voussoirs; i++) {
+        const a = Math.PI * (i / (voussoirs - 1));
+        const block = new THREE.Mesh(new THREE.BoxGeometry(2.2, 2.6, 7.6), stone);
+        block.position.set(Math.cos(a) * gateWidth * 0.5, 15.4 + Math.sin(a) * 3.6, 0);
+        block.rotation.z = a - Math.PI / 2;
+        block.castShadow = true;
+        group.add(block);
+    }
+
+    // Ameias no topo da muralha.
+    const merlons = Math.round(wallWidth / 3.2);
+    for (let i = 0; i < merlons; i++) {
+        const m = new THREE.Mesh(new THREE.BoxGeometry(1.7, 1.8, 6.6), stone);
+        m.position.set(-wallWidth / 2 + 1.6 + i * 3.2, 23, 0);
+        m.castShadow = true;
+        group.add(m);
+    }
+
+    // ---- Portão / grade levadiça ----
+    const gate = new THREE.Group();
+    const gateMat = woodMaterial(true, 0x4a3016);
+    for (let i = 0; i < 9; i++) {
+        const bar = new THREE.Mesh(new THREE.BoxGeometry(0.42, 16, 0.42), gateMat);
+        bar.position.set(-gateWidth / 2 + 1 + i * (gateWidth - 2) / 8, 8, 0);
+        bar.castShadow = true;
+        gate.add(bar);
+    }
+    for (let i = 0; i < 4; i++) {
+        const rail = new THREE.Mesh(new THREE.BoxGeometry(gateWidth - 1, 0.5, 0.5), metalMaterial(0x50483d, 0.55));
+        rail.position.set(0, 1.6 + i * 4.6, 0);
+        gate.add(rail);
+    }
+    for (let i = 0; i < 9; i++) {
+        const spike = new THREE.Mesh(new THREE.ConeGeometry(0.24, 0.7, 6), metalMaterial(0x8b8579, 0.4));
+        spike.position.set(-gateWidth / 2 + 1 + i * (gateWidth - 2) / 8, 0, 0);
+        spike.rotation.x = Math.PI;
+        gate.add(spike);
+    }
+    group.add(gate);
+
+    // ---- Torres ----
+    const towers = [];
+    const towerSpots = [
+        { x: -gateWidth / 2 - 7, r: 4.4, h: 26, roof: true },
+        { x: gateWidth / 2 + 7, r: 4.4, h: 26, roof: true },
+        { x: -wallWidth / 2 + 5, r: 3.4, h: 19, roof: true },
+        { x: wallWidth / 2 - 5, r: 3.4, h: 19, roof: true }
+    ];
+    for (const spot of towerSpots) {
+        const tower = buildTower(spot.r, spot.h, { roof: spot.roof });
+        tower.position.set(spot.x, 0, 0);
+        group.add(tower);
+        towers.push(tower);
+    }
+
+    // A margem interna do castelo: tudo fica ao lado do canal, para que o
+    // drakkar consiga atravessar o portão e chegar às docas.
+    const sideOffset = gateWidth / 2 + 13;
+
+    // ---- Torre da princesa (mais alta, atrás da muralha) ----
+    const keepX = sideOffset;
+    const keepZ = -34;
+    const keepRadius = 6.2;
+    const keep = buildTower(keepRadius, 40, { tint: '#948f85' });
+    keep.position.set(keepX, 0, keepZ);
+    group.add(keep);
+
+    // Sacada voltada para o rio, onde a princesa aparece.
+    const balconyZ = keepZ + keepRadius + 1.1;
+    const balcony = new THREE.Mesh(new THREE.BoxGeometry(6.4, 0.7, 3.4), stone);
+    balcony.position.set(keepX, 32.9, balconyZ);
+    balcony.castShadow = true;
+    group.add(balcony);
+
+    for (let i = -2; i <= 2; i++) {
+        const baluster = new THREE.Mesh(new THREE.BoxGeometry(0.5, 1.5, 0.5), stone);
+        baluster.position.set(keepX + i * 1.5, 34, balconyZ + 1.4);
+        group.add(baluster);
+    }
+
+    const window_ = new THREE.Mesh(
+        new THREE.BoxGeometry(2.6, 3.8, 0.4),
+        plainMaterial(0xffdca8, 0.5, 0, 0xffb45c, 1.8)
+    );
+    window_.position.set(keepX, 35.6, keepZ + keepRadius - 0.2);
+    group.add(window_);
+
+    const windowLight = new THREE.PointLight(0xffb45c, 30, 52, 2);
+    windowLight.position.set(keepX, 35.6, keepZ + keepRadius + 0.8);
+    group.add(windowLight);
+
+    // Luz quente só para a princesa: sem ela a torre vira silhueta no crepúsculo.
+    const princessLight = new THREE.PointLight(0xffd9a8, 22, 32, 2);
+    princessLight.position.set(keepX, 36.5, balconyZ + 3.5);
+    group.add(princessLight);
+
+    const princess = buildPrincess();
+    princess.position.set(keepX, 33.3, balconyZ + 0.2);
+    princess.scale.setScalar(1.8);
+    group.add(princess);
+
+    // ---- Corpo do castelo (blocos atrás da muralha) ----
+    const hallGeo = new THREE.BoxGeometry(26, 16, 18);
+    const hall = new THREE.Mesh(hallGeo, stone);
+    hall.position.set(-sideOffset - 6, 8, -26);
+    hall.castShadow = true;
+    hall.receiveShadow = true;
+    group.add(hall);
+
+    const roof = new THREE.Mesh(
+        new THREE.ConeGeometry(17, 9, 4),
+        plainMaterial(COLORS.roof, 0.78, 0.04)
+    );
+    roof.position.set(-sideOffset - 6, 20.4, -26);
+    roof.rotation.y = Math.PI / 4;
+    roof.castShadow = true;
+    group.add(roof);
+
+    // ---- Tochas ----
+    const torches = [];
+    const torchSpots = [
+        [-gateWidth / 2 - 1.4, 12, 3.6],
+        [gateWidth / 2 + 1.4, 12, 3.6],
+        [-gateWidth / 2 - 7, 27, 0],
+        [gateWidth / 2 + 7, 27, 0]
+    ];
+    for (const [tx, ty, tz] of torchSpots) {
+        const torch = buildTorch();
+        torch.position.set(tx, ty, tz);
+        group.add(torch);
+        torches.push(torch);
+    }
+
+    // ---- Docas de pedra junto às margens ----
+    for (const side of [-1, 1]) {
+        const dockX = side * (hw + 6);
+        const dock = new THREE.Mesh(new THREE.BoxGeometry(12, 3, 26), stone);
+        const groundY = terrainHeight(cx + dockX, z + 16);
+        dock.position.set(dockX, Math.max(0.5, groundY * 0.4), 16);
+        dock.castShadow = true;
+        dock.receiveShadow = true;
+        group.add(dock);
+    }
+
+    let gateOpen = 0;
+    let gateTarget = 0;
+
+    return {
+        group,
+        princess,
+        z,
+        centerX: cx,
+        gateWidth,
+        princessWorld: new THREE.Vector3(cx + keepX, 35.6, z + balconyZ + 0.2),
+        openGate() {
+            gateTarget = 1;
+        },
+        get gateProgress() {
+            return gateOpen;
+        },
+        update(dt, time) {
+            gateOpen = damp(gateOpen, gateTarget, 1.1, dt);
+            gate.position.y = gateOpen * 15.5;
+
+            for (const torch of torches) {
+                const flame = torch.userData.flame;
+                const light = torch.userData.light;
+                const flicker = 0.82 + Math.sin(time * 11 + torch.position.x) * 0.12 + Math.random() * 0.06;
+                flame.scale.set(flicker, flicker * 1.5, flicker);
+                light.intensity = 9 * flicker;
+            }
+
+            windowLight.intensity = 22 + Math.sin(time * 3.1) * 3;
+
+            const arm = princess.userData.arm;
+            arm.rotation.z = -0.6 + Math.sin(time * 4.2) * 0.75;
+            princess.rotation.y = Math.sin(time * 0.8) * 0.2;
+        },
+        emitTorchSparks(effects) {
+            for (const torch of torches) {
+                if (Math.random() < 0.25) {
+                    const p = new THREE.Vector3();
+                    torch.getWorldPosition(p);
+                    effects.fire(p.x, p.y + 0.4, p.z, 1, 0.7);
+                }
+            }
+        }
+    };
+}
+
+/* ================================================================== */
+/* Barcaça Negra (chefe)                                               */
+/* ================================================================== */
+
+export class BossBarge {
+    constructor(scene) {
+        const group = new THREE.Group();
+        this.group = group;
+        this.scene = scene;
+
+        const { group: hull, parts } = buildLongship({
+            length: 30,
+            beam: 8.5,
+            hullColor: 0x241a16,
+            sailBase: '#1a1420',
+            sailStripe: '#7a1220',
+            emblem: 'rune',
+            shields: true,
+            oars: true,
+            dragon: true,
+            lantern: false
+        });
+        hull.scale.set(1, 1.25, 1);
+        group.add(hull);
+        this.hullGroup = hull;
+        this.parts = parts;
+
+        // Aríete de ferro na proa.
+        const ram = new THREE.Mesh(new THREE.ConeGeometry(1.2, 5, 8), metalMaterial(0x4a4740, 0.5));
+        ram.rotation.x = -Math.PI / 2;
+        ram.position.set(0, -0.4, -17.5);
+        ram.castShadow = true;
+        group.add(ram);
+
+        // Torres de balista.
+        this.ballistae = [];
+        for (const side of [-1, 1]) {
+            const tower = new THREE.Group();
+            const base = new THREE.Mesh(new THREE.CylinderGeometry(1.5, 1.8, 3.4, 8), woodMaterial(true, 0x2b2018));
+            base.position.y = 1.7;
+            base.castShadow = true;
+            tower.add(base);
+
+            const bow = new THREE.Mesh(new THREE.BoxGeometry(4.4, 0.35, 0.35), woodMaterial(true, 0x3b2a1c));
+            bow.position.y = 3.6;
+            tower.add(bow);
+
+            const brazier = new THREE.Mesh(
+                new THREE.SphereGeometry(0.55, 10, 8),
+                plainMaterial(0xff9a4a, 0.4, 0, 0xff5a10, 3)
+            );
+            brazier.position.y = 4.1;
+            tower.add(brazier);
+            tower.userData.brazier = brazier;
+
+            const light = new THREE.PointLight(0xff6a2a, 14, 30, 2);
+            light.position.y = 4.2;
+            tower.add(light);
+            tower.userData.light = light;
+
+            tower.position.set(side * 3.4, 1.4, side * 3);
+            group.add(tower);
+            this.ballistae.push(tower);
+        }
+
+        // Estandarte do vilão.
+        const banner = buildBanner('#12070c', '#c0303c', 2.4, 4.6);
+        banner.position.set(0, 9.5, 6);
+        group.add(banner);
+
+        group.visible = false;
+        scene.add(group);
+
+        this.maxHp = 20;
+        this.hp = this.maxHp;
+        this.active = false;
+        this.dying = 0;
+        this.radius = 9;
+        this.fireTimer = 0;
+        this.lane = 0;
+        this.laneTimer = 0;
+        this.z = 0;
+        this.enraged = false;
+    }
+
+    spawn(z, difficulty) {
+        this.z = z;
+        this.hp = this.maxHp;
+        this.active = true;
+        this.dying = 0;
+        this.enraged = false;
+        this.fireTimer = 2.2;
+        this.lane = 0;
+        this.laneTimer = 0;
+        this.difficulty = difficulty;
+        this.group.visible = true;
+        this.group.position.set(centerX(z), 0, z);
+        this.group.rotation.set(0, 0, 0);
+        this.group.scale.setScalar(1);
+    }
+
+    get healthRatio() {
+        return clamp(this.hp / this.maxHp, 0, 1);
+    }
+
+    update(dt, ctx) {
+        if (!this.active) return;
+        const pos = this.group.position;
+
+        if (this.dying > 0) {
+            this.dying += dt;
+            pos.y -= dt * 1.1;
+            this.group.rotation.z += dt * 0.35;
+            this.group.rotation.x += dt * 0.12;
+            if (Math.random() < 0.9) {
+                ctx.effects.fire(
+                    pos.x + randRange(-7, 7),
+                    pos.y + randRange(0, 5),
+                    pos.z + randRange(-12, 12),
+                    2,
+                    1.4
+                );
+                ctx.effects.smokePuff(pos.x + randRange(-6, 6), pos.y + 3, pos.z + randRange(-10, 10), 2, 2.4);
+            }
+            if (this.dying > 4.5) {
+                this.active = false;
+                this.group.visible = false;
+            }
+            return;
+        }
+
+        // Recua devagar em direção ao castelo conforme perde vida.
+        const retreat = (1 - this.healthRatio) * 26;
+        const targetZ = this.z - retreat;
+
+        // Persegue lateralmente o jogador para bloquear a passagem.
+        this.laneTimer -= dt;
+        if (this.laneTimer <= 0) {
+            this.laneTimer = randRange(1.1, 2.2);
+            const playerLane = (ctx.player.x - centerX(ctx.player.z)) / Math.max(1, halfWidth(ctx.player.z));
+            this.lane = clamp(playerLane * 0.85 + randRange(-0.2, 0.2), -0.55, 0.55);
+        }
+        const targetX = centerX(pos.z) + this.lane * halfWidth(pos.z) * 0.8;
+
+        pos.x = damp(pos.x, targetX, this.enraged ? 1.5 : 0.9, dt);
+        pos.z = damp(pos.z, targetZ, 0.7, dt);
+        pos.y = waterHeight(pos.x, pos.z, ctx.time) + 1.1;
+
+        waterSlope(pos.x, pos.z, ctx.time, tmpSlope);
+        this.group.rotation.z = -tmpSlope.dx * 1.2;
+        this.group.rotation.x = tmpSlope.dz * 0.9;
+
+        for (const oar of this.parts.oars) {
+            oar.rotation.x = Math.sin(ctx.time * 2.1 + oar.userData.phase) * 0.5;
+            oar.rotation.z = oar.userData.baseRoll - oar.userData.side * Math.sin(ctx.time * 2.1 + oar.userData.phase + 1.2) * 0.18;
+        }
+
+        for (const tower of this.ballistae) {
+            const b = tower.userData.brazier;
+            const s = 0.85 + Math.sin(ctx.time * 8 + tower.position.x) * 0.18;
+            b.scale.set(s, s * 1.3, s);
+            tower.userData.light.intensity = 12 * s;
+            if (Math.random() < 0.3) {
+                const p = new THREE.Vector3();
+                b.getWorldPosition(p);
+                ctx.effects.fire(p.x, p.y, p.z, 1, 0.9);
+            }
+        }
+
+        // Salvas de flechas.
+        this.fireTimer -= dt;
+        if (this.fireTimer <= 0) {
+            const rate = this.enraged ? 1.35 : 2.1;
+            this.fireTimer = rate / (this.difficulty?.enemyFireScale || 1);
+            const shots = this.enraged ? 5 : 3;
+            for (let i = 0; i < shots; i++) {
+                const spread = (i - (shots - 1) / 2) * 3.2;
+                ctx.fireArrow(pos.x + spread, pos.y + 4.5, pos.z - 12, 1.15);
+            }
+            ctx.audio.sfx('arrow');
+        }
+    }
+
+    hit(damage, ctx) {
+        if (!this.active || this.dying > 0) return false;
+        this.hp -= damage;
+        const pos = this.group.position;
+        ctx.effects.impact(pos.x + randRange(-4, 4), pos.y + randRange(1, 4), pos.z + randRange(-8, 8), 0xffb066);
+        ctx.audio.sfx('hitWood');
+
+        if (!this.enraged && this.healthRatio < 0.45) {
+            this.enraged = true;
+            ctx.onEnrage?.();
+        }
+
+        if (this.hp <= 0) {
+            this.dying = 0.001;
+            ctx.effects.explosion(pos.x, pos.y + 2, pos.z, 3.4, 0.06);
+            ctx.effects.explosion(pos.x + 5, pos.y + 3, pos.z - 6, 2.4, 0.09);
+            ctx.effects.explosion(pos.x - 5, pos.y + 1, pos.z + 6, 2.4, 0.05);
+            ctx.audio.sfx('explosion', 1.4);
+            ctx.onKill?.(SCORE.bossKill, pos);
+            return true;
+        }
+        return false;
+    }
+
+    reset() {
+        this.active = false;
+        this.dying = 0;
+        this.group.visible = false;
+    }
+}

--- a/labs/river-knight/src/config.js
+++ b/labs/river-knight/src/config.js
@@ -1,0 +1,203 @@
+/**
+ * River Knight — configuração central.
+ *
+ * Todos os números que definem a "sensação" do jogo moram aqui para facilitar
+ * o ajuste fino sem caçar constantes espalhadas pelos módulos.
+ */
+
+/** Distância total (em metros de jogo) até o castelo. */
+export const COURSE_LENGTH = 4200;
+
+/** Onde o castelo é posicionado no eixo Z (o barco navega no sentido -Z). */
+export const CASTLE_Z = -COURSE_LENGTH;
+
+/** Ponto em que a barcaça do vilão bloqueia o rio. */
+export const BOSS_Z = CASTLE_Z + 240;
+
+export const BOAT = {
+    baseSpeed: 26,
+    boostSpeed: 41,
+    brakeSpeed: 13,
+    accel: 16,
+    strafeSpeed: 15.5,
+    strafeAccel: 46,
+    maxHull: 5,
+    throwCooldown: 0.42,
+    furyCooldown: 0.16,
+    invulnAfterHit: 1.4,
+    bankLimitPadding: 3.4
+};
+
+export const AXE = {
+    speed: 78,
+    gravity: 16,
+    life: 2.6,
+    damage: 1,
+    spin: 22
+};
+
+export const DIFFICULTY = {
+    squire: {
+        id: 'squire',
+        label: 'Escudeiro',
+        blurb: 'Rio calmo, inimigos raros. Ideal para conhecer o trecho.',
+        spawnScale: 0.68,
+        enemyFireScale: 0.72,
+        damageScale: 1,
+        hull: 6,
+        scoreScale: 0.8
+    },
+    warrior: {
+        id: 'warrior',
+        label: 'Guerreiro',
+        blurb: 'O equilíbrio da campanha: pressão constante, margem para erro.',
+        spawnScale: 1,
+        enemyFireScale: 1,
+        damageScale: 1,
+        hull: 5,
+        scoreScale: 1
+    },
+    legend: {
+        id: 'legend',
+        label: 'Lenda',
+        blurb: 'Rio infestado, arqueiros precisos e casco frágil. Boa sorte.',
+        spawnScale: 1.42,
+        enemyFireScale: 1.35,
+        damageScale: 1,
+        hull: 4,
+        scoreScale: 1.35
+    }
+};
+
+export const SCORE = {
+    enemyShip: 320,
+    tower: 260,
+    barricade: 150,
+    rock: 0,
+    coin: 90,
+    bossPart: 900,
+    bossKill: 4000,
+    distancePerMeter: 1.4,
+    hullBonus: 800,
+    comboStep: 0.12,
+    comboMax: 4
+};
+
+/** Presets de qualidade gráfica. */
+export const QUALITY = {
+    low: {
+        id: 'low',
+        label: 'Performance',
+        pixelRatio: 1,
+        antialias: false,
+        shadows: false,
+        shadowSize: 1024,
+        bloom: false,
+        terrainSegments: 150,
+        waterSegments: 110,
+        scatterScale: 0.5,
+        fogDensity: 0.0024,
+        drawDistance: 620
+    },
+    medium: {
+        id: 'medium',
+        label: 'Equilibrada',
+        pixelRatio: 1.35,
+        antialias: true,
+        shadows: true,
+        shadowSize: 1536,
+        bloom: true,
+        terrainSegments: 216,
+        waterSegments: 168,
+        scatterScale: 0.8,
+        fogDensity: 0.0017,
+        drawDistance: 900
+    },
+    high: {
+        id: 'high',
+        label: 'Cinemática',
+        pixelRatio: 2,
+        antialias: true,
+        shadows: true,
+        shadowSize: 2048,
+        bloom: true,
+        terrainSegments: 268,
+        waterSegments: 220,
+        scatterScale: 1,
+        fogDensity: 0.0014,
+        drawDistance: 1150
+    }
+};
+
+/**
+ * Paleta do "golden hour" medieval. As cores do céu são interpoladas ao longo
+ * da corrida (amanhecer enevoado → dourado → crepúsculo sobre o castelo).
+ */
+export const SKY_STOPS = [
+    {
+        at: 0,
+        zenith: [0.09, 0.19, 0.38],
+        horizon: [0.52, 0.50, 0.50],
+        ground: [0.11, 0.12, 0.14],
+        sun: [1.0, 0.88, 0.68],
+        sunDir: [0.80, 0.28, -0.53],
+        fog: [0.44, 0.47, 0.54],
+        light: [1.0, 0.94, 0.84],
+        lightIntensity: 1.35,
+        ambient: [0.30, 0.38, 0.52]
+    },
+    {
+        at: 0.45,
+        zenith: [0.07, 0.16, 0.40],
+        horizon: [0.82, 0.50, 0.24],
+        ground: [0.14, 0.11, 0.10],
+        sun: [1.0, 0.74, 0.38],
+        sunDir: [0.90, 0.20, -0.39],
+        fog: [0.52, 0.38, 0.30],
+        light: [1.0, 0.80, 0.56],
+        lightIntensity: 1.5,
+        ambient: [0.30, 0.32, 0.46]
+    },
+    {
+        at: 0.82,
+        zenith: [0.035, 0.055, 0.17],
+        horizon: [0.60, 0.21, 0.14],
+        ground: [0.09, 0.06, 0.08],
+        sun: [1.0, 0.46, 0.22],
+        sunDir: [0.62, 0.11, -0.78],
+        fog: [0.27, 0.15, 0.17],
+        light: [1.0, 0.56, 0.34],
+        lightIntensity: 1.25,
+        ambient: [0.20, 0.21, 0.36]
+    },
+    {
+        at: 1,
+        zenith: [0.018, 0.026, 0.085],
+        horizon: [0.32, 0.10, 0.11],
+        ground: [0.05, 0.035, 0.055],
+        sun: [1.0, 0.36, 0.18],
+        sunDir: [0.34, 0.05, -0.94],
+        fog: [0.14, 0.08, 0.11],
+        light: [1.0, 0.44, 0.28],
+        lightIntensity: 1.05,
+        ambient: [0.16, 0.17, 0.32]
+    }
+];
+
+export const COLORS = {
+    hull: 0x6b4429,
+    hullDark: 0x4a2f1d,
+    hullTrim: 0xb98a4b,
+    sail: 0xdccfae,
+    sailStripe: 0x9c2b2b,
+    enemySail: 0x241d28,
+    enemyStripe: 0x8b1d1d,
+    stone: 0x8d8b86,
+    stoneDark: 0x5f5d59,
+    roof: 0x5a2f3a,
+    gold: 0xf3c96b,
+    fire: 0xff8a3c,
+    princess: 0xe8b7d4
+};
+
+export const STORAGE_KEY = 'river-knight:v1';

--- a/labs/river-knight/src/effects.js
+++ b/labs/river-knight/src/effects.js
@@ -1,0 +1,575 @@
+/**
+ * Sistema de efeitos: partículas, esteira do barco, ondas de choque,
+ * explosões e fogos de artifício.
+ *
+ * Tudo vive em poucos buffers pré-alocados — nada de criar/destruir objetos
+ * durante o jogo, o que manteria o coletor de lixo trabalhando e causaria
+ * engasgos na animação.
+ */
+
+import * as THREE from 'three';
+import { sparkTexture, smokeTexture, foamTexture } from './textures.js';
+import { waterHeight } from './water.js';
+
+/* ------------------------------------------------------------------ */
+/* Partículas                                                          */
+/* ------------------------------------------------------------------ */
+
+class ParticleSystem {
+    constructor({ texture, max = 600, blending = THREE.AdditiveBlending, depthWrite = false }) {
+        this.max = max;
+        this.cursor = 0;
+
+        this.positions = new Float32Array(max * 3);
+        this.colors = new Float32Array(max * 3);
+        this.sizes = new Float32Array(max);
+        this.alphas = new Float32Array(max);
+
+        this.vel = new Float32Array(max * 3);
+        this.life = new Float32Array(max);
+        this.maxLife = new Float32Array(max);
+        this.gravity = new Float32Array(max);
+        this.drag = new Float32Array(max);
+        this.grow = new Float32Array(max);
+        this.baseSize = new Float32Array(max);
+
+        const geo = new THREE.BufferGeometry();
+        geo.setAttribute('position', new THREE.BufferAttribute(this.positions, 3));
+        geo.setAttribute('aColor', new THREE.BufferAttribute(this.colors, 3));
+        geo.setAttribute('aSize', new THREE.BufferAttribute(this.sizes, 1));
+        geo.setAttribute('aAlpha', new THREE.BufferAttribute(this.alphas, 1));
+        geo.boundingSphere = new THREE.Sphere(new THREE.Vector3(), 1e6);
+
+        const material = new THREE.ShaderMaterial({
+            transparent: true,
+            depthWrite,
+            blending,
+            uniforms: {
+                uMap: { value: texture },
+                uScale: { value: 700 }
+            },
+            vertexShader: /* glsl */ `
+                attribute vec3 aColor;
+                attribute float aSize;
+                attribute float aAlpha;
+                varying vec3 vColor;
+                varying float vAlpha;
+                uniform float uScale;
+                void main() {
+                    vColor = aColor;
+                    vAlpha = aAlpha;
+                    vec4 mv = modelViewMatrix * vec4(position, 1.0);
+                    gl_PointSize = aSize * uScale / max(0.001, -mv.z);
+                    gl_Position = projectionMatrix * mv;
+                }
+            `,
+            fragmentShader: /* glsl */ `
+                uniform sampler2D uMap;
+                varying vec3 vColor;
+                varying float vAlpha;
+                void main() {
+                    if (vAlpha <= 0.001) discard;
+                    vec4 tex = texture2D(uMap, gl_PointCoord);
+                    gl_FragColor = vec4(vColor * tex.rgb, tex.a * vAlpha);
+                    #include <tonemapping_fragment>
+                    #include <colorspace_fragment>
+                }
+            `
+        });
+
+        this.points = new THREE.Points(geo, material);
+        this.points.frustumCulled = false;
+        this.points.renderOrder = 12;
+        this.geometry = geo;
+    }
+
+    spawn(x, y, z, vx, vy, vz, {
+        life = 1,
+        size = 1,
+        color = new THREE.Color(1, 1, 1),
+        gravity = 0,
+        drag = 0.6,
+        grow = 0
+    } = {}) {
+        const i = this.cursor;
+        this.cursor = (this.cursor + 1) % this.max;
+
+        this.positions[i * 3] = x;
+        this.positions[i * 3 + 1] = y;
+        this.positions[i * 3 + 2] = z;
+        this.vel[i * 3] = vx;
+        this.vel[i * 3 + 1] = vy;
+        this.vel[i * 3 + 2] = vz;
+        this.life[i] = life;
+        this.maxLife[i] = life;
+        this.gravity[i] = gravity;
+        this.drag[i] = drag;
+        this.grow[i] = grow;
+        this.baseSize[i] = size;
+        this.sizes[i] = size;
+        this.alphas[i] = 1;
+        this.colors[i * 3] = color.r;
+        this.colors[i * 3 + 1] = color.g;
+        this.colors[i * 3 + 2] = color.b;
+    }
+
+    update(dt) {
+        const { positions, vel, life, maxLife, alphas, sizes, gravity, drag, grow, baseSize } = this;
+        for (let i = 0; i < this.max; i++) {
+            if (life[i] <= 0) {
+                if (alphas[i] !== 0) alphas[i] = 0;
+                continue;
+            }
+            life[i] -= dt;
+            if (life[i] <= 0) {
+                alphas[i] = 0;
+                continue;
+            }
+            const d = Math.exp(-drag[i] * dt);
+            vel[i * 3] *= d;
+            vel[i * 3 + 1] = vel[i * 3 + 1] * d - gravity[i] * dt;
+            vel[i * 3 + 2] *= d;
+
+            positions[i * 3] += vel[i * 3] * dt;
+            positions[i * 3 + 1] += vel[i * 3 + 1] * dt;
+            positions[i * 3 + 2] += vel[i * 3 + 2] * dt;
+
+            const t = life[i] / maxLife[i];
+            alphas[i] = t < 0.25 ? t / 0.25 : 1;
+            sizes[i] = baseSize[i] * (1 + grow[i] * (1 - t));
+        }
+
+        this.geometry.attributes.position.needsUpdate = true;
+        this.geometry.attributes.aAlpha.needsUpdate = true;
+        this.geometry.attributes.aSize.needsUpdate = true;
+        this.geometry.attributes.aColor.needsUpdate = true;
+    }
+
+    reset() {
+        this.life.fill(0);
+        this.alphas.fill(0);
+        this.geometry.attributes.aAlpha.needsUpdate = true;
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* Esteira (rastro de espuma atrás do barco)                           */
+/* ------------------------------------------------------------------ */
+
+class Wake {
+    constructor(samples = 46) {
+        this.samples = samples;
+        this.trail = [];
+        this.positions = new Float32Array(samples * 2 * 3);
+        this.uvs = new Float32Array(samples * 2 * 2);
+        this.alphas = new Float32Array(samples * 2);
+
+        const indices = [];
+        for (let i = 0; i < samples - 1; i++) {
+            const a = i * 2;
+            indices.push(a, a + 1, a + 2, a + 1, a + 3, a + 2);
+        }
+
+        const geo = new THREE.BufferGeometry();
+        geo.setAttribute('position', new THREE.BufferAttribute(this.positions, 3));
+        geo.setAttribute('uv', new THREE.BufferAttribute(this.uvs, 2));
+        geo.setAttribute('aAlpha', new THREE.BufferAttribute(this.alphas, 1));
+        geo.setIndex(indices);
+        geo.boundingSphere = new THREE.Sphere(new THREE.Vector3(), 1e6);
+        this.geometry = geo;
+
+        const material = new THREE.ShaderMaterial({
+            transparent: true,
+            depthWrite: false,
+            uniforms: {
+                uMap: { value: foamTexture() },
+                uTime: { value: 0 }
+            },
+            vertexShader: /* glsl */ `
+                attribute float aAlpha;
+                varying float vAlpha;
+                varying vec2 vUv;
+                void main() {
+                    vAlpha = aAlpha;
+                    vUv = uv;
+                    gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+                }
+            `,
+            fragmentShader: /* glsl */ `
+                uniform sampler2D uMap;
+                uniform float uTime;
+                varying float vAlpha;
+                varying vec2 vUv;
+                void main() {
+                    float edge = smoothstep(0.0, 0.42, vUv.x) * (1.0 - smoothstep(0.58, 1.0, vUv.x));
+                    vec2 uv2 = vec2(vUv.x * 1.4, vUv.y * 2.2 - uTime * 0.04);
+                    float f = texture2D(uMap, uv2).a;
+                    float a = vAlpha * edge * (0.18 + f * 0.85);
+                    if (a <= 0.005) discard;
+                    gl_FragColor = vec4(vec3(0.95, 0.97, 1.0), a);
+                    #include <tonemapping_fragment>
+                    #include <colorspace_fragment>
+                }
+            `
+        });
+
+        this.mesh = new THREE.Mesh(geo, material);
+        this.mesh.frustumCulled = false;
+        this.mesh.renderOrder = 6;
+        this.material = material;
+    }
+
+    push(x, z, width, strength) {
+        const last = this.trail[this.trail.length - 1];
+        if (last) {
+            const dx = x - last.x;
+            const dz = z - last.z;
+            if (dx * dx + dz * dz < 1.6) return;
+        }
+        this.trail.push({ x, z, width, strength, age: 0 });
+        if (this.trail.length > this.samples) this.trail.shift();
+    }
+
+    update(dt, time) {
+        const trail = this.trail;
+        for (let i = trail.length - 1; i >= 0; i--) {
+            trail[i].age += dt;
+            trail[i].width += dt * 1.5;
+            if (trail[i].age > 2.6) trail.splice(i, 1);
+        }
+
+        const n = this.samples;
+        for (let i = 0; i < n; i++) {
+            const idx = i - (n - trail.length);
+            const s = idx >= 0 ? trail[idx] : null;
+            const a = i * 6;
+            const u = i * 4;
+
+            if (!s) {
+                this.alphas[i * 2] = 0;
+                this.alphas[i * 2 + 1] = 0;
+                continue;
+            }
+
+            const prev = idx > 0 ? trail[idx - 1] : s;
+            const next = idx < trail.length - 1 ? trail[idx + 1] : s;
+            let dx = next.x - prev.x;
+            let dz = next.z - prev.z;
+            const len = Math.hypot(dx, dz) || 1;
+            dx /= len;
+            dz /= len;
+            // Perpendicular no plano da água.
+            const px = -dz;
+            const pz = dx;
+
+            const w = s.width;
+            const y = waterHeight(s.x, s.z, time) + 0.07;
+            this.positions[a] = s.x - px * w;
+            this.positions[a + 1] = y;
+            this.positions[a + 2] = s.z - pz * w;
+            this.positions[a + 3] = s.x + px * w;
+            this.positions[a + 4] = y;
+            this.positions[a + 5] = s.z + pz * w;
+
+            this.uvs[u] = 0;
+            this.uvs[u + 1] = idx / this.samples;
+            this.uvs[u + 2] = 1;
+            this.uvs[u + 3] = idx / this.samples;
+
+            const headFade = Math.min(1, s.age / 0.35);
+            const fade = Math.max(0, 1 - s.age / 2.6) ** 1.6 * s.strength * 0.62 * headFade;
+            this.alphas[i * 2] = fade;
+            this.alphas[i * 2 + 1] = fade;
+        }
+
+        this.material.uniforms.uTime.value = time;
+        this.geometry.attributes.position.needsUpdate = true;
+        this.geometry.attributes.uv.needsUpdate = true;
+        this.geometry.attributes.aAlpha.needsUpdate = true;
+    }
+
+    reset() {
+        this.trail.length = 0;
+        this.alphas.fill(0);
+        this.geometry.attributes.aAlpha.needsUpdate = true;
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* Anéis de impacto na água                                            */
+/* ------------------------------------------------------------------ */
+
+class RingPool {
+    constructor(count = 10) {
+        const geo = new THREE.RingGeometry(0.55, 1, 28);
+        geo.rotateX(-Math.PI / 2);
+        this.items = [];
+        this.group = new THREE.Group();
+        for (let i = 0; i < count; i++) {
+            const mat = new THREE.MeshBasicMaterial({
+                color: 0xdfeaf2,
+                transparent: true,
+                opacity: 0,
+                depthWrite: false,
+                side: THREE.DoubleSide
+            });
+            const mesh = new THREE.Mesh(geo, mat);
+            mesh.visible = false;
+            mesh.renderOrder = 7;
+            this.group.add(mesh);
+            this.items.push({ mesh, mat, life: 0, maxLife: 1, scale: 1 });
+        }
+        this.cursor = 0;
+    }
+
+    spawn(x, y, z, scale = 1, life = 0.9, color = 0xdfeaf2) {
+        const item = this.items[this.cursor];
+        this.cursor = (this.cursor + 1) % this.items.length;
+        item.mesh.position.set(x, y, z);
+        item.mesh.scale.setScalar(scale * 0.4);
+        item.mesh.visible = true;
+        item.mat.color.set(color);
+        item.life = life;
+        item.maxLife = life;
+        item.scale = scale;
+    }
+
+    update(dt) {
+        for (const item of this.items) {
+            if (item.life <= 0) continue;
+            item.life -= dt;
+            const t = Math.max(0, item.life / item.maxLife);
+            item.mesh.scale.setScalar(item.scale * (0.4 + (1 - t) * 2.6));
+            item.mat.opacity = t * 0.75;
+            if (item.life <= 0) item.mesh.visible = false;
+        }
+    }
+
+    reset() {
+        for (const item of this.items) {
+            item.life = 0;
+            item.mesh.visible = false;
+        }
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* Fachada                                                             */
+/* ------------------------------------------------------------------ */
+
+const tmpColor = new THREE.Color();
+
+export class Effects {
+    constructor(scene, quality) {
+        this.scene = scene;
+        const scale = quality.id === 'low' ? 0.5 : 1;
+
+        this.spray = new ParticleSystem({
+            texture: sparkTexture(),
+            max: Math.round(520 * scale),
+            blending: THREE.NormalBlending
+        });
+        this.embers = new ParticleSystem({
+            texture: sparkTexture(),
+            max: Math.round(620 * scale),
+            blending: THREE.AdditiveBlending
+        });
+        this.smoke = new ParticleSystem({
+            texture: smokeTexture(),
+            max: Math.round(320 * scale),
+            blending: THREE.NormalBlending
+        });
+
+        this.wake = new Wake(quality.id === 'low' ? 30 : 46);
+        this.rings = new RingPool(quality.id === 'low' ? 6 : 12);
+
+        scene.add(this.spray.points, this.embers.points, this.smoke.points, this.wake.mesh, this.rings.group);
+
+        // Luzes temporárias para explosões (pool pequeno: luzes são caras).
+        this.flashes = [];
+        const flashCount = quality.id === 'low' ? 1 : 3;
+        for (let i = 0; i < flashCount; i++) {
+            const light = new THREE.PointLight(0xff8a3c, 0, 60, 2);
+            light.visible = false;
+            scene.add(light);
+            this.flashes.push({ light, life: 0, power: 0 });
+        }
+        this.flashCursor = 0;
+    }
+
+    /** Respingo branco de água. */
+    splash(x, y, z, amount = 12, power = 1) {
+        for (let i = 0; i < amount; i++) {
+            const a = Math.random() * Math.PI * 2;
+            const s = (0.6 + Math.random() * 1.6) * power;
+            this.spray.spawn(
+                x + Math.cos(a) * 0.4,
+                y + 0.1,
+                z + Math.sin(a) * 0.4,
+                Math.cos(a) * s * 2.2,
+                2.4 + Math.random() * 3.4 * power,
+                Math.sin(a) * s * 2.2,
+                {
+                    life: 0.45 + Math.random() * 0.5,
+                    size: 0.2 + Math.random() * 0.38,
+                    color: tmpColor.setRGB(0.86, 0.92, 0.96),
+                    gravity: 11,
+                    drag: 0.9,
+                    grow: 1.3
+                }
+            );
+        }
+    }
+
+    /** Fagulhas de fogo (chama contínua, tochas, destroços em chamas). */
+    fire(x, y, z, amount = 2, power = 1) {
+        for (let i = 0; i < amount; i++) {
+            this.embers.spawn(
+                x + (Math.random() - 0.5) * 0.5 * power,
+                y + Math.random() * 0.4,
+                z + (Math.random() - 0.5) * 0.5 * power,
+                (Math.random() - 0.5) * 1.4,
+                1.6 + Math.random() * 2.6 * power,
+                (Math.random() - 0.5) * 1.4,
+                {
+                    life: 0.45 + Math.random() * 0.7,
+                    size: (0.16 + Math.random() * 0.26) * power,
+                    color: tmpColor.setHSL(0.07 + Math.random() * 0.05, 1, 0.6),
+                    gravity: -1.6,
+                    drag: 1.1,
+                    grow: 0.8
+                }
+            );
+        }
+    }
+
+    smokePuff(x, y, z, amount = 3, power = 1) {
+        for (let i = 0; i < amount; i++) {
+            this.smoke.spawn(
+                x + (Math.random() - 0.5) * power,
+                y + Math.random() * 0.6,
+                z + (Math.random() - 0.5) * power,
+                (Math.random() - 0.5) * 1.6,
+                1.2 + Math.random() * 1.8,
+                (Math.random() - 0.5) * 1.6,
+                {
+                    life: 1.5 + Math.random() * 1.5,
+                    size: (0.8 + Math.random() * 0.9) * power,
+                    color: tmpColor.setRGB(0.22, 0.2, 0.19),
+                    gravity: -0.9,
+                    drag: 1.4,
+                    grow: 2.6
+                }
+            );
+        }
+    }
+
+    /** Explosão completa: clarão, fogo, fumaça, estilhaços e onda na água. */
+    explosion(x, y, z, power = 1, colorHue = 0.07) {
+        const embers = Math.round(34 * power);
+        for (let i = 0; i < embers; i++) {
+            const a = Math.random() * Math.PI * 2;
+            const p = Math.random() * Math.PI - Math.PI / 2;
+            const s = (4 + Math.random() * 12) * power;
+            this.embers.spawn(
+                x, y, z,
+                Math.cos(a) * Math.cos(p) * s,
+                Math.abs(Math.sin(p)) * s * 0.9 + 2,
+                Math.sin(a) * Math.cos(p) * s,
+                {
+                    life: 0.55 + Math.random() * 0.8,
+                    size: (0.22 + Math.random() * 0.4) * power,
+                    color: tmpColor.setHSL(colorHue + Math.random() * 0.06, 1, 0.55 + Math.random() * 0.3),
+                    gravity: 6,
+                    drag: 0.75,
+                    grow: 0.6
+                }
+            );
+        }
+        this.smokePuff(x, y + 0.5, z, Math.round(8 * power), power * 1.4);
+        this.splash(x, 0.1, z, Math.round(16 * power), power);
+        this.rings.spawn(x, 0.12, z, 2.2 * power, 1.1, 0xffd9a8);
+
+        const flash = this.flashes[this.flashCursor];
+        if (flash) {
+            this.flashCursor = (this.flashCursor + 1) % this.flashes.length;
+            flash.light.position.set(x, y + 1.2, z);
+            flash.light.color.setHSL(colorHue, 1, 0.55);
+            flash.life = 0.42;
+            flash.power = 70 * power;
+            flash.light.visible = true;
+        }
+    }
+
+    /** Impacto seco (flecha na madeira, machado no casco). */
+    impact(x, y, z, color = 0xffc987) {
+        for (let i = 0; i < 12; i++) {
+            const a = Math.random() * Math.PI * 2;
+            this.embers.spawn(
+                x, y, z,
+                Math.cos(a) * (2 + Math.random() * 5),
+                1 + Math.random() * 4,
+                Math.sin(a) * (2 + Math.random() * 5),
+                {
+                    life: 0.28 + Math.random() * 0.35,
+                    size: 0.13 + Math.random() * 0.17,
+                    color: tmpColor.set(color),
+                    gravity: 9,
+                    drag: 1.2
+                }
+            );
+        }
+    }
+
+    /** Fogos de artifício da vitória. */
+    firework(x, y, z, hue = Math.random()) {
+        const count = 60;
+        for (let i = 0; i < count; i++) {
+            const a = Math.random() * Math.PI * 2;
+            const p = Math.acos(2 * Math.random() - 1);
+            const s = 8 + Math.random() * 10;
+            this.embers.spawn(
+                x, y, z,
+                Math.sin(p) * Math.cos(a) * s,
+                Math.cos(p) * s,
+                Math.sin(p) * Math.sin(a) * s,
+                {
+                    life: 1.1 + Math.random() * 1.0,
+                    size: 0.28 + Math.random() * 0.3,
+                    color: tmpColor.setHSL((hue + Math.random() * 0.12) % 1, 0.95, 0.62),
+                    gravity: 5.5,
+                    drag: 0.55,
+                    grow: -0.3
+                }
+            );
+        }
+    }
+
+    update(dt, time) {
+        this.spray.update(dt);
+        this.embers.update(dt);
+        this.smoke.update(dt);
+        this.wake.update(dt, time);
+        this.rings.update(dt);
+
+        for (const flash of this.flashes) {
+            if (flash.life <= 0) continue;
+            flash.life -= dt;
+            const t = Math.max(0, flash.life / 0.42);
+            flash.light.intensity = flash.power * t * t;
+            if (flash.life <= 0) flash.light.visible = false;
+        }
+    }
+
+    reset() {
+        this.spray.reset();
+        this.embers.reset();
+        this.smoke.reset();
+        this.wake.reset();
+        this.rings.reset();
+        for (const flash of this.flashes) {
+            flash.life = 0;
+            flash.light.visible = false;
+        }
+    }
+}

--- a/labs/river-knight/src/entities.js
+++ b/labs/river-knight/src/entities.js
@@ -1,0 +1,689 @@
+/**
+ * Entidades do rio: barcos inimigos, torres, barricadas, rochas, redemoinhos,
+ * itens, flechas e machados.
+ *
+ * Todas vivem em pools de tamanho fixo criados no início da partida. Durante o
+ * jogo nada é instanciado: objetos apenas alternam entre ativo e inativo.
+ */
+
+import * as THREE from 'three';
+import {
+    buildLongship,
+    buildWatchtower,
+    buildBarricade,
+    buildRockGeometry,
+    buildPickup,
+    buildArrowMesh,
+    buildAxeMesh,
+    plainMaterial
+} from './models.js';
+import { waterHeight, waterSlope } from './water.js';
+import { centerX, halfWidth, terrainHeight } from './river.js';
+import { AXE, SCORE } from './config.js';
+import { clamp, damp, randRange } from './utils.js';
+
+const tmpSlope = { dx: 0, dz: 0 };
+
+/* ================================================================== */
+/* Base                                                                */
+/* ================================================================== */
+
+class Entity {
+    constructor(group) {
+        this.group = group;
+        this.group.visible = false;
+        this.active = false;
+        this.radius = 2;
+        this.hp = 1;
+        this.maxHp = 1;
+        this.kind = 'entity';
+    }
+
+    get position() {
+        return this.group.position;
+    }
+
+    activate() {
+        this.active = true;
+        this.group.visible = true;
+    }
+
+    deactivate() {
+        this.active = false;
+        this.group.visible = false;
+    }
+}
+
+/* ================================================================== */
+/* Barco inimigo                                                       */
+/* ================================================================== */
+
+class EnemyShip extends Entity {
+    constructor() {
+        const { group, parts } = buildLongship({
+            length: 11,
+            beam: 2.9,
+            hullColor: 0x33241c,
+            sailBase: '#241d28',
+            sailStripe: '#8b1d1d',
+            emblem: 'rune',
+            shields: false,
+            oars: true,
+            dragon: true,
+            lantern: false
+        });
+        super(group);
+        this.parts = parts;
+        this.kind = 'enemyShip';
+        this.radius = 4.2;
+        this.maxHp = 3;
+        this.fireTimer = 0;
+        this.sinking = 0;
+        this.lane = 0;
+    }
+
+    spawn(x, z, { fireRate = 2.6, speed = 7 } = {}) {
+        this.group.position.set(x, 0, z);
+        this.group.rotation.set(0, 0, 0);
+        this.group.scale.setScalar(1);
+        this.hp = this.maxHp;
+        this.fireTimer = randRange(0.8, fireRate);
+        this.fireRate = fireRate;
+        this.speed = speed;
+        this.sinking = 0;
+        this.lane = randRange(-0.5, 0.5);
+        this.laneTimer = randRange(1.5, 3.5);
+        this.activate();
+    }
+
+    update(dt, ctx) {
+        const pos = this.group.position;
+
+        if (this.sinking > 0) {
+            this.sinking += dt;
+            pos.y -= dt * 1.4;
+            this.group.rotation.z += dt * 0.7;
+            this.group.rotation.x += dt * 0.25;
+            if (ctx.effects && Math.random() < 0.5) {
+                ctx.effects.smokePuff(pos.x, pos.y + 1.5, pos.z, 1, 1.2);
+                ctx.effects.fire(pos.x, pos.y + 1.2, pos.z, 1, 0.8);
+            }
+            if (this.sinking > 3.4) this.deactivate();
+            return;
+        }
+
+        // Navega contra a corrente, em direção ao jogador.
+        pos.z += this.speed * dt;
+
+        // Ajusta a faixa lateral para cruzar o caminho do jogador.
+        this.laneTimer -= dt;
+        if (this.laneTimer <= 0) {
+            this.laneTimer = randRange(1.6, 3.4);
+            const playerLane = (ctx.player.x - centerX(ctx.player.z)) / Math.max(1, halfWidth(ctx.player.z));
+            this.lane = clamp(playerLane + randRange(-0.45, 0.45), -0.72, 0.72);
+        }
+        const targetX = centerX(pos.z) + this.lane * halfWidth(pos.z);
+        pos.x = damp(pos.x, targetX, 1.1, dt);
+
+        // Flutuação sobre as ondas.
+        pos.y = waterHeight(pos.x, pos.z, ctx.time) + 0.72;
+        waterSlope(pos.x, pos.z, ctx.time, tmpSlope);
+        this.group.rotation.z = -tmpSlope.dx * 1.6;
+        this.group.rotation.x = tmpSlope.dz * 1.3;
+        this.group.rotation.y = Math.PI + Math.sin(ctx.time * 0.6) * 0.05;
+
+        // Remos.
+        for (const oar of this.parts.oars) {
+            oar.rotation.x = Math.sin(ctx.time * 2.6 + oar.userData.phase) * 0.42;
+            oar.rotation.z = oar.userData.baseRoll - oar.userData.side * Math.sin(ctx.time * 2.6 + oar.userData.phase + 1.4) * 0.2;
+        }
+
+        // Ataque.
+        const dz = pos.z - ctx.player.z;
+        this.fireTimer -= dt;
+        if (this.fireTimer <= 0 && dz < 10 && dz > -190) {
+            this.fireTimer = this.fireRate * randRange(0.8, 1.25);
+            ctx.fireArrow(pos.x, pos.y + 2.2, pos.z - 4, 1);
+        }
+
+        if (dz > 40) this.deactivate();
+    }
+
+    hit(damage, ctx) {
+        this.hp -= damage;
+        if (this.hp > 0) {
+            ctx.effects.impact(this.position.x, this.position.y + 1.4, this.position.z, 0xffd08a);
+            ctx.audio.sfx('hitWood');
+            return false;
+        }
+        this.sinking = 0.001;
+        ctx.effects.explosion(this.position.x, this.position.y + 1.2, this.position.z, 1.3);
+        ctx.audio.sfx('explosion', 0.9);
+        return true;
+    }
+}
+
+/* ================================================================== */
+/* Torre de vigia                                                      */
+/* ================================================================== */
+
+class Tower extends Entity {
+    constructor() {
+        super(buildWatchtower());
+        this.kind = 'tower';
+        this.radius = 3.4;
+        this.maxHp = 4;
+        this.crumble = 0;
+    }
+
+    spawn(x, z, { fireRate = 3.2 } = {}) {
+        const y = terrainHeight(x, z);
+        this.group.position.set(x, Math.max(-1.2, y) - 0.6, z);
+        this.group.rotation.set(0, randRange(0, Math.PI * 2), 0);
+        this.group.scale.setScalar(1);
+        this.hp = this.maxHp;
+        this.fireRate = fireRate;
+        this.fireTimer = randRange(1, fireRate);
+        this.crumble = 0;
+        this.activate();
+    }
+
+    update(dt, ctx) {
+        const pos = this.group.position;
+
+        if (this.crumble > 0) {
+            this.crumble += dt;
+            this.group.scale.y = Math.max(0.02, 1 - this.crumble * 0.9);
+            this.group.position.y -= dt * 1.2;
+            if (this.crumble > 1.3) this.deactivate();
+            return;
+        }
+
+        const fire = this.group.userData.fire;
+        if (fire) {
+            const s = 0.85 + Math.sin(ctx.time * 9 + pos.x) * 0.15;
+            fire.scale.set(s, s * 1.25, s);
+        }
+        if (Math.random() < 0.35) {
+            ctx.effects.fire(pos.x, pos.y + 11, pos.z, 1, 0.9);
+        }
+
+        const dz = pos.z - ctx.player.z;
+        this.fireTimer -= dt;
+        if (this.fireTimer <= 0 && dz < 6 && dz > -150) {
+            this.fireTimer = this.fireRate * randRange(0.85, 1.2);
+            ctx.fireArrow(pos.x, pos.y + 10, pos.z, 1);
+        }
+
+        if (dz > 60) this.deactivate();
+    }
+
+    hit(damage, ctx) {
+        this.hp -= damage;
+        const pos = this.position;
+        if (this.hp > 0) {
+            ctx.effects.impact(pos.x, pos.y + 9, pos.z, 0xcfc9bd);
+            ctx.audio.sfx('hitMetal');
+            return false;
+        }
+        this.crumble = 0.001;
+        ctx.effects.explosion(pos.x, pos.y + 8, pos.z, 1.5, 0.09);
+        ctx.effects.smokePuff(pos.x, pos.y + 6, pos.z, 8, 2.2);
+        ctx.audio.sfx('explosion');
+        const light = this.group.userData.light;
+        if (light) light.intensity = 0;
+        return true;
+    }
+}
+
+/* ================================================================== */
+/* Barricada de troncos                                                */
+/* ================================================================== */
+
+class Barricade extends Entity {
+    constructor() {
+        super(buildBarricade());
+        this.kind = 'barricade';
+        this.radius = 4.4;
+        this.maxHp = 2;
+    }
+
+    spawn(x, z) {
+        this.group.position.set(x, 0, z);
+        this.group.rotation.set(0, randRange(-0.25, 0.25), 0);
+        this.hp = this.maxHp;
+        this.activate();
+    }
+
+    update(dt, ctx) {
+        const pos = this.group.position;
+        pos.y = waterHeight(pos.x, pos.z, ctx.time) + 0.35;
+        waterSlope(pos.x, pos.z, ctx.time, tmpSlope);
+        this.group.rotation.z = -tmpSlope.dx * 2.2;
+        if (pos.z - ctx.player.z > 40) this.deactivate();
+    }
+
+    hit(damage, ctx) {
+        this.hp -= damage;
+        const pos = this.position;
+        if (this.hp > 0) {
+            ctx.effects.impact(pos.x, pos.y + 0.5, pos.z, 0xd9b98a);
+            ctx.audio.sfx('hitWood');
+            return false;
+        }
+        ctx.effects.explosion(pos.x, pos.y + 0.4, pos.z, 0.9, 0.08);
+        ctx.audio.sfx('explosion', 0.7);
+        this.deactivate();
+        return true;
+    }
+}
+
+/* ================================================================== */
+/* Rocha                                                               */
+/* ================================================================== */
+
+class RockObstacle extends Entity {
+    constructor(index) {
+        const geo = buildRockGeometry(index * 1.7 + 0.4);
+        const mesh = new THREE.Mesh(geo, plainMaterial(0x4f4b45, 0.95, 0.02));
+        mesh.castShadow = true;
+        mesh.receiveShadow = true;
+        const group = new THREE.Group();
+        group.add(mesh);
+        super(group);
+        this.kind = 'rock';
+        this.radius = 2.6;
+        this.mesh = mesh;
+        this.indestructible = true;
+    }
+
+    spawn(x, z, scale = 1) {
+        this.group.position.set(x, -0.6, z);
+        this.group.rotation.set(randRange(-0.2, 0.2), randRange(0, Math.PI * 2), randRange(-0.2, 0.2));
+        this.mesh.scale.setScalar(scale * randRange(1.4, 2.4));
+        this.radius = 1.9 * this.mesh.scale.x * 0.75;
+        this.activate();
+    }
+
+    update(dt, ctx) {
+        const pos = this.group.position;
+        if (Math.random() < 0.12) {
+            ctx.effects.splash(
+                pos.x + randRange(-1.4, 1.4),
+                waterHeight(pos.x, pos.z, ctx.time),
+                pos.z + randRange(-1.4, 1.4),
+                1,
+                0.5
+            );
+        }
+        if (pos.z - ctx.player.z > 40) this.deactivate();
+    }
+
+    hit() {
+        return false;
+    }
+}
+
+/* ================================================================== */
+/* Redemoinho                                                          */
+/* ================================================================== */
+
+class Whirlpool extends Entity {
+    constructor() {
+        const group = new THREE.Group();
+        const mat = new THREE.MeshBasicMaterial({
+            color: 0x9fd6e0,
+            transparent: true,
+            opacity: 0.32,
+            side: THREE.DoubleSide,
+            depthWrite: false
+        });
+        for (let i = 0; i < 3; i++) {
+            const ring = new THREE.Mesh(new THREE.TorusGeometry(3.2 - i * 0.9, 0.22, 6, 26), mat);
+            ring.rotation.x = Math.PI / 2;
+            ring.position.y = -i * 0.35;
+            group.add(ring);
+        }
+        const funnel = new THREE.Mesh(
+            new THREE.ConeGeometry(3.4, 3.2, 22, 1, true),
+            new THREE.MeshBasicMaterial({
+                color: 0x0d2430,
+                transparent: true,
+                opacity: 0.55,
+                side: THREE.DoubleSide,
+                depthWrite: false
+            })
+        );
+        funnel.position.y = -1.7;
+        funnel.rotation.x = Math.PI;
+        group.add(funnel);
+        super(group);
+        this.kind = 'whirlpool';
+        this.radius = 5.4;
+        this.indestructible = true;
+    }
+
+    spawn(x, z) {
+        this.group.position.set(x, 0.1, z);
+        this.activate();
+    }
+
+    update(dt, ctx) {
+        const pos = this.group.position;
+        this.group.rotation.y += dt * 1.8;
+        pos.y = waterHeight(pos.x, pos.z, ctx.time) + 0.12;
+        if (Math.random() < 0.4) {
+            const a = Math.random() * Math.PI * 2;
+            ctx.effects.splash(pos.x + Math.cos(a) * 3, pos.y, pos.z + Math.sin(a) * 3, 1, 0.4);
+        }
+        if (pos.z - ctx.player.z > 40) this.deactivate();
+    }
+
+    hit() {
+        return false;
+    }
+}
+
+/* ================================================================== */
+/* Itens                                                               */
+/* ================================================================== */
+
+const PICKUP_KINDS = ['coin', 'heart', 'shield', 'fury'];
+
+class PickupItem extends Entity {
+    constructor() {
+        const group = new THREE.Group();
+        const meshes = {};
+        for (const kind of PICKUP_KINDS) {
+            const mesh = buildPickup(kind);
+            mesh.visible = false;
+            group.add(mesh);
+            meshes[kind] = mesh;
+        }
+        const halo = new THREE.Mesh(
+            new THREE.RingGeometry(0.7, 1.05, 22),
+            new THREE.MeshBasicMaterial({
+                color: 0xffe1a3,
+                transparent: true,
+                opacity: 0.35,
+                side: THREE.DoubleSide,
+                depthWrite: false
+            })
+        );
+        halo.rotation.x = -Math.PI / 2;
+        halo.position.y = -0.7;
+        group.add(halo);
+        super(group);
+        this.kind = 'pickup';
+        this.radius = 2.4;
+        this.meshes = meshes;
+        this.halo = halo;
+        this.type = 'coin';
+    }
+
+    spawn(x, z, type) {
+        this.type = type;
+        for (const key of PICKUP_KINDS) this.meshes[key].visible = key === type;
+        this.halo.material.color.set(
+            type === 'heart' ? 0xff8fa3 : type === 'shield' ? 0x8fd0ff : type === 'fury' ? 0xffa15c : 0xffe1a3
+        );
+        this.group.position.set(x, 1.2, z);
+        this.activate();
+    }
+
+    update(dt, ctx) {
+        const pos = this.group.position;
+        pos.y = waterHeight(pos.x, pos.z, ctx.time) + 1.35 + Math.sin(ctx.time * 2.2 + pos.x) * 0.22;
+        this.group.rotation.y += dt * 1.6;
+        this.halo.scale.setScalar(1 + Math.sin(ctx.time * 3 + pos.z) * 0.12);
+        if (pos.z - ctx.player.z > 30) this.deactivate();
+    }
+}
+
+/* ================================================================== */
+/* Projéteis                                                           */
+/* ================================================================== */
+
+class Arrow extends Entity {
+    constructor() {
+        super(buildArrowMesh());
+        this.kind = 'arrow';
+        this.radius = 1.1;
+        this.velocity = new THREE.Vector3();
+        this.life = 0;
+    }
+
+    spawn(x, y, z, target, speed = 34) {
+        this.group.position.set(x, y, z);
+        const dir = target.clone().sub(this.group.position).normalize();
+        this.velocity.copy(dir).multiplyScalar(speed);
+        this.velocity.y += 2.4;
+        this.life = 5;
+        this.activate();
+    }
+
+    update(dt, ctx) {
+        this.velocity.y -= 9.5 * dt;
+        this.group.position.addScaledVector(this.velocity, dt);
+        this.group.lookAt(
+            this.group.position.x + this.velocity.x,
+            this.group.position.y + this.velocity.y,
+            this.group.position.z + this.velocity.z
+        );
+
+        const flame = this.group.userData.flame;
+        if (flame) {
+            const s = 0.9 + Math.sin(ctx.time * 24) * 0.2;
+            flame.scale.set(s, s, s * 1.8);
+        }
+        if (Math.random() < 0.7) {
+            ctx.effects.fire(this.group.position.x, this.group.position.y, this.group.position.z, 1, 0.5);
+        }
+
+        this.life -= dt;
+        const pos = this.group.position;
+        if (pos.y < waterHeight(pos.x, pos.z, ctx.time)) {
+            ctx.effects.splash(pos.x, 0.1, pos.z, 8, 0.7);
+            ctx.audio.sfx('splash', 0.4);
+            this.deactivate();
+            return;
+        }
+        if (this.life <= 0 || pos.z - ctx.player.z > 30) this.deactivate();
+    }
+}
+
+class Axe extends Entity {
+    constructor() {
+        super(buildAxeMesh(1));
+        this.kind = 'axe';
+        this.radius = 1.4;
+        this.velocity = new THREE.Vector3();
+        this.life = 0;
+        this.spin = 0;
+    }
+
+    spawn(x, y, z, dirX, dirZ, speed = AXE.speed) {
+        this.group.position.set(x, y, z);
+        this.velocity.set(dirX * speed, 6.5, dirZ * speed);
+        this.life = AXE.life;
+        this.spin = 0;
+        this.activate();
+    }
+
+    update(dt, ctx) {
+        this.velocity.y -= AXE.gravity * dt;
+        this.group.position.addScaledVector(this.velocity, dt);
+        this.spin += AXE.spin * dt;
+        this.group.rotation.set(this.spin, 0.2, Math.PI * 0.12);
+        this.life -= dt;
+
+        const pos = this.group.position;
+        if (pos.y < waterHeight(pos.x, pos.z, ctx.time) - 0.2) {
+            ctx.effects.splash(pos.x, 0.1, pos.z, 10, 0.8);
+            ctx.audio.sfx('splash', 0.5);
+            this.deactivate();
+            return;
+        }
+        if (this.life <= 0) this.deactivate();
+    }
+}
+
+/* ================================================================== */
+/* Gerenciador                                                         */
+/* ================================================================== */
+
+const POOL_SIZES = {
+    enemyShips: 6,
+    towers: 5,
+    barricades: 5,
+    rocks: 12,
+    whirlpools: 3,
+    pickups: 16,
+    arrows: 46,
+    axes: 22
+};
+
+export class Entities {
+    constructor(scene, quality) {
+        this.scene = scene;
+        this.quality = quality;
+        this.pools = {};
+
+        const make = (key, factory, count) => {
+            const list = [];
+            for (let i = 0; i < count; i++) {
+                const item = factory(i);
+                scene.add(item.group);
+                list.push(item);
+            }
+            this.pools[key] = list;
+        };
+
+        make('enemyShips', () => new EnemyShip(), POOL_SIZES.enemyShips);
+        make('towers', () => new Tower(), POOL_SIZES.towers);
+        make('barricades', () => new Barricade(), POOL_SIZES.barricades);
+        make('rocks', (i) => new RockObstacle(i), POOL_SIZES.rocks);
+        make('whirlpools', () => new Whirlpool(), POOL_SIZES.whirlpools);
+        make('pickups', () => new PickupItem(), POOL_SIZES.pickups);
+        make('arrows', () => new Arrow(), POOL_SIZES.arrows);
+        make('axes', () => new Axe(), POOL_SIZES.axes);
+
+        this.targets = ['enemyShips', 'towers', 'barricades', 'rocks', 'whirlpools'];
+    }
+
+    _free(key) {
+        return this.pools[key].find((e) => !e.active) || null;
+    }
+
+    spawnEnemyShip(x, z, opts) {
+        const e = this._free('enemyShips');
+        e?.spawn(x, z, opts);
+        return e;
+    }
+
+    spawnTower(x, z, opts) {
+        const e = this._free('towers');
+        e?.spawn(x, z, opts);
+        return e;
+    }
+
+    spawnBarricade(x, z) {
+        const e = this._free('barricades');
+        e?.spawn(x, z);
+        return e;
+    }
+
+    spawnRock(x, z, scale) {
+        const e = this._free('rocks');
+        e?.spawn(x, z, scale);
+        return e;
+    }
+
+    spawnWhirlpool(x, z) {
+        const e = this._free('whirlpools');
+        e?.spawn(x, z);
+        return e;
+    }
+
+    spawnPickup(x, z, type) {
+        const e = this._free('pickups');
+        e?.spawn(x, z, type);
+        return e;
+    }
+
+    spawnArrow(x, y, z, target, speed) {
+        const e = this._free('arrows');
+        e?.spawn(x, y, z, target, speed);
+        return e;
+    }
+
+    throwAxe(x, y, z, dirX, dirZ, speed) {
+        const e = this._free('axes');
+        e?.spawn(x, y, z, dirX, dirZ, speed);
+        return e;
+    }
+
+    /** Atualiza todas as entidades ativas. */
+    update(dt, ctx) {
+        for (const key of Object.keys(this.pools)) {
+            for (const entity of this.pools[key]) {
+                if (entity.active) entity.update(dt, ctx);
+            }
+        }
+    }
+
+    /** Colisão dos machados do jogador com alvos destrutíveis. */
+    resolveAxeHits(ctx) {
+        for (const axe of this.pools.axes) {
+            if (!axe.active) continue;
+            const ap = axe.group.position;
+
+            for (const key of this.targets) {
+                for (const target of this.pools[key]) {
+                    if (!target.active || target.indestructible || target.sinking > 0 || target.crumble > 0) continue;
+                    const dx = target.position.x - ap.x;
+                    const dz = target.position.z - ap.z;
+                    const dy = target.position.y - ap.y;
+                    const r = target.radius + axe.radius;
+                    if (dx * dx + dz * dz > r * r) continue;
+                    if (Math.abs(dy) > (key === 'towers' ? 12 : 5)) continue;
+
+                    const killed = target.hit(AXE.damage, ctx);
+                    axe.deactivate();
+                    if (killed) {
+                        const points =
+                            key === 'enemyShips' ? SCORE.enemyShip : key === 'towers' ? SCORE.tower : SCORE.barricade;
+                        ctx.onKill(points, target.position);
+                    }
+                    break;
+                }
+            }
+        }
+
+        // Machados também derrubam flechas em voo (defesa de última hora).
+        for (const axe of this.pools.axes) {
+            if (!axe.active) continue;
+            for (const arrow of this.pools.arrows) {
+                if (!arrow.active) continue;
+                const d = axe.group.position.distanceToSquared(arrow.group.position);
+                if (d < 6) {
+                    ctx.effects.impact(arrow.group.position.x, arrow.group.position.y, arrow.group.position.z, 0xffc987);
+                    ctx.audio.sfx('hitMetal');
+                    arrow.deactivate();
+                }
+            }
+        }
+    }
+
+    reset() {
+        for (const key of Object.keys(this.pools)) {
+            for (const entity of this.pools[key]) entity.deactivate();
+        }
+    }
+
+    countActive(key) {
+        return this.pools[key].reduce((n, e) => n + (e.active ? 1 : 0), 0);
+    }
+}
+
+export { EnemyShip, Tower, Barricade, RockObstacle, Whirlpool, PickupItem, Arrow, Axe };

--- a/labs/river-knight/src/hud.js
+++ b/labs/river-knight/src/hud.js
@@ -1,0 +1,255 @@
+/**
+ * Camada de interface: tudo que é DOM (HUD, menus, overlays) vive aqui,
+ * separado da lógica 3D.
+ */
+
+import { formatTime } from './utils.js';
+import { DIFFICULTY } from './config.js';
+
+const $ = (id) => document.getElementById(id);
+
+export class Hud {
+    constructor() {
+        this.el = {
+            hud: $('hud'),
+            hullPips: $('hullPips'),
+            hullPanel: document.querySelector('.hull-panel'),
+            furyFill: $('furyFill'),
+            distance: $('distanceValue'),
+            progressFill: $('progressFill'),
+            progressBoat: $('progressBoat'),
+            score: $('scoreValue'),
+            combo: $('comboBadge'),
+            time: $('timeValue'),
+            bossPanel: $('bossPanel'),
+            bossFill: $('bossFill'),
+            message: $('message'),
+            hitFlash: $('hitFlash'),
+            fps: $('fpsCounter'),
+            touch: $('touchControls'),
+            steerZone: $('steerZone'),
+            soundButton: $('soundButton'),
+            pauseButton: $('pauseButton'),
+
+            loading: $('loadingOverlay'),
+            loadingFill: $('loadingFill'),
+            loadingText: $('loadingText'),
+            menu: $('menuOverlay'),
+            pause: $('pauseOverlay'),
+            gameOver: $('gameOverOverlay'),
+            victory: $('victoryOverlay'),
+            error: $('errorOverlay'),
+            errorText: $('errorText'),
+
+            difficultyOptions: $('difficultyOptions'),
+            difficultyBlurb: $('difficultyBlurb'),
+            qualitySelect: $('qualitySelect'),
+            volumeSlider: $('volumeSlider'),
+            volumeValue: $('volumeValue'),
+            bestScore: $('bestScore'),
+            defeatStats: $('defeatStats'),
+            victoryStats: $('victoryStats')
+        };
+
+        this.pipCount = 0;
+        this.messageTimer = null;
+        this.flashTimer = null;
+        this.lastScore = -1;
+    }
+
+    /* ------------------------------ estado ------------------------------ */
+
+    setState(state) {
+        document.body.dataset.state = state;
+    }
+
+    showHud(visible) {
+        this.el.hud.hidden = !visible;
+    }
+
+    setTouchVisible(visible) {
+        this.el.touch.hidden = !visible;
+    }
+
+    setLoading(progress, text) {
+        if (text) this.el.loadingText.textContent = text;
+        this.el.loadingFill.style.width = `${Math.round(progress * 100)}%`;
+    }
+
+    hideLoading() {
+        this.el.loading.hidden = true;
+    }
+
+    showError(message) {
+        if (message) this.el.errorText.textContent = message;
+        this.el.error.hidden = false;
+        this.el.loading.hidden = true;
+    }
+
+    /* ------------------------------ HUD --------------------------------- */
+
+    buildPips(max) {
+        if (this.pipCount === max) return;
+        this.pipCount = max;
+        this.el.hullPips.innerHTML = '';
+        for (let i = 0; i < max; i++) {
+            const pip = document.createElement('span');
+            pip.className = 'pip';
+            this.el.hullPips.appendChild(pip);
+        }
+    }
+
+    setHull(value, max) {
+        this.buildPips(max);
+        const pips = this.el.hullPips.children;
+        for (let i = 0; i < pips.length; i++) {
+            pips[i].dataset.empty = String(i >= value);
+        }
+    }
+
+    setFury(ratio, active) {
+        this.el.furyFill.style.width = `${Math.max(0, Math.min(1, ratio)) * 100}%`;
+        this.el.hullPanel.dataset.fury = String(Boolean(active));
+    }
+
+    setProgress(ratio, metersLeft) {
+        const pct = Math.max(0, Math.min(1, ratio)) * 100;
+        this.el.progressFill.style.width = `${pct}%`;
+        this.el.progressBoat.style.left = `${pct}%`;
+        this.el.distance.textContent = `${Math.max(0, Math.round(metersLeft))} m`;
+    }
+
+    setScore(score) {
+        const rounded = Math.round(score);
+        if (rounded === this.lastScore) return;
+        this.lastScore = rounded;
+        this.el.score.textContent = rounded.toLocaleString('pt-BR');
+    }
+
+    setCombo(multiplier) {
+        const active = multiplier > 1.01;
+        this.el.combo.textContent = `x${multiplier.toFixed(1)}`;
+        this.el.combo.dataset.active = String(active);
+    }
+
+    setTime(seconds) {
+        this.el.time.textContent = formatTime(seconds);
+    }
+
+    setFps(fps) {
+        this.el.fps.textContent = `${Math.round(fps)} fps`;
+    }
+
+    showBoss(show) {
+        this.el.bossPanel.hidden = !show;
+    }
+
+    setBossHealth(ratio) {
+        this.el.bossFill.style.width = `${Math.max(0, Math.min(1, ratio)) * 100}%`;
+    }
+
+    message(text, tone = 'default', duration = 2600) {
+        const el = this.el.message;
+        el.textContent = text;
+        el.dataset.tone = tone;
+        el.dataset.show = 'true';
+        clearTimeout(this.messageTimer);
+        if (duration > 0) {
+            this.messageTimer = setTimeout(() => {
+                el.dataset.show = 'false';
+            }, duration);
+        }
+    }
+
+    clearMessage() {
+        clearTimeout(this.messageTimer);
+        this.el.message.dataset.show = 'false';
+    }
+
+    flash(tone = 'danger') {
+        const el = this.el.hitFlash;
+        el.dataset.tone = tone;
+        el.dataset.show = 'true';
+        clearTimeout(this.flashTimer);
+        this.flashTimer = setTimeout(() => {
+            el.dataset.show = 'false';
+        }, 90);
+    }
+
+    /* ---------------------------- overlays ------------------------------ */
+
+    hideOverlays() {
+        this.el.menu.hidden = true;
+        this.el.pause.hidden = true;
+        this.el.gameOver.hidden = true;
+        this.el.victory.hidden = true;
+    }
+
+    showMenu() {
+        this.hideOverlays();
+        this.el.menu.hidden = false;
+    }
+
+    showPause() {
+        this.el.pause.hidden = false;
+    }
+
+    hidePause() {
+        this.el.pause.hidden = true;
+    }
+
+    showGameOver(stats) {
+        this.hideOverlays();
+        this.el.defeatStats.innerHTML = this._statsMarkup(stats);
+        this.el.gameOver.hidden = false;
+    }
+
+    showVictory(stats) {
+        this.hideOverlays();
+        this.el.victoryStats.innerHTML = this._statsMarkup(stats);
+        this.el.victory.hidden = false;
+    }
+
+    _statsMarkup(stats) {
+        return stats
+            .map(
+                (s) => `<div class="stat${s.gold ? ' stat--gold' : ''}">
+                    <span>${s.label}</span>
+                    <strong>${s.value}</strong>
+                </div>`
+            )
+            .join('');
+    }
+
+    /* ----------------------------- menu --------------------------------- */
+
+    buildDifficulties(current, onSelect) {
+        const wrap = this.el.difficultyOptions;
+        wrap.innerHTML = '';
+        Object.values(DIFFICULTY).forEach((diff) => {
+            const chip = document.createElement('button');
+            chip.type = 'button';
+            chip.className = 'chip';
+            chip.textContent = diff.label;
+            chip.setAttribute('role', 'radio');
+            chip.setAttribute('aria-checked', String(diff.id === current));
+            chip.addEventListener('click', () => {
+                wrap.querySelectorAll('.chip').forEach((c) => c.setAttribute('aria-checked', 'false'));
+                chip.setAttribute('aria-checked', 'true');
+                this.el.difficultyBlurb.textContent = diff.blurb;
+                onSelect(diff.id);
+            });
+            wrap.appendChild(chip);
+        });
+        this.el.difficultyBlurb.textContent = DIFFICULTY[current].blurb;
+    }
+
+    setBestScore(value) {
+        this.el.bestScore.textContent = value ? Math.round(value).toLocaleString('pt-BR') : '—';
+    }
+
+    setSoundButton(enabled) {
+        this.el.soundButton.setAttribute('aria-pressed', String(enabled));
+        this.el.soundButton.textContent = enabled ? '♪' : '✕';
+    }
+}

--- a/labs/river-knight/src/input.js
+++ b/labs/river-knight/src/input.js
@@ -1,0 +1,241 @@
+/**
+ * Entrada unificada: teclado, mouse, toque e gamepad.
+ *
+ * O jogo lê apenas `input.steer`, `input.boost`, `input.brake` e
+ * `input.consumeFire()` — de onde veio o comando é problema deste módulo.
+ */
+
+import { clamp } from './utils.js';
+
+const KEY_MAP = {
+    ArrowLeft: 'left',
+    KeyA: 'left',
+    ArrowRight: 'right',
+    KeyD: 'right',
+    ArrowUp: 'boost',
+    KeyW: 'boost',
+    ArrowDown: 'brake',
+    KeyS: 'brake',
+    Space: 'fire',
+    KeyJ: 'fire'
+};
+
+const ACTION_KEYS = {
+    KeyP: 'pause',
+    Escape: 'pause',
+    KeyM: 'mute',
+    KeyC: 'camera',
+    Enter: 'confirm'
+};
+
+export class Input {
+    constructor(canvas) {
+        this.canvas = canvas;
+        this.keys = new Set();
+        this.touchSteer = 0;
+        this.touchBoost = false;
+        this.firePressed = false;
+        this.fireHeld = false;
+        this.pointerFire = false;
+        this.listeners = new Map();
+        this.enabled = true;
+        this.touchOrigin = null;
+        this.gamepadIndex = null;
+
+        this._bind();
+    }
+
+    on(action, handler) {
+        if (!this.listeners.has(action)) this.listeners.set(action, new Set());
+        this.listeners.get(action).add(handler);
+        return () => this.listeners.get(action).delete(handler);
+    }
+
+    emit(action, payload) {
+        this.listeners.get(action)?.forEach((fn) => fn(payload));
+    }
+
+    _bind() {
+        this._onKeyDown = (e) => {
+            if (e.repeat) return;
+            const action = ACTION_KEYS[e.code];
+            if (action) {
+                // Enter só interessa quando o foco não está num botão.
+                if (action === 'confirm' && document.activeElement?.tagName === 'BUTTON') return;
+                this.emit(action);
+                if (action !== 'confirm') e.preventDefault();
+            }
+            const key = KEY_MAP[e.code];
+            if (!key) return;
+            e.preventDefault();
+            this.keys.add(key);
+            if (key === 'fire') {
+                this.firePressed = true;
+                this.fireHeld = true;
+            }
+        };
+
+        this._onKeyUp = (e) => {
+            const key = KEY_MAP[e.code];
+            if (!key) return;
+            this.keys.delete(key);
+            if (key === 'fire') this.fireHeld = false;
+        };
+
+        this._onBlur = () => {
+            this.keys.clear();
+            this.fireHeld = false;
+            this.touchSteer = 0;
+            this.touchBoost = false;
+            this.pointerFire = false;
+        };
+
+        this._onPointerDown = (e) => {
+            if (e.pointerType === 'touch') return;
+            if (e.button !== 0) return;
+            this.firePressed = true;
+            this.pointerFire = true;
+        };
+
+        this._onPointerUp = () => {
+            this.pointerFire = false;
+        };
+
+        window.addEventListener('keydown', this._onKeyDown, { passive: false });
+        window.addEventListener('keyup', this._onKeyUp);
+        window.addEventListener('blur', this._onBlur);
+        this.canvas.addEventListener('pointerdown', this._onPointerDown);
+        window.addEventListener('pointerup', this._onPointerUp);
+        this.canvas.addEventListener('contextmenu', (e) => e.preventDefault());
+    }
+
+    /** Liga a área de arraste e os botões da interface de toque. */
+    bindTouch({ steerZone, buttons }) {
+        if (!steerZone) return;
+
+        const start = (e) => {
+            this.touchOrigin = { id: e.pointerId, x: e.clientX };
+            steerZone.setPointerCapture?.(e.pointerId);
+            e.preventDefault();
+        };
+
+        const move = (e) => {
+            if (!this.touchOrigin || this.touchOrigin.id !== e.pointerId) return;
+            const dx = e.clientX - this.touchOrigin.x;
+            this.touchSteer = clamp(dx / 80, -1, 1);
+            e.preventDefault();
+        };
+
+        const end = (e) => {
+            if (this.touchOrigin && this.touchOrigin.id !== e.pointerId) return;
+            this.touchOrigin = null;
+            this.touchSteer = 0;
+        };
+
+        steerZone.addEventListener('pointerdown', start);
+        steerZone.addEventListener('pointermove', move);
+        steerZone.addEventListener('pointerup', end);
+        steerZone.addEventListener('pointercancel', end);
+
+        buttons?.forEach((btn) => {
+            const control = btn.dataset.control;
+            const down = (e) => {
+                e.preventDefault();
+                btn.dataset.active = 'true';
+                if (control === 'throw') {
+                    this.firePressed = true;
+                    this.fireHeld = true;
+                } else if (control === 'boost') {
+                    this.touchBoost = true;
+                }
+            };
+            const up = () => {
+                btn.dataset.active = 'false';
+                if (control === 'throw') this.fireHeld = false;
+                else if (control === 'boost') this.touchBoost = false;
+            };
+            btn.addEventListener('pointerdown', down);
+            btn.addEventListener('pointerup', up);
+            btn.addEventListener('pointerleave', up);
+            btn.addEventListener('pointercancel', up);
+        });
+    }
+
+    _gamepad() {
+        if (!navigator.getGamepads) return null;
+        const pads = navigator.getGamepads();
+        for (const pad of pads) {
+            if (pad?.connected) return pad;
+        }
+        return null;
+    }
+
+    /** Direção lateral desejada, de -1 (bombordo) a 1 (boreste). */
+    get steer() {
+        let value = 0;
+        if (this.keys.has('left')) value -= 1;
+        if (this.keys.has('right')) value += 1;
+        value += this.touchSteer;
+
+        const pad = this._gamepad();
+        if (pad) {
+            const axis = pad.axes[0] || 0;
+            if (Math.abs(axis) > 0.16) value += axis;
+            if (pad.buttons[14]?.pressed) value -= 1;
+            if (pad.buttons[15]?.pressed) value += 1;
+        }
+
+        return clamp(value, -1, 1);
+    }
+
+    get boost() {
+        const pad = this._gamepad();
+        return this.keys.has('boost') || this.touchBoost || Boolean(pad?.buttons[7]?.pressed);
+    }
+
+    get brake() {
+        const pad = this._gamepad();
+        return this.keys.has('brake') || Boolean(pad?.buttons[6]?.pressed);
+    }
+
+    /** Verdadeiro apenas uma vez por toque/clique/tecla. */
+    consumeFire() {
+        const pad = this._gamepad();
+        if (pad?.buttons[0]?.pressed || pad?.buttons[2]?.pressed) {
+            if (!this._padFireHeld) {
+                this._padFireHeld = true;
+                return true;
+            }
+        } else {
+            this._padFireHeld = false;
+        }
+
+        if (this.firePressed) {
+            this.firePressed = false;
+            return true;
+        }
+        return false;
+    }
+
+    /** Disparo contínuo (usado no modo fúria). */
+    get firing() {
+        return this.fireHeld || this.pointerFire;
+    }
+
+    reset() {
+        this.keys.clear();
+        this.firePressed = false;
+        this.fireHeld = false;
+        this.pointerFire = false;
+        this.touchSteer = 0;
+        this.touchBoost = false;
+    }
+
+    dispose() {
+        window.removeEventListener('keydown', this._onKeyDown);
+        window.removeEventListener('keyup', this._onKeyUp);
+        window.removeEventListener('blur', this._onBlur);
+        window.removeEventListener('pointerup', this._onPointerUp);
+        this.listeners.clear();
+    }
+}

--- a/labs/river-knight/src/main.js
+++ b/labs/river-knight/src/main.js
@@ -1,0 +1,1055 @@
+/**
+ * River Knight — laço principal, máquina de estados e integração de todos os
+ * sistemas (mundo, entidades, câmera, interface, áudio).
+ */
+
+import * as THREE from 'three';
+
+import {
+    QUALITY,
+    DIFFICULTY,
+    SCORE,
+    COURSE_LENGTH,
+    CASTLE_Z,
+    BOSS_Z,
+    STORAGE_KEY
+} from './config.js';
+import { createSky, createSkyUniforms, sampleSkyPalette, applySkyPalette } from './sky.js';
+import { createWater, waterHeight } from './water.js';
+import { createTerrain } from './terrain.js';
+import { Effects } from './effects.js';
+import { Entities } from './entities.js';
+import { World } from './world.js';
+import { Player } from './player.js';
+import { createCastle, BossBarge } from './castle.js';
+import { Hud } from './hud.js';
+import { Input } from './input.js';
+import { GameAudio } from './audio.js';
+import { updateCloth } from './models.js';
+import { centerX, halfWidth } from './river.js';
+import { clamp, damp, detectMobile, formatTime, randRange } from './utils.js';
+
+const WHITE = new THREE.Color(1, 1, 1);
+
+const CAMERA_MODES = [
+    { name: 'perseguição', offset: new THREE.Vector3(0, 9.6, 22), look: new THREE.Vector3(0, 2.6, -17) },
+    { name: 'proa', offset: new THREE.Vector3(0, 6.2, 14.5), look: new THREE.Vector3(0, 2.2, -22) },
+    { name: 'aérea', offset: new THREE.Vector3(0, 17, 30), look: new THREE.Vector3(0, 1.5, -12) }
+];
+
+class Game {
+    constructor() {
+        this.hud = new Hud();
+        this.canvas = document.getElementById('scene');
+        this.settings = this.loadSettings();
+        this.state = 'loading';
+        this.time = 0;
+        this.elapsed = 0;
+        this.score = 0;
+        this.combo = 1;
+        this.comboTimer = 0;
+        this.kills = 0;
+        this.coins = 0;
+        this.cameraMode = 0;
+        this.bossStarted = false;
+        this.gateOpened = false;
+        this.victoryTimer = 0;
+        this.defeatTimer = 0;
+        this.fpsAccum = 0;
+        this.fpsFrames = 0;
+        this.hudAccum = 0;
+        this.pullVec = { x: 0, drag: 0 };
+    }
+
+    /* ------------------------------------------------------------------ */
+    /* Configurações persistidas                                           */
+    /* ------------------------------------------------------------------ */
+
+    loadSettings() {
+        const fallback = {
+            difficulty: 'warrior',
+            quality: 'auto',
+            volume: 70,
+            muted: false,
+            best: 0
+        };
+        try {
+            const raw = localStorage.getItem(STORAGE_KEY);
+            return raw ? { ...fallback, ...JSON.parse(raw) } : fallback;
+        } catch (err) {
+            return fallback;
+        }
+    }
+
+    saveSettings() {
+        try {
+            localStorage.setItem(STORAGE_KEY, JSON.stringify(this.settings));
+        } catch (err) {
+            /* modo privado: seguimos sem persistir */
+        }
+    }
+
+    resolveQuality() {
+        const choice = this.settings.quality;
+        if (choice !== 'auto' && QUALITY[choice]) return QUALITY[choice];
+        if (detectMobile()) return QUALITY.low;
+        const big = Math.min(window.innerWidth, window.innerHeight) >= 900;
+        return big ? QUALITY.high : QUALITY.medium;
+    }
+
+    /* ------------------------------------------------------------------ */
+    /* Boot                                                                */
+    /* ------------------------------------------------------------------ */
+
+    async init() {
+        this.hud.setLoading(0.1, 'Acordando o rio…');
+
+        const quality = this.resolveQuality();
+        this.quality = quality;
+
+        try {
+            this.renderer = new THREE.WebGLRenderer({
+                canvas: this.canvas,
+                antialias: quality.antialias,
+                powerPreference: 'high-performance',
+                stencil: false
+            });
+        } catch (err) {
+            this.hud.showError('Não foi possível iniciar o WebGL neste navegador.');
+            return;
+        }
+
+        if (!this.renderer.capabilities.isWebGL2 && !this.renderer.getContext()) {
+            this.hud.showError('Este laboratório precisa de WebGL.');
+            return;
+        }
+
+        const pixelRatio = Math.min(window.devicePixelRatio || 1, quality.pixelRatio);
+        this.renderer.setPixelRatio(pixelRatio);
+        this.renderer.setSize(window.innerWidth, window.innerHeight, false);
+        this.renderer.toneMapping = THREE.ACESFilmicToneMapping;
+        this.renderer.toneMappingExposure = 0.98;
+        this.renderer.shadowMap.enabled = quality.shadows;
+        this.renderer.shadowMap.type = THREE.PCFShadowMap;
+
+        this.scene = new THREE.Scene();
+        this.camera = new THREE.PerspectiveCamera(
+            58,
+            window.innerWidth / window.innerHeight,
+            0.4,
+            quality.drawDistance * 3.2
+        );
+        this.camera.position.set(0, 12, 30);
+
+        this.hud.setLoading(0.25, 'Pintando o céu…');
+        this.skyUniforms = createSkyUniforms();
+        this.sky = createSky(this.skyUniforms);
+        this.scene.add(this.sky);
+
+        this.palette = sampleSkyPalette(0);
+        applySkyPalette(this.skyUniforms, this.palette);
+        this.scene.fog = new THREE.FogExp2(this.palette.fog.getHex(), quality.fogDensity);
+
+        this.sun = new THREE.DirectionalLight(this.palette.light.getHex(), this.palette.lightIntensity);
+        this.sun.castShadow = quality.shadows;
+        if (quality.shadows) {
+            this.sun.shadow.mapSize.set(quality.shadowSize, quality.shadowSize);
+            this.sun.shadow.camera.near = 1;
+            this.sun.shadow.camera.far = 260;
+            this.sun.shadow.camera.left = -70;
+            this.sun.shadow.camera.right = 70;
+            this.sun.shadow.camera.top = 70;
+            this.sun.shadow.camera.bottom = -70;
+            this.sun.shadow.bias = -0.0012;
+            this.sun.shadow.normalBias = 0.55;
+        }
+        this.scene.add(this.sun, this.sun.target);
+
+        this.hemi = new THREE.HemisphereLight(this.palette.ambient.getHex(), 0x241a12, 0.75);
+        this.scene.add(this.hemi);
+
+        // Luz de preenchimento presa à câmera: sem ela o barco fica só silhueta
+        // quando o sol está de frente.
+        this.fill = new THREE.DirectionalLight(0xbcd2ff, 0.55);
+        this.fill.castShadow = false;
+        this.scene.add(this.fill, this.fill.target);
+
+        this.hud.setLoading(0.42, 'Escavando o vale…');
+        this.terrain = createTerrain(quality);
+        this.scene.add(this.terrain.mesh);
+
+        this.hud.setLoading(0.55, 'Enchendo o rio…');
+        this.water = createWater(this.skyUniforms, quality);
+        this.water.uniforms.uFogColor.value.copy(this.palette.fog);
+        this.scene.add(this.water.mesh);
+
+        this.hud.setLoading(0.68, 'Plantando as margens…');
+        this.effects = new Effects(this.scene, quality);
+        this.world = new World(this.scene, quality);
+        this.entities = new Entities(this.scene, quality);
+
+        this.hud.setLoading(0.82, 'Erguendo o castelo…');
+        this.castle = createCastle(this.scene);
+        this.boss = new BossBarge(this.scene);
+
+        this.hud.setLoading(0.92, 'Preparando o guerreiro…');
+        this.player = new Player(this.scene);
+
+        this.audio = new GameAudio();
+        this.audio.enabled = !this.settings.muted;
+        this.audio.volume = this.settings.volume / 100;
+
+        this.input = new Input(this.canvas);
+        this.bindUi();
+
+        this.isTouch = detectMobile();
+        this.hud.setTouchVisible(false);
+
+        await this.setupPostProcessing(quality);
+
+        // Primeiro quadro "a frio" para compilar shaders antes de mostrar o menu.
+        this.world.reset(0);
+        this.player.reset(DIFFICULTY[this.settings.difficulty]);
+        this.updateCamera(1, true);
+        this.renderer.compile(this.scene, this.camera);
+        this.render();
+
+        this.hud.setLoading(1, 'Pronto');
+        setTimeout(() => this.hud.hideLoading(), 260);
+
+        this.enterMenu();
+        this.lastFrame = performance.now();
+        this.renderer.setAnimationLoop((now) => this.frame(now));
+
+        window.addEventListener('resize', () => this.resize());
+        document.addEventListener('visibilitychange', () => {
+            if (document.hidden && this.state === 'playing') this.pause();
+        });
+    }
+
+    async setupPostProcessing(quality) {
+        if (!quality.bloom) return;
+        try {
+            const [{ EffectComposer }, { RenderPass }, { UnrealBloomPass }, { OutputPass }] = await Promise.all([
+                import('three/addons/postprocessing/EffectComposer.js'),
+                import('three/addons/postprocessing/RenderPass.js'),
+                import('three/addons/postprocessing/UnrealBloomPass.js'),
+                import('three/addons/postprocessing/OutputPass.js')
+            ]);
+
+            const composer = new EffectComposer(this.renderer);
+            composer.setPixelRatio(this.renderer.getPixelRatio());
+            composer.setSize(window.innerWidth, window.innerHeight);
+            composer.addPass(new RenderPass(this.scene, this.camera));
+
+            const bloom = new UnrealBloomPass(
+                new THREE.Vector2(window.innerWidth, window.innerHeight),
+                0.30,
+                0.75,
+                0.92
+            );
+            composer.addPass(bloom);
+            composer.addPass(new OutputPass());
+
+            this.composer = composer;
+            this.bloom = bloom;
+        } catch (err) {
+            // Sem pós-processamento o jogo continua funcionando normalmente.
+            this.composer = null;
+        }
+    }
+
+    /* ------------------------------------------------------------------ */
+    /* Interface                                                           */
+    /* ------------------------------------------------------------------ */
+
+    bindUi() {
+        const hud = this.hud;
+
+        hud.buildDifficulties(this.settings.difficulty, (id) => {
+            this.settings.difficulty = id;
+            this.saveSettings();
+        });
+        hud.setBestScore(this.settings.best);
+        hud.setSoundButton(!this.settings.muted);
+
+        hud.el.qualitySelect.value = this.settings.quality;
+        hud.el.qualitySelect.addEventListener('change', (e) => {
+            this.settings.quality = e.target.value;
+            this.saveSettings();
+            hud.message('A qualidade muda ao recarregar a página', 'gold', 3200);
+        });
+
+        hud.el.volumeSlider.value = this.settings.volume;
+        hud.el.volumeValue.textContent = String(this.settings.volume);
+        hud.el.volumeSlider.addEventListener('input', (e) => {
+            const value = Number(e.target.value);
+            this.settings.volume = value;
+            hud.el.volumeValue.textContent = String(value);
+            this.audio.setVolume(value / 100);
+            this.saveSettings();
+        });
+
+        document.getElementById('startButton').addEventListener('click', () => this.startRun());
+        document.getElementById('resumeButton').addEventListener('click', () => this.resume());
+        document.getElementById('pauseMenuButton').addEventListener('click', () => this.enterMenu());
+        document.getElementById('retryButton').addEventListener('click', () => this.startRun());
+        document.getElementById('defeatMenuButton').addEventListener('click', () => this.enterMenu());
+        document.getElementById('replayButton').addEventListener('click', () => this.startRun());
+        document.getElementById('victoryMenuButton').addEventListener('click', () => this.enterMenu());
+
+        hud.el.pauseButton.addEventListener('click', () => {
+            if (this.state === 'playing') this.pause();
+            else if (this.state === 'paused') this.resume();
+        });
+
+        hud.el.soundButton.addEventListener('click', () => this.toggleSound());
+
+        this.input.on('pause', () => {
+            if (this.state === 'playing') this.pause();
+            else if (this.state === 'paused') this.resume();
+        });
+        this.input.on('mute', () => this.toggleSound());
+        this.input.on('camera', () => {
+            this.cameraMode = (this.cameraMode + 1) % CAMERA_MODES.length;
+            this.hud.message(`Câmera: ${CAMERA_MODES[this.cameraMode].name}`, 'gold', 1400);
+        });
+        this.input.on('confirm', () => {
+            if (this.state === 'menu') this.startRun();
+            else if (this.state === 'gameover' || this.state === 'victory') this.startRun();
+            else if (this.state === 'paused') this.resume();
+        });
+
+        this.input.bindTouch({
+            steerZone: hud.el.steerZone,
+            buttons: Array.from(document.querySelectorAll('.touch-controls .pad'))
+        });
+    }
+
+    toggleSound() {
+        this.settings.muted = !this.settings.muted;
+        this.audio.setEnabled(!this.settings.muted);
+        this.hud.setSoundButton(!this.settings.muted);
+        this.saveSettings();
+    }
+
+    /* ------------------------------------------------------------------ */
+    /* Estados                                                             */
+    /* ------------------------------------------------------------------ */
+
+    enterMenu() {
+        this.state = 'menu';
+        this.hud.setState('menu');
+        this.hud.showHud(false);
+        this.hud.showMenu();
+        this.hud.setTouchVisible(false);
+        this.hud.clearMessage();
+        this.hud.showBoss(false);
+        this.hud.setBestScore(this.settings.best);
+
+        this.entities?.reset();
+        this.boss?.reset();
+        this.effects?.reset();
+        this.player.reset(DIFFICULTY[this.settings.difficulty]);
+        this.player.z = -120;
+        this.player.x = centerX(-120);
+        this.world.reset(-120);
+        this.menuAngle = 0;
+
+        if (this.audio.ctx) this.audio.playMusic('menu');
+    }
+
+    startRun() {
+        this.audio.init();
+        this.audio.setVolume(this.settings.volume / 100);
+        this.audio.setEnabled(!this.settings.muted);
+        this.audio.playMusic('river');
+
+        this.difficulty = DIFFICULTY[this.settings.difficulty];
+        this.state = 'playing';
+        this.hud.setState('playing');
+        this.hud.hideOverlays();
+        this.hud.showHud(true);
+        this.hud.showBoss(false);
+        this.hud.setTouchVisible(this.isTouch);
+
+        this.score = 0;
+        this.combo = 1;
+        this.comboTimer = 0;
+        this.kills = 0;
+        this.coins = 0;
+        this.elapsed = 0;
+        this.bossStarted = false;
+        this.gateOpened = false;
+        this.victoryTimer = 0;
+        this.defeatTimer = 0;
+        this.cameraMode = 0;
+
+        this.entities.reset();
+        this.boss.reset();
+        this.effects.reset();
+        this.input.reset();
+        this.player.reset(this.difficulty);
+        this.world.reset(0);
+
+        this.hud.setHull(this.player.hull, this.player.maxHull);
+        this.hud.setFury(0, false);
+        this.hud.setProgress(0, COURSE_LENGTH);
+        this.hud.setScore(0);
+        this.hud.setCombo(1);
+        this.hud.setTime(0);
+        this.hud.message('Rume ao castelo!', 'gold', 2600);
+
+        this.updateCamera(1, true);
+    }
+
+    pause() {
+        if (this.state !== 'playing') return;
+        this.state = 'paused';
+        this.hud.setState('paused');
+        this.hud.showPause();
+        this.input.reset();
+    }
+
+    resume() {
+        if (this.state !== 'paused') return;
+        this.state = 'playing';
+        this.hud.setState('playing');
+        this.hud.hidePause();
+        this.lastFrame = performance.now();
+    }
+
+    gameOver() {
+        this.state = 'defeat';
+        this.hud.setState('defeat');
+        this.hud.showBoss(false);
+        this.hud.message('O casco cedeu…', 'danger', 3000);
+        this.audio.playMusic('defeat');
+        this.audio.sfx('explosion', 1.3);
+        this.effects.explosion(this.player.x, this.player.position.y + 1, this.player.z, 2.6);
+        this.defeatTimer = 0;
+    }
+
+    showDefeatScreen() {
+        this.state = 'gameover';
+        this.hud.setState('gameover');
+        this.hud.showHud(false);
+        this.hud.setTouchVisible(false);
+        this.registerScore();
+        this.hud.showGameOver([
+            { label: 'Glória', value: Math.round(this.score).toLocaleString('pt-BR'), gold: true },
+            { label: 'Distância', value: `${Math.round(Math.min(COURSE_LENGTH, this.player.distance))} m` },
+            { label: 'Abatidos', value: String(this.kills) },
+            { label: 'Tempo', value: formatTime(this.elapsed) }
+        ]);
+    }
+
+    startVictory() {
+        this.state = 'victory-seq';
+        this.hud.setState('cinematic');
+        this.hud.showBoss(false);
+        this.hud.setTouchVisible(false);
+        this.hud.message('A princesa está livre!', 'gold', 4200);
+        this.audio.playMusic('victory');
+        this.audio.sfx('horn');
+        this.victoryTimer = 0;
+        this.hud.setProgress(1, 0);
+        this.player.startDocking(CASTLE_Z - 30);
+    }
+
+    showVictoryScreen() {
+        this.state = 'victory';
+        this.hud.setState('victory');
+        this.hud.showHud(false);
+        this.registerScore();
+        this.hud.showVictory([
+            { label: 'Glória', value: Math.round(this.score).toLocaleString('pt-BR'), gold: true },
+            { label: 'Tempo', value: formatTime(this.elapsed) },
+            { label: 'Abatidos', value: String(this.kills) },
+            { label: 'Casco', value: `${this.player.hull}/${this.player.maxHull}` }
+        ]);
+    }
+
+    registerScore() {
+        const bonus = this.player.hull * SCORE.hullBonus * (this.state === 'victory' ? 1 : 0);
+        this.score += bonus;
+        if (this.score > (this.settings.best || 0)) {
+            this.settings.best = Math.round(this.score);
+            this.saveSettings();
+        }
+    }
+
+    /* ------------------------------------------------------------------ */
+    /* Pontuação                                                           */
+    /* ------------------------------------------------------------------ */
+
+    addScore(points) {
+        this.score += points * this.combo * (this.difficulty?.scoreScale ?? 1);
+    }
+
+    onKill(points, position) {
+        this.kills++;
+        this.addScore(points);
+        this.combo = Math.min(SCORE.comboMax, this.combo + SCORE.comboStep);
+        this.comboTimer = 4.5;
+        if (position && this.combo > 1.5 && Math.random() < 0.4) {
+            this.hud.message(`Combo x${this.combo.toFixed(1)}`, 'gold', 1100);
+        }
+    }
+
+    /* ------------------------------------------------------------------ */
+    /* Laço                                                                */
+    /* ------------------------------------------------------------------ */
+
+    frame(now) {
+        const raw = (now - this.lastFrame) / 1000;
+        this.lastFrame = now;
+        const dt = Math.min(0.05, Math.max(0.0005, raw));
+
+        this.fpsAccum += raw;
+        this.fpsFrames++;
+        if (this.fpsAccum > 0.5) {
+            this.hud.setFps(this.fpsFrames / this.fpsAccum);
+            this.fpsAccum = 0;
+            this.fpsFrames = 0;
+        }
+
+        if (this.state === 'paused') {
+            this.render();
+            return;
+        }
+
+        this.time += dt;
+        updateCloth(this.time);
+
+        switch (this.state) {
+            case 'menu':
+                this.updateMenu(dt);
+                break;
+            case 'playing':
+                this.updatePlaying(dt);
+                break;
+            case 'defeat':
+                this.updateDefeat(dt);
+                break;
+            case 'victory-seq':
+                this.updateVictorySequence(dt);
+                break;
+            default:
+                this.updateIdle(dt);
+                break;
+        }
+
+        this.effects.update(dt, this.time);
+        this.updateEnvironment(dt);
+        this.render();
+    }
+
+    updateIdle(dt) {
+        // Telas finais: o rio continua vivo ao fundo.
+        this.world.update(dt, this.time, this.player.z);
+        this.entities.update(dt, this.makeContext(dt));
+        this.castle.update(dt, this.time);
+        this.updateCamera(dt);
+    }
+
+    updateMenu(dt) {
+        // Câmera cinematográfica orbitando o drakkar parado.
+        this.menuAngle += dt * 0.16;
+        const p = this.player;
+        p.z -= dt * 7;
+        p.x = damp(p.x, centerX(p.z), 1.2, dt);
+        const wy = waterHeight(p.x, p.z, this.time);
+        p.root.position.set(p.x, wy + 0.62, p.z);
+        p.root.rotation.z = Math.sin(this.time * 0.7) * 0.035;
+        p.root.rotation.x = Math.sin(this.time * 0.5) * 0.02;
+
+        for (const oar of p.parts.oars) {
+            const phase = this.time * 1.8 + oar.userData.phase;
+            oar.rotation.x = Math.sin(phase) * 0.3;
+            oar.rotation.z = oar.userData.side * (0.3 + Math.sin(phase + 1.2) * 0.18);
+        }
+        p.wParts.armR.rotation.x = -0.25 + Math.sin(this.time * 1.2) * 0.08;
+        p.wParts.torso.rotation.z = Math.sin(this.time * 1.4) * 0.05;
+
+        this.effects.wake.push(p.x, p.z + 6.5, 1.5, 0.5);
+        if (Math.random() < 0.4) this.effects.splash(p.x, wy, p.z - 6.5, 2, 0.4);
+
+        const radius = 26;
+        const cx = p.x + Math.cos(this.menuAngle) * radius;
+        const cz = p.z + Math.sin(this.menuAngle) * radius;
+        this.camera.position.set(cx, wy + 9 + Math.sin(this.menuAngle * 2) * 2.2, cz);
+        this.camera.lookAt(p.x, wy + 2.6, p.z);
+
+        this.world.update(dt, this.time, p.z);
+        this.castle.update(dt, this.time);
+    }
+
+    makeContext(dt) {
+        return {
+            dt,
+            time: this.time,
+            input: this.input,
+            effects: this.effects,
+            audio: this.audio,
+            player: { x: this.player.x, y: this.player.position.y, z: this.player.z },
+            difficulty: this.difficulty,
+            fireArrow: (x, y, z, speedScale = 1) => this.fireArrow(x, y, z, speedScale),
+            onKill: (points, pos) => this.onKill(points, pos),
+            onEnrage: () => {
+                this.hud.message('Morvain enfurece!', 'danger', 2400);
+                this.audio.sfx('horn');
+            },
+            onScrape: () => {
+                if (Math.random() < 0.05) this.audio.sfx('hitWood');
+            }
+        };
+    }
+
+    fireArrow(x, y, z, speedScale = 1) {
+        const lead = this.player.speed * 0.42;
+        const target = new THREE.Vector3(
+            this.player.x + randRange(-2.4, 2.4),
+            this.player.position.y + 1.4,
+            this.player.z - lead + randRange(-4, 4)
+        );
+        const speed = (30 + this.player.speed * 0.5) * speedScale;
+        if (this.entities.spawnArrow(x, y, z, target, speed)) {
+            this.audio.sfx('arrow');
+        }
+    }
+
+    updatePlaying(dt) {
+        this.elapsed += dt;
+        const ctx = this.makeContext(dt);
+
+        // Redemoinhos exercem tração antes do movimento do jogador.
+        this.computePull();
+        ctx.pull = this.pullVec;
+        ctx.speedScale = this.bossStarted && this.boss.active && this.boss.dying <= 0 ? 0.92 : 1;
+
+        if (this.input.consumeFire() || (this.player.hasFury && this.input.firing)) {
+            if (this.player.throwAxe(this.entities, ctx)) this.audio.sfx('throw');
+        }
+
+        this.player.update(dt, ctx);
+
+        // O chefe fecha o rio: não dá para passar por ele.
+        if (this.boss.active && this.boss.dying <= 0) {
+            const wall = this.boss.group.position.z + 34;
+            if (this.player.z < wall) {
+                this.player.z = wall;
+                this.player.speed = Math.min(this.player.speed, 12);
+            }
+        }
+
+        // Perto do castelo o rio afunila no vão do portão.
+        if (this.player.z < CASTLE_Z + 70) {
+            const gateHalf = this.castle.gateWidth / 2 - 4;
+            const cx = this.castle.centerX;
+            this.player.x = clamp(this.player.x, cx - gateHalf, cx + gateHalf);
+        }
+
+        this.world.direct(this.player.z, this.entities, this.difficulty);
+        this.world.update(dt, this.time, this.player.z);
+        this.entities.update(dt, ctx);
+        this.entities.resolveAxeHits(ctx);
+        this.castle.update(dt, this.time);
+        this.castle.emitTorchSparks(this.effects);
+
+        this.updateBoss(dt, ctx);
+        this.resolveCollisions(ctx);
+
+        // Combo esfria com o tempo.
+        if (this.comboTimer > 0) {
+            this.comboTimer -= dt;
+            if (this.comboTimer <= 0) this.combo = 1;
+        }
+
+        this.score += this.player.speed * dt * SCORE.distancePerMeter * (this.difficulty?.scoreScale ?? 1);
+
+        if (!this.player.alive) {
+            this.gameOver();
+            return;
+        }
+
+        // Chegada: o drakkar cruza o vão do portão.
+        if (this.player.z <= CASTLE_Z - 4 && this.gateOpened) {
+            this.startVictory();
+        }
+
+        this.updateHud(dt);
+        this.updateCamera(dt);
+        this.audio.intensity = clamp(this.entities.countActive('enemyShips') / 3, 0, 1);
+    }
+
+    computePull() {
+        this.pullVec.x = 0;
+        this.pullVec.drag = 0;
+        for (const w of this.entities.pools.whirlpools) {
+            if (!w.active) continue;
+            const dx = w.position.x - this.player.x;
+            const dz = w.position.z - this.player.z;
+            const dist = Math.hypot(dx, dz);
+            if (dist > 16) continue;
+            const strength = (1 - dist / 16) ** 2;
+            this.pullVec.x += (dx / (dist || 1)) * strength * 16;
+            this.pullVec.drag += strength * 1.4;
+        }
+    }
+
+    updateBoss(dt, ctx) {
+        const boss = this.boss;
+
+        if (!this.bossStarted && this.player.z < BOSS_Z + 340) {
+            this.bossStarted = true;
+            boss.spawn(BOSS_Z, this.difficulty);
+            this.hud.showBoss(true);
+            this.hud.setBossHealth(1);
+            this.hud.message('A Barcaça Negra bloqueia o rio!', 'danger', 3400);
+            this.audio.playMusic('boss');
+            this.audio.sfx('horn');
+        }
+
+        if (!boss.active) return;
+        boss.update(dt, ctx);
+
+        if (boss.dying <= 0) {
+            // Machados contra o chefe.
+            for (const axe of this.entities.pools.axes) {
+                if (!axe.active) continue;
+                const dx = axe.group.position.x - boss.group.position.x;
+                const dz = axe.group.position.z - boss.group.position.z;
+                const dy = axe.group.position.y - boss.group.position.y;
+                if (Math.abs(dx) < 7 && Math.abs(dz) < 17 && dy < 9 && dy > -3) {
+                    axe.deactivate();
+                    boss.hit(1, ctx);
+                    this.hud.setBossHealth(boss.healthRatio);
+                }
+            }
+
+            // Aríete: encostar na barcaça machuca.
+            const dx = this.player.x - boss.group.position.x;
+            const dz = this.player.z - boss.group.position.z;
+            if (Math.abs(dx) < 9 && Math.abs(dz) < 19) {
+                if (this.player.damage(1, ctx)) this.gameOver();
+                this.hud.setHull(this.player.hull, this.player.maxHull);
+                this.hud.flash('danger');
+                this.player.z += 6;
+            }
+        } else if (!this.gateOpened) {
+            this.gateOpened = true;
+            this.castle.openGate();
+            this.hud.showBoss(false);
+            this.hud.message('O portão está aberto!', 'gold', 3600);
+            this.audio.sfx('gate');
+            this.audio.playMusic('river');
+        }
+    }
+
+    resolveCollisions(ctx) {
+        const player = this.player;
+        const px = player.x;
+        const pz = player.z;
+        const playerRadius = 3.6;
+
+        const hurt = (amount, hint) => {
+            const died = player.damage(amount, ctx);
+            this.hud.setHull(player.hull, player.maxHull);
+            this.hud.flash(player.hasShield ? 'gold' : 'danger');
+            this.combo = 1;
+            this.comboTimer = 0;
+            if (hint && Math.random() < 0.5) this.hud.message(hint, 'danger', 1600);
+            if (died) this.gameOver();
+        };
+
+        // --- flechas inimigas ---
+        for (const arrow of this.entities.pools.arrows) {
+            if (!arrow.active) continue;
+            const p = arrow.group.position;
+            if (Math.abs(p.y - player.position.y) > 4.2) continue;
+            const dx = p.x - px;
+            const dz = p.z - pz;
+            if (dx * dx + dz * dz > 20) continue;
+
+            arrow.deactivate();
+            this.effects.impact(p.x, p.y, p.z, 0xffc987);
+            hurt(1, 'Flecha em chamas!');
+            if (!player.alive) return;
+        }
+
+        // --- obstáculos e barcos ---
+        for (const key of ['enemyShips', 'towers', 'barricades', 'rocks']) {
+            for (const entity of this.entities.pools[key]) {
+                if (!entity.active) continue;
+                if (entity.sinking > 0 || entity.crumble > 0) continue;
+
+                const dx = entity.position.x - px;
+                const dz = entity.position.z - pz;
+                const reach = entity.radius + playerRadius;
+                if (dx * dx + dz * dz > reach * reach) continue;
+
+                if (key === 'towers') {
+                    // Torres ficam na margem: só raspa se o barco encostar mesmo.
+                    if (Math.abs(dx) > entity.radius + 2) continue;
+                }
+
+                // Empurrão lateral para o jogador não "grudar" no obstáculo.
+                const push = Math.sign(dx || 1) * -1;
+                player.x += push * 2.4;
+                player.lateral = push * 8;
+                player.speed *= 0.55;
+
+                if (key === 'enemyShips' || key === 'barricades') {
+                    entity.hit(2, ctx);
+                    if (!entity.active || entity.sinking > 0) {
+                        this.onKill(key === 'enemyShips' ? SCORE.enemyShip : SCORE.barricade, entity.position);
+                    }
+                }
+
+                this.effects.splash(px, player.position.y, pz - 3, 14, 1.2);
+                hurt(1, key === 'rocks' ? 'Cuidado com as pedras!' : null);
+                if (!player.alive) return;
+            }
+        }
+
+        // --- itens ---
+        for (const item of this.entities.pools.pickups) {
+            if (!item.active) continue;
+            const dx = item.position.x - px;
+            const dz = item.position.z - pz;
+            const reach = item.radius + playerRadius;
+            if (dx * dx + dz * dz > reach * reach) continue;
+
+            item.deactivate();
+            this.collect(item.type);
+        }
+    }
+
+    collect(type) {
+        const p = this.player;
+        const pos = p.position;
+
+        switch (type) {
+            case 'coin':
+                this.coins++;
+                this.addScore(SCORE.coin);
+                this.audio.sfx('coin');
+                this.effects.impact(pos.x, pos.y + 1.4, pos.z, 0xffd97a);
+                break;
+            case 'heart':
+                if (p.hull < p.maxHull) {
+                    p.heal(1);
+                    this.hud.message('Casco reparado', 'gold', 1600);
+                } else {
+                    this.addScore(SCORE.coin * 2);
+                }
+                this.hud.setHull(p.hull, p.maxHull);
+                this.audio.sfx('pickup');
+                this.hud.flash('gold');
+                break;
+            case 'shield':
+                p.grantShield(8);
+                this.hud.message('Bênção do escudo', 'gold', 1800);
+                this.audio.sfx('pickup');
+                break;
+            case 'fury':
+                p.grantFury(9);
+                this.hud.message('Fúria do guerreiro!', 'gold', 1800);
+                this.audio.sfx('fury');
+                this.effects.explosion(pos.x, pos.y + 1, pos.z, 1.1, 0.06);
+                break;
+            default:
+                break;
+        }
+    }
+
+    updateHud(dt) {
+        this.hudAccum += dt;
+        if (this.hudAccum < 0.08) return;
+        this.hudAccum = 0;
+
+        const progress = clamp(this.player.distance / COURSE_LENGTH, 0, 1);
+        this.hud.setProgress(progress, COURSE_LENGTH - this.player.distance);
+        this.hud.setScore(this.score);
+        this.hud.setCombo(this.combo);
+        this.hud.setTime(this.elapsed);
+        this.hud.setHull(this.player.hull, this.player.maxHull);
+
+        const furyRatio = this.player.hasFury ? this.player.furyTime / 9 : this.player.hasShield ? this.player.shieldTime / 8 : 0;
+        this.hud.setFury(furyRatio, this.player.hasFury);
+    }
+
+    updateDefeat(dt) {
+        this.defeatTimer += dt;
+        const p = this.player;
+        p.root.position.y -= dt * 1.1;
+        p.root.rotation.z += dt * 0.55;
+        p.root.rotation.x += dt * 0.2;
+
+        if (Math.random() < 0.7) {
+            this.effects.fire(p.x + randRange(-2, 2), p.root.position.y + 1.5, p.z + randRange(-4, 4), 2, 1.1);
+            this.effects.smokePuff(p.x, p.root.position.y + 2, p.z, 1, 1.8);
+        }
+
+        this.world.update(dt, this.time, p.z);
+        this.entities.update(dt, this.makeContext(dt));
+        this.castle.update(dt, this.time);
+        this.updateCamera(dt);
+
+        if (this.defeatTimer > 2.8) this.showDefeatScreen();
+    }
+
+    updateVictorySequence(dt) {
+        this.victoryTimer += dt;
+        const ctx = this.makeContext(dt);
+        this.player.update(dt, ctx);
+        this.world.update(dt, this.time, this.player.z);
+        this.entities.update(dt, ctx);
+        this.castle.update(dt, this.time);
+
+        // Fogos sobre o castelo.
+        if (Math.random() < dt * 2.2) {
+            this.effects.firework(
+                this.castle.centerX + randRange(-40, 40),
+                randRange(38, 62),
+                CASTLE_Z - randRange(10, 60)
+            );
+            this.audio.sfx('firework', 0.7);
+        }
+
+        this.updateCamera(dt);
+        if (this.victoryTimer > 7) this.showVictoryScreen();
+    }
+
+    /* ------------------------------------------------------------------ */
+    /* Câmera e ambiente                                                   */
+    /* ------------------------------------------------------------------ */
+
+    updateCamera(dt, instant = false) {
+        const p = this.player;
+        const mode = CAMERA_MODES[this.cameraMode];
+
+        let offsetY = mode.offset.y;
+        let offsetZ = mode.offset.z;
+        let lookY = mode.look.y;
+        let lookZ = mode.look.z;
+
+        if (this.state === 'victory-seq') {
+            // A câmera sai de trás do drakkar e se reposiciona para enquadrar,
+            // no mesmo plano, o barco atracado e a princesa na torre.
+            const raw = clamp(this.victoryTimer / 5.5, 0, 1);
+            const t = raw * raw * (3 - 2 * raw);
+            const pr = this.castle.princessWorld;
+
+            const desiredX = lerpNum(p.position.x, p.position.x - 17, t);
+            const desiredY = lerpNum(p.position.y + mode.offset.y, p.position.y + 13, t);
+            const desiredZ = lerpNum(p.position.z + mode.offset.z, p.position.z + 27, t);
+
+            const lambda = instant ? 999 : 2.4;
+            this.camera.position.x = damp(this.camera.position.x, desiredX, lambda, dt);
+            this.camera.position.y = damp(this.camera.position.y, desiredY, lambda, dt);
+            this.camera.position.z = damp(this.camera.position.z, desiredZ, lambda, dt);
+
+            this.lookTarget = this.lookTarget || new THREE.Vector3();
+            this.lookTarget.set(
+                lerpNum(p.position.x, lerpNum(p.position.x, pr.x, 0.5), t),
+                lerpNum(p.position.y + 2.6, lerpNum(p.position.y + 3.0, pr.y, 0.46), t),
+                lerpNum(p.position.z - 16, lerpNum(p.position.z, pr.z, 0.5), t)
+            );
+            this.camera.lookAt(this.lookTarget);
+            return;
+        }
+
+        if (this.state === 'defeat') {
+            offsetY += this.defeatTimer * 2.4;
+            offsetZ += this.defeatTimer * 3.2;
+        }
+
+        const yaw = p.root.rotation.y * 0.5;
+        const desiredX = p.position.x + Math.sin(yaw) * offsetZ * -1;
+        const desiredZ = p.position.z + Math.cos(yaw) * offsetZ;
+        const waterY = waterHeight(desiredX, desiredZ, this.time);
+        const desiredY = Math.max(waterY + 3.2, p.position.y + offsetY);
+
+        if (instant) {
+            this.camera.position.set(desiredX, desiredY, desiredZ);
+        } else {
+            const lambda = this.state === 'playing' ? 6.5 : 2.6;
+            this.camera.position.x = damp(this.camera.position.x, desiredX, lambda, dt);
+            this.camera.position.y = damp(this.camera.position.y, desiredY, lambda * 0.8, dt);
+            this.camera.position.z = damp(this.camera.position.z, desiredZ, lambda, dt);
+        }
+
+        this.lookTarget = this.lookTarget || new THREE.Vector3();
+        const aheadX = centerX(p.position.z + lookZ);
+        this.lookTarget.set(
+            lerpNum(p.position.x, aheadX, 0.18),
+            p.position.y + lookY,
+            p.position.z + lookZ
+        );
+        this.camera.lookAt(this.lookTarget);
+    }
+
+    updateEnvironment(dt) {
+        const progress = clamp(this.player.distance / COURSE_LENGTH, 0, 1);
+        const palette = sampleSkyPalette(progress);
+        applySkyPalette(this.skyUniforms, palette);
+
+        this.scene.fog.color.copy(palette.fog);
+        this.water.uniforms.uFogColor.value.copy(palette.fog);
+        this.sun.color.copy(palette.light);
+        this.sun.intensity = palette.lightIntensity;
+        this.hemi.color.copy(palette.ambient);
+
+        // Direção do sol: mantém uma elevação mínima para as sombras ficarem legíveis.
+        const dir = palette.sunDir;
+        const sx = dir.x;
+        const sy = Math.max(dir.y, 0) + 0.45;
+        const sz = dir.z;
+        const len = Math.hypot(sx, sy, sz) || 1;
+        const cam = this.camera.position;
+        this.sun.position.set(cam.x + (sx / len) * 120, (sy / len) * 120, cam.z + (sz / len) * 120);
+        this.sun.target.position.set(cam.x, 0, cam.z - 20);
+        this.sun.target.updateMatrixWorld();
+
+        this.fill.position.set(cam.x, cam.y + 6, cam.z + 4);
+        this.fill.target.position.set(this.player.position.x, this.player.position.y, this.player.position.z - 8);
+        this.fill.target.updateMatrixWorld();
+        this.fill.color.copy(palette.ambient).lerp(WHITE, 0.35);
+
+        this.sky.position.copy(cam);
+        this.sky.material.uniforms.uTime.value = this.time;
+        this.sky.material.uniforms.uCloud.value = 0.42 + progress * 0.42;
+
+        this.water.update(this.time, this.camera);
+        this.terrain.update(this.camera);
+    }
+
+    render() {
+        if (this.composer) this.composer.render();
+        else this.renderer.render(this.scene, this.camera);
+    }
+
+    resize() {
+        const w = window.innerWidth;
+        const h = window.innerHeight;
+        this.camera.aspect = w / h;
+        this.camera.updateProjectionMatrix();
+        this.renderer.setSize(w, h, false);
+        this.composer?.setSize(w, h);
+        this.bloom?.setSize(w, h);
+    }
+}
+
+function lerpNum(a, b, t) {
+    return a + (b - a) * t;
+}
+
+const game = new Game();
+game.init().catch((err) => {
+    console.error(err);
+    game.hud.showError('Algo deu errado ao montar o rio. Recarregue a página.');
+});
+
+window.__riverKnight = game;

--- a/labs/river-knight/src/models.js
+++ b/labs/river-knight/src/models.js
@@ -1,0 +1,904 @@
+/**
+ * Modelos 3D construídos por código — nenhum arquivo .glb/.obj envolvido.
+ *
+ * O casco do drakkar é gerado por "loft": seções transversais em U ao longo
+ * do comprimento, com as bordas subindo em direção à proa e à popa (a linha
+ * de sheer típica dos barcos nórdicos).
+ */
+
+import * as THREE from 'three';
+import { COLORS } from './config.js';
+import { woodTexture, sailTexture, shieldTexture, stoneTexture, bannerTexture } from './textures.js';
+
+/* ------------------------------------------------------------------ */
+/* Materiais                                                           */
+/* ------------------------------------------------------------------ */
+
+const materialCache = new Map();
+
+function cachedMaterial(key, factory) {
+    if (!materialCache.has(key)) materialCache.set(key, factory());
+    return materialCache.get(key);
+}
+
+export function woodMaterial(dark = false, color = COLORS.hull) {
+    return cachedMaterial(`wood:${dark}:${color}`, () => new THREE.MeshStandardMaterial({
+        map: woodTexture(dark),
+        color,
+        roughness: 0.82,
+        metalness: 0.04
+    }));
+}
+
+export function metalMaterial(color = 0xa9adb4, roughness = 0.34) {
+    return cachedMaterial(`metal:${color}:${roughness}`, () => new THREE.MeshStandardMaterial({
+        color,
+        roughness,
+        metalness: 0.88
+    }));
+}
+
+export function plainMaterial(color, roughness = 0.7, metalness = 0.05, emissive = 0x000000, emissiveIntensity = 1) {
+    return cachedMaterial(`plain:${color}:${roughness}:${metalness}:${emissive}:${emissiveIntensity}`, () =>
+        new THREE.MeshStandardMaterial({
+            color,
+            roughness,
+            metalness,
+            emissive,
+            emissiveIntensity
+        }));
+}
+
+export function stoneMaterial(tint = '#8f8d87') {
+    return cachedMaterial(`stone:${tint}`, () => new THREE.MeshStandardMaterial({
+        map: stoneTexture(tint),
+        roughness: 0.95,
+        metalness: 0.02
+    }));
+}
+
+/**
+ * Material de tecido: injeta ondulação no vertex shader (vela, capa e
+ * estandartes usam o mesmo shader, com ventos diferentes).
+ * `uv.x` define o quanto cada ponto está livre para tremular.
+ */
+export function clothMaterial({ map = null, color = 0xffffff, side = THREE.DoubleSide, wind = 1 } = {}) {
+    const material = new THREE.MeshStandardMaterial({
+        map,
+        color,
+        side,
+        roughness: 0.86,
+        metalness: 0,
+        transparent: Boolean(map),
+        alphaTest: map ? 0.35 : 0
+    });
+
+    material.userData.uniforms = {
+        uTime: { value: 0 },
+        uWind: { value: wind }
+    };
+
+    material.onBeforeCompile = (shader) => {
+        shader.uniforms.uTime = material.userData.uniforms.uTime;
+        shader.uniforms.uWind = material.userData.uniforms.uWind;
+
+        shader.vertexShader = shader.vertexShader
+            .replace(
+                '#include <common>',
+                /* glsl */ `
+                #include <common>
+                uniform float uTime;
+                uniform float uWind;
+                `
+            )
+            .replace(
+                '#include <begin_vertex>',
+                /* glsl */ `
+                #include <begin_vertex>
+                float rkFree = uv.x;
+                float rkFlap = sin(uv.x * 6.2 + uTime * 3.1) * 0.55
+                             + sin(uv.y * 4.1 - uTime * 2.2) * 0.32
+                             + sin((uv.x + uv.y) * 9.0 + uTime * 5.0) * 0.13;
+                transformed.z += rkFlap * rkFree * rkFree * uWind;
+                transformed.x += rkFlap * rkFree * 0.12 * uWind;
+                `
+            )
+            .replace(
+                '#include <beginnormal_vertex>',
+                /* glsl */ `
+                #include <beginnormal_vertex>
+                float rkN = cos(uv.x * 6.2 + uTime * 3.1) * 0.5;
+                objectNormal = normalize(objectNormal + vec3(0.0, 0.0, 0.0) + vec3(rkN * uv.x * 0.35, 0.0, 0.0));
+                `
+            );
+    };
+
+    material.customProgramCacheKey = () => 'river-knight-cloth';
+    return material;
+}
+
+/** Avança a animação de todos os tecidos criados. */
+const clothMaterials = new Set();
+export function registerCloth(material) {
+    clothMaterials.add(material);
+    return material;
+}
+export function updateCloth(time) {
+    clothMaterials.forEach((m) => {
+        m.userData.uniforms.uTime.value = time;
+    });
+}
+
+/* ------------------------------------------------------------------ */
+/* Casco                                                               */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Gera o casco por seções transversais.
+ * @param {object} o dimensões do barco
+ */
+export function buildHullGeometry({
+    length = 15,
+    beam = 3.6,
+    depth = 1.6,
+    rise = 1.9,
+    rings = 30,
+    arcSteps = 12
+} = {}) {
+    const positions = [];
+    const uvs = [];
+    const indices = [];
+
+    const shapeAt = (t) => {
+        // t ∈ [-1, 1]: -1 popa, +1 proa.
+        const taper = Math.pow(Math.max(0, 1 - t * t), 0.42);
+        return {
+            hw: Math.max(0.09, (beam / 2) * taper),
+            dep: depth * (0.55 + 0.45 * taper),
+            sheer: rise * Math.pow(Math.abs(t), 2.6),
+            z: (t * length) / 2
+        };
+    };
+
+    for (let r = 0; r <= rings; r++) {
+        const t = (r / rings) * 2 - 1;
+        const { hw, dep, sheer, z } = shapeAt(t);
+        for (let a = 0; a <= arcSteps; a++) {
+            const s = a / arcSteps;
+            const ang = -Math.PI / 2 + s * Math.PI;
+            const x = hw * Math.sin(ang);
+            const y = sheer - dep * Math.pow(Math.cos(ang), 1.25);
+            positions.push(x, y, z);
+            uvs.push(s * 1.6, (r / rings) * 3.2);
+        }
+    }
+
+    const perRing = arcSteps + 1;
+    for (let r = 0; r < rings; r++) {
+        for (let a = 0; a < arcSteps; a++) {
+            const i0 = r * perRing + a;
+            const i1 = i0 + 1;
+            const i2 = i0 + perRing;
+            const i3 = i2 + 1;
+            indices.push(i0, i2, i1, i1, i2, i3);
+        }
+    }
+
+    // Convés: liga bordo a bordo um pouco abaixo da amurada.
+    const deckStart = positions.length / 3;
+    for (let r = 0; r <= rings; r++) {
+        const t = (r / rings) * 2 - 1;
+        const { hw, sheer, z } = shapeAt(t);
+        const y = sheer - 0.42;
+        positions.push(-hw * 0.94, y, z, hw * 0.94, y, z);
+        uvs.push(0, (r / rings) * 3.2, 1, (r / rings) * 3.2);
+    }
+    for (let r = 0; r < rings; r++) {
+        const i0 = deckStart + r * 2;
+        const i1 = i0 + 1;
+        const i2 = i0 + 2;
+        const i3 = i0 + 3;
+        indices.push(i0, i1, i2, i1, i3, i2);
+    }
+
+    const geo = new THREE.BufferGeometry();
+    geo.setAttribute('position', new THREE.Float32BufferAttribute(positions, 3));
+    geo.setAttribute('uv', new THREE.Float32BufferAttribute(uvs, 2));
+    geo.setIndex(indices);
+    geo.computeVertexNormals();
+    geo.computeBoundingSphere();
+    return geo;
+}
+
+/** Cabeça de dragão da proa. */
+function buildDragonHead(color) {
+    const group = new THREE.Group();
+    const mat = woodMaterial(true, color);
+
+    const neck = new THREE.Mesh(new THREE.CylinderGeometry(0.16, 0.26, 1.5, 10), mat);
+    neck.rotation.x = -0.35;
+    neck.position.y = 0.7;
+    group.add(neck);
+
+    const skull = new THREE.Mesh(new THREE.BoxGeometry(0.42, 0.4, 0.95), mat);
+    skull.position.set(0, 1.42, 0.42);
+    skull.rotation.x = 0.25;
+    group.add(skull);
+
+    const snout = new THREE.Mesh(new THREE.BoxGeometry(0.3, 0.24, 0.55), mat);
+    snout.position.set(0, 1.3, 1.0);
+    snout.rotation.x = 0.25;
+    group.add(snout);
+
+    // Crista de espinhos.
+    for (let i = 0; i < 4; i++) {
+        const spike = new THREE.Mesh(new THREE.ConeGeometry(0.09, 0.34, 6), mat);
+        spike.position.set(0, 1.6 - i * 0.06, 0.1 - i * 0.28);
+        spike.rotation.x = -0.5;
+        group.add(spike);
+    }
+
+    // Olhos brilhantes.
+    const eyeMat = plainMaterial(0xffb347, 0.3, 0, 0xff7a1a, 2.4);
+    for (const sx of [-1, 1]) {
+        const eye = new THREE.Mesh(new THREE.SphereGeometry(0.07, 8, 8), eyeMat);
+        eye.position.set(sx * 0.17, 1.46, 0.72);
+        group.add(eye);
+    }
+
+    return group;
+}
+
+/**
+ * Drakkar completo. Retorna o grupo e as partes animáveis.
+ */
+export function buildLongship({
+    length = 15,
+    beam = 3.6,
+    hullColor = COLORS.hull,
+    sailBase = '#ded1b0',
+    sailStripe = '#a02f2f',
+    emblem = 'cross',
+    shields = true,
+    oars = true,
+    dragon = true,
+    lantern = true
+} = {}) {
+    const group = new THREE.Group();
+    const parts = { oars: [], shields: [], lights: [] };
+
+    const hull = new THREE.Mesh(buildHullGeometry({ length, beam }), woodMaterial(false, hullColor));
+    hull.castShadow = true;
+    hull.receiveShadow = true;
+    group.add(hull);
+    parts.hull = hull;
+
+    // Amurada (borda superior) — dois "trilhos" curvos de madeira escura.
+    const railMat = woodMaterial(true, hullColor);
+    const railSteps = 24;
+    for (const side of [-1, 1]) {
+        const pts = [];
+        for (let i = 0; i <= railSteps; i++) {
+            const t = (i / railSteps) * 2 - 1;
+            const taper = Math.pow(Math.max(0, 1 - t * t), 0.42);
+            const hw = Math.max(0.09, (beam / 2) * taper);
+            const sheer = 1.9 * Math.pow(Math.abs(t), 2.6);
+            pts.push(new THREE.Vector3(side * hw, sheer + 0.03, (t * length) / 2));
+        }
+        const rail = new THREE.Mesh(
+            new THREE.TubeGeometry(new THREE.CatmullRomCurve3(pts), railSteps, 0.11, 6, false),
+            railMat
+        );
+        rail.castShadow = true;
+        group.add(rail);
+    }
+
+    // Quilha e cadastes.
+    const keel = new THREE.Mesh(new THREE.BoxGeometry(0.16, 0.22, length * 0.98), railMat);
+    keel.position.y = -1.35;
+    group.add(keel);
+
+    if (dragon) {
+        const head = buildDragonHead(hullColor);
+        head.position.set(0, 0.9, length / 2 - 0.35);
+        head.castShadow = true;
+        group.add(head);
+        parts.dragon = head;
+
+        const tail = new THREE.Mesh(new THREE.TorusGeometry(0.6, 0.11, 6, 12, Math.PI * 1.2), railMat);
+        tail.position.set(0, 1.5, -length / 2 + 0.2);
+        tail.rotation.set(Math.PI / 2, 0, Math.PI * 0.1);
+        tail.rotation.y = Math.PI / 2;
+        group.add(tail);
+    }
+
+    // Bancos de remo.
+    const benchMat = woodMaterial(true, hullColor);
+    const benchCount = 4;
+    for (let i = 0; i < benchCount; i++) {
+        const t = -0.5 + (i / (benchCount - 1)) * 1.0;
+        const bench = new THREE.Mesh(new THREE.BoxGeometry(beam * 0.78, 0.12, 0.42), benchMat);
+        bench.position.set(0, 0.05, (t * length) / 2);
+        bench.castShadow = true;
+        group.add(bench);
+    }
+
+    // Mastro + verga + vela. O mastro fica à frente do centro para que a vela
+    // não tape o guerreiro na câmera de perseguição.
+    const mastZ = length * 0.16;
+    const mastHeight = beam * 1.85;
+    const mast = new THREE.Mesh(new THREE.CylinderGeometry(0.11, 0.15, mastHeight, 10), railMat);
+    mast.position.set(0, mastHeight / 2 - 0.4, mastZ);
+    mast.castShadow = true;
+    group.add(mast);
+    parts.mast = mast;
+
+    const yardY = mastHeight - 0.85;
+    const yard = new THREE.Mesh(new THREE.CylinderGeometry(0.075, 0.075, beam * 1.55, 8), railMat);
+    yard.rotation.z = Math.PI / 2;
+    yard.position.set(0, yardY, mastZ);
+    group.add(yard);
+
+    const sailMat = registerCloth(clothMaterial({
+        map: sailTexture({ base: sailBase, stripe: sailStripe, emblem }),
+        side: THREE.DoubleSide,
+        wind: 0.5
+    }));
+    sailMat.transparent = false;
+    sailMat.alphaTest = 0;
+
+    const sailHeight = beam * 0.95;
+    const sailGeo = new THREE.PlaneGeometry(beam * 1.45, sailHeight, 14, 10);
+    const sail = new THREE.Mesh(sailGeo, sailMat);
+    sail.position.set(0, yardY - sailHeight / 2 - 0.1, mastZ);
+    sail.castShadow = true;
+    group.add(sail);
+    parts.sail = sail;
+
+    // Cordame.
+    const ropes = new THREE.BufferGeometry().setFromPoints([
+        new THREE.Vector3(-beam * 0.75, yardY, mastZ),
+        new THREE.Vector3(0, 0.5, length / 2 - 1.4),
+        new THREE.Vector3(beam * 0.75, yardY, mastZ),
+        new THREE.Vector3(0, 0.5, length / 2 - 1.4),
+        new THREE.Vector3(-beam * 0.75, yardY, mastZ),
+        new THREE.Vector3(0, 0.7, -length / 2 + 1.2),
+        new THREE.Vector3(beam * 0.75, yardY, mastZ),
+        new THREE.Vector3(0, 0.7, -length / 2 + 1.2)
+    ]);
+    group.add(new THREE.LineSegments(ropes, new THREE.LineBasicMaterial({ color: 0x2a2118 })));
+
+    if (shields) {
+        const shieldGeo = new THREE.CylinderGeometry(0.46, 0.46, 0.1, 16);
+        const shieldMats = [
+            new THREE.MeshStandardMaterial({ map: shieldTexture('#b23a3a', '#e5d6ae'), roughness: 0.7 }),
+            new THREE.MeshStandardMaterial({ map: shieldTexture('#2f5d7c', '#e5d6ae'), roughness: 0.7 }),
+            new THREE.MeshStandardMaterial({ map: shieldTexture('#2f6b45', '#efe3bf'), roughness: 0.7 })
+        ];
+        const count = 5;
+        for (const side of [-1, 1]) {
+            for (let i = 0; i < count; i++) {
+                const t = -0.62 + (i / (count - 1)) * 1.24;
+                const taper = Math.pow(Math.max(0, 1 - t * t), 0.42);
+                const hw = Math.max(0.09, (beam / 2) * taper);
+                const sheer = 1.9 * Math.pow(Math.abs(t), 2.6);
+                const shield = new THREE.Mesh(shieldGeo, shieldMats[(i + (side > 0 ? 1 : 0)) % shieldMats.length]);
+                shield.rotation.z = Math.PI / 2;
+                shield.position.set(side * (hw + 0.06), sheer - 0.28, (t * length) / 2);
+                shield.castShadow = true;
+                group.add(shield);
+                parts.shields.push(shield);
+            }
+        }
+    }
+
+    if (oars) {
+        const oarGeo = new THREE.BoxGeometry(0.09, 0.09, 3.6);
+        const bladeGeo = new THREE.BoxGeometry(0.22, 0.05, 0.9);
+        const oarMat = woodMaterial(true, hullColor);
+        const perSide = 3;
+        for (const side of [-1, 1]) {
+            for (let i = 0; i < perSide; i++) {
+                const pivot = new THREE.Group();
+                const t = -0.42 + (i / (perSide - 1)) * 0.84;
+                const taper = Math.pow(Math.max(0, 1 - t * t), 0.42);
+                const hw = Math.max(0.09, (beam / 2) * taper);
+                pivot.position.set(side * hw, 0.35, (t * length) / 2);
+
+                const shaft = new THREE.Mesh(oarGeo, oarMat);
+                shaft.position.set(side * 1.5, -0.2, 0);
+                shaft.rotation.y = side * Math.PI * 0.5;
+                shaft.castShadow = true;
+                pivot.add(shaft);
+
+                const blade = new THREE.Mesh(bladeGeo, oarMat);
+                blade.position.set(side * 3.1, -0.5, 0);
+                blade.rotation.y = side * Math.PI * 0.5;
+                pivot.add(blade);
+
+                pivot.userData.side = side;
+                pivot.userData.phase = i * 0.35;
+                // Remos apontam para baixo, tocando a água.
+                pivot.userData.baseRoll = -side * 0.34;
+                pivot.rotation.z = pivot.userData.baseRoll;
+                group.add(pivot);
+                parts.oars.push(pivot);
+            }
+        }
+    }
+
+    if (lantern) {
+        const lanternGroup = new THREE.Group();
+        const cage = new THREE.Mesh(new THREE.CylinderGeometry(0.16, 0.2, 0.42, 8), metalMaterial(0x6b6257, 0.5));
+        lanternGroup.add(cage);
+        const flame = new THREE.Mesh(
+            new THREE.SphereGeometry(0.1, 8, 8),
+            plainMaterial(0xffd08a, 0.3, 0, 0xff9a3c, 1.4)
+        );
+        lanternGroup.add(flame);
+        const light = new THREE.PointLight(0xffa54a, 2.2, 9, 2);
+        light.position.y = 0.1;
+        lanternGroup.add(light);
+        lanternGroup.position.set(0, 1.85, -length / 2 + 0.9);
+        group.add(lanternGroup);
+        parts.lantern = lanternGroup;
+        parts.lanternFlame = flame;
+        parts.lights.push(light);
+    }
+
+    group.userData.parts = parts;
+    return { group, parts };
+}
+
+/* ------------------------------------------------------------------ */
+/* Guerreiro                                                           */
+/* ------------------------------------------------------------------ */
+
+export function buildWarrior({ tunic = 0x8c2f3a, cape = 0x7a1f2b } = {}) {
+    const group = new THREE.Group();
+    const steel = metalMaterial(0xb6bcc4, 0.3);
+    const darkSteel = metalMaterial(0x5c6169, 0.45);
+    const leather = plainMaterial(0x4a3524, 0.85, 0.02);
+    const skin = plainMaterial(0xd9a77c, 0.75, 0);
+    const cloth = plainMaterial(tunic, 0.85, 0);
+
+    // Pernas.
+    for (const sx of [-1, 1]) {
+        const leg = new THREE.Mesh(new THREE.CylinderGeometry(0.115, 0.1, 0.78, 8), leather);
+        leg.position.set(sx * 0.15, 0.39, 0);
+        leg.castShadow = true;
+        group.add(leg);
+        const boot = new THREE.Mesh(new THREE.BoxGeometry(0.2, 0.14, 0.34), plainMaterial(0x2e2116, 0.9, 0));
+        boot.position.set(sx * 0.15, 0.07, 0.04);
+        group.add(boot);
+    }
+
+    const torso = new THREE.Group();
+    torso.position.y = 0.78;
+    group.add(torso);
+
+    const chest = new THREE.Mesh(new THREE.CylinderGeometry(0.29, 0.24, 0.62, 10), cloth);
+    chest.position.y = 0.3;
+    chest.castShadow = true;
+    torso.add(chest);
+
+    // Cota de malha / peitoral.
+    const plate = new THREE.Mesh(new THREE.CylinderGeometry(0.3, 0.26, 0.36, 10), steel);
+    plate.position.y = 0.42;
+    plate.castShadow = true;
+    torso.add(plate);
+
+    const belt = new THREE.Mesh(new THREE.CylinderGeometry(0.26, 0.26, 0.1, 10), leather);
+    belt.position.y = 0.04;
+    torso.add(belt);
+
+    // Ombreiras.
+    for (const sx of [-1, 1]) {
+        const pauldron = new THREE.Mesh(new THREE.SphereGeometry(0.16, 10, 8, 0, Math.PI * 2, 0, Math.PI / 2), steel);
+        pauldron.position.set(sx * 0.3, 0.56, 0);
+        pauldron.rotation.z = sx * 0.35;
+        pauldron.castShadow = true;
+        torso.add(pauldron);
+    }
+
+    // Cabeça + elmo.
+    const head = new THREE.Group();
+    head.position.y = 0.74;
+    torso.add(head);
+
+    const skull = new THREE.Mesh(new THREE.SphereGeometry(0.17, 12, 10), skin);
+    head.add(skull);
+
+    const helm = new THREE.Mesh(new THREE.SphereGeometry(0.2, 12, 10, 0, Math.PI * 2, 0, Math.PI * 0.62), steel);
+    helm.position.y = 0.02;
+    helm.castShadow = true;
+    head.add(helm);
+
+    const nasal = new THREE.Mesh(new THREE.BoxGeometry(0.05, 0.2, 0.05), steel);
+    nasal.position.set(0, -0.03, 0.17);
+    head.add(nasal);
+
+    for (const sx of [-1, 1]) {
+        const horn = new THREE.Mesh(new THREE.ConeGeometry(0.055, 0.34, 7), plainMaterial(0xe8dfc8, 0.6, 0));
+        horn.position.set(sx * 0.19, 0.12, -0.02);
+        horn.rotation.z = sx * -0.85;
+        horn.rotation.x = -0.15;
+        head.add(horn);
+    }
+
+    const beard = new THREE.Mesh(new THREE.ConeGeometry(0.13, 0.22, 8), plainMaterial(0x8a5b2f, 0.9, 0));
+    beard.position.set(0, -0.14, 0.06);
+    beard.rotation.x = Math.PI;
+    head.add(beard);
+
+    // Braços (pivô no ombro).
+    const armGeo = new THREE.CylinderGeometry(0.085, 0.075, 0.56, 8);
+    const armR = new THREE.Group();
+    armR.position.set(0.3, 0.52, 0);
+    torso.add(armR);
+    const armRMesh = new THREE.Mesh(armGeo, cloth);
+    armRMesh.position.y = -0.28;
+    armRMesh.castShadow = true;
+    armR.add(armRMesh);
+    const bracerR = new THREE.Mesh(new THREE.CylinderGeometry(0.095, 0.09, 0.18, 8), darkSteel);
+    bracerR.position.y = -0.5;
+    armR.add(bracerR);
+
+    const armL = new THREE.Group();
+    armL.position.set(-0.3, 0.52, 0);
+    torso.add(armL);
+    const armLMesh = new THREE.Mesh(armGeo, cloth);
+    armLMesh.position.y = -0.28;
+    armLMesh.castShadow = true;
+    armL.add(armLMesh);
+
+    // Escudo no braço esquerdo.
+    const shield = new THREE.Mesh(
+        new THREE.CylinderGeometry(0.34, 0.34, 0.08, 16),
+        new THREE.MeshStandardMaterial({ map: shieldTexture('#2f5d7c', '#e8dcb8'), roughness: 0.68 })
+    );
+    shield.rotation.z = Math.PI / 2;
+    shield.rotation.y = 0.2;
+    shield.position.set(-0.16, -0.5, 0.06);
+    shield.castShadow = true;
+    armL.add(shield);
+
+    // Machado na mão direita.
+    const axe = buildAxeMesh(0.85);
+    axe.position.set(0.02, -0.62, 0.06);
+    axe.rotation.set(-0.4, 0, 0.3);
+    armR.add(axe);
+
+    // Capa.
+    const capeMat = registerCloth(clothMaterial({ color: cape, side: THREE.DoubleSide, wind: 0.4 }));
+    capeMat.transparent = false;
+    capeMat.alphaTest = 0;
+    const capeMesh = new THREE.Mesh(new THREE.PlaneGeometry(0.66, 0.95, 8, 8), capeMat);
+    capeMesh.position.set(0, 0.18, -0.26);
+    capeMesh.rotation.x = 0.12;
+    capeMesh.castShadow = true;
+    torso.add(capeMesh);
+
+    group.userData.parts = { torso, head, armR, armL, axe, cape: capeMesh };
+    return { group, parts: group.userData.parts };
+}
+
+/** Machado de arremesso (também usado como projétil). */
+export function buildAxeMesh(scale = 1) {
+    const group = new THREE.Group();
+    const handle = new THREE.Mesh(
+        new THREE.CylinderGeometry(0.035, 0.045, 0.8, 7),
+        woodMaterial(true, 0x6b4a2a)
+    );
+    group.add(handle);
+
+    const head = new THREE.Mesh(new THREE.BoxGeometry(0.08, 0.26, 0.1), metalMaterial(0xc9ced6, 0.28));
+    head.position.set(0, 0.3, 0.06);
+    group.add(head);
+
+    const bladeShape = new THREE.Shape();
+    bladeShape.moveTo(0, -0.14);
+    bladeShape.quadraticCurveTo(0.34, -0.24, 0.4, 0.02);
+    bladeShape.quadraticCurveTo(0.34, 0.24, 0, 0.16);
+    bladeShape.lineTo(0, -0.14);
+    const blade = new THREE.Mesh(
+        new THREE.ExtrudeGeometry(bladeShape, { depth: 0.05, bevelEnabled: true, bevelSize: 0.012, bevelThickness: 0.012, bevelSegments: 1 }),
+        metalMaterial(0xd7dce3, 0.22)
+    );
+    blade.position.set(0.03, 0.3, -0.025);
+    group.add(blade);
+
+    const wrap = new THREE.Mesh(new THREE.CylinderGeometry(0.05, 0.05, 0.14, 7), plainMaterial(0x3b2a19, 0.9, 0));
+    wrap.position.y = -0.3;
+    group.add(wrap);
+
+    group.scale.setScalar(scale);
+    group.traverse((c) => {
+        c.castShadow = true;
+    });
+    return group;
+}
+
+/** Flecha incendiária dos inimigos. */
+export function buildArrowMesh() {
+    const group = new THREE.Group();
+    const shaft = new THREE.Mesh(
+        new THREE.CylinderGeometry(0.035, 0.035, 1.5, 6),
+        woodMaterial(true, 0x6b4a2a)
+    );
+    shaft.rotation.x = Math.PI / 2;
+    group.add(shaft);
+
+    const tip = new THREE.Mesh(new THREE.ConeGeometry(0.09, 0.3, 7), metalMaterial(0xb9bec6, 0.3));
+    tip.rotation.x = Math.PI / 2;
+    tip.position.z = 0.85;
+    group.add(tip);
+
+    const flame = new THREE.Mesh(
+        new THREE.SphereGeometry(0.2, 8, 8),
+        plainMaterial(0xffb765, 0.4, 0, 0xff6a1a, 3.5)
+    );
+    flame.position.z = 0.6;
+    flame.scale.set(1, 1, 1.8);
+    group.add(flame);
+    group.userData.flame = flame;
+
+    for (let i = 0; i < 3; i++) {
+        const fletch = new THREE.Mesh(new THREE.BoxGeometry(0.02, 0.16, 0.26), plainMaterial(0x8a2b2b, 0.9, 0));
+        fletch.position.z = -0.6;
+        fletch.rotation.z = (i * Math.PI * 2) / 3;
+        group.add(fletch);
+    }
+    return group;
+}
+
+/* ------------------------------------------------------------------ */
+/* Cenário: árvores, rochas, torres, barricadas, itens                 */
+/* ------------------------------------------------------------------ */
+
+/** Pinheiro em camadas — geometria única para uso em InstancedMesh. */
+export function buildPineGeometry() {
+    const parts = [];
+    const trunk = new THREE.CylinderGeometry(0.22, 0.34, 3.4, 7);
+    trunk.translate(0, 1.7, 0);
+    parts.push({ geo: trunk, color: new THREE.Color(0x4a3423) });
+
+    for (let i = 0; i < 4; i++) {
+        const r = 2.3 - i * 0.45;
+        const h = 2.4 - i * 0.28;
+        const cone = new THREE.ConeGeometry(r, h, 8);
+        cone.translate(0, 2.9 + i * 1.35, 0);
+        parts.push({ geo: cone, color: new THREE.Color().setHSL(0.31, 0.42, 0.16 + i * 0.035) });
+    }
+    return mergeWithColors(parts);
+}
+
+/** Árvore folhosa (copa em aglomerado de esferas achatadas). */
+export function buildOakGeometry() {
+    const parts = [];
+    const trunk = new THREE.CylinderGeometry(0.28, 0.42, 2.8, 7);
+    trunk.translate(0, 1.4, 0);
+    parts.push({ geo: trunk, color: new THREE.Color(0x53381f) });
+
+    const blobs = [
+        [0, 3.9, 0, 1.9],
+        [1.3, 3.4, 0.4, 1.35],
+        [-1.2, 3.5, -0.5, 1.4],
+        [0.2, 4.6, -1.1, 1.15]
+    ];
+    for (const [x, y, z, r] of blobs) {
+        const s = new THREE.SphereGeometry(r, 9, 7);
+        s.scale(1, 0.82, 1);
+        s.translate(x, y, z);
+        parts.push({ geo: s, color: new THREE.Color().setHSL(0.26, 0.38, 0.19 + Math.random() * 0.06) });
+    }
+    return mergeWithColors(parts);
+}
+
+/** Rocha facetada. */
+export function buildRockGeometry(seed = 1) {
+    const geo = new THREE.IcosahedronGeometry(1, 1);
+    const pos = geo.attributes.position;
+    for (let i = 0; i < pos.count; i++) {
+        const x = pos.getX(i);
+        const y = pos.getY(i);
+        const z = pos.getZ(i);
+        const n = Math.sin(x * 3.1 + seed) * Math.cos(z * 2.7 - seed) * 0.22 + Math.sin(y * 4.3) * 0.12;
+        pos.setXYZ(i, x * (1 + n), y * (0.72 + n * 0.6), z * (1 + n * 0.8));
+    }
+    geo.computeVertexNormals();
+    return geo;
+}
+
+/**
+ * Concatena geometrias aplicando uma cor por parte no atributo `color`.
+ * Evita depender do BufferGeometryUtils e mantém tudo em um único draw call.
+ */
+export function mergeWithColors(parts) {
+    let vertexCount = 0;
+    let indexCount = 0;
+    for (const { geo } of parts) {
+        vertexCount += geo.attributes.position.count;
+        indexCount += geo.index ? geo.index.count : geo.attributes.position.count;
+    }
+
+    const positions = new Float32Array(vertexCount * 3);
+    const normals = new Float32Array(vertexCount * 3);
+    const colors = new Float32Array(vertexCount * 3);
+    const indices = new Uint32Array(indexCount);
+
+    let vOffset = 0;
+    let iOffset = 0;
+    for (const { geo, color } of parts) {
+        const p = geo.attributes.position;
+        if (!geo.attributes.normal) geo.computeVertexNormals();
+        const n = geo.attributes.normal;
+        for (let i = 0; i < p.count; i++) {
+            positions[(vOffset + i) * 3] = p.getX(i);
+            positions[(vOffset + i) * 3 + 1] = p.getY(i);
+            positions[(vOffset + i) * 3 + 2] = p.getZ(i);
+            normals[(vOffset + i) * 3] = n.getX(i);
+            normals[(vOffset + i) * 3 + 1] = n.getY(i);
+            normals[(vOffset + i) * 3 + 2] = n.getZ(i);
+            colors[(vOffset + i) * 3] = color.r;
+            colors[(vOffset + i) * 3 + 1] = color.g;
+            colors[(vOffset + i) * 3 + 2] = color.b;
+        }
+        if (geo.index) {
+            for (let i = 0; i < geo.index.count; i++) indices[iOffset + i] = geo.index.getX(i) + vOffset;
+            iOffset += geo.index.count;
+        } else {
+            for (let i = 0; i < p.count; i++) indices[iOffset + i] = i + vOffset;
+            iOffset += p.count;
+        }
+        vOffset += p.count;
+        geo.dispose();
+    }
+
+    const merged = new THREE.BufferGeometry();
+    merged.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+    merged.setAttribute('normal', new THREE.BufferAttribute(normals, 3));
+    merged.setAttribute('color', new THREE.BufferAttribute(colors, 3));
+    merged.setIndex(new THREE.BufferAttribute(indices, 1));
+    merged.computeBoundingSphere();
+    return merged;
+}
+
+/** Torre de vigia inimiga fincada na margem. */
+export function buildWatchtower() {
+    const group = new THREE.Group();
+    const stone = stoneMaterial('#7d7a72');
+
+    const base = new THREE.Mesh(new THREE.CylinderGeometry(2.1, 2.6, 9, 10), stone);
+    base.position.y = 4.5;
+    base.castShadow = true;
+    base.receiveShadow = true;
+    group.add(base);
+
+    const crown = new THREE.Mesh(new THREE.CylinderGeometry(2.5, 2.2, 1.2, 10), stone);
+    crown.position.y = 9.4;
+    crown.castShadow = true;
+    group.add(crown);
+
+    // Ameias.
+    for (let i = 0; i < 8; i++) {
+        const a = (i / 8) * Math.PI * 2;
+        const merlon = new THREE.Mesh(new THREE.BoxGeometry(0.7, 0.9, 0.6), stone);
+        merlon.position.set(Math.cos(a) * 2.2, 10.4, Math.sin(a) * 2.2);
+        merlon.rotation.y = -a;
+        merlon.castShadow = true;
+        group.add(merlon);
+    }
+
+    // Braseiro no topo.
+    const brazier = new THREE.Mesh(new THREE.CylinderGeometry(0.5, 0.35, 0.5, 8), metalMaterial(0x4b4038, 0.6));
+    brazier.position.y = 10.4;
+    group.add(brazier);
+    const fire = new THREE.Mesh(
+        new THREE.SphereGeometry(0.45, 8, 8),
+        plainMaterial(0xffc477, 0.4, 0, 0xff7a20, 3)
+    );
+    fire.position.y = 10.9;
+    group.add(fire);
+    const light = new THREE.PointLight(0xff8c3a, 14, 32, 2);
+    light.position.y = 11;
+    group.add(light);
+
+    group.userData.fire = fire;
+    group.userData.light = light;
+    return group;
+}
+
+/** Barricada flutuante de troncos acorrentados. */
+export function buildBarricade() {
+    const group = new THREE.Group();
+    const wood = woodMaterial(true, 0x53381f);
+    for (let i = 0; i < 3; i++) {
+        const log = new THREE.Mesh(new THREE.CylinderGeometry(0.42, 0.46, 7.5, 8), wood);
+        log.rotation.z = Math.PI / 2;
+        log.position.set(0, 0.2 + i * 0.1, -0.9 + i * 0.9);
+        log.rotation.y = (i - 1) * 0.08;
+        log.castShadow = true;
+        group.add(log);
+    }
+    for (const sx of [-1, 1]) {
+        const spike = new THREE.Mesh(new THREE.ConeGeometry(0.28, 1.6, 7), wood);
+        spike.position.set(sx * 2.6, 1.0, 0);
+        spike.rotation.z = sx * -0.5;
+        group.add(spike);
+    }
+    const chain = new THREE.Mesh(new THREE.TorusGeometry(0.4, 0.06, 5, 10), metalMaterial(0x6d6a63, 0.5));
+    chain.position.set(0, 0.6, 0);
+    chain.rotation.y = Math.PI / 2;
+    group.add(chain);
+    return group;
+}
+
+/** Itens coletáveis. */
+export function buildPickup(kind) {
+    const group = new THREE.Group();
+
+    if (kind === 'coin') {
+        const coin = new THREE.Mesh(
+            new THREE.CylinderGeometry(0.42, 0.42, 0.08, 18),
+            plainMaterial(COLORS.gold, 0.25, 0.95, 0x6b4a10, 0.9)
+        );
+        coin.rotation.x = Math.PI / 2;
+        group.add(coin);
+        const rim = new THREE.Mesh(new THREE.TorusGeometry(0.42, 0.05, 6, 20), plainMaterial(0xffe9a8, 0.2, 0.9));
+        group.add(rim);
+    } else if (kind === 'heart') {
+        const mat = plainMaterial(0xe0455f, 0.4, 0.1, 0x7a0f22, 1.4);
+        for (const sx of [-1, 1]) {
+            const lobe = new THREE.Mesh(new THREE.SphereGeometry(0.26, 12, 10), mat);
+            lobe.position.set(sx * 0.19, 0.16, 0);
+            group.add(lobe);
+        }
+        const tip = new THREE.Mesh(new THREE.ConeGeometry(0.38, 0.55, 12), mat);
+        tip.position.y = -0.2;
+        tip.rotation.x = Math.PI;
+        group.add(tip);
+    } else if (kind === 'shield') {
+        const shield = new THREE.Mesh(
+            new THREE.CylinderGeometry(0.46, 0.46, 0.1, 18),
+            new THREE.MeshStandardMaterial({
+                map: shieldTexture('#2f5d7c', '#eee3c0'),
+                roughness: 0.5,
+                emissive: new THREE.Color(0x1a4a6b),
+                emissiveIntensity: 0.7
+            })
+        );
+        shield.rotation.x = Math.PI / 2;
+        group.add(shield);
+    } else if (kind === 'fury') {
+        const mat = plainMaterial(0xff7a2f, 0.3, 0.4, 0xff4d00, 2.2);
+        const core = new THREE.Mesh(new THREE.OctahedronGeometry(0.42, 0), mat);
+        group.add(core);
+        const ring = new THREE.Mesh(new THREE.TorusGeometry(0.62, 0.05, 6, 22), mat);
+        ring.rotation.x = Math.PI / 2;
+        group.add(ring);
+    }
+
+    group.traverse((c) => {
+        c.castShadow = true;
+    });
+    return group;
+}
+
+/** Estandarte tremulando (usado no castelo e nas torres). */
+export function buildBanner(colorA = '#8a1f2d', colorB = '#f3c96b', width = 1.1, height = 2.2) {
+    const mat = registerCloth(clothMaterial({
+        map: bannerTexture(colorA, colorB),
+        side: THREE.DoubleSide,
+        wind: 0.85
+    }));
+    const mesh = new THREE.Mesh(new THREE.PlaneGeometry(width, height, 8, 10), mat);
+    mesh.castShadow = true;
+    return mesh;
+}
+
+export function disposeMaterials() {
+    materialCache.forEach((m) => m.dispose());
+    materialCache.clear();
+    clothMaterials.clear();
+}

--- a/labs/river-knight/src/player.js
+++ b/labs/river-knight/src/player.js
@@ -1,0 +1,322 @@
+/**
+ * O drakkar do jogador e o guerreiro a bordo.
+ *
+ * Guarda a física da navegação (velocidade, deriva lateral, limites do rio),
+ * a animação do casco sobre as ondas, os remos, o arremesso de machado e os
+ * poderes temporários (escudo e fúria).
+ */
+
+import * as THREE from 'three';
+import { buildLongship, buildWarrior } from './models.js';
+import { waterHeight, waterSlope } from './water.js';
+import { centerX, halfWidth } from './river.js';
+import { BOAT, AXE } from './config.js';
+import { clamp, damp, lerp } from './utils.js';
+
+const tmpSlope = { dx: 0, dz: 0 };
+
+export class Player {
+    constructor(scene) {
+        this.root = new THREE.Group();
+        scene.add(this.root);
+
+        // O modelo é construído com a proa em +Z; o grupo interno gira 180°
+        // para que o "para frente" do jogador seja -Z no mundo.
+        const { group: ship, parts } = buildLongship({
+            length: 15,
+            beam: 3.6,
+            hullColor: 0x6b4429,
+            sailBase: '#ded1b0',
+            sailStripe: '#a02f2f',
+            emblem: 'cross'
+        });
+        ship.rotation.y = Math.PI;
+        this.root.add(ship);
+        this.ship = ship;
+        this.parts = parts;
+
+        const { group: warrior, parts: wParts } = buildWarrior({});
+        warrior.position.set(0, 0.32, -1.6);
+        ship.add(warrior);
+        this.warrior = warrior;
+        this.wParts = wParts;
+
+        // Bolha de escudo.
+        this.shieldBubble = new THREE.Mesh(
+            new THREE.SphereGeometry(5.6, 20, 14),
+            new THREE.MeshBasicMaterial({
+                color: 0x7ec8ff,
+                transparent: true,
+                opacity: 0.16,
+                depthWrite: false,
+                side: THREE.DoubleSide
+            })
+        );
+        this.shieldBubble.visible = false;
+        this.root.add(this.shieldBubble);
+
+        this.reset();
+    }
+
+    reset(difficulty) {
+        this.maxHull = difficulty?.hull ?? BOAT.maxHull;
+        this.hull = this.maxHull;
+        this.x = centerX(0);
+        this.z = 0;
+        this.speed = BOAT.baseSpeed;
+        this.lateral = 0;
+        this.yaw = 0;
+        this.roll = 0;
+        this.throwTimer = 0;
+        this.invuln = 0;
+        this.shieldTime = 0;
+        this.furyTime = 0;
+        this.throwAnim = 0;
+        this.alive = true;
+        this.distance = 0;
+        this.docking = false;
+        this.dockZ = 0;
+
+        this.root.position.set(this.x, 0, 0);
+        this.root.rotation.set(0, 0, 0);
+        this.shieldBubble.visible = false;
+        this._setOpacity(1);
+    }
+
+    get position() {
+        return this.root.position;
+    }
+
+    get hasShield() {
+        return this.shieldTime > 0;
+    }
+
+    get hasFury() {
+        return this.furyTime > 0;
+    }
+
+    _setOpacity(value) {
+        this.root.traverse((child) => {
+            if (!child.material || child === this.shieldBubble) return;
+            const mats = Array.isArray(child.material) ? child.material : [child.material];
+            for (const m of mats) {
+                if (m.userData.baseOpacity === undefined) {
+                    m.userData.baseOpacity = m.opacity;
+                    m.userData.baseTransparent = m.transparent;
+                }
+                if (value >= 1) {
+                    m.opacity = m.userData.baseOpacity;
+                    m.transparent = m.userData.baseTransparent;
+                } else {
+                    m.transparent = true;
+                    m.opacity = m.userData.baseOpacity * value;
+                }
+            }
+        });
+    }
+
+    /* ------------------------------------------------------------------ */
+
+    update(dt, ctx) {
+        const { input, time, effects } = ctx;
+
+        // --- velocidade longitudinal ---
+        let targetSpeed = BOAT.baseSpeed;
+        if (this.docking) {
+            // Aproximação final: desacelera até parar em frente à torre.
+            targetSpeed = clamp((this.z - this.dockZ) * 0.75, 0, 11);
+        } else if (input.boost) targetSpeed = BOAT.boostSpeed;
+        else if (input.brake) targetSpeed = BOAT.brakeSpeed;
+        targetSpeed *= ctx.speedScale ?? 1;
+
+        this.speed = damp(this.speed, targetSpeed, BOAT.accel / 6, dt);
+        this.z -= this.speed * dt;
+        this.distance = -this.z;
+
+        // --- deriva lateral ---
+        const steer = this.docking ? 0 : input.steer;
+        const targetLateral = steer * BOAT.strafeSpeed;
+        this.lateral = damp(this.lateral, targetLateral, BOAT.strafeAccel / 8, dt);
+        this.x += this.lateral * dt;
+
+        // Correnteza empurra suavemente para o centro nas curvas.
+        const cx = centerX(this.z);
+        const hw = halfWidth(this.z);
+        this.x += (cx - this.x) * 0.22 * dt;
+
+        // Puxão dos redemoinhos.
+        if (ctx.pull) {
+            this.x += ctx.pull.x * dt;
+            this.speed *= 1 - clamp(ctx.pull.drag * dt, 0, 0.6);
+        }
+
+        // Limite das margens: raspar na margem custa velocidade.
+        const limit = hw - BOAT.bankLimitPadding;
+        const offset = this.x - cx;
+        if (Math.abs(offset) > limit) {
+            this.x = cx + Math.sign(offset) * limit;
+            this.lateral *= -0.25;
+            this.speed = damp(this.speed, BOAT.brakeSpeed, 6, dt);
+            if (Math.random() < 0.5) {
+                effects.splash(this.x, 0.2, this.z - 2, 3, 0.7);
+            }
+            ctx.onScrape?.();
+        }
+
+        // --- assentamento sobre as ondas ---
+        const wy = waterHeight(this.x, this.z, time);
+        waterSlope(this.x, this.z, time, tmpSlope);
+
+        this.root.position.set(this.x, wy + 0.62, this.z);
+
+        const steerYaw = clamp(-this.lateral / BOAT.strafeSpeed, -1, 1) * 0.26;
+        this.yaw = damp(this.yaw, steerYaw, 6, dt);
+        this.roll = damp(this.roll, steerYaw * 1.5 - tmpSlope.dx * 1.4, 5, dt);
+
+        this.root.rotation.y = this.yaw;
+        this.root.rotation.z = this.roll;
+        this.root.rotation.x = tmpSlope.dz * 1.1 + Math.sin(time * 1.3) * 0.012;
+
+        // --- remos ---
+        const rowSpeed = 2.2 + (this.speed / BOAT.boostSpeed) * 3.4;
+        for (const oar of this.parts.oars) {
+            const phase = time * rowSpeed + oar.userData.phase;
+            oar.rotation.x = Math.sin(phase) * 0.46;
+            oar.rotation.z = oar.userData.baseRoll - oar.userData.side * Math.sin(phase + 1.3) * 0.22;
+        }
+
+        // --- guerreiro ---
+        const sway = Math.sin(time * 1.6) * 0.05;
+        this.wParts.torso.rotation.z = sway - this.roll * 0.5;
+        this.wParts.torso.rotation.x = -this.root.rotation.x * 0.6 + Math.sin(time * 1.1) * 0.03;
+        this.wParts.head.rotation.y = clamp(-steer * 0.5, -0.5, 0.5) + Math.sin(time * 0.7) * 0.08;
+        this.wParts.armL.rotation.x = -0.35 + Math.sin(time * 1.5) * 0.06;
+        this.wParts.armL.rotation.z = 0.22;
+
+        if (this.throwAnim > 0) {
+            this.throwAnim = Math.max(0, this.throwAnim - dt * 3.6);
+            const t = 1 - this.throwAnim; // 0 → 1 ao longo do arremesso
+            const swing = t < 0.35
+                ? lerp(0, -2.2, t / 0.35)          // recuo
+                : lerp(-2.2, 0.9, (t - 0.35) / 0.65); // golpe
+            this.wParts.armR.rotation.x = swing;
+            this.wParts.torso.rotation.y = swing * 0.18;
+        } else {
+            this.wParts.armR.rotation.x = damp(this.wParts.armR.rotation.x, -0.25 + Math.sin(time * 1.4) * 0.07, 8, dt);
+            this.wParts.torso.rotation.y = damp(this.wParts.torso.rotation.y, 0, 6, dt);
+        }
+
+        // Machado da mão some enquanto está em voo.
+        this.wParts.axe.visible = this.throwTimer < (this.hasFury ? BOAT.furyCooldown : BOAT.throwCooldown) * 0.45;
+
+        // --- lanterna e brasas ---
+        if (this.parts.lanternFlame) {
+            const s = 0.85 + Math.sin(time * 8.5) * 0.15;
+            this.parts.lanternFlame.scale.set(s, s * 1.35, s);
+        }
+
+        // --- espuma da proa e esteira ---
+        const speedRatio = this.speed / BOAT.boostSpeed;
+        effects.wake.push(this.x, this.z + 6.5, 1.5 + speedRatio * 1.4, 0.55 + speedRatio * 0.45);
+
+        if (Math.random() < 0.4 + speedRatio * 0.35) {
+            const bowX = this.x + Math.sin(this.yaw) * 6.5;
+            const bowZ = this.z - 6.8;
+            effects.splash(bowX, wy + 0.1, bowZ, 1, 0.3 + speedRatio * 0.35);
+        }
+
+        // --- temporizadores ---
+        this.throwTimer = Math.max(0, this.throwTimer - dt);
+        this.invuln = Math.max(0, this.invuln - dt);
+        this.shieldTime = Math.max(0, this.shieldTime - dt);
+        this.furyTime = Math.max(0, this.furyTime - dt);
+
+        // Piscar durante a invulnerabilidade.
+        if (this.invuln > 0 && !this.hasShield) {
+            this._setOpacity(0.35 + Math.abs(Math.sin(time * 22)) * 0.65);
+        } else {
+            this._setOpacity(1);
+        }
+
+        this.shieldBubble.visible = this.hasShield;
+        if (this.hasShield) {
+            const pulse = 0.14 + Math.sin(time * 5) * 0.05 + (this.shieldTime < 1.6 ? Math.sin(time * 22) * 0.08 : 0);
+            this.shieldBubble.material.opacity = Math.max(0.04, pulse);
+            this.shieldBubble.scale.setScalar(1 + Math.sin(time * 3) * 0.03);
+        }
+
+        if (this.hasFury) {
+            const glow = 0.6 + Math.sin(time * 12) * 0.4;
+            this.parts.hull.material.emissive?.setRGB(glow * 0.16, glow * 0.05, 0);
+            if (Math.random() < 0.4) {
+                effects.fire(this.x, wy + 1.6, this.z + 1.2, 1, 0.7);
+            }
+        } else if (this.parts.hull.material.emissive) {
+            this.parts.hull.material.emissive.setRGB(0, 0, 0);
+        }
+    }
+
+    /* ------------------------------------------------------------------ */
+
+    canThrow() {
+        return this.alive && this.throwTimer <= 0;
+    }
+
+    /** Lança o machado a partir da mão do guerreiro. */
+    throwAxe(entities, ctx) {
+        if (!this.canThrow()) return false;
+        this.throwTimer = this.hasFury ? BOAT.furyCooldown : BOAT.throwCooldown;
+        this.throwAnim = 1;
+
+        const origin = new THREE.Vector3();
+        this.wParts.armR.getWorldPosition(origin);
+
+        // Mira: levemente à frente, seguindo a inclinação do barco.
+        const dirX = Math.sin(this.yaw) * 0.55 + (ctx?.aimX ?? 0);
+        const dir = new THREE.Vector3(dirX, 0, -1).normalize();
+
+        entities.throwAxe(origin.x, origin.y + 0.3, origin.z - 1.2, dir.x, dir.z, AXE.speed);
+        return true;
+    }
+
+    damage(amount, ctx) {
+        if (!this.alive || this.invuln > 0) return false;
+        if (this.hasShield) {
+            this.shieldTime = 0;
+            this.invuln = BOAT.invulnAfterHit;
+            ctx.effects.explosion(this.x, this.position.y + 1, this.z, 0.9, 0.55);
+            ctx.audio.sfx('hitMetal');
+            return false;
+        }
+
+        this.hull -= amount;
+        this.invuln = BOAT.invulnAfterHit;
+        ctx.effects.explosion(this.x, this.position.y + 1, this.z, 0.8);
+        ctx.audio.sfx('damage');
+
+        if (this.hull <= 0) {
+            this.hull = 0;
+            this.alive = false;
+            return true;
+        }
+        return false;
+    }
+
+    heal(amount = 1) {
+        this.hull = Math.min(this.maxHull, this.hull + amount);
+    }
+
+    grantShield(seconds = 8) {
+        this.shieldTime = seconds;
+    }
+
+    grantFury(seconds = 9) {
+        this.furyTime = seconds;
+    }
+
+    /** Sequência final: o barco encosta na doca do castelo. */
+    startDocking(targetZ) {
+        this.docking = true;
+        this.dockZ = targetZ;
+    }
+}

--- a/labs/river-knight/src/river.js
+++ b/labs/river-knight/src/river.js
@@ -1,0 +1,158 @@
+/**
+ * Geometria analítica do rio.
+ *
+ * O mundo inteiro (terreno, colocação de árvores, limites de navegação e IA)
+ * deriva de três funções puras de `z`:
+ *
+ *   centerX(z)   → deslocamento lateral do leito (as curvas do rio)
+ *   halfWidth(z) → metade da largura navegável
+ *   height(x, z) → altura do terreno
+ *
+ * As mesmas fórmulas existem em GLSL (`RIVER_GLSL`) para que o terreno possa
+ * ser deslocado inteiramente na GPU — sem isso, atualizar ~65k vértices por
+ * quadro na CPU custaria caro. Constantes são injetadas no shader a partir
+ * deste arquivo, então JS e GLSL nunca saem de sincronia.
+ */
+
+/** Z do castelo — precisa ser conhecido aqui para aplainar a esplanada. */
+import { CASTLE_Z } from './config.js';
+
+export const RIVER = {
+    bendAmp1: 38,
+    bendFreq1: 0.0059,
+    bendAmp2: 14,
+    bendFreq2: 0.0171,
+    bendPhase2: 2.1,
+
+    halfWidth: 27,
+    widthAmp: 6,
+    widthFreq: 0.0089,
+    widthPhase: 0.7,
+
+    bankRamp: 30,
+    bankHeight: 21,
+    bedDepth: 5.4,
+
+    ridgeAmp: 5.5,
+    ridgeFreqA: 0.019,
+    ridgeFreqB: 0.041,
+
+    hillStart: 78,
+    hillRamp: 150,
+    hillHeight: 96,
+
+    esplanadeInner: 60,
+    esplanadeFade: 90,
+    esplanadeHeight: 3.4
+};
+
+const clamp01 = (v) => (v < 0 ? 0 : v > 1 ? 1 : v);
+const smoothstep01 = (v) => {
+    const t = clamp01(v);
+    return t * t * (3 - 2 * t);
+};
+
+/** Deslocamento lateral do centro do rio na posição `z`. */
+export function centerX(z) {
+    return (
+        RIVER.bendAmp1 * Math.sin(z * RIVER.bendFreq1) +
+        RIVER.bendAmp2 * Math.sin(z * RIVER.bendFreq2 + RIVER.bendPhase2)
+    );
+}
+
+/** Derivada de `centerX` — usada para alinhar objetos à direção do rio. */
+export function centerSlope(z) {
+    return (
+        RIVER.bendAmp1 * RIVER.bendFreq1 * Math.cos(z * RIVER.bendFreq1) +
+        RIVER.bendAmp2 * RIVER.bendFreq2 * Math.cos(z * RIVER.bendFreq2 + RIVER.bendPhase2)
+    );
+}
+
+/** Metade da largura navegável na posição `z`. */
+export function halfWidth(z) {
+    return RIVER.halfWidth + RIVER.widthAmp * Math.sin(z * RIVER.widthFreq + RIVER.widthPhase);
+}
+
+/** Altura do terreno — negativa dentro do leito, positiva nas margens. */
+export function terrainHeight(x, z) {
+    const d = Math.abs(x - centerX(z));
+    const w = halfWidth(z);
+    const s = smoothstep01((d - w) / RIVER.bankRamp);
+
+    let h = -RIVER.bedDepth + (RIVER.bedDepth + RIVER.bankHeight) * s;
+
+    // Relevo das margens: some suavemente dentro d'água (fator `s`).
+    h += s * RIVER.ridgeAmp * (
+        0.62 * Math.sin(z * RIVER.ridgeFreqA + x * 0.013) +
+        0.38 * Math.sin(x * RIVER.ridgeFreqB - z * 0.011)
+    );
+
+    // Montanhas distantes fechando o vale.
+    const hill = smoothstep01((d - w - RIVER.hillStart) / RIVER.hillRamp);
+    h += hill * hill * RIVER.hillHeight * (
+        0.62 + 0.38 * Math.sin(z * 0.0041 + x * 0.0029)
+    );
+
+    // Esplanada do castelo: o vale se abre num terreno plano para que muralhas
+    // e torres tenham onde se apoiar.
+    const flat = 1 - smoothstep01((Math.abs(z - CASTLE_Z) - RIVER.esplanadeInner) / RIVER.esplanadeFade);
+    if (flat > 0) {
+        const plateau = -RIVER.bedDepth + (RIVER.bedDepth + RIVER.esplanadeHeight) * s;
+        h = h + (plateau - h) * flat;
+    }
+
+    return h;
+}
+
+/** Posição navegável mais próxima, dado um alvo lateral em [-1, 1]. */
+export function lanePosition(z, lane) {
+    return centerX(z) + lane * halfWidth(z);
+}
+
+const f = (v) => {
+    const s = v.toFixed(6);
+    return s.includes('.') ? s : `${s}.0`;
+};
+
+/**
+ * Versão GLSL das funções acima (nomes prefixados com `rk` para evitar
+ * colisão com o código gerado pelo three.js).
+ */
+export const RIVER_GLSL = /* glsl */ `
+float rkCenterX(float z) {
+    return ${f(RIVER.bendAmp1)} * sin(z * ${f(RIVER.bendFreq1)})
+         + ${f(RIVER.bendAmp2)} * sin(z * ${f(RIVER.bendFreq2)} + ${f(RIVER.bendPhase2)});
+}
+
+float rkHalfWidth(float z) {
+    return ${f(RIVER.halfWidth)} + ${f(RIVER.widthAmp)} * sin(z * ${f(RIVER.widthFreq)} + ${f(RIVER.widthPhase)});
+}
+
+float rkShoreDist(float x, float z) {
+    return abs(x - rkCenterX(z)) - rkHalfWidth(z);
+}
+
+float rkHeight(float x, float z) {
+    float d = abs(x - rkCenterX(z));
+    float w = rkHalfWidth(z);
+    float s = smoothstep(0.0, 1.0, (d - w) / ${f(RIVER.bankRamp)});
+
+    float h = -${f(RIVER.bedDepth)} + (${f(RIVER.bedDepth)} + ${f(RIVER.bankHeight)}) * s;
+
+    h += s * ${f(RIVER.ridgeAmp)} * (
+        0.62 * sin(z * ${f(RIVER.ridgeFreqA)} + x * 0.013) +
+        0.38 * sin(x * ${f(RIVER.ridgeFreqB)} - z * 0.011)
+    );
+
+    float hill = smoothstep(0.0, 1.0, (d - w - ${f(RIVER.hillStart)}) / ${f(RIVER.hillRamp)});
+    h += hill * hill * ${f(RIVER.hillHeight)} * (0.62 + 0.38 * sin(z * 0.0041 + x * 0.0029));
+
+    // Esplanada do castelo. (\`flat\` é palavra reservada em GLSL ES 3.0.)
+    float rkFlat = 1.0 - smoothstep(0.0, 1.0,
+        (abs(z - ${f(CASTLE_Z)}) - ${f(RIVER.esplanadeInner)}) / ${f(RIVER.esplanadeFade)});
+    float plateau = -${f(RIVER.bedDepth)} + (${f(RIVER.bedDepth)} + ${f(RIVER.esplanadeHeight)}) * s;
+    h = mix(h, plateau, clamp(rkFlat, 0.0, 1.0));
+
+    return h;
+}
+`;

--- a/labs/river-knight/src/sky.js
+++ b/labs/river-knight/src/sky.js
@@ -1,0 +1,216 @@
+/**
+ * Céu procedural.
+ *
+ * Um domo com shader próprio desenha gradiente, sol, halo e nuvens em fBm.
+ * A mesma função `rkSky(dir)` é reaproveitada pelo shader da água para gerar
+ * o reflexo — assim reflexo e céu nunca divergem, e não é preciso pagar por
+ * um render target de reflexão.
+ */
+
+import * as THREE from 'three';
+import { SKY_STOPS } from './config.js';
+
+export const SKY_GLSL = /* glsl */ `
+uniform vec3 uZenith;
+uniform vec3 uHorizon;
+uniform vec3 uGround;
+uniform vec3 uSunColor;
+uniform vec3 uSunDir;
+uniform float uSunPower;
+
+vec3 rkSky(vec3 dir) {
+    float h = dir.y;
+    float t = clamp(h * 1.25 + 0.05, 0.0, 1.0);
+    vec3 col = mix(uHorizon, uZenith, pow(t, 0.62));
+
+    // Bruma sobre o horizonte e "solo" refletido abaixo dele.
+    col = mix(uGround, col, smoothstep(-0.10, 0.035, h));
+
+    float sd = max(dot(normalize(dir), uSunDir), 0.0);
+    col += uSunColor * pow(sd, 4.0) * 0.09;    // clarão amplo
+    col += uSunColor * pow(sd, 64.0) * 0.30;   // halo
+    col += uSunColor * pow(sd, 900.0) * 0.9;   // borda do disco
+    col += uSunColor * smoothstep(0.9994, 0.99985, sd) * uSunPower; // disco
+
+    return col;
+}
+`;
+
+const NOISE_GLSL = /* glsl */ `
+float rkHash(vec2 p) {
+    p = fract(p * vec2(123.34, 456.21));
+    p += dot(p, p + 45.32);
+    return fract(p.x * p.y);
+}
+
+float rkValueNoise(vec2 p) {
+    vec2 i = floor(p);
+    vec2 f = fract(p);
+    f = f * f * (3.0 - 2.0 * f);
+    float a = rkHash(i);
+    float b = rkHash(i + vec2(1.0, 0.0));
+    float c = rkHash(i + vec2(0.0, 1.0));
+    float d = rkHash(i + vec2(1.0, 1.0));
+    return mix(mix(a, b, f.x), mix(c, d, f.x), f.y);
+}
+
+float rkFbm(vec2 p) {
+    float v = 0.0;
+    float amp = 0.5;
+    for (int i = 0; i < 5; i++) {
+        v += amp * rkValueNoise(p);
+        p = p * 2.03 + 17.3;
+        amp *= 0.5;
+    }
+    return v;
+}
+`;
+
+/** Uniforms compartilhados entre céu, água e névoa. */
+export function createSkyUniforms() {
+    const stop = SKY_STOPS[0];
+    return {
+        uZenith: { value: new THREE.Color().fromArray(stop.zenith) },
+        uHorizon: { value: new THREE.Color().fromArray(stop.horizon) },
+        uGround: { value: new THREE.Color().fromArray(stop.ground) },
+        uSunColor: { value: new THREE.Color().fromArray(stop.sun) },
+        uSunDir: { value: new THREE.Vector3().fromArray(stop.sunDir).normalize() },
+        uSunPower: { value: 22 }
+    };
+}
+
+const tmpColorA = new THREE.Color();
+const tmpColorB = new THREE.Color();
+const tmpVecA = new THREE.Vector3();
+const tmpVecB = new THREE.Vector3();
+
+/**
+ * Interpola a paleta do céu conforme o progresso da corrida (0 → 1).
+ * Retorna um objeto reutilizável com cores e direção do sol.
+ */
+const paletteOut = {
+    zenith: new THREE.Color(),
+    horizon: new THREE.Color(),
+    ground: new THREE.Color(),
+    sun: new THREE.Color(),
+    fog: new THREE.Color(),
+    light: new THREE.Color(),
+    ambient: new THREE.Color(),
+    sunDir: new THREE.Vector3(),
+    lightIntensity: 2
+};
+
+export function sampleSkyPalette(progress) {
+    const p = Math.max(0, Math.min(1, progress));
+    let a = SKY_STOPS[0];
+    let b = SKY_STOPS[SKY_STOPS.length - 1];
+
+    for (let i = 0; i < SKY_STOPS.length - 1; i++) {
+        if (p >= SKY_STOPS[i].at && p <= SKY_STOPS[i + 1].at) {
+            a = SKY_STOPS[i];
+            b = SKY_STOPS[i + 1];
+            break;
+        }
+    }
+
+    const span = Math.max(1e-5, b.at - a.at);
+    const t = Math.max(0, Math.min(1, (p - a.at) / span));
+
+    const lerpColor = (key, out) => {
+        tmpColorA.fromArray(a[key]);
+        tmpColorB.fromArray(b[key]);
+        out.copy(tmpColorA).lerp(tmpColorB, t);
+    };
+
+    lerpColor('zenith', paletteOut.zenith);
+    lerpColor('horizon', paletteOut.horizon);
+    lerpColor('ground', paletteOut.ground);
+    lerpColor('sun', paletteOut.sun);
+    lerpColor('fog', paletteOut.fog);
+    lerpColor('light', paletteOut.light);
+    lerpColor('ambient', paletteOut.ambient);
+
+    tmpVecA.fromArray(a.sunDir);
+    tmpVecB.fromArray(b.sunDir);
+    paletteOut.sunDir.copy(tmpVecA).lerp(tmpVecB, t).normalize();
+    paletteOut.lightIntensity = a.lightIntensity + (b.lightIntensity - a.lightIntensity) * t;
+
+    return paletteOut;
+}
+
+/** Copia a paleta interpolada para os uniforms compartilhados. */
+export function applySkyPalette(uniforms, palette) {
+    uniforms.uZenith.value.copy(palette.zenith);
+    uniforms.uHorizon.value.copy(palette.horizon);
+    uniforms.uGround.value.copy(palette.ground);
+    uniforms.uSunColor.value.copy(palette.sun);
+    uniforms.uSunDir.value.copy(palette.sunDir);
+}
+
+/** Domo do céu (esfera invertida gigante que acompanha a câmera). */
+export function createSky(uniforms) {
+    const material = new THREE.ShaderMaterial({
+        side: THREE.BackSide,
+        depthWrite: false,
+        fog: false,
+        uniforms: {
+            ...uniforms,
+            uTime: { value: 0 },
+            uCloud: { value: 0.55 }
+        },
+        vertexShader: /* glsl */ `
+            varying vec3 vDir;
+            void main() {
+                vDir = position;
+                vec4 mvPosition = modelViewMatrix * vec4(position, 1.0);
+                gl_Position = projectionMatrix * mvPosition;
+                gl_Position.z = gl_Position.w; // sempre no fundo
+            }
+        `,
+        fragmentShader: /* glsl */ `
+            varying vec3 vDir;
+            uniform float uTime;
+            uniform float uCloud;
+            ${SKY_GLSL}
+            ${NOISE_GLSL}
+
+            void main() {
+                vec3 dir = normalize(vDir);
+                vec3 col = rkSky(dir);
+
+                // Nuvens: projeção das direções em um plano alto.
+                float up = max(dir.y, 0.015);
+                vec2 cp = dir.xz / up;
+                vec2 drift = vec2(uTime * 0.0065, uTime * 0.0022);
+                float clouds = rkFbm(cp * 0.55 + drift);
+                clouds = smoothstep(0.46, 0.92, clouds) * uCloud;
+                clouds *= smoothstep(0.0, 0.20, dir.y);
+
+                float sunFacing = max(dot(dir, uSunDir), 0.0);
+                vec3 cloudLit = mix(uHorizon * 0.85, uSunColor, pow(sunFacing, 2.0) * 0.7);
+                vec3 cloudShadow = mix(uZenith * 0.7, uHorizon * 0.45, 0.5);
+                vec3 cloudCol = mix(cloudShadow, cloudLit, clamp(clouds * 1.6, 0.0, 1.0));
+
+                col = mix(col, cloudCol, clouds * 0.85);
+
+                // Estrelas tênues no zênite quando escurece.
+                float night = clamp(1.0 - length(uHorizon) * 0.9, 0.0, 1.0);
+                float stars = step(0.9975, rkHash(floor(dir.xz * 420.0 / max(dir.y, 0.25))));
+                col += vec3(0.9, 0.95, 1.0) * stars * night * smoothstep(0.15, 0.6, dir.y);
+
+                gl_FragColor = vec4(col, 1.0);
+                #include <tonemapping_fragment>
+                #include <colorspace_fragment>
+            }
+        `
+    });
+
+    const mesh = new THREE.Mesh(new THREE.SphereGeometry(1, 48, 32), material);
+    mesh.scale.setScalar(4000);
+    mesh.frustumCulled = false;
+    mesh.renderOrder = -1000;
+    mesh.name = 'sky';
+    return mesh;
+}
+
+export { NOISE_GLSL };

--- a/labs/river-knight/src/terrain.js
+++ b/labs/river-knight/src/terrain.js
@@ -1,0 +1,155 @@
+/**
+ * Terreno do vale.
+ *
+ * Usa `MeshStandardMaterial` com `onBeforeCompile`: o deslocamento e as cores
+ * vêm das funções analíticas do rio (GPU), mas o material continua sendo PBR
+ * de verdade — recebe sombras, névoa e a mesma iluminação dos outros objetos.
+ */
+
+import * as THREE from 'three';
+import { buildRadialGrid } from './utils.js';
+import { RIVER_GLSL } from './river.js';
+import { NOISE_GLSL } from './sky.js';
+
+export function createTerrain(quality) {
+    const geometry = buildRadialGrid(
+        quality.id === 'low' ? 110 : 168,
+        quality.terrainSegments,
+        2600,
+        1.6
+    );
+
+    const material = new THREE.MeshStandardMaterial({
+        color: 0xffffff,
+        roughness: 0.94,
+        metalness: 0.0,
+        dithering: true
+    });
+
+    material.onBeforeCompile = (shader) => {
+        material.userData.shader = shader;
+
+        shader.vertexShader = shader.vertexShader
+            .replace(
+                '#include <common>',
+                /* glsl */ `
+                #include <common>
+                varying vec3 vTerrainWorld;
+                varying float vTerrainSlope;
+                ${RIVER_GLSL}
+                `
+            )
+            .replace(
+                '#include <beginnormal_vertex>',
+                /* glsl */ `
+                vec3 rkWorld = (modelMatrix * vec4(position, 1.0)).xyz;
+                float rkDist = length(rkWorld.xz - cameraPosition.xz);
+                float rkEps = 0.55 + rkDist * 0.012;
+                float rkH = rkHeight(rkWorld.x, rkWorld.z);
+                float rkHL = rkHeight(rkWorld.x - rkEps, rkWorld.z);
+                float rkHR = rkHeight(rkWorld.x + rkEps, rkWorld.z);
+                float rkHD = rkHeight(rkWorld.x, rkWorld.z - rkEps);
+                float rkHU = rkHeight(rkWorld.x, rkWorld.z + rkEps);
+                vec3 objectNormal = normalize(vec3(rkHL - rkHR, 2.0 * rkEps, rkHD - rkHU));
+                vTerrainSlope = objectNormal.y;
+                vTerrainWorld = vec3(rkWorld.x, rkH, rkWorld.z);
+                `
+            )
+            .replace(
+                '#include <begin_vertex>',
+                /* glsl */ `
+                // Saia da borda: os anéis mais externos afundam para que o
+                // limite do disco de terreno nunca apareça contra o céu.
+                float rkSkirt = smoothstep(0.88, 1.0, uv.x) * 900.0;
+                vec3 transformed = vec3(position.x, rkH - rkSkirt, position.z);
+                `
+            );
+
+        shader.fragmentShader = shader.fragmentShader
+            .replace(
+                '#include <common>',
+                /* glsl */ `
+                #include <common>
+                varying vec3 vTerrainWorld;
+                varying float vTerrainSlope;
+                ${NOISE_GLSL}
+
+                vec3 rkTerrainColor(vec3 p, float slope) {
+                    float h = p.y;
+
+                    vec3 silt = vec3(0.11, 0.10, 0.08);
+                    vec3 sand = vec3(0.46, 0.40, 0.29);
+                    vec3 grass = vec3(0.13, 0.21, 0.09);
+                    vec3 grassDry = vec3(0.25, 0.24, 0.11);
+                    vec3 rock = vec3(0.22, 0.21, 0.20);
+                    vec3 snow = vec3(0.82, 0.84, 0.88);
+
+                    float n1 = rkFbm(p.xz * 0.045);
+                    float n2 = rkValueNoise(p.xz * 0.35);
+
+                    // Leito submerso → areia da praia → grama.
+                    vec3 col = mix(silt, sand, smoothstep(-3.4, -0.4, h));
+                    col = mix(col, mix(grass, grassDry, n1), smoothstep(0.15, 2.4, h));
+
+                    // Faixas de rocha nas encostas íngremes.
+                    float rocky = 1.0 - smoothstep(0.52, 0.82, slope);
+                    col = mix(col, rock * (0.75 + n2 * 0.5), rocky);
+
+                    // Cumes distantes recebem neve.
+                    col = mix(col, snow, smoothstep(52.0, 88.0, h) * smoothstep(0.55, 0.85, slope));
+
+                    // Variação orgânica de tom.
+                    col *= 0.78 + n1 * 0.38;
+                    col *= 0.94 + n2 * 0.12;
+
+                    // Linha úmida junto à água.
+                    col *= mix(0.55, 1.0, smoothstep(-0.6, 1.1, h));
+                    return col;
+                }
+                `
+            )
+            .replace(
+                '#include <color_fragment>',
+                /* glsl */ `
+                #include <color_fragment>
+                diffuseColor.rgb = rkTerrainColor(vTerrainWorld, vTerrainSlope);
+                `
+            )
+            .replace(
+                '#include <roughnessmap_fragment>',
+                /* glsl */ `
+                #include <roughnessmap_fragment>
+                roughnessFactor *= 0.86 + 0.2 * rkValueNoise(vTerrainWorld.xz * 0.6);
+                `
+            )
+            .replace(
+                '#include <normal_fragment_maps>',
+                /* glsl */ `
+                #include <normal_fragment_maps>
+                float rkBumpE = 0.9;
+                float rkB0 = rkFbm(vTerrainWorld.xz * 0.55);
+                float rkBx = rkFbm((vTerrainWorld.xz + vec2(rkBumpE, 0.0)) * 0.55);
+                float rkBz = rkFbm((vTerrainWorld.xz + vec2(0.0, rkBumpE)) * 0.55);
+                float rkBumpFade = 1.0 - smoothstep(60.0, 220.0, length(vTerrainWorld.xz - cameraPosition.xz));
+                normal = normalize(normal + vec3(rkB0 - rkBx, 0.0, rkB0 - rkBz) * 0.85 * rkBumpFade);
+                `
+            );
+    };
+
+    // Chave de cache: garante que o three não reaproveite um program de outro
+    // material standard sem as injeções acima.
+    material.customProgramCacheKey = () => 'river-knight-terrain';
+
+    const mesh = new THREE.Mesh(geometry, material);
+    mesh.frustumCulled = false;
+    mesh.receiveShadow = true;
+    mesh.name = 'terrain';
+
+    return {
+        mesh,
+        material,
+        update(camera) {
+            mesh.position.set(camera.position.x, 0, camera.position.z);
+        }
+    };
+}

--- a/labs/river-knight/src/textures.js
+++ b/labs/river-knight/src/textures.js
@@ -1,0 +1,425 @@
+/**
+ * Texturas procedurais desenhadas em `<canvas>`.
+ *
+ * O lab é 100 % autocontido: nada de PNG/JPG externos. Cada textura é gerada
+ * uma única vez (cache por chave) e reutilizada por todos os materiais.
+ */
+
+import * as THREE from 'three';
+
+const cache = new Map();
+
+function canvas(size, height = size) {
+    const el = document.createElement('canvas');
+    el.width = size;
+    el.height = height;
+    return el;
+}
+
+function toTexture(el, { repeat = [1, 1], srgb = true, aniso = 4 } = {}) {
+    const tex = new THREE.CanvasTexture(el);
+    tex.wrapS = tex.wrapT = THREE.RepeatWrapping;
+    tex.repeat.set(repeat[0], repeat[1]);
+    tex.anisotropy = aniso;
+    if (srgb) tex.colorSpace = THREE.SRGBColorSpace;
+    tex.needsUpdate = true;
+    return tex;
+}
+
+function cached(key, factory) {
+    if (!cache.has(key)) cache.set(key, factory());
+    return cache.get(key);
+}
+
+/** Ruído de valor simples e determinístico (para grão e manchas). */
+function noise2(x, y, seed = 0) {
+    const n = Math.sin(x * 127.1 + y * 311.7 + seed * 74.7) * 43758.5453;
+    return n - Math.floor(n);
+}
+
+function grain(ctx, w, h, amount, seed = 0) {
+    const img = ctx.getImageData(0, 0, w, h);
+    const data = img.data;
+    for (let i = 0, p = 0; i < data.length; i += 4, p++) {
+        const x = p % w;
+        const y = (p / w) | 0;
+        const n = (noise2(x, y, seed) - 0.5) * amount;
+        data[i] = Math.max(0, Math.min(255, data[i] + n));
+        data[i + 1] = Math.max(0, Math.min(255, data[i + 1] + n));
+        data[i + 2] = Math.max(0, Math.min(255, data[i + 2] + n));
+    }
+    ctx.putImageData(img, 0, 0);
+}
+
+/* ------------------------------------------------------------------ */
+/* Madeira do casco                                                    */
+/* ------------------------------------------------------------------ */
+
+export function woodTexture(dark = false) {
+    return cached(`wood:${dark}`, () => {
+        const size = 512;
+        const el = canvas(size);
+        const ctx = el.getContext('2d');
+        const base = dark ? '#3a2417' : '#6d472a';
+        const light = dark ? '#4c3120' : '#8a5c37';
+
+        ctx.fillStyle = base;
+        ctx.fillRect(0, 0, size, size);
+
+        // Tábuas horizontais com veios.
+        const planks = 8;
+        const ph = size / planks;
+        for (let i = 0; i < planks; i++) {
+            const y = i * ph;
+            const shade = 0.82 + noise2(i, 3.1) * 0.36;
+            ctx.fillStyle = light;
+            ctx.globalAlpha = 0.35 * shade;
+            ctx.fillRect(0, y + 1, size, ph - 2);
+            ctx.globalAlpha = 1;
+
+            // Veios longitudinais.
+            for (let g = 0; g < 26; g++) {
+                const gy = y + 3 + noise2(i * 31 + g, 7.7) * (ph - 6);
+                ctx.strokeStyle = `rgba(30, 18, 10, ${0.05 + noise2(g, i) * 0.14})`;
+                ctx.lineWidth = 0.6 + noise2(g, i * 2) * 1.4;
+                ctx.beginPath();
+                ctx.moveTo(0, gy);
+                for (let x = 0; x <= size; x += 24) {
+                    ctx.lineTo(x, gy + Math.sin((x + i * 40) * 0.02) * 1.6 + (noise2(x, gy) - 0.5) * 1.4);
+                }
+                ctx.stroke();
+            }
+
+            // Sombra entre tábuas.
+            ctx.fillStyle = 'rgba(18, 10, 5, 0.55)';
+            ctx.fillRect(0, y, size, 2);
+
+            // Rebites de ferro.
+            for (let r = 0; r < 10; r++) {
+                const rx = (r + 0.5) * (size / 10) + (noise2(r, i) - 0.5) * 8;
+                const ry = y + ph * 0.5;
+                const grd = ctx.createRadialGradient(rx, ry, 0, rx, ry, 4);
+                grd.addColorStop(0, 'rgba(210, 205, 195, 0.75)');
+                grd.addColorStop(0.6, 'rgba(90, 84, 76, 0.55)');
+                grd.addColorStop(1, 'rgba(30, 24, 18, 0)');
+                ctx.fillStyle = grd;
+                ctx.beginPath();
+                ctx.arc(rx, ry, 4, 0, Math.PI * 2);
+                ctx.fill();
+            }
+        }
+
+        grain(ctx, size, size, 26, dark ? 5 : 1);
+        return toTexture(el, { repeat: [1, 1] });
+    });
+}
+
+/* ------------------------------------------------------------------ */
+/* Pano da vela                                                        */
+/* ------------------------------------------------------------------ */
+
+export function sailTexture({ base = '#ded1b0', stripe = '#a02f2f', emblem = 'cross' } = {}) {
+    return cached(`sail:${base}:${stripe}:${emblem}`, () => {
+        const size = 512;
+        const el = canvas(size);
+        const ctx = el.getContext('2d');
+
+        ctx.fillStyle = base;
+        ctx.fillRect(0, 0, size, size);
+
+        // Trama do tecido.
+        ctx.globalAlpha = 0.08;
+        for (let i = 0; i < size; i += 3) {
+            ctx.fillStyle = i % 6 === 0 ? '#000' : '#fff';
+            ctx.fillRect(i, 0, 1, size);
+            ctx.fillRect(0, i, size, 1);
+        }
+        ctx.globalAlpha = 1;
+
+        // Listras verticais.
+        ctx.fillStyle = stripe;
+        ctx.globalAlpha = 0.85;
+        const stripes = 4;
+        for (let i = 0; i < stripes; i++) {
+            const x = (i + 0.5) * (size / stripes) - size / (stripes * 6);
+            ctx.fillRect(x, 0, size / (stripes * 3), size);
+        }
+        ctx.globalAlpha = 1;
+
+        // Emblema central.
+        ctx.save();
+        ctx.translate(size / 2, size / 2);
+        if (emblem === 'cross') {
+            ctx.fillStyle = 'rgba(28, 22, 16, 0.82)';
+            ctx.fillRect(-26, -120, 52, 240);
+            ctx.fillRect(-110, -30, 220, 52);
+            ctx.fillStyle = 'rgba(243, 201, 107, 0.9)';
+            ctx.fillRect(-16, -110, 32, 220);
+            ctx.fillRect(-100, -20, 200, 32);
+        } else if (emblem === 'rune') {
+            ctx.strokeStyle = 'rgba(220, 60, 40, 0.9)';
+            ctx.lineWidth = 18;
+            ctx.lineCap = 'round';
+            ctx.beginPath();
+            ctx.moveTo(0, -130);
+            ctx.lineTo(0, 130);
+            ctx.moveTo(0, -60);
+            ctx.lineTo(90, -130);
+            ctx.moveTo(0, -60);
+            ctx.lineTo(-90, -130);
+            ctx.moveTo(0, 30);
+            ctx.lineTo(80, -30);
+            ctx.moveTo(0, 30);
+            ctx.lineTo(-80, -30);
+            ctx.stroke();
+            ctx.strokeStyle = 'rgba(255, 160, 90, 0.35)';
+            ctx.lineWidth = 34;
+            ctx.stroke();
+        }
+        ctx.restore();
+
+        // Desgaste nas bordas.
+        const vign = ctx.createRadialGradient(size / 2, size / 2, size * 0.25, size / 2, size / 2, size * 0.72);
+        vign.addColorStop(0, 'rgba(0,0,0,0)');
+        vign.addColorStop(1, 'rgba(40, 28, 18, 0.35)');
+        ctx.fillStyle = vign;
+        ctx.fillRect(0, 0, size, size);
+
+        grain(ctx, size, size, 16, 9);
+        return toTexture(el);
+    });
+}
+
+/* ------------------------------------------------------------------ */
+/* Pedra do castelo e das torres                                       */
+/* ------------------------------------------------------------------ */
+
+export function stoneTexture(tint = '#8f8d87') {
+    return cached(`stone:${tint}`, () => {
+        const size = 512;
+        const el = canvas(size);
+        const ctx = el.getContext('2d');
+        ctx.fillStyle = '#3a3833';
+        ctx.fillRect(0, 0, size, size);
+
+        const rows = 10;
+        const rh = size / rows;
+        for (let r = 0; r < rows; r++) {
+            const offset = (r % 2) * (size / 12);
+            const cols = 6;
+            for (let c = -1; c < cols; c++) {
+                const x = c * (size / cols) + offset + 2;
+                const y = r * rh + 2;
+                const w = size / cols - 4;
+                const h = rh - 4;
+                const shade = 0.72 + noise2(c * 3.7, r * 5.3) * 0.5;
+                ctx.fillStyle = tint;
+                ctx.globalAlpha = Math.min(1, shade);
+                ctx.fillRect(x, y, w, h);
+                ctx.globalAlpha = 1;
+
+                // Luz no topo e sombra na base do bloco.
+                ctx.fillStyle = 'rgba(255,255,255,0.10)';
+                ctx.fillRect(x, y, w, 3);
+                ctx.fillStyle = 'rgba(0,0,0,0.22)';
+                ctx.fillRect(x, y + h - 3, w, 3);
+
+                // Manchas de musgo.
+                if (noise2(c, r * 1.7) > 0.74) {
+                    ctx.fillStyle = 'rgba(86, 110, 58, 0.30)';
+                    ctx.beginPath();
+                    ctx.ellipse(x + w * 0.5, y + h * 0.7, w * 0.35, h * 0.28, 0, 0, Math.PI * 2);
+                    ctx.fill();
+                }
+            }
+        }
+
+        grain(ctx, size, size, 30, 4);
+        return toTexture(el);
+    });
+}
+
+/* ------------------------------------------------------------------ */
+/* Escudos pendurados no costado                                       */
+/* ------------------------------------------------------------------ */
+
+export function shieldTexture(colorA = '#b23a3a', colorB = '#e5d6ae') {
+    return cached(`shield:${colorA}:${colorB}`, () => {
+        const size = 256;
+        const el = canvas(size);
+        const ctx = el.getContext('2d');
+        ctx.fillStyle = colorB;
+        ctx.fillRect(0, 0, size, size);
+
+        ctx.fillStyle = colorA;
+        for (let i = 0; i < 8; i++) {
+            ctx.save();
+            ctx.translate(size / 2, size / 2);
+            ctx.rotate((i * Math.PI) / 4);
+            ctx.beginPath();
+            ctx.moveTo(0, 0);
+            ctx.arc(0, 0, size / 2, -0.2, 0.2);
+            ctx.closePath();
+            ctx.fill();
+            ctx.restore();
+        }
+
+        // Umbo central metálico.
+        const grd = ctx.createRadialGradient(size / 2 - 8, size / 2 - 8, 2, size / 2, size / 2, 40);
+        grd.addColorStop(0, '#f2efe6');
+        grd.addColorStop(0.55, '#9a958a');
+        grd.addColorStop(1, '#4a463f');
+        ctx.fillStyle = grd;
+        ctx.beginPath();
+        ctx.arc(size / 2, size / 2, 38, 0, Math.PI * 2);
+        ctx.fill();
+
+        ctx.strokeStyle = 'rgba(60, 44, 28, 0.85)';
+        ctx.lineWidth = 14;
+        ctx.beginPath();
+        ctx.arc(size / 2, size / 2, size / 2 - 8, 0, Math.PI * 2);
+        ctx.stroke();
+
+        grain(ctx, size, size, 18, 12);
+        return toTexture(el);
+    });
+}
+
+/* ------------------------------------------------------------------ */
+/* Sprites de partículas (alpha puro, sem sRGB)                        */
+/* ------------------------------------------------------------------ */
+
+export function sparkTexture() {
+    return cached('spark', () => {
+        const size = 128;
+        const el = canvas(size);
+        const ctx = el.getContext('2d');
+        const grd = ctx.createRadialGradient(size / 2, size / 2, 0, size / 2, size / 2, size / 2);
+        grd.addColorStop(0, 'rgba(255,255,255,1)');
+        grd.addColorStop(0.25, 'rgba(255,225,170,0.9)');
+        grd.addColorStop(0.55, 'rgba(255,150,60,0.35)');
+        grd.addColorStop(1, 'rgba(255,120,40,0)');
+        ctx.fillStyle = grd;
+        ctx.fillRect(0, 0, size, size);
+        return toTexture(el, { srgb: true });
+    });
+}
+
+export function smokeTexture() {
+    return cached('smoke', () => {
+        const size = 128;
+        const el = canvas(size);
+        const ctx = el.getContext('2d');
+        const grd = ctx.createRadialGradient(size / 2, size / 2, 0, size / 2, size / 2, size / 2);
+        grd.addColorStop(0, 'rgba(255,255,255,0.85)');
+        grd.addColorStop(0.45, 'rgba(255,255,255,0.35)');
+        grd.addColorStop(1, 'rgba(255,255,255,0)');
+        ctx.fillStyle = grd;
+        ctx.fillRect(0, 0, size, size);
+
+        // Nódulos para quebrar a forma perfeitamente circular.
+        for (let i = 0; i < 14; i++) {
+            const a = noise2(i, 2.2) * Math.PI * 2;
+            const r = 18 + noise2(i, 5.5) * 34;
+            const x = size / 2 + Math.cos(a) * r;
+            const y = size / 2 + Math.sin(a) * r;
+            const rad = 12 + noise2(i, 8.8) * 22;
+            const g2 = ctx.createRadialGradient(x, y, 0, x, y, rad);
+            g2.addColorStop(0, 'rgba(255,255,255,0.22)');
+            g2.addColorStop(1, 'rgba(255,255,255,0)');
+            ctx.fillStyle = g2;
+            ctx.beginPath();
+            ctx.arc(x, y, rad, 0, Math.PI * 2);
+            ctx.fill();
+        }
+        return toTexture(el, { srgb: true });
+    });
+}
+
+export function foamTexture() {
+    return cached('foam', () => {
+        const size = 256;
+        const el = canvas(size);
+        const ctx = el.getContext('2d');
+        ctx.clearRect(0, 0, size, size);
+
+        // Bolhas de espuma distribuídas de forma tileável no eixo X.
+        for (let i = 0; i < 900; i++) {
+            const x = noise2(i, 1.3) * size;
+            const y = noise2(i, 4.9) * size;
+            const r = 2.4 + noise2(i, 7.1) * 9.0;
+            const a = 0.06 + noise2(i, 9.4) * 0.42;
+            for (const dx of [-size, 0, size]) {
+                const g = ctx.createRadialGradient(x + dx, y, 0, x + dx, y, r);
+                g.addColorStop(0, `rgba(255,255,255,${a})`);
+                g.addColorStop(1, 'rgba(255,255,255,0)');
+                ctx.fillStyle = g;
+                ctx.beginPath();
+                ctx.arc(x + dx, y, r, 0, Math.PI * 2);
+                ctx.fill();
+            }
+        }
+        return toTexture(el, { srgb: true });
+    });
+}
+
+/* ------------------------------------------------------------------ */
+/* Estandartes                                                         */
+/* ------------------------------------------------------------------ */
+
+export function bannerTexture(colorA = '#8a1f2d', colorB = '#f3c96b') {
+    return cached(`banner:${colorA}:${colorB}`, () => {
+        const w = 128;
+        const h = 256;
+        const el = canvas(w, h);
+        const ctx = el.getContext('2d');
+        ctx.fillStyle = colorA;
+        ctx.fillRect(0, 0, w, h);
+
+        ctx.fillStyle = colorB;
+        ctx.fillRect(0, 0, w, 10);
+        ctx.fillRect(0, h - 46, w, 8);
+
+        // Flor-de-lis estilizada.
+        ctx.save();
+        ctx.translate(w / 2, h * 0.42);
+        ctx.fillStyle = colorB;
+        ctx.beginPath();
+        ctx.moveTo(0, -52);
+        ctx.quadraticCurveTo(20, -18, 0, 6);
+        ctx.quadraticCurveTo(-20, -18, 0, -52);
+        ctx.fill();
+        ctx.beginPath();
+        ctx.moveTo(-34, -6);
+        ctx.quadraticCurveTo(-6, -10, 0, 10);
+        ctx.quadraticCurveTo(-14, 24, -34, -6);
+        ctx.fill();
+        ctx.beginPath();
+        ctx.moveTo(34, -6);
+        ctx.quadraticCurveTo(6, -10, 0, 10);
+        ctx.quadraticCurveTo(14, 24, 34, -6);
+        ctx.fill();
+        ctx.fillRect(-6, 6, 12, 44);
+        ctx.fillRect(-22, 34, 44, 9);
+        ctx.restore();
+
+        // Recorte em "V" na ponta.
+        ctx.globalCompositeOperation = 'destination-out';
+        ctx.beginPath();
+        ctx.moveTo(0, h);
+        ctx.lineTo(w / 2, h - 38);
+        ctx.lineTo(w, h);
+        ctx.closePath();
+        ctx.fill();
+        ctx.globalCompositeOperation = 'source-over';
+
+        grain(ctx, w, h, 14, 21);
+        return toTexture(el);
+    });
+}
+
+/** Libera todas as texturas em cache (usado ao destruir o jogo). */
+export function disposeTextures() {
+    cache.forEach((tex) => tex.dispose());
+    cache.clear();
+}

--- a/labs/river-knight/src/utils.js
+++ b/labs/river-knight/src/utils.js
@@ -1,0 +1,156 @@
+/** Utilitários numéricos e de geometria compartilhados pelo jogo. */
+
+import * as THREE from 'three';
+
+export const clamp = (v, min, max) => (v < min ? min : v > max ? max : v);
+export const lerp = (a, b, t) => a + (b - a) * t;
+export const smoothstep = (edge0, edge1, x) => {
+    const t = clamp((x - edge0) / (edge1 - edge0), 0, 1);
+    return t * t * (3 - 2 * t);
+};
+
+/**
+ * Interpolação exponencial independente do frame rate.
+ * `damp(atual, alvo, 6, dt)` converge de forma estável em 30 ou 144 fps.
+ */
+export const damp = (current, target, lambda, dt) =>
+    lerp(current, target, 1 - Math.exp(-lambda * dt));
+
+export const snap = (value, step) => Math.round(value / step) * step;
+
+export const randRange = (min, max) => min + Math.random() * (max - min);
+export const randInt = (min, max) => Math.floor(randRange(min, max + 1));
+export const pick = (arr) => arr[Math.floor(Math.random() * arr.length)];
+
+/**
+ * Malha radial no plano XZ: densa no centro (onde está o barco) e cada vez
+ * mais esparsa em direção ao horizonte.
+ *
+ * É o truque que permite terreno e água "infinitos" sem costuras: a malha só
+ * é transladada para acompanhar a câmera, e a altura de cada vértice vem de
+ * uma função analítica avaliada em coordenadas de mundo dentro do shader.
+ * Assim os vértices atravessam o campo de ondas sem "nadar" com a câmera.
+ */
+export function buildRadialGrid(spokes, rings, maxRadius, firstRing = 1.2) {
+    // Progressão geométrica dos raios: resolve o fator `k` por bisseção.
+    const total = (k) => (k === 1 ? firstRing * rings : (firstRing * (k ** rings - 1)) / (k - 1));
+    let lo = 1.0001;
+    let hi = 1.4;
+    for (let i = 0; i < 60; i++) {
+        const mid = (lo + hi) / 2;
+        if (total(mid) < maxRadius) lo = mid;
+        else hi = mid;
+    }
+    const k = (lo + hi) / 2;
+
+    const radii = new Float32Array(rings + 1);
+    let acc = 0;
+    let step = firstRing;
+    for (let i = 1; i <= rings; i++) {
+        acc += step;
+        step *= k;
+        radii[i] = acc;
+    }
+
+    const vertCount = 1 + rings * spokes;
+    const positions = new Float32Array(vertCount * 3);
+    const uvs = new Float32Array(vertCount * 2);
+    const indices = [];
+
+    // Vértice central.
+    uvs[0] = 0.5;
+    uvs[1] = 0.5;
+
+    for (let r = 1; r <= rings; r++) {
+        const radius = radii[r];
+        for (let s = 0; s < spokes; s++) {
+            const idx = 1 + (r - 1) * spokes + s;
+            const a = (s / spokes) * Math.PI * 2;
+            positions[idx * 3] = Math.cos(a) * radius;
+            positions[idx * 3 + 2] = Math.sin(a) * radius;
+            uvs[idx * 2] = r / rings;
+            uvs[idx * 2 + 1] = s / spokes;
+        }
+    }
+
+    // Leque central. A ordem dos índices deixa a normal apontando para +Y
+    // (faces frontais vistas de cima) — invertê-la some com o terreno.
+    for (let s = 0; s < spokes; s++) {
+        indices.push(0, 1 + ((s + 1) % spokes), 1 + s);
+    }
+
+    // Anéis subsequentes.
+    for (let r = 1; r < rings; r++) {
+        const inner = 1 + (r - 1) * spokes;
+        const outer = 1 + r * spokes;
+        for (let s = 0; s < spokes; s++) {
+            const sn = (s + 1) % spokes;
+            indices.push(inner + s, inner + sn, outer + s);
+            indices.push(inner + sn, outer + sn, outer + s);
+        }
+    }
+
+    const geo = new THREE.BufferGeometry();
+    geo.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+    geo.setAttribute('uv', new THREE.BufferAttribute(uvs, 2));
+    geo.setAttribute('normal', new THREE.BufferAttribute(new Float32Array(vertCount * 3), 3));
+    geo.setIndex(vertCount > 65535
+        ? new THREE.BufferAttribute(new Uint32Array(indices), 1)
+        : new THREE.BufferAttribute(new Uint16Array(indices), 1));
+    geo.computeBoundingSphere();
+    geo.boundingSphere.radius = maxRadius * 1.4;
+    return geo;
+}
+
+/** Remove um objeto da cena liberando geometrias e materiais. */
+export function disposeObject(obj) {
+    obj.traverse((child) => {
+        if (child.geometry) child.geometry.dispose();
+        const mat = child.material;
+        if (Array.isArray(mat)) mat.forEach((m) => m.dispose());
+        else if (mat) mat.dispose();
+    });
+    obj.parent?.remove(obj);
+}
+
+/** Detecta dispositivos com pouca folga de GPU/tela pequena. */
+export function detectMobile() {
+    if (typeof navigator === 'undefined') return false;
+    const coarse = window.matchMedia?.('(pointer: coarse)')?.matches;
+    const narrow = Math.min(window.innerWidth, window.innerHeight) < 760;
+    return Boolean(coarse && narrow) || /Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
+}
+
+/** Formata segundos como m:ss. */
+export function formatTime(seconds) {
+    const s = Math.max(0, Math.floor(seconds));
+    const m = Math.floor(s / 60);
+    return `${m}:${String(s % 60).padStart(2, '0')}`;
+}
+
+/** Pool genérico de objetos reaproveitáveis. */
+export class Pool {
+    constructor(factory, reset) {
+        this.factory = factory;
+        this.reset = reset;
+        this.free = [];
+        this.active = [];
+    }
+
+    spawn(...args) {
+        const item = this.free.pop() || this.factory();
+        this.reset?.(item, ...args);
+        this.active.push(item);
+        return item;
+    }
+
+    release(item) {
+        const idx = this.active.indexOf(item);
+        if (idx >= 0) this.active.splice(idx, 1);
+        this.free.push(item);
+    }
+
+    releaseAll() {
+        while (this.active.length) this.free.push(this.active.pop());
+    }
+}

--- a/labs/river-knight/src/water.js
+++ b/labs/river-knight/src/water.js
@@ -1,0 +1,242 @@
+/**
+ * Água: ondas de Gerstner na GPU + reflexo do céu procedural.
+ *
+ * As mesmas ondas são avaliadas na CPU (`waterHeight`) para que o barco, os
+ * destroços e a espuma acompanhem exatamente a superfície desenhada.
+ */
+
+import * as THREE from 'three';
+import { buildRadialGrid } from './utils.js';
+import { RIVER_GLSL } from './river.js';
+import { SKY_GLSL, NOISE_GLSL } from './sky.js';
+import { foamTexture } from './textures.js';
+
+/**
+ * Conjunto de ondas: direção (normalizada), amplitude, comprimento, velocidade.
+ * Amplitudes pequenas — é um rio, não mar aberto.
+ */
+export const WAVES = [
+    { dx: 0.86, dz: 0.51, amp: 0.22, len: 31, speed: 4.6, steep: 0.45 },
+    { dx: -0.42, dz: 0.91, amp: 0.135, len: 17, speed: 3.7, steep: 0.4 },
+    { dx: 0.24, dz: -0.97, amp: 0.075, len: 9.5, speed: 3.0, steep: 0.32 },
+    { dx: -0.93, dz: -0.37, amp: 0.042, len: 5.4, speed: 2.4, steep: 0.26 }
+];
+
+const TWO_PI = Math.PI * 2;
+
+/** Altura da superfície em (x, z) no instante `t`. */
+export function waterHeight(x, z, t) {
+    let y = 0;
+    for (let i = 0; i < WAVES.length; i++) {
+        const w = WAVES[i];
+        const k = TWO_PI / w.len;
+        const phase = k * (w.dx * x + w.dz * z) - w.speed * k * t;
+        y += w.amp * Math.sin(phase);
+    }
+    return y;
+}
+
+/** Inclinação aproximada da superfície — usada para balançar os barcos. */
+export function waterSlope(x, z, t, out = { dx: 0, dz: 0 }) {
+    let sx = 0;
+    let sz = 0;
+    for (let i = 0; i < WAVES.length; i++) {
+        const w = WAVES[i];
+        const k = TWO_PI / w.len;
+        const phase = k * (w.dx * x + w.dz * z) - w.speed * k * t;
+        const c = Math.cos(phase) * w.amp * k;
+        sx += c * w.dx;
+        sz += c * w.dz;
+    }
+    out.dx = sx;
+    out.dz = sz;
+    return out;
+}
+
+const num = (v) => {
+    const s = Number(v).toFixed(6);
+    return s.includes('.') ? s : `${s}.0`;
+};
+
+/** Gera o trecho GLSL das ondas já desenrolado (evita índices dinâmicos). */
+function gerstnerGLSL() {
+    let body = '';
+    for (const w of WAVES) {
+        const k = TWO_PI / w.len;
+        const q = w.steep / (k * w.amp * WAVES.length);
+        body += `
+    {
+        vec2 dir = vec2(${num(w.dx)}, ${num(w.dz)});
+        float k = ${num(k)};
+        float a = ${num(w.amp)};
+        float q = ${num(q)};
+        float f = k * dot(dir, p) - ${num(w.speed * k)} * t;
+        float c = cos(f);
+        float s = sin(f);
+        disp.x += q * a * dir.x * c;
+        disp.z += q * a * dir.y * c;
+        disp.y += a * s;
+        nrm.x -= dir.x * k * a * c;
+        nrm.z -= dir.y * k * a * c;
+        nrm.y -= q * k * a * s;
+        phase += s;
+    }`;
+    }
+
+    return /* glsl */ `
+void rkGerstner(vec2 p, float t, out vec3 disp, out vec3 nrm, out float phase) {
+    disp = vec3(0.0);
+    nrm = vec3(0.0, 1.0, 0.0);
+    phase = 0.0;
+    ${body}
+    nrm = normalize(nrm);
+}
+`;
+}
+
+export function createWater(skyUniforms, quality) {
+    const geometry = buildRadialGrid(
+        quality.id === 'low' ? 96 : 152,
+        quality.waterSegments,
+        2300,
+        1.1
+    );
+
+    const uniforms = {
+        ...skyUniforms,
+        uTime: { value: 0 },
+        uFoam: { value: foamTexture() },
+        uFogColor: { value: new THREE.Color(0.7, 0.7, 0.75) },
+        uFogDensity: { value: quality.fogDensity },
+        uShallow: { value: new THREE.Color(0.15, 0.33, 0.29) },
+        uDeep: { value: new THREE.Color(0.022, 0.062, 0.095) }
+    };
+
+    const material = new THREE.ShaderMaterial({
+        uniforms,
+        fog: false,
+        vertexShader: /* glsl */ `
+            varying vec3 vWorld;
+            varying vec3 vWaveNormal;
+            varying float vPhase;
+            uniform float uTime;
+            ${gerstnerGLSL()}
+
+            void main() {
+                vec3 world = (modelMatrix * vec4(position, 1.0)).xyz;
+                vec3 disp;
+                vec3 nrm;
+                float phase;
+                rkGerstner(world.xz, uTime, disp, nrm, phase);
+
+                // Ondas encolhem à distância para evitar aliasing na malha esparsa.
+                float fade = 1.0 - smoothstep(120.0, 620.0, length(world.xz - cameraPosition.xz));
+                world += disp * mix(0.25, 1.0, fade);
+
+                vWorld = world;
+                vWaveNormal = normalize(mix(vec3(0.0, 1.0, 0.0), nrm, mix(0.2, 1.0, fade)));
+                vPhase = phase;
+
+                gl_Position = projectionMatrix * viewMatrix * vec4(world, 1.0);
+            }
+        `,
+        fragmentShader: /* glsl */ `
+            varying vec3 vWorld;
+            varying vec3 vWaveNormal;
+            varying float vPhase;
+
+            uniform float uTime;
+            uniform sampler2D uFoam;
+            uniform vec3 uFogColor;
+            uniform float uFogDensity;
+            uniform vec3 uShallow;
+            uniform vec3 uDeep;
+
+            ${SKY_GLSL}
+            ${RIVER_GLSL}
+            ${NOISE_GLSL}
+
+            void main() {
+                vec3 N = normalize(vWaveNormal);
+
+                // Marolas de alta frequência (detalhe que a malha não resolve).
+                vec2 rp = vWorld.xz;
+                float r1 = rkValueNoise(rp * 1.15 + vec2(uTime * 0.30, -uTime * 0.22)) - 0.5;
+                float r2 = rkValueNoise(rp * 2.60 + vec2(-uTime * 0.42, uTime * 0.36)) - 0.5;
+                float r3 = rkValueNoise(rp * 5.30 + vec2(uTime * 0.55, uTime * 0.48)) - 0.5;
+                float detailFade = 1.0 - smoothstep(30.0, 180.0, length(vWorld.xz - cameraPosition.xz));
+                N = normalize(N + vec3(
+                    (r1 * 0.085 + r2 * 0.05 + r3 * 0.03) * detailFade,
+                    0.0,
+                    (r1 * 0.075 - r2 * 0.055 + r3 * 0.03) * detailFade
+                ));
+
+                vec3 V = normalize(cameraPosition - vWorld);
+                float ndv = clamp(dot(N, V), 0.0, 1.0);
+                float fres = 0.022 + 0.978 * pow(1.0 - ndv, 5.0);
+
+                vec3 R = reflect(-V, N);
+                R.y = abs(R.y) + 0.008;
+                // Água não é espelho perfeito: o reflexo perde energia e ganha
+                // difusão conforme a distância (microrrugosidade da superfície).
+                vec3 refl = rkSky(R) * 0.82;
+                float blur = smoothstep(60.0, 500.0, length(vWorld.xz - cameraPosition.xz));
+                refl = mix(refl, rkSky(normalize(vec3(R.x, R.y + 0.35, R.z))) * 0.78, blur * 0.6);
+
+                // Corpo d'água: quanto mais fundo, mais escuro e frio.
+                float bed = rkHeight(vWorld.x, vWorld.z);
+                float depth = clamp(-bed / 5.0, 0.0, 1.0);
+                vec3 body = mix(uShallow, uDeep, depth * depth);
+                float sunLit = clamp(dot(N, uSunDir) * 0.5 + 0.6, 0.0, 1.2);
+                body *= sunLit;
+                body += uSunColor * 0.06 * (1.0 - depth);
+                // Luz atravessando a crista da onda (subsurface fake).
+                body += uSunColor * uShallow * smoothstep(0.6, 1.9, vPhase) * 0.10 * (1.0 - depth * 0.65);
+
+                vec3 col = mix(body, refl, fres * 0.88);
+
+                // Brilho especular do sol na crista das ondas.
+                vec3 H = normalize(V + uSunDir);
+                float spec = pow(max(dot(N, H), 0.0), 380.0);
+                float sparkle = pow(max(dot(N, H), 0.0), 60.0) *
+                    smoothstep(0.55, 1.0, rkValueNoise(rp * 3.1 + uTime * 0.6));
+                col += uSunColor * (spec * 3.4 + sparkle * 0.5);
+
+                // Espuma junto às margens e nas cristas mais altas.
+                float shore = rkShoreDist(vWorld.x, vWorld.z);
+                // smoothstep exige edge0 < edge1 (fora disso o resultado é indefinido em GLSL).
+                float band = smoothstep(-9.0, -4.0, shore) * (1.0 - smoothstep(-3.2, 0.5, shore));
+                float crest = smoothstep(1.35, 2.35, vPhase);
+                vec2 fuv = vWorld.xz * 0.05 + vec2(uTime * 0.006, uTime * 0.009);
+                float ftex = texture2D(uFoam, fuv).a;
+                float foam = clamp(band * 1.05 + crest * 0.16, 0.0, 1.0) * smoothstep(0.08, 0.55, ftex);
+                col = mix(col, vec3(0.88, 0.93, 0.96), clamp(foam, 0.0, 1.0) * 0.85);
+
+                // Névoa exponencial casada com o céu.
+                float dist = length(cameraPosition - vWorld);
+                float fogAmt = 1.0 - exp(-pow(dist * uFogDensity, 2.0));
+                col = mix(col, uFogColor, clamp(fogAmt, 0.0, 1.0));
+
+                gl_FragColor = vec4(col, 1.0);
+                #include <tonemapping_fragment>
+                #include <colorspace_fragment>
+            }
+        `
+    });
+
+    const mesh = new THREE.Mesh(geometry, material);
+    mesh.frustumCulled = false;
+    mesh.renderOrder = 1;
+    mesh.name = 'water';
+    mesh.receiveShadow = false;
+
+    return {
+        mesh,
+        material,
+        uniforms,
+        update(time, camera) {
+            uniforms.uTime.value = time;
+            mesh.position.set(camera.position.x, 0, camera.position.z);
+        }
+    };
+}

--- a/labs/river-knight/src/world.js
+++ b/labs/river-knight/src/world.js
@@ -1,0 +1,290 @@
+/**
+ * O mundo: vegetação das margens, pássaros e o "diretor" que decide o que
+ * aparece à frente do jogador conforme ele avança rumo ao castelo.
+ */
+
+import * as THREE from 'three';
+import { buildPineGeometry, buildOakGeometry, buildRockGeometry, plainMaterial } from './models.js';
+import { centerX, halfWidth, terrainHeight } from './river.js';
+import { COURSE_LENGTH, BOSS_Z } from './config.js';
+import { clamp, randRange, pick } from './utils.js';
+
+const SPAWN_AHEAD = 430;
+const RECYCLE_BEHIND = 90;
+
+/* ------------------------------------------------------------------ */
+/* Vegetação instanciada                                               */
+/* ------------------------------------------------------------------ */
+
+class Scatter {
+    constructor(scene, geometry, count, { minDist, maxDist, scale, sink = 0.6, tint = null }) {
+        const material = new THREE.MeshStandardMaterial({
+            vertexColors: !tint,
+            color: tint || 0xffffff,
+            roughness: 0.92,
+            metalness: 0
+        });
+
+        this.mesh = new THREE.InstancedMesh(geometry, material, count);
+        this.mesh.instanceMatrix.setUsage(THREE.DynamicDrawUsage);
+        this.mesh.castShadow = true;
+        this.mesh.receiveShadow = true;
+        this.mesh.frustumCulled = false;
+        scene.add(this.mesh);
+
+        this.count = count;
+        this.minDist = minDist;
+        this.maxDist = maxDist;
+        this.scaleRange = scale;
+        this.sink = sink;
+        this.items = new Array(count);
+        this.dummy = new THREE.Object3D();
+
+        for (let i = 0; i < count; i++) {
+            this.items[i] = { x: 0, y: 0, z: 0, scale: 1, rot: 0, tilt: 0 };
+        }
+    }
+
+    /** Sorteia uma posição válida na margem, na frente do jogador. */
+    _place(item, z) {
+        const side = Math.random() < 0.5 ? -1 : 1;
+        const dist = randRange(this.minDist, this.maxDist);
+        const x = centerX(z) + side * (halfWidth(z) + dist);
+        const y = terrainHeight(x, z);
+        item.x = x;
+        item.y = y - this.sink;
+        item.z = z;
+        item.scale = randRange(this.scaleRange[0], this.scaleRange[1]);
+        item.rot = randRange(0, Math.PI * 2);
+        item.tilt = randRange(-0.06, 0.06);
+        item.valid = y > 0.4;
+    }
+
+    /** Distribui tudo de uma vez ao (re)iniciar a partida. */
+    reset(playerZ) {
+        for (let i = 0; i < this.count; i++) {
+            const z = playerZ + 60 - (i / this.count) * (SPAWN_AHEAD + 120) * 1.1 - randRange(0, 12);
+            this._place(this.items[i], z);
+            this._write(i);
+        }
+        this.mesh.instanceMatrix.needsUpdate = true;
+    }
+
+    _write(i) {
+        const item = this.items[i];
+        const d = this.dummy;
+        d.position.set(item.x, item.y, item.z);
+        d.rotation.set(item.tilt, item.rot, item.tilt * 0.6);
+        d.scale.setScalar(item.valid ? item.scale : 0.0001);
+        d.updateMatrix();
+        this.mesh.setMatrixAt(i, d.matrix);
+    }
+
+    update(playerZ) {
+        let dirty = false;
+        for (let i = 0; i < this.count; i++) {
+            const item = this.items[i];
+            if (item.z > playerZ + RECYCLE_BEHIND) {
+                this._place(item, playerZ - SPAWN_AHEAD - randRange(0, 80));
+                this._write(i);
+                dirty = true;
+            }
+        }
+        if (dirty) this.mesh.instanceMatrix.needsUpdate = true;
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* Pássaros                                                            */
+/* ------------------------------------------------------------------ */
+
+class Birds {
+    constructor(scene, count = 14) {
+        const geo = new THREE.BufferGeometry();
+        // Um "V" simples: duas asas.
+        geo.setAttribute('position', new THREE.Float32BufferAttribute([
+            -0.9, 0, 0, 0, 0.25, 0.15, 0, 0.25, 0.15, 0.9, 0, 0
+        ], 3));
+        const material = new THREE.LineBasicMaterial({ color: 0x2b2621, transparent: true, opacity: 0.75 });
+
+        this.group = new THREE.Group();
+        this.birds = [];
+        for (let i = 0; i < count; i++) {
+            const line = new THREE.LineSegments(geo, material);
+            this.group.add(line);
+            this.birds.push({
+                line,
+                phase: Math.random() * Math.PI * 2,
+                speed: randRange(7, 12),
+                radius: randRange(30, 90),
+                height: randRange(24, 52),
+                offset: randRange(-120, 120)
+            });
+        }
+        this.group.frustumCulled = false;
+        scene.add(this.group);
+    }
+
+    update(dt, time, playerZ) {
+        for (const b of this.birds) {
+            b.phase += dt * 0.22;
+            const x = centerX(playerZ - 120) + Math.cos(b.phase) * b.radius;
+            const z = playerZ - 120 + Math.sin(b.phase) * b.radius * 0.6 + b.offset;
+            b.line.position.set(x, b.height + Math.sin(time * 0.6 + b.phase) * 2.4, z);
+            b.line.rotation.y = -b.phase + Math.PI / 2;
+            const flap = Math.sin(time * b.speed + b.phase) * 0.5;
+            b.line.rotation.z = flap * 0.35;
+            b.line.scale.set(2.2, 1 + flap * 0.9, 2.2);
+        }
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* Diretor de encontros                                                */
+/* ------------------------------------------------------------------ */
+
+export class World {
+    constructor(scene, quality) {
+        const s = quality.scatterScale;
+        this.pines = new Scatter(scene, buildPineGeometry(), Math.round(150 * s), {
+            minDist: 1.5,
+            maxDist: 120,
+            scale: [0.75, 1.5]
+        });
+        this.oaks = new Scatter(scene, buildOakGeometry(), Math.round(70 * s), {
+            minDist: 2,
+            maxDist: 95,
+            scale: [0.7, 1.35]
+        });
+        this.bankRocks = new Scatter(scene, buildRockGeometry(5), Math.round(80 * s), {
+            minDist: -2.5,
+            maxDist: 70,
+            scale: [0.8, 2.6],
+            sink: 0.9,
+            tint: 0x54504a
+        });
+
+        this.birds = quality.id === 'low' ? null : new Birds(scene, 12);
+        this.nextSpawnZ = 0;
+        this.lastKind = null;
+    }
+
+    reset(playerZ) {
+        this.pines.reset(playerZ);
+        this.oaks.reset(playerZ);
+        this.bankRocks.reset(playerZ);
+        this.nextSpawnZ = playerZ - 150;
+        this.lastKind = null;
+    }
+
+    update(dt, time, playerZ) {
+        this.pines.update(playerZ);
+        this.oaks.update(playerZ);
+        this.bankRocks.update(playerZ);
+        this.birds?.update(dt, time, playerZ);
+    }
+
+    /**
+     * Sorteia encontros à frente do jogador. A mistura muda com o progresso:
+     * o começo é quase só navegação, o fim é um corredor de guerra.
+     */
+    direct(playerZ, entities, difficulty) {
+        const progress = clamp(-playerZ / COURSE_LENGTH, 0, 1);
+
+        while (this.nextSpawnZ > playerZ - SPAWN_AHEAD) {
+            const z = this.nextSpawnZ;
+            if (z > BOSS_Z + 130) this._spawnEncounter(z, progress, entities, difficulty);
+
+            const gap = randRange(54, 104) / (0.8 + difficulty.spawnScale * 0.45 + progress * 0.5);
+            this.nextSpawnZ -= Math.max(26, gap);
+            if (this.nextSpawnZ < BOSS_Z + 130) break;
+        }
+    }
+
+    _spawnEncounter(z, progress, entities, difficulty) {
+        const cx = centerX(z);
+        const hw = halfWidth(z);
+        const lane = () => randRange(-0.62, 0.62);
+
+        // Pesos por fase da jornada.
+        const weights = [
+            ['rock', 26 - progress * 10],
+            ['pickup', 20 - progress * 6],
+            ['enemyShip', 6 + progress * 26],
+            ['tower', 4 + progress * 20],
+            ['barricade', 8 + progress * 12],
+            ['whirlpool', 4 + progress * 8]
+        ];
+
+        // Evita repetir o mesmo tipo duas vezes seguidas.
+        const total = weights.reduce((sum, [kind, w]) => sum + (kind === this.lastKind ? w * 0.35 : w), 0);
+        let roll = Math.random() * total;
+        let kind = 'rock';
+        for (const [k, w] of weights) {
+            roll -= k === this.lastKind ? w * 0.35 : w;
+            if (roll <= 0) {
+                kind = k;
+                break;
+            }
+        }
+        this.lastKind = kind;
+
+        switch (kind) {
+            case 'rock': {
+                const cluster = Math.random() < 0.45 ? 2 : 1;
+                const base = lane();
+                for (let i = 0; i < cluster; i++) {
+                    const l = clamp(base + randRange(-0.22, 0.22), -0.8, 0.8);
+                    entities.spawnRock(cx + l * hw, z - i * randRange(6, 14), randRange(0.7, 1.15));
+                }
+                break;
+            }
+            case 'pickup': {
+                const type = Math.random() < 0.58
+                    ? 'coin'
+                    : Math.random() < 0.5
+                        ? 'heart'
+                        : pick(['shield', 'fury']);
+                const l = lane();
+                const count = type === 'coin' ? 3 : 1;
+                for (let i = 0; i < count; i++) {
+                    entities.spawnPickup(cx + l * hw + randRange(-1, 1), z - i * 7, type);
+                }
+                break;
+            }
+            case 'enemyShip': {
+                entities.spawnEnemyShip(cx + lane() * hw, z, {
+                    fireRate: (2.9 - progress * 1.1) / difficulty.enemyFireScale,
+                    speed: randRange(5, 9) + progress * 4
+                });
+                if (progress > 0.55 && Math.random() < 0.35) {
+                    entities.spawnEnemyShip(cx + lane() * hw, z - randRange(18, 34), {
+                        fireRate: 3.2 / difficulty.enemyFireScale,
+                        speed: randRange(5, 8)
+                    });
+                }
+                break;
+            }
+            case 'tower': {
+                const side = Math.random() < 0.5 ? -1 : 1;
+                const x = cx + side * (hw + randRange(3, 11));
+                entities.spawnTower(x, z, { fireRate: (3.6 - progress * 1.3) / difficulty.enemyFireScale });
+                break;
+            }
+            case 'barricade': {
+                // Deixa sempre um vão navegável.
+                const l = lane();
+                entities.spawnBarricade(cx + l * hw, z);
+                if (Math.random() < 0.35) {
+                    entities.spawnBarricade(cx + clamp(l + (l > 0 ? -0.55 : 0.55), -0.7, 0.7) * hw, z - randRange(9, 18));
+                }
+                break;
+            }
+            case 'whirlpool':
+                entities.spawnWhirlpool(cx + lane() * hw * 0.8, z);
+                break;
+            default:
+                break;
+        }
+    }
+}

--- a/labs/river-knight/style.css
+++ b/labs/river-knight/style.css
@@ -1,0 +1,1133 @@
+/* ================================================================
+   River Knight — interface
+   Paleta: noite fria + pergaminho + ouro velho + sangue.
+   ================================================================ */
+
+:root {
+    --ink: oklch(14% 0.03 285);
+    --ink-deep: oklch(9% 0.025 285);
+    --parchment: oklch(93% 0.04 85);
+    --gold: oklch(80% 0.13 82);
+    --gold-deep: oklch(62% 0.12 68);
+    --blood: oklch(52% 0.19 22);
+    --blood-soft: oklch(64% 0.19 25);
+    --steel: oklch(72% 0.02 250);
+    --river: oklch(70% 0.11 200);
+
+    --text: oklch(95% 0.012 85);
+    --text-soft: oklch(80% 0.02 80);
+    --text-dim: oklch(63% 0.02 80);
+
+    --panel: color-mix(in oklab, oklch(16% 0.03 285) 62%, transparent);
+    --panel-strong: color-mix(in oklab, oklch(11% 0.03 285) 82%, transparent);
+    --line: color-mix(in oklab, var(--gold) 26%, transparent);
+    --line-soft: color-mix(in oklab, var(--parchment) 12%, transparent);
+
+    --radius: 14px;
+    --radius-lg: 22px;
+    --blur: 20px;
+
+    --safe-top: env(safe-area-inset-top, 0px);
+    --safe-bottom: env(safe-area-inset-bottom, 0px);
+    --safe-left: env(safe-area-inset-left, 0px);
+    --safe-right: env(safe-area-inset-right, 0px);
+
+    --ease: cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+*, *::before, *::after {
+    box-sizing: border-box;
+    -webkit-tap-highlight-color: transparent;
+}
+
+html, body {
+    margin: 0;
+    width: 100%;
+    height: 100%;
+    overflow: clip;
+    overscroll-behavior: none;
+    background: var(--ink-deep);
+}
+
+body {
+    min-height: 100dvh;
+    padding: 0;
+    color: var(--text);
+    font-family: 'Outfit', system-ui, -apple-system, 'Segoe UI', sans-serif;
+    user-select: none;
+    -webkit-user-select: none;
+    touch-action: none;
+}
+
+button, input, select {
+    font: inherit;
+    color: inherit;
+}
+
+button {
+    background: none;
+    border: 0;
+    cursor: pointer;
+}
+
+.mono {
+    font-variant-numeric: tabular-nums;
+    font-feature-settings: 'tnum' 1;
+}
+
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip-path: inset(50%);
+}
+
+:focus-visible {
+    outline: 2px solid var(--gold);
+    outline-offset: 3px;
+}
+
+/* ===== palco ===== */
+.game-shell {
+    position: fixed;
+    inset: 0;
+    overflow: hidden;
+    background:
+        radial-gradient(120% 90% at 50% 0%, oklch(20% 0.05 275) 0%, var(--ink-deep) 70%);
+}
+
+#scene {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    display: block;
+    touch-action: none;
+}
+
+/* ===== cabeçalho do lab ===== */
+.game-shell > header {
+    position: absolute;
+    top: calc(0.9rem + var(--safe-top));
+    left: calc(1rem + var(--safe-left));
+    right: calc(1rem + var(--safe-right));
+    z-index: 40;
+    margin: 0;
+    padding: 0;
+    max-width: none;
+    width: auto;
+    pointer-events: none;
+    gap: 0.6rem;
+}
+
+.game-shell > header > * {
+    pointer-events: auto;
+}
+
+.game-shell > header .back-link {
+    background: var(--panel-strong);
+    backdrop-filter: blur(var(--blur));
+    -webkit-backdrop-filter: blur(var(--blur));
+    border-color: var(--line);
+    color: var(--text-soft);
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.4);
+}
+
+.game-shell > header .back-link:hover {
+    color: var(--gold);
+    border-color: var(--gold);
+}
+
+.game-shell > header .app-logo {
+    font-family: 'Cinzel', Georgia, serif;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    font-size: 1rem;
+    color: var(--parchment);
+    text-shadow: 0 2px 18px rgba(0, 0, 0, 0.7);
+}
+
+.game-shell > header .brand-mark {
+    filter: drop-shadow(0 0 10px oklch(70% 0.16 60 / 0.6));
+}
+
+.game-shell > header .theme-switch-wrapper {
+    display: none;
+}
+
+.lab-foot {
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: calc(0.4rem + var(--safe-bottom));
+    z-index: 30;
+    margin: 0;
+    padding: 0.4rem;
+    border: 0;
+    font-size: 0.72rem;
+    color: var(--text-dim);
+    opacity: 0.55;
+    pointer-events: none;
+}
+
+.lab-foot a {
+    color: var(--text-soft);
+    pointer-events: auto;
+}
+
+body[data-state="playing"] .lab-foot,
+body[data-state="cinematic"] .lab-foot,
+body[data-state="playing"] .game-shell > header .app-logo {
+    opacity: 0;
+    transition: opacity 0.5s var(--ease);
+}
+
+/* ================================================================
+   HUD
+   ================================================================ */
+.hud {
+    position: absolute;
+    inset: 0;
+    z-index: 20;
+    pointer-events: none;
+    display: grid;
+    grid-template-rows: auto 1fr auto;
+    padding: calc(4.2rem + var(--safe-top)) calc(1rem + var(--safe-right)) calc(1rem + var(--safe-bottom))
+        calc(1rem + var(--safe-left));
+    gap: 0.75rem;
+}
+
+.hud[hidden] {
+    display: none;
+}
+
+.panel {
+    background: var(--panel);
+    backdrop-filter: blur(var(--blur)) saturate(1.15);
+    -webkit-backdrop-filter: blur(var(--blur)) saturate(1.15);
+    border: 1px solid var(--line-soft);
+    border-radius: var(--radius);
+    box-shadow: 0 12px 34px rgba(0, 0, 0, 0.42), inset 0 1px 0 rgba(255, 255, 255, 0.06);
+    padding: 0.6rem 0.85rem;
+}
+
+.hud-label {
+    font-family: 'Cinzel', Georgia, serif;
+    font-size: 0.62rem;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--gold);
+    opacity: 0.85;
+}
+
+.hud-top {
+    display: grid;
+    grid-template-columns: minmax(150px, 1fr) minmax(220px, 2fr) minmax(150px, 1fr);
+    align-items: start;
+    gap: 0.75rem;
+}
+
+/* --- casco + fúria --- */
+.hull-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    justify-self: start;
+    min-width: 168px;
+}
+
+.pips {
+    display: flex;
+    gap: 0.28rem;
+}
+
+.pip {
+    width: 22px;
+    height: 22px;
+    border-radius: 6px 6px 9px 9px;
+    background: linear-gradient(160deg, var(--blood-soft), var(--blood));
+    border: 1px solid oklch(80% 0.1 30 / 0.55);
+    box-shadow: 0 0 12px oklch(60% 0.2 25 / 0.45), inset 0 1px 0 rgba(255, 255, 255, 0.25);
+    transition: transform 0.25s var(--ease), opacity 0.25s var(--ease), filter 0.25s var(--ease);
+}
+
+.pip[data-empty="true"] {
+    background: transparent;
+    border-color: var(--line-soft);
+    box-shadow: none;
+    opacity: 0.4;
+    transform: scale(0.82);
+}
+
+.fury {
+    display: flex;
+    align-items: center;
+    gap: 0.45rem;
+}
+
+.meter {
+    flex: 1;
+    height: 7px;
+    border-radius: 99px;
+    background: rgba(255, 255, 255, 0.09);
+    overflow: hidden;
+    border: 1px solid var(--line-soft);
+}
+
+.meter i {
+    display: block;
+    height: 100%;
+    width: 0%;
+    border-radius: 99px;
+    background: linear-gradient(90deg, oklch(72% 0.17 55), oklch(85% 0.19 85));
+    box-shadow: 0 0 14px oklch(75% 0.19 65 / 0.8);
+    transition: width 0.18s linear;
+}
+
+.hull-panel[data-fury="true"] .meter i {
+    background: linear-gradient(90deg, oklch(70% 0.22 25), oklch(85% 0.2 70));
+    animation: furyPulse 0.7s ease-in-out infinite;
+}
+
+@keyframes furyPulse {
+    0%, 100% { filter: brightness(1); }
+    50% { filter: brightness(1.55); }
+}
+
+/* --- trilha da viagem --- */
+.voyage-panel {
+    justify-self: center;
+    width: min(460px, 100%);
+    display: flex;
+    flex-direction: column;
+    gap: 0.45rem;
+}
+
+.voyage-head {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 0.75rem;
+}
+
+.voyage-head strong {
+    font-size: 0.95rem;
+    color: var(--parchment);
+    letter-spacing: 0.02em;
+}
+
+.rail {
+    position: relative;
+    height: 10px;
+    border-radius: 99px;
+    background: linear-gradient(90deg, rgba(255, 255, 255, 0.06), rgba(255, 255, 255, 0.12));
+    border: 1px solid var(--line-soft);
+}
+
+.rail i {
+    position: absolute;
+    inset: 0 auto 0 0;
+    width: 0%;
+    border-radius: 99px;
+    background: linear-gradient(90deg, oklch(62% 0.12 200), oklch(80% 0.13 85));
+    box-shadow: 0 0 16px oklch(72% 0.12 190 / 0.7);
+    transition: width 0.25s linear;
+}
+
+.rail-boat {
+    position: absolute;
+    top: 50%;
+    left: 0;
+    translate: -50% -50%;
+    font-size: 1.05rem;
+    filter: drop-shadow(0 2px 6px rgba(0, 0, 0, 0.8));
+    transition: left 0.25s linear;
+}
+
+.rail-castle {
+    position: absolute;
+    top: 50%;
+    right: -4px;
+    translate: 50% -50%;
+    font-size: 1.15rem;
+    filter: drop-shadow(0 0 10px oklch(72% 0.14 70 / 0.7));
+}
+
+/* --- glória --- */
+.score-panel {
+    justify-self: end;
+    min-width: 150px;
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+}
+
+.score-row {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 0.6rem;
+}
+
+.score-row strong {
+    font-size: 1.25rem;
+    font-weight: 600;
+    color: var(--parchment);
+}
+
+.score-row--sub {
+    color: var(--text-dim);
+    font-size: 0.8rem;
+}
+
+.combo {
+    font-family: 'Cinzel', Georgia, serif;
+    font-size: 0.72rem;
+    letter-spacing: 0.08em;
+    padding: 0.1rem 0.42rem;
+    border-radius: 99px;
+    border: 1px solid var(--line-soft);
+    color: var(--text-dim);
+    transition: all 0.2s var(--ease);
+}
+
+.combo[data-active="true"] {
+    color: oklch(18% 0.04 80);
+    background: linear-gradient(120deg, var(--gold), oklch(88% 0.15 95));
+    border-color: transparent;
+    box-shadow: 0 0 18px oklch(78% 0.15 80 / 0.55);
+}
+
+/* --- chefe --- */
+.boss-panel {
+    justify-self: center;
+    align-self: start;
+    width: min(560px, 92%);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.35rem;
+    grid-row: 2;
+    margin-top: 0.5rem;
+    animation: dropIn 0.6s var(--ease);
+}
+
+.boss-panel[hidden] {
+    display: none;
+}
+
+.boss-name {
+    font-family: 'Cinzel', Georgia, serif;
+    font-size: 0.8rem;
+    letter-spacing: 0.22em;
+    text-transform: uppercase;
+    color: oklch(84% 0.12 30);
+    text-shadow: 0 2px 18px oklch(40% 0.2 25 / 0.9);
+}
+
+.boss-bar {
+    width: 100%;
+    height: 12px;
+    border-radius: 99px;
+    background: rgba(0, 0, 0, 0.5);
+    border: 1px solid oklch(60% 0.16 25 / 0.6);
+    overflow: hidden;
+    box-shadow: 0 8px 28px rgba(0, 0, 0, 0.5);
+}
+
+.boss-bar i {
+    display: block;
+    height: 100%;
+    width: 100%;
+    background: linear-gradient(90deg, oklch(45% 0.2 25), oklch(68% 0.22 32));
+    box-shadow: 0 0 20px oklch(60% 0.22 28 / 0.8);
+    transition: width 0.3s var(--ease);
+}
+
+@keyframes dropIn {
+    from { opacity: 0; transform: translateY(-14px); }
+    to { opacity: 1; transform: none; }
+}
+
+/* --- mensagens --- */
+.message {
+    grid-row: 2;
+    align-self: end;
+    justify-self: center;
+    margin: 0 0 1.2rem;
+    font-family: 'Cinzel', Georgia, serif;
+    font-size: clamp(1rem, 3.4vw, 1.55rem);
+    letter-spacing: 0.05em;
+    text-align: center;
+    color: var(--parchment);
+    text-shadow: 0 2px 24px rgba(0, 0, 0, 0.9);
+    opacity: 0;
+    transform: translateY(10px) scale(0.97);
+    transition: opacity 0.35s var(--ease), transform 0.35s var(--ease);
+}
+
+.message[data-show="true"] {
+    opacity: 1;
+    transform: none;
+}
+
+.message[data-tone="danger"] { color: oklch(78% 0.16 28); }
+.message[data-tone="gold"] { color: var(--gold); }
+
+/* --- ações --- */
+.hud-actions {
+    grid-row: 3;
+    justify-self: end;
+    align-self: end;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    pointer-events: auto;
+}
+
+.icon-button {
+    width: 40px;
+    height: 40px;
+    display: grid;
+    place-items: center;
+    border-radius: 12px;
+    background: var(--panel);
+    backdrop-filter: blur(var(--blur));
+    -webkit-backdrop-filter: blur(var(--blur));
+    border: 1px solid var(--line-soft);
+    color: var(--text-soft);
+    font-size: 0.95rem;
+    transition: all 0.22s var(--ease);
+}
+
+.icon-button:hover {
+    color: var(--gold);
+    border-color: var(--line);
+    transform: translateY(-2px);
+}
+
+.icon-button[aria-pressed="false"] {
+    opacity: 0.45;
+}
+
+.fps {
+    font-size: 0.7rem;
+    color: var(--text-dim);
+    padding: 0 0.3rem;
+}
+
+/* --- controles de toque --- */
+.touch-controls {
+    position: absolute;
+    inset: auto 0 0 0;
+    height: 45%;
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between;
+    padding: 0 calc(1rem + var(--safe-left)) calc(1.2rem + var(--safe-bottom)) calc(1rem + var(--safe-right));
+    pointer-events: none;
+}
+
+.touch-controls[hidden] {
+    display: none;
+}
+
+.steer-zone {
+    pointer-events: auto;
+    width: 45%;
+    height: 100%;
+    display: grid;
+    place-items: end start;
+    padding: 1rem;
+}
+
+.steer-hint {
+    font-size: 0.68rem;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: var(--text-dim);
+    opacity: 0.5;
+}
+
+.touch-buttons {
+    display: flex;
+    align-items: flex-end;
+    gap: 0.7rem;
+    pointer-events: auto;
+}
+
+.pad {
+    border-radius: 50%;
+    background: var(--panel-strong);
+    backdrop-filter: blur(var(--blur));
+    -webkit-backdrop-filter: blur(var(--blur));
+    border: 1px solid var(--line);
+    color: var(--parchment);
+    font-family: 'Cinzel', Georgia, serif;
+    font-size: 0.72rem;
+    letter-spacing: 0.1em;
+    display: grid;
+    place-items: center;
+    transition: transform 0.12s var(--ease), background 0.12s var(--ease);
+}
+
+.pad-boost {
+    width: 74px;
+    height: 74px;
+}
+
+.pad-throw {
+    width: 92px;
+    height: 92px;
+    font-size: 2rem;
+    border-color: oklch(70% 0.16 30 / 0.7);
+    box-shadow: 0 0 26px oklch(55% 0.2 28 / 0.35);
+}
+
+.pad:active,
+.pad[data-active="true"] {
+    transform: scale(0.92);
+    background: color-mix(in oklab, var(--gold) 28%, var(--panel-strong));
+}
+
+/* --- flash de dano --- */
+.hit-flash {
+    position: absolute;
+    inset: 0;
+    z-index: 25;
+    pointer-events: none;
+    opacity: 0;
+    background: radial-gradient(120% 90% at 50% 50%, transparent 45%, oklch(45% 0.22 25 / 0.85) 100%);
+    transition: opacity 0.45s var(--ease);
+}
+
+.hit-flash[data-show="true"] {
+    opacity: 1;
+    transition: opacity 0.06s linear;
+}
+
+.hit-flash[data-tone="gold"] {
+    background: radial-gradient(120% 90% at 50% 50%, transparent 50%, oklch(80% 0.16 85 / 0.55) 100%);
+}
+
+/* ================================================================
+   Overlays
+   ================================================================ */
+.overlay {
+    position: absolute;
+    inset: 0;
+    z-index: 50;
+    display: grid;
+    place-items: center;
+    padding: calc(1.2rem + var(--safe-top)) 1.2rem calc(1.2rem + var(--safe-bottom));
+    background:
+        radial-gradient(140% 100% at 50% 0%, oklch(16% 0.05 280 / 0.28), oklch(6% 0.02 285 / 0.78));
+    backdrop-filter: blur(5px) saturate(0.9);
+    -webkit-backdrop-filter: blur(5px) saturate(0.9);
+    animation: fadeIn 0.4s var(--ease);
+    overflow-y: auto;
+}
+
+.overlay[hidden] {
+    display: none;
+}
+
+@keyframes fadeIn {
+    from { opacity: 0; }
+    to { opacity: 1; }
+}
+
+/* shared.css estiliza `header`/`footer` globalmente para a galeria de labs;
+   dentro dos cartões precisamos do comportamento neutro. */
+.overlay-card header,
+.overlay-card footer {
+    display: block;
+    grid-template-columns: none;
+    grid-template-areas: none;
+    width: auto;
+    max-width: none;
+    margin: 0;
+    padding: 0;
+    border: 0;
+    text-align: inherit;
+    color: inherit;
+    font-size: inherit;
+}
+
+.overlay-card {
+    width: min(980px, 100%);
+    background: linear-gradient(160deg,
+            color-mix(in oklab, oklch(17% 0.03 285) 92%, transparent),
+            color-mix(in oklab, oklch(10% 0.03 285) 95%, transparent));
+    border: 1px solid var(--line);
+    border-radius: var(--radius-lg);
+    box-shadow:
+        0 40px 90px rgba(0, 0, 0, 0.65),
+        inset 0 1px 0 rgba(255, 255, 255, 0.08);
+    padding: clamp(1.3rem, 3.5vw, 2.4rem);
+    position: relative;
+    overflow: hidden;
+    animation: cardIn 0.55s var(--ease);
+}
+
+.overlay-card::before {
+    content: '';
+    position: absolute;
+    inset: -40% -20% auto -20%;
+    height: 70%;
+    background: radial-gradient(60% 100% at 50% 100%, oklch(70% 0.13 70 / 0.16), transparent 70%);
+    pointer-events: none;
+}
+
+@keyframes cardIn {
+    from { opacity: 0; transform: translateY(18px) scale(0.985); }
+    to { opacity: 1; transform: none; }
+}
+
+.compact-card {
+    width: min(520px, 100%);
+    text-align: center;
+}
+
+.eyebrow {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin: 0 0 0.7rem;
+    font-family: 'Cinzel', Georgia, serif;
+    font-size: 0.68rem;
+    letter-spacing: 0.24em;
+    text-transform: uppercase;
+    color: var(--gold);
+}
+
+.eyebrow i {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: var(--gold);
+    box-shadow: 0 0 12px var(--gold);
+    animation: blip 2.4s ease-in-out infinite;
+}
+
+.eyebrow--danger { color: oklch(72% 0.18 28); }
+.eyebrow--danger i { background: oklch(65% 0.2 28); box-shadow: 0 0 12px oklch(65% 0.2 28); }
+.eyebrow--gold { color: oklch(86% 0.15 90); }
+
+@keyframes blip {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.25; }
+}
+
+.overlay-card h1 {
+    margin: 0 0 0.5rem;
+    font-family: 'Cinzel', Georgia, serif;
+    font-weight: 800;
+    font-size: clamp(2.3rem, 7vw, 4rem);
+    line-height: 0.95;
+    letter-spacing: 0.02em;
+    color: var(--parchment);
+    text-shadow: 0 8px 40px rgba(0, 0, 0, 0.6);
+}
+
+.overlay-card h1 span {
+    background: linear-gradient(120deg, var(--gold), oklch(92% 0.13 95), var(--gold-deep));
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+}
+
+.overlay-card h2 {
+    margin: 0 0 0.8rem;
+    font-family: 'Cinzel', Georgia, serif;
+    font-weight: 700;
+    font-size: clamp(1.5rem, 4.5vw, 2.1rem);
+    line-height: 1.08;
+    color: var(--parchment);
+}
+
+.lede {
+    margin: 0;
+    max-width: 62ch;
+    color: var(--text-soft);
+    font-size: clamp(0.92rem, 2.2vw, 1.02rem);
+    line-height: 1.6;
+    font-weight: 300;
+}
+
+.menu-head {
+    margin-bottom: 1.4rem;
+}
+
+.menu-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+    gap: 1.1rem 1.6rem;
+    padding: 1.2rem 0;
+    border-top: 1px solid var(--line-soft);
+    border-bottom: 1px solid var(--line-soft);
+}
+
+.menu-section h2 {
+    margin: 0 0 0.6rem;
+    font-family: 'Cinzel', Georgia, serif;
+    font-size: 0.7rem;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: var(--gold);
+    font-weight: 600;
+}
+
+.section-note {
+    margin: 0.6rem 0 0;
+    font-size: 0.8rem;
+    color: var(--text-dim);
+    line-height: 1.5;
+}
+
+.section-note b {
+    color: var(--parchment);
+    font-weight: 600;
+}
+
+.chip-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.45rem;
+}
+
+.chip {
+    padding: 0.45rem 0.85rem;
+    border-radius: 99px;
+    border: 1px solid var(--line-soft);
+    background: rgba(255, 255, 255, 0.03);
+    color: var(--text-soft);
+    font-size: 0.82rem;
+    transition: all 0.22s var(--ease);
+}
+
+.chip:hover {
+    border-color: var(--line);
+    color: var(--parchment);
+    transform: translateY(-1px);
+}
+
+.chip[aria-checked="true"] {
+    background: linear-gradient(120deg, var(--gold), oklch(88% 0.14 95));
+    border-color: transparent;
+    color: oklch(20% 0.04 80);
+    font-weight: 600;
+    box-shadow: 0 6px 22px oklch(72% 0.14 80 / 0.35);
+}
+
+.keys {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    font-size: 0.84rem;
+    color: var(--text-soft);
+}
+
+kbd {
+    display: inline-block;
+    min-width: 1.6em;
+    padding: 0.1rem 0.4rem;
+    margin-right: 0.2rem;
+    border-radius: 6px;
+    border: 1px solid var(--line-soft);
+    border-bottom-width: 2px;
+    background: rgba(255, 255, 255, 0.05);
+    font-family: 'Outfit', sans-serif;
+    font-size: 0.76rem;
+    text-align: center;
+    color: var(--parchment);
+}
+
+.settings-grid {
+    display: grid;
+    gap: 0.7rem;
+}
+
+.field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+    font-size: 0.8rem;
+    color: var(--text-soft);
+}
+
+.field b {
+    color: var(--parchment);
+}
+
+select {
+    padding: 0.5rem 0.6rem;
+    border-radius: 10px;
+    border: 1px solid var(--line-soft);
+    background: oklch(16% 0.02 285);
+    color: var(--text);
+    font-size: 0.85rem;
+}
+
+input[type="range"] {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 100%;
+    height: 5px;
+    border-radius: 99px;
+    background: rgba(255, 255, 255, 0.12);
+    outline: none;
+}
+
+input[type="range"]::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    background: var(--gold);
+    box-shadow: 0 0 12px oklch(75% 0.15 80 / 0.7);
+    cursor: pointer;
+}
+
+input[type="range"]::-moz-range-thumb {
+    width: 16px;
+    height: 16px;
+    border: 0;
+    border-radius: 50%;
+    background: var(--gold);
+    cursor: pointer;
+}
+
+.menu-foot {
+    display: flex;
+    justify-content: center;
+    padding-top: 1.3rem;
+    gap: 1rem;
+}
+
+.card-actions {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 0.6rem;
+    margin-top: 1.3rem;
+}
+
+.primary-button {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.7rem;
+    padding: 0.85rem 1.9rem;
+    border-radius: 99px;
+    background: linear-gradient(120deg, var(--gold-deep), var(--gold));
+    color: oklch(18% 0.05 70);
+    font-family: 'Cinzel', Georgia, serif;
+    font-weight: 700;
+    font-size: 0.95rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    box-shadow: 0 14px 40px oklch(65% 0.14 70 / 0.35), inset 0 1px 0 rgba(255, 255, 255, 0.4);
+    transition: transform 0.22s var(--ease), box-shadow 0.22s var(--ease), filter 0.22s var(--ease);
+}
+
+.primary-button:hover {
+    transform: translateY(-2px);
+    filter: brightness(1.08);
+    box-shadow: 0 20px 52px oklch(68% 0.15 72 / 0.45);
+}
+
+.primary-button:active {
+    transform: translateY(0) scale(0.98);
+}
+
+.primary-button i {
+    font-style: normal;
+    transition: transform 0.22s var(--ease);
+}
+
+.primary-button:hover i {
+    transform: translateX(4px);
+}
+
+.ghost-button {
+    padding: 0.8rem 1.4rem;
+    border-radius: 99px;
+    border: 1px solid var(--line-soft);
+    color: var(--text-soft);
+    font-size: 0.86rem;
+    transition: all 0.22s var(--ease);
+}
+
+.ghost-button:hover {
+    color: var(--parchment);
+    border-color: var(--line);
+    transform: translateY(-2px);
+}
+
+.stats {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));
+    gap: 0.7rem;
+    margin-top: 1.1rem;
+    padding-top: 1.1rem;
+    border-top: 1px solid var(--line-soft);
+}
+
+.stat {
+    display: flex;
+    flex-direction: column;
+    gap: 0.1rem;
+}
+
+.stat span {
+    font-family: 'Cinzel', Georgia, serif;
+    font-size: 0.6rem;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--text-dim);
+}
+
+.stat strong {
+    font-size: 1.35rem;
+    font-weight: 600;
+    color: var(--parchment);
+}
+
+.stat--gold strong {
+    color: var(--gold);
+}
+
+.defeat-card { border-color: oklch(50% 0.16 25 / 0.55); }
+.victory-card { border-color: oklch(78% 0.14 85 / 0.55); }
+
+.victory-card::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(70% 60% at 50% 0%, oklch(80% 0.15 85 / 0.16), transparent 70%);
+    pointer-events: none;
+}
+
+/* ===== carregamento ===== */
+.loading-overlay {
+    background: radial-gradient(120% 100% at 50% 0%, oklch(16% 0.05 280), oklch(6% 0.02 285));
+}
+
+.loading-card {
+    text-align: center;
+    display: grid;
+    gap: 0.7rem;
+    justify-items: center;
+}
+
+.loading-mark {
+    font-size: 3rem;
+    filter: drop-shadow(0 0 24px oklch(70% 0.16 60 / 0.7));
+    animation: sway 2.6s ease-in-out infinite;
+}
+
+@keyframes sway {
+    0%, 100% { transform: rotate(-8deg) translateY(0); }
+    50% { transform: rotate(8deg) translateY(-6px); }
+}
+
+.loading-card h1 {
+    margin: 0;
+    font-family: 'Cinzel', Georgia, serif;
+    font-size: clamp(1.8rem, 6vw, 2.6rem);
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--parchment);
+}
+
+.loading-card p {
+    margin: 0;
+    color: var(--text-dim);
+    font-size: 0.88rem;
+}
+
+.loading-bar {
+    width: min(320px, 70vw);
+    height: 4px;
+    border-radius: 99px;
+    background: rgba(255, 255, 255, 0.1);
+    overflow: hidden;
+}
+
+.loading-bar i {
+    display: block;
+    height: 100%;
+    width: 10%;
+    border-radius: 99px;
+    background: linear-gradient(90deg, var(--gold-deep), var(--gold));
+    transition: width 0.3s var(--ease);
+}
+
+/* ================================================================
+   Responsivo
+   ================================================================ */
+@media (max-width: 900px) {
+    .hud-top {
+        grid-template-columns: 1fr 1fr;
+        grid-template-areas:
+            "hull score"
+            "voyage voyage";
+    }
+
+    .hull-panel { grid-area: hull; }
+    .score-panel { grid-area: score; }
+    .voyage-panel { grid-area: voyage; width: 100%; }
+}
+
+@media (max-width: 640px) {
+    .hud {
+        padding-top: calc(3.6rem + var(--safe-top));
+        gap: 0.5rem;
+    }
+
+    .panel {
+        padding: 0.5rem 0.65rem;
+        border-radius: 12px;
+    }
+
+    .pip {
+        width: 17px;
+        height: 17px;
+    }
+
+    .score-row strong { font-size: 1.05rem; }
+
+    .hud-actions {
+        align-self: start;
+        grid-row: 1;
+        position: absolute;
+        top: calc(3.4rem + var(--safe-top));
+        right: calc(0.7rem + var(--safe-right));
+    }
+
+    .message { margin-bottom: 40vh; }
+
+    .menu-grid {
+        grid-template-columns: 1fr;
+        gap: 1rem;
+    }
+
+    .lab-foot { display: none; }
+}
+
+@media (max-height: 520px) and (orientation: landscape) {
+    .hud { padding-top: calc(3rem + var(--safe-top)); }
+    .voyage-panel { max-width: 320px; }
+    .overlay-card { padding: 1rem 1.2rem; }
+    .menu-grid { padding: 0.8rem 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+    }
+}

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -121,6 +121,12 @@
     <priority>0.7</priority>
   </url>
   <url>
+    <loc>https://diogopaulino.com.br/labs/river-knight/</loc>
+    <lastmod>2026-08-13</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
     <loc>https://diogopaulino.com.br/labs/rock-kombat/</loc>
     <lastmod>2026-08-12</lastmod>
     <changefreq>monthly</changefreq>


### PR DESCRIPTION
Novo laboratório em `/labs/river-knight/`: um jogo 3D onde o guerreiro medieval navega o drakkar rio abaixo, atravessa quatro quilômetros de emboscadas e resgata a princesa no castelo de Morvain.

## Renderização

- **Água**: ondas de Gerstner deslocadas no vertex shader e avaliadas também na CPU (`waterHeight`/`waterSlope`), para que barcos, itens e espuma acompanhem exatamente a superfície desenhada.
- **Céu procedural**: gradiente, disco solar, halo, nuvens em fBm e estrelas. A mesma função GLSL (`rkSky`) alimenta o reflexo da água — reflexo e céu nunca divergem e não é preciso um render target extra.
- **Terreno analítico**: vale, margens, montanhas e a esplanada do castelo saem das mesmas funções do rio (`river.js`), com as constantes injetadas no GLSL a partir do JS para que as duas versões não saiam de sincronia. O material continua sendo `MeshStandardMaterial` (recebe sombra, névoa e a iluminação da cena) via `onBeforeCompile`.
- **Malha radial** para água e terreno: densa junto ao barco, esparsa no horizonte — mundo contínuo sem costuras e sem recalcular vértices na CPU.
- **Paleta dinâmica**: céu, névoa, sol e luz ambiente interpolam ao longo da corrida (amanhecer enevoado → dourado → crepúsculo sobre o castelo).
- **Sem assets externos**: casco em *loft*, guerreiro, castelo, torres, barcaça e itens são geometria gerada em código; madeira, pedra, vela, escudos, espuma e estandartes são texturas desenhadas em `<canvas>`.
- Pós-processamento opcional (bloom) carregado dinamicamente: se o addon não carregar, o jogo segue normalmente.

## Jogo

- Navegação com aceleração, deriva lateral, correnteza e limites de margem.
- Machados de arremesso contra barcos inimigos, torres de vigia e barricadas; rochas e redemoinhos como obstáculos.
- Itens: reparo de casco, escudo, fúria (arremesso contínuo) e ouro, com multiplicador de combo.
- Chefe final (Barcaça Negra de Morvain) que bloqueia o rio, enfurece abaixo de 45 % de vida e, ao cair, abre o portão do castelo.
- Sequência de vitória: o drakkar atraca, a câmera reenquadra a torre, a princesa acena e os fogos sobem sobre o castelo.
- Três dificuldades, três câmeras, pausa, recordes em `localStorage`.
- HUD em vidro fosco com casco, fúria, trilha da viagem, glória, combo e barra do chefe; controles de toque para celular e suporte a gamepad.
- Trilha e efeitos sonoros sintetizados na Web Audio API (alaúde, tambores, coro, metais), com camadas que mudam entre menu, rio, chefe, vitória e derrota.

## Integração

- Card na galeria (`labs/index.html`), linha no README e entrada no `sitemap.xml`.
- Segue o padrão dos outros labs: estático, sem build, `three@0.185.1` via importmap no CDN (mesma versão já usada pelo F1 Grand Prix).

## Verificação

Testado em Chromium headless (WebGL por SwiftShader) com capturas de tela em cada etapa: menu, corrida, aproximação do chefe, portão do castelo e sequência final; layout de celular em 390×844. Checagem funcional cobrindo arremesso de machado, dano em inimigo, dano no jogador, coleta de itens, flechas inimigas e inicialização do áudio — todos passando, sem erros no console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y8C48dyscXz9bptwCrY6Z5

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y8C48dyscXz9bptwCrY6Z5)_