### PR TITLE
feat(ravi-123): polish Mickey 123 — animações, UI e servir comidas

### DIFF
--- a/labs/ravi-123/anim.js
+++ b/labs/ravi-123/anim.js
@@ -1,0 +1,42 @@
+/* ==========================================================================
+   Ravi 1·2·3 — helpers de animação (baratos, sem alocação)
+   --------------------------------------------------------------------------
+   Tudo em funções puras sobre `t` (segundos). O loop de render só chama
+   Math.sin/floor — nenhum objeto novo por frame.
+   ========================================================================== */
+
+/** Oscilação suave −amp..+amp, arredondada para pixel. */
+export function wave(t, speed, amp, phase = 0) {
+  return Math.round(Math.sin(t * speed + phase) * amp);
+}
+
+/** Salto de dança: sobe e cai (0..amp). */
+export function hop(t, speed, amp, phase = 0) {
+  return Math.round(Math.abs(Math.sin(t * speed + phase)) * amp);
+}
+
+/** Ease bounce de saída (flashcard, balões). */
+export function bounceOut(p) {
+  if (p <= 0) return 0;
+  if (p >= 1) return 1;
+  const n1 = 7.5625;
+  const d1 = 2.75;
+  if (p < 1 / d1) return n1 * p * p;
+  if (p < 2 / d1) { p -= 1.5 / d1; return n1 * p * p + 0.75; }
+  if (p < 2.5 / d1) { p -= 2.25 / d1; return n1 * p * p + 0.9375; }
+  p -= 2.625 / d1;
+  return n1 * p * p + 0.984375;
+}
+
+/** Pop elástico 0→1 com overshoot leve. */
+export function popIn(p) {
+  if (p <= 0) return 0;
+  if (p >= 1) return 1;
+  return bounceOut(p);
+}
+
+/** Parallax / scroll modular positivo. */
+export function wrap(v, span) {
+  const m = v % span;
+  return m < 0 ? m + span : m;
+}

--- a/labs/ravi-123/assets.js
+++ b/labs/ravi-123/assets.js
@@ -257,8 +257,8 @@ export function sliceSpriteSheet(imageName, targetHeight = 0) {
       const w = maxX - minX + 1;
       const h = maxY - minY + 1;
       
-      // Filtro: ignorar textos compridos
-      if (w > h * 2.5) continue;
+      // Filtro: ignorar textos compridos / faixas largas
+      if (w > h * 1.6) continue;
       if (h > w * 3) continue;
 
       rects.push({x: minX, y: minY, w, h});

--- a/labs/ravi-123/audio.js
+++ b/labs/ravi-123/audio.js
@@ -96,8 +96,8 @@ function pump() {
     const u = new SpeechSynthesisUtterance(item);
     if (voice) u.voice = voice;
     u.lang = 'pt-BR';
-    u.rate = 1.02;
-    u.pitch = 1.15;
+    u.rate = 0.88;
+    u.pitch = 1.12;
     u.volume = muted ? 0 : 0.95;
     const next = () => { speaking = false; pump(); };
     u.onend = next;

--- a/labs/ravi-123/game.js
+++ b/labs/ravi-123/game.js
@@ -16,6 +16,7 @@ import * as F from './font.js';
 import { Audio } from './audio.js';
 import { SPR, HEROES, TOYS, FOODS, VEHICLES, buildSprites } from './sprites.js';
 import * as Sc from './scenes.js';
+import { wave, hop } from './anim.js';
 
 const STAGE_H = Sc.STAGE_H;
 
@@ -94,12 +95,16 @@ function freshState() {
     lumpX: 96,
     marketIdx: 0,
     serveIdx: 0,
+    servePlacing: 0,
+    serveHero: -1,
+    serveFoodId: null,
+    served: {},
     guestsIn: 0,
     balloonsHung: 0,
     bannerUp: false,
     fridgeFull: false,
     guestX: [],
-    confetti: Sc.makeConfetti(60)
+    confetti: Sc.makeConfetti(90)
   };
 }
 
@@ -114,6 +119,14 @@ function readyForParty() {
 /** Comidas efetivamente compradas (balão não é comida). */
 function boughtFoods() {
   return FOODS.filter((f) => f.id !== 'balloon' && (S.cart[f.id] || 0) > 0);
+}
+
+/**
+ * Lista de quem come na festa: convidados + aniversariante.
+ * No Mickey 123 cada personagem recebe cada item comprado.
+ */
+function partyRoster() {
+  return S.invited.concat(S.honoree);
 }
 
 /* --------------------------------------------------------------------------
@@ -146,7 +159,7 @@ function hideFlash() {
  * Anexa à timeline uma contagem de 1 até n: flashcard, nota e número falado.
  * É o coração educativo do jogo — aparece em quase toda cena.
  */
-function addCount(tl, n, onStep, stepDur = 0.72) {
+function addCount(tl, n, onStep, stepDur = 1.15) {
   for (let i = 1; i <= n; i++) {
     tl.add(stepDur, () => {
       showFlash(i);
@@ -154,7 +167,7 @@ function addCount(tl, n, onStep, stepDur = 0.72) {
       if (onStep) onStep(i);
     });
   }
-  tl.add(0.45, () => hideFlash());
+  tl.add(0.75, () => hideFlash());
   return tl;
 }
 
@@ -164,6 +177,7 @@ function addCount(tl, n, onStep, stepDur = 0.72) {
 
 function go(next) {
   if (scene && scene.exit) scene.exit();
+  Audio.stopSpeech();
   scene = next;
   timeline = null;
   hideFlash();
@@ -208,28 +222,57 @@ const SCENES = {
     },
     draw(ctx) {
       const pen = new Pen(ctx);
-      blitFoot(ctx, SPR.ravi.sleep, 150, 152);
+      // Ravi dormindo com Zzz flutuando
+      const snore = hop(clock, 1.6, 2);
+      blitFoot(ctx, SPR.ravi.sleep, 150, 152 + snore);
+      const zz = ((clock * 1.2) % 3);
+      F.text(ctx, 'z', 168, 100 - Math.round(zz * 8), K.CYAN, { scale: 1 + (zz > 1.5 ? 1 : 0), shadow: K.BLACK });
+      F.text(ctx, 'z', 176, 92 - Math.round(zz * 6), K.BLU_L, { shadow: K.BLACK });
 
-      // Logotipo — alto o bastante para cobrir a janela do cenário
-      pen.col(K.BLACK).rect(28, 4, 264, 70);
-      pen.bevel(30, 6, 260, 66, K.NAVY, K.BLU, K.NIGHT);
-      F.textCenter(ctx, 'RAVI', 160, 13, K.YEL_L, { scale: 3, shadow: K.RED_D });
+      // Logotipo com moldura, estrelas e “respiração”
+      const breathe = hop(clock, 1.2, 1);
+      const ly = 4 - breathe;
+      const lh = 70 + breathe * 2;
+      pen.col(K.BLACK).rect(26, ly + 2, 268, lh);
+      pen.bevel(28, ly, 264, lh, K.NAVY, K.BLU, K.NIGHT);
+      pen.col(K.OCHRE).frame(30, ly + 2, 260, lh - 4);
+      pen.col(K.YEL).frame(31, ly + 3, 258, lh - 6);
+      // Estrelas nos cantos
+      const sparkY = ly + 8;
+      for (const sx of [38, 278]) {
+        pen.col(K.YEL_L).px(sx, sparkY - 1).px(sx - 1, sparkY).px(sx, sparkY).px(sx + 1, sparkY).px(sx, sparkY + 1);
+      }
+      F.textCenter(ctx, 'RAVI', 160, 13 - breathe, K.YEL_L, { scale: 3, shadow: K.RED_D });
+      // Faixa do subtítulo
+      pen.col(K.NIGHT).rect(70, 36, 180, 14);
+      pen.col(K.BLU_D).rect(71, 37, 178, 12);
       F.textCenter(ctx, '1 · 2 · 3', 160, 38, K.CYAN, { scale: 2, shadow: K.BLACK });
-      F.textCenter(ctx, 'A GRANDE FESTA SURPRESA', 160, 57, K.WHITE, { shadow: K.BLACK });
+      F.textCenter(ctx, 'A GRANDE FESTA SURPRESA', 160, 57 + breathe, K.WHITE, { shadow: K.BLACK });
 
-      // Balões numerados
+      // Balões numerados — balançam e o fio acompanha
       for (const spot of this.spots) {
-        const bob = Math.round(2 * Math.sin(clock * 2 + spot.n));
-        const cx = spot.x + spot.w / 2;
+        const bob = wave(clock, 2.1, 3, spot.n * 0.9);
+        const sway = wave(clock, 1.5, 2, spot.n);
+        const cx = spot.x + spot.w / 2 + sway;
         const cy = spot.y + 14 + bob;
         const color = [K.RED, K.YEL, K.GRN, K.BLU, K.PINK, K.ORANGE, K.CYAN, K.PUR, K.RED_L][spot.n - 1];
+        // Sombra do balão
+        pen.col(K.BLACK).ellipse(cx + 1, cy + 2, 11, 12);
         pen.col(K.BLACK).ellipse(cx, cy, 12, 14);
         pen.col(color).ellipse(cx, cy, 11, 13);
+        // Brilho + nó
         pen.col(K.WHITE).ellipse(cx - 4, cy - 5, 2, 3);
-        pen.col(K.CREAM).vline(cx, cy + 14, 14);
+        pen.col(K.BLACK).px(cx, cy + 13);
+        pen.col(color).px(cx, cy + 14);
+        // Fio
+        pen.col(K.CREAM);
+        pen.line(cx, cy + 15, spot.x + spot.w / 2, spot.y + 40);
+        // Badge do número (legível em qualquer cor de balão)
         const label = String(spot.n);
         const tw = F.measure(label, 2);
-        F.text(ctx, label, Math.round(cx - tw / 2), cy - 7, K.BLACK, { scale: 2 });
+        pen.col(K.CREAM).rect(Math.round(cx - tw / 2 - 2), cy - 8, tw + 4, 12);
+        pen.col(K.WHITE).hline(Math.round(cx - tw / 2 - 1), cy - 7, tw + 2);
+        F.text(ctx, label, Math.round(cx - tw / 2), cy - 7, K.RED, { scale: 2, shadow: K.SAND });
       }
     }
   },
@@ -242,16 +285,16 @@ const SCENES = {
       S.sheep = [];
       say(`O Ravi está sonhando. Vamos contar ${n} carneirinho${n > 1 ? 's' : ''}!`);
       const tl = new Timeline();
-      tl.add(1.6, () => {});
+      tl.add(2.2, () => {});
       addCount(tl, n, (i) => {
         S.sheep.push({ born: clock, i });
         Audio.sheep();
-      });
-      tl.add(0.9, () => {
+      }, 1.25);
+      tl.add(1.2, () => {
         Audio.magic();
         say('Bom dia! Já sei: vou fazer uma festa surpresa!');
       });
-      tl.add(3.2, null);
+      tl.add(4.0, null);
       tl.add(0.1, () => go(SCENES.wake));
       timeline = tl;
     },
@@ -259,14 +302,27 @@ const SCENES = {
       if (timeline) timeline.update(dt);
     },
     draw(ctx) {
-      blitFoot(ctx, SPR.ravi.sleep, 40, 160);
+      const pen = new Pen(ctx);
+      const snore = hop(clock, 1.5, 2);
+      blitFoot(ctx, SPR.ravi.sleep, 40, 160 + snore);
+      // Zzz
+      const zz = (clock * 1.4) % 2.5;
+      F.text(ctx, 'z', 58, 110 - Math.round(zz * 10), K.WHITE, { shadow: K.BLACK });
+
       for (const sh of S.sheep) {
         const age = clock - sh.born;
-        const x = -20 + age * 120;
-        if (x > W + 24) continue;
-        // Salto sobre a cerca
-        const jump = Math.max(0, Math.sin(Math.min(1, (x - 40) / 240) * Math.PI)) * 26;
-        blitFoot(ctx, SPR.misc.sheep, x, 140 - jump);
+        const x = -24 + age * 95;
+        if (x > W + 28) continue;
+        // Arco sobre a cerca + “squash” no pouso
+        const along = Math.min(1, Math.max(0, (x - 30) / 220));
+        const jump = Math.sin(along * Math.PI) * 30;
+        const squash = jump < 4 && along > 0.85 ? 1 : 0;
+        const foot = 142 - jump + squash;
+        blitFoot(ctx, SPR.misc.sheep, x, foot);
+        // Nuvenzinha de poeira ao pousar
+        if (squash) {
+          pen.col(K.GRAY_L).px(x - 6, foot).px(x + 6, foot).px(x, foot + 1);
+        }
       }
     }
   },
@@ -279,9 +335,9 @@ const SCENES = {
       const h = honoree();
       say(`A festa é para ${h.name}, ${h.title}!`);
       const tl = new Timeline();
-      tl.add(3.4, () => Audio.fanfare());
-      tl.add(0.2, () => say('Vamos à placa de caminhos escolher para onde ir!'));
-      tl.add(2.8, null);
+      tl.add(4.0, () => Audio.fanfare());
+      tl.add(0.3, () => say('Vamos à placa de caminhos escolher para onde ir!'));
+      tl.add(3.5, null);
       tl.add(0.1, () => go(SCENES.crossroads));
       timeline = tl;
     },
@@ -290,14 +346,26 @@ const SCENES = {
     },
     draw(ctx) {
       const pen = new Pen(ctx);
-      blitFoot(ctx, SPR.ravi.cheer, 110, 160);
-      // Balão de pensamento com o aniversariante
-      pen.col(K.BLACK).ellipse(224, 62, 47, 39);
-      pen.col(K.WHITE).ellipse(224, 62, 45, 37);
-      pen.col(K.BLACK).ellipse(180, 100, 6, 5).ellipse(168, 112, 4, 3);
+      const bounce = hop(clock, 3.2, 3);
+      blitFoot(ctx, SPR.ravi.cheer, 110, 160 - bounce);
+      // Balão de pensamento com moldura e pop suave
+      const pop = 0.9 + hop(clock, 2, 1) * 0.02;
+      const brx = Math.round(48 * pop);
+      const bry = Math.round(40 * pop);
+      pen.col(K.BLACK).ellipse(224, 62, brx + 2, bry + 2);
+      pen.col(K.NAVY).ellipse(224, 62, brx + 1, bry + 1);
+      pen.col(K.WHITE).ellipse(224, 62, brx - 1, bry - 1);
+      pen.col(K.CREAM).ellipse(224, 62, brx - 3, bry - 3);
+      // Rabicho
+      pen.col(K.BLACK).ellipse(180, 100, 7, 6).ellipse(168, 112, 5, 4);
       pen.col(K.WHITE).ellipse(180, 100, 5, 4).ellipse(168, 112, 3, 2);
       blitFoot(ctx, SPR.hero[honoree().id], 224, 88);
-      F.textCenter(ctx, honoree().name, 224, 32, K.RED_D);
+      // Plaquinha do nome
+      const name = honoree().name;
+      const tw = F.measure(name, 1);
+      pen.col(K.BLACK).rect(224 - (tw >> 1) - 4, 28, tw + 8, 12);
+      pen.bevel(224 - (tw >> 1) - 3, 29, tw + 6, 10, K.YEL, K.YEL_L, K.OCHRE);
+      F.textCenter(ctx, name, 224, 31, K.RED, { shadow: K.SAND });
     }
   },
 
@@ -328,8 +396,8 @@ const SCENES = {
     },
     draw(ctx) {
       Sc.drawSignpost(ctx, this.spots, S);
-      blitFoot(ctx, SPR.ravi.wave, 40, 160);
-      blitFoot(ctx, SPR.hero[honoree().id], 288, 160);
+      blitFoot(ctx, SPR.ravi.wave, 40, 160 - hop(clock, 2.8, 2));
+      blitFoot(ctx, SPR.hero[honoree().id], 288, 160 - hop(clock, 2.4, 2, 1));
     }
   },
 
@@ -358,25 +426,42 @@ const SCENES = {
     backdrop: 'street',
     spots: null,
     enter() {
+      this.beginTrip();
+    },
+    /** Como no Mickey's 123: dá para trocar o meio de transporte no caminho. */
+    beginTrip() {
       const v = S.vehicle;
-      S.travelX = -100;
+      S.travelX = -80;
+      this.rolling = false;
+      this.spots = Sc.travelSwapSpots();
       Audio.engine();
       say(v.wheels === 0
         ? 'A pé! Nenhuma roda. Zero!'
-        : `${v.name}! Vamos contar as rodas.`);
+        : `${v.name}! Vamos contar as ${v.wheels} roda${v.wheels > 1 ? 's' : ''}!`);
 
+      // Viagem bem pausada: a criança precisa ver o veículo e contar as rodas
+      const tripDur = 8.5 + Math.min(v.wheels, 9) * 0.35;
       const tl = new Timeline();
-      tl.add(1.4, null);
+      tl.add(2.0, null);
       if (v.wheels === 0) {
-        tl.add(1.0, () => { showFlash(0); Audio.countStep(0); });
-        tl.add(0.4, () => hideFlash());
+        tl.add(1.4, () => { showFlash(0); Audio.countStep(0); });
+        tl.add(0.9, () => hideFlash());
       } else {
-        addCount(tl, v.wheels, null);
+        addCount(tl, v.wheels, null, 1.25);
       }
-      tl.add(2.4, () => say('Lá vamos nós!'), (p) => {
-        S.travelX = -100 + (W + 160) * easeInOut(p);
+      // Para no meio da tela um instante para o veículo ficar bem visível
+      tl.add(0.4, () => {
+        this.rolling = true;
+        say('Lá vamos nós! Aperte outro número para trocar de veículo!');
       });
-      tl.add(0.1, () => {
+      tl.add(tripDur * 0.42, null, (p) => {
+        S.travelX = -80 + (W / 2 + 80) * easeInOut(p);
+      });
+      tl.add(1.6, null); // pausa no centro
+      tl.add(tripDur * 0.58, null, (p) => {
+        S.travelX = W / 2 + (W / 2 + 100) * easeInOut(p);
+      });
+      tl.add(0.2, () => {
         if (S.destination === 'factory') go(SCENES.factoryPick);
         else if (S.destination === 'market') go(SCENES.market);
         else go(SCENES.post);
@@ -386,23 +471,67 @@ const SCENES = {
     update(dt) {
       if (timeline) timeline.update(dt);
     },
+    input(n) {
+      if (n < 0 || n > 9) return;
+      if (S.vehicle && S.vehicle.id === VEHICLES[n].id) return;
+      Audio.click();
+      Audio.stopSpeech();
+      hideFlash();
+      S.vehicle = VEHICLES[n];
+      this.beginTrip();
+    },
     draw(ctx) {
       const v = S.vehicle;
-      const bob = Math.round(Math.sin(clock * 14));
+      const bob = this.rolling ? wave(clock, 9, 2) : 0;
+      const groundY = 158;
+      const pen = new Pen(ctx);
+
+      // Trilha / poeira quando rola
+      if (this.rolling && v.wheels > 0) {
+        const dust = ((clock * 14) | 0) % 5;
+        pen.col(K.GRAY);
+        for (let i = 0; i < 3; i++) {
+          pen.px(
+            Math.round(S.travelX - 18 - i * 6 - dust),
+            groundY - 2 - ((clock * 10 + i * 3) | 0) % 3
+          );
+        }
+      }
+
       if (v.wheels === 0) {
-        blitFoot(ctx, SPR.ravi[Math.floor(clock * 8) % 2 ? 'walk1' : 'walk0'], S.travelX, 160);
+        const pose = this.rolling
+          ? (Math.floor(clock * 4) % 2 ? 'walk1' : 'walk0')
+          : 'idle';
+        blitFoot(ctx, SPR.ravi[pose], S.travelX, groundY);
       } else {
         const sprite = SPR.vehicle[v.id];
-        blit(ctx, sprite, Math.round(S.travelX - sprite.w / 2), 160 - sprite.h + bob);
-        blitFoot(ctx, SPR.ravi.wave, S.travelX, 160 - sprite.h + 12 + bob);
+        const vx = Math.round(S.travelX - sprite.w / 2);
+        const vy = groundY - sprite.h + bob;
+        blit(ctx, sprite, vx, vy);
+        // “Rodas girando”: tracinhos no aro
+        if (this.rolling) {
+          const spin = ((clock * 16) | 0) % 4;
+          pen.col(K.YEL_L);
+          const wy = groundY - 3 + bob;
+          for (let i = 0; i < Math.min(v.wheels, 6); i++) {
+            const wx = vx + 6 + Math.round((i * (sprite.w - 12)) / Math.max(1, Math.min(v.wheels, 6) - 1));
+            if (spin === i % 4) pen.px(wx, wy);
+          }
+        }
+        blitFoot(ctx, SPR.ravi.wave, S.travelX - 4, vy + 10);
       }
       if (v.wheels > 0) {
-        const pen = new Pen(ctx);
-        pen.col(K.BLACK).rect(8, 8, 54, 26);
-        pen.bevel(9, 9, 52, 24, K.CREAM, K.WHITE, K.GRAY_D);
-        F.text(ctx, 'RODAS', 13, 12, K.GRAY_XD);
-        F.text(ctx, String(v.wheels), 42, 14, K.RED, { scale: 2 });
+        pen.col(K.BLACK).rect(7, 27, 56, 30);
+        pen.bevel(8, 28, 54, 28, K.NAVY, K.BLU, K.NIGHT);
+        pen.col(K.OCHRE).hline(10, 29, 50);
+        F.text(ctx, 'RODAS', 14, 32, K.CYAN, { shadow: K.BLACK });
+        // Badge do número
+        pen.col(K.BLACK).rect(28, 40, 22, 14);
+        pen.bevel(29, 41, 20, 12, K.YEL, K.YEL_L, K.OCHRE);
+        const tw = F.measure(String(v.wheels), 2);
+        F.text(ctx, String(v.wheels), Math.round(39 - tw / 2), 42, K.RED, { scale: 2, shadow: K.SAND });
       }
+      if (this.spots) Sc.drawTravelSwap(ctx, this.spots, v.wheels);
     }
   },
 
@@ -446,19 +575,19 @@ const SCENES = {
         timeline.update(dt);
         return;
       }
-      S.lumpX += dt * (14 + S.mold * 5);
+      S.lumpX += dt * (7 + S.mold * 3);
       if (S.lumpX >= 238 && !this.finishing) {
         this.finishing = true;
         const tl = new Timeline();
-        tl.add(0.5, () => Audio.stamp());
-        tl.add(0.9, () => {
+        tl.add(0.6, () => Audio.stamp());
+        tl.add(1.1, () => {
           S.presentDone = true;
           if (!S.made.includes(S.present.id)) S.made.push(S.present.id);
           Audio.success();
           showFlash(TOYS.findIndex((t) => t.id === S.present.id) + 1);
           say(`Pronto! Um ${S.present.name} lindo para a festa!`);
         });
-        tl.add(2.4, null);
+        tl.add(3.4, null);
         tl.add(0.1, () => go(SCENES.crossroads));
         timeline = tl;
       }
@@ -480,21 +609,24 @@ const SCENES = {
       const shift = Math.floor(clock * 26) % 12;
       for (let x = 55 - shift; x < 247; x += 12) pen.vline(Math.max(55, x), 105, 12);
 
-      // Prensa no fim da esteira
+      // Prensa — pistão sobe/desce; bate forte ao carimbar
       pen.col(K.BLACK).rect(248, 26, 60, 78);
       pen.bevel(249, 27, 58, 76, K.GRAY, K.GRAY_L, K.GRAY_D);
       pen.col(K.CYAN).rect(257, 36, 42, 20);
       pen.col(K.BLACK).ellipse(269, 46, 5, 5).ellipse(287, 46, 5, 5);
       pen.col(K.WHITE).ellipse(269, 46, 3, 3).ellipse(287, 46, 3, 3);
       pen.col(K.BLACK).ellipse(269, 47, 1, 2).ellipse(287, 47, 1, 2);
-      const press = this.finishing ? 26 : 12;  // o pistão desce ao carimbar
+      const press = this.finishing
+        ? 12 + hop(clock, 10, 14)
+        : 10 + hop(clock, 1.2, 2);
       pen.col(K.BLACK).rect(258, 62, 40, press);
       pen.col(K.GRAY_D).rect(259, 62, 38, press - 1);
 
       // Massa / brinquedo na esteira
       const lump = Math.round(S.lumpX);
+      const lumpBob = hop(clock, 8, 1);
       if (S.presentDone && this.finishing) {
-        blitMid(ctx, SPR.toy[S.present.id], lump, 96);
+        blitMid(ctx, SPR.toy[S.present.id], lump, 96 - lumpBob);
       } else {
         pen.col(K.BLACK).ellipse(lump, 96, 10, 8);
         pen.col(K.GRAY).ellipse(lump, 96, 9, 7);
@@ -503,12 +635,13 @@ const SCENES = {
           // A massa vai virando o brinquedo conforme os números são apertados
           ctx.save();
           ctx.globalAlpha = S.mold / 9;
-          blitMid(ctx, SPR.toy[S.present.id], lump, 96);
+          blitMid(ctx, SPR.toy[S.present.id], lump, 96 - lumpBob);
           ctx.restore();
         }
       }
 
-      blitFoot(ctx, SPR.ravi.idle, 26, 158);
+      const raviBob = hop(clock, 2.8, 2);
+      blitFoot(ctx, S.mold > 0 ? SPR.ravi.wave : SPR.ravi.idle, 26, 158 - raviBob);
       Sc.drawMachinePanel(ctx, this.spots, S.mold);
     }
   },
@@ -527,19 +660,19 @@ const SCENES = {
       if (S.marketIdx >= FOODS.length) {
         this.spots = null;
         const tl = new Timeline();
-        tl.add(0.2, () => {
+        tl.add(0.3, () => {
           S.marketDone = true;
           Audio.success();
           say('Compras feitas! De volta à placa.');
         });
-        tl.add(2.4, null);
+        tl.add(3.2, null);
         tl.add(0.1, () => go(SCENES.crossroads));
         timeline = tl;
         return;
       }
       this.spots = Sc.quantitySpots();
       const item = FOODS[S.marketIdx];
-      say(`Quantos ${item.name.toLowerCase()} vamos levar? Aperte de 1 a 9.`);
+      say(`${item.how || 'Quantos'} ${item.ask || item.name.toLowerCase()} vamos levar? Aperte de 1 a 9.`);
     },
     update(dt) {
       if (timeline) timeline.update(dt);
@@ -556,9 +689,9 @@ const SCENES = {
       this.spots = null;
 
       const tl = new Timeline();
-      tl.add(0.3, () => say(`${n} ${item.name.toLowerCase()}!`));
+      tl.add(0.5, () => say(`${n} ${item.ask || item.name.toLowerCase()}!`));
       addCount(tl, n, null);
-      tl.add(0.1, () => {
+      tl.add(0.25, () => {
         S.marketIdx++;
         timeline = null;
         this.ask();
@@ -566,29 +699,26 @@ const SCENES = {
       timeline = tl;
     },
     draw(ctx) {
-      blitFoot(ctx, SPR.ravi.idle, 40, 160);
+      // Ravi empurra o carrinho; as compras ficam DENTRO do cesto
+      const push = hop(clock, 3.5, 1);
+      blitFoot(ctx, SPR.ravi.idle, 28, 158 - push);
+      Sc.drawShoppingCart(ctx, S.cart, 88, 158 - push, clock);
 
       if (S.marketIdx < FOODS.length) {
         const item = FOODS[S.marketIdx];
         const pen = new Pen(ctx);
-        // Vitrine com o produto da vez
-        pen.col(K.BLACK).rect(98, 26, 96, 76);
-        pen.bevel(99, 27, 94, 74, K.CREAM, K.WHITE, K.GRAY_D);
+        const pulse = hop(clock, 2.4, 2);
+        // Vitrine com moldura de madeira + vidro
+        pen.col(K.BLACK).rect(128, 16 - pulse, 76, 74);
+        pen.bevel(129, 17 - pulse, 74, 72, K.WOOD_D, K.OCHRE, K.GRAY_XD);
+        pen.col(K.CREAM).rect(133, 21 - pulse, 66, 48);
+        pen.col(K.WHITE).hline(134, 22 - pulse, 20);
+        pen.col(K.CYAN).rect(135, 23 - pulse, 62, 44);
         const sprite = SPR.food[item.id];
-        ctx.drawImage(sprite.canvas, 125, 34, sprite.w * 3, sprite.h * 3);
-        F.textCenter(ctx, item.name, 146, 88, K.GRAY_XD);
+        ctx.drawImage(sprite.canvas, 148, 28 - pulse, sprite.w * 3, sprite.h * 3);
+        pen.col(K.NAVY).rect(133, 70 - pulse, 66, 14);
+        F.textCenter(ctx, item.name, 166, 73 - pulse, K.YEL_L, { shadow: K.BLACK });
         if (this.spots) Sc.drawQuantityBoard(ctx, this.spots, 'QUANTOS?');
-      }
-
-      // Carrinho de compras já preenchido
-      let slot = 0;
-      for (const food of FOODS) {
-        const qty = S.cart[food.id] || 0;
-        for (let i = 0; i < qty && slot < 18; i++, slot++) {
-          const col = slot % 9;
-          const row = (slot / 9) | 0;
-          blitMid(ctx, SPR.food[food.id], 74 + col * 17, 128 + row * 18);
-        }
       }
     }
   },
@@ -648,10 +778,10 @@ const SCENES = {
       const hero = HEROES[idx];
       say(`Convite para ${hero.name}! O carteiro já está a caminho.`);
       const tl = new Timeline();
-      tl.add(0.4, () => { showFlash(idx + 1); Audio.note(idx); });
-      tl.add(2.6, null, (p) => { S.mailmanX = -40 + (W + 80) * easeOut(p); });
-      tl.add(0.2, () => { hideFlash(); Audio.pop(); });
-      tl.add(0.1, () => go(SCENES.post));
+      tl.add(0.5, () => { showFlash(idx + 1); Audio.note(idx); });
+      tl.add(3.2, null, (p) => { S.mailmanX = -40 + (W + 80) * easeOut(p); });
+      tl.add(0.35, () => { hideFlash(); Audio.pop(); });
+      tl.add(0.15, () => go(SCENES.post));
       timeline = tl;
     },
     update(dt) {
@@ -659,8 +789,10 @@ const SCENES = {
     },
     draw(ctx) {
       Sc.drawMailboxes(ctx, this.boxes, S);
-      blitFoot(ctx, SPR.misc.mailman, S.mailmanX, 164);
-      blit(ctx, SPR.misc.envelope, Math.round(S.mailmanX + 14), 118);
+      const bob = hop(clock, 11, 2);
+      const sway = wave(clock, 14, 1);
+      blitFoot(ctx, SPR.misc.mailman, S.mailmanX + sway, 164 - bob);
+      blit(ctx, SPR.misc.envelope, Math.round(S.mailmanX + 14 + sway), 118 - bob - hop(clock, 7, 1));
     }
   },
 
@@ -677,14 +809,14 @@ const SCENES = {
       say('Hora da festa! Vamos guardar a comida.');
 
       const tl = new Timeline();
-      tl.add(2.6, () => { S.fridgeFull = true; });
-      tl.add(0.2, () => say('Agora a faixa: SURPRESA!'));
-      tl.add(2.2, () => { S.bannerUp = true; });
+      tl.add(3.2, () => { S.fridgeFull = true; });
+      tl.add(0.3, () => say('Agora a faixa: SURPRESA!'));
+      tl.add(2.8, () => { S.bannerUp = true; });
       const balloons = Math.max(1, S.balloons);
-      tl.add(0.2, () => say(`Vamos pendurar ${balloons} balão${balloons > 1 ? 'ões' : ''}!`));
-      addCount(tl, balloons, (i) => { S.balloonsHung = i; });
-      tl.add(0.2, () => say('Shh... os convidados estão chegando!'));
-      tl.add(2.0, null);
+      tl.add(0.3, () => say(`Vamos pendurar ${balloons} balão${balloons > 1 ? 'ões' : ''}!`));
+      addCount(tl, balloons, (i) => { S.balloonsHung = i; }, 1.2);
+      tl.add(0.3, () => say('Shh... os convidados estão chegando!'));
+      tl.add(2.6, null);
       tl.add(0.1, () => go(SCENES.partyArrive));
       timeline = tl;
     },
@@ -694,7 +826,7 @@ const SCENES = {
     draw(ctx) {
       drawPartyBack(ctx);
       drawPartyFront(ctx);
-      blitFoot(ctx, SPR.ravi.wave, 46, 160);
+      blitFoot(ctx, SPR.ravi.wave, 46, 160 - hop(clock, 3.2, 2));
     }
   },
 
@@ -707,14 +839,14 @@ const SCENES = {
       S.guestX = layoutGuests(S.invited.length + 1);
       const tl = new Timeline();
       for (let i = 0; i < S.invited.length; i++) {
-        tl.add(0.55, () => { S.guestsIn = i + 1; Audio.pop(); });
+        tl.add(0.85, () => { S.guestsIn = i + 1; Audio.pop(); });
       }
-      tl.add(0.6, () => { S.guestsIn = S.invited.length + 1; Audio.click(); });
-      tl.add(0.3, () => {
+      tl.add(0.9, () => { S.guestsIn = S.invited.length + 1; Audio.click(); });
+      tl.add(0.4, () => {
         Audio.fanfare();
         say(`SURPRESA, ${honoree().name}!`);
       });
-      tl.add(3.4, null);
+      tl.add(4.2, null);
       tl.add(0.1, () => {
         if (boughtFoods().length === 0 || S.invited.length === 0) go(SCENES.partyEnd);
         else go(SCENES.partyServe);
@@ -728,12 +860,9 @@ const SCENES = {
       drawPartyBack(ctx);
       drawGuests(ctx);
       drawPartyFront(ctx);
-      blitFoot(ctx, SPR.ravi.cheer, 46, 160);
+      blitFoot(ctx, SPR.ravi.cheer, 46, 160 - hop(clock, 5.5, 4));
       if (S.guestsIn > S.invited.length) {
         Sc.drawConfetti(ctx, S.confetti, clock);
-        if (Math.floor(clock * 3) % 2 === 0) {
-          F.textCenter(ctx, 'SURPRESA!', 160, 74, K.YEL_L, { scale: 2, shadow: K.RED_D });
-        }
       }
     }
   },
@@ -743,7 +872,12 @@ const SCENES = {
     backdrop: 'party',
     spots: null,
     enter() {
+      // Mickey 123: cada convidado recebe CADA comida comprada
       S.serveIdx = 0;
+      S.servePlacing = 0;
+      S.serveHero = -1;
+      S.serveFoodId = null;
+      S.served = {};
       S.guestsIn = S.invited.length + 1;
       S.guestX = layoutGuests(S.invited.length + 1);
       this.spots = Sc.plateSpots();
@@ -751,18 +885,40 @@ const SCENES = {
     },
     ask() {
       const menu = boughtFoods();
-      if (S.serveIdx >= S.invited.length || menu.length === 0) {
+      const roster = partyRoster();
+      if (menu.length === 0 || roster.length === 0) {
         this.spots = null;
         const tl = new Timeline();
         tl.add(0.1, () => go(SCENES.partyEnd));
         timeline = tl;
         return;
       }
-      const hero = HEROES[S.invited[S.serveIdx]];
-      const food = menu[S.serveIdx % menu.length];
+      // Índice plano: convidado × comida (como no original)
+      const total = roster.length * menu.length;
+      if (S.serveIdx >= total) {
+        this.spots = null;
+        S.servePlacing = 0;
+        S.serveHero = -1;
+        S.serveFoodId = null;
+        const tl = new Timeline();
+        tl.add(0.8, () => say('Todo mundo servido! Que delícia!'));
+        tl.add(2.4, null);
+        tl.add(0.1, () => go(SCENES.partyEnd));
+        timeline = tl;
+        return;
+      }
+      const gi = (S.serveIdx / menu.length) | 0;
+      const fi = S.serveIdx % menu.length;
+      const heroIdx = roster[gi];
+      const hero = HEROES[heroIdx];
+      const food = menu[fi];
       this.food = food;
+      S.serveHero = heroIdx;
+      S.serveFoodId = food.id;
+      S.servePlacing = 0;
       this.spots = Sc.plateSpots();
-      say(`Quantos ${food.name.toLowerCase()} para ${hero.name}? Aperte de 1 a 9.`);
+      const how = food.how || 'Quantos';
+      say(`${how} ${food.ask || food.name.toLowerCase()} para ${hero.name}? Aperte de 1 a 9.`);
     },
     update(dt) {
       if (timeline) timeline.update(dt);
@@ -773,12 +929,25 @@ const SCENES = {
         Audio.bonk();
         return;
       }
-      const hero = HEROES[S.invited[S.serveIdx]];
+      const menu = boughtFoods();
+      const roster = partyRoster();
+      const gi = (S.serveIdx / menu.length) | 0;
+      const fi = S.serveIdx % menu.length;
+      const heroIdx = roster[gi];
+      const hero = HEROES[heroIdx];
+      const food = menu[fi];
       this.spots = null;
+
       const tl = new Timeline();
-      addCount(tl, n, null);
-      tl.add(0.9, () => say(`${n} para ${hero.name}!`));
-      tl.add(0.1, () => {
+      // Contagem um pouco mais ágil na festa (várias rodadas guest×comida)
+      addCount(tl, n, (i) => { S.servePlacing = i; }, 0.95);
+      tl.add(0.9, () => {
+        if (!S.served[heroIdx]) S.served[heroIdx] = {};
+        S.served[heroIdx][food.id] = n;
+        S.servePlacing = 0;
+        say(`${n} ${food.ask || food.name.toLowerCase()} para ${hero.name}!`);
+      });
+      tl.add(1.35, () => {
         S.serveIdx++;
         timeline = null;
         this.ask();
@@ -788,8 +957,9 @@ const SCENES = {
     draw(ctx) {
       drawPartyBack(ctx);
       drawGuests(ctx);
+      drawGuestMeals(ctx);
       drawPartyFront(ctx);
-      blitFoot(ctx, SPR.ravi.wave, 22, 158);
+      blitFoot(ctx, SPR.ravi.wave, 22, 158 - hop(clock, 3.6, 2));
       if (this.spots) Sc.drawPlates(ctx, this.spots, this.food);
     }
   },
@@ -803,12 +973,12 @@ const SCENES = {
       Audio.party();
       say('Que festa incrível! Os heróis dançam até a porta.');
       const tl = new Timeline();
-      tl.add(3.6, null, (p) => { this.leave = p; });
-      tl.add(0.2, () => {
+      tl.add(4.5, null, (p) => { this.leave = p; });
+      tl.add(0.3, () => {
         Audio.success();
         say('Obrigado por ajudar! Aperte um número para outra festa.');
       });
-      tl.add(1.2, null);
+      tl.add(2.0, null);
       tl.add(0.1, () => {
         this.done = true;
         // A tela inteira vira alvo de toque para recomeçar
@@ -828,14 +998,21 @@ const SCENES = {
     draw(ctx) {
       drawPartyBack(ctx);
       drawGuests(ctx, Math.round(this.leave * 210));
+      drawGuestMeals(ctx, Math.round(this.leave * 210));
       drawPartyFront(ctx);
-      blitFoot(ctx, SPR.ravi.cheer, 46, 160);
+      blitFoot(ctx, SPR.ravi.cheer, 46, 160 - hop(clock, 5.2, 3));
       Sc.drawConfetti(ctx, S.confetti, clock);
 
       if (this.done) {
         const pen = new Pen(ctx);
-        pen.col(K.BLACK).rect(48, 50, 224, 62);
-        pen.bevel(50, 52, 220, 58, K.NAVY, K.BLU, K.NIGHT);
+        pen.col(K.BLACK).rect(46, 48, 228, 66);
+        pen.bevel(48, 50, 224, 62, K.NAVY, K.BLU, K.NIGHT);
+        pen.col(K.OCHRE).frame(50, 52, 220, 58);
+        pen.col(K.YEL).frame(51, 53, 218, 56);
+        // Estrelas
+        for (const sx of [58, 258]) {
+          pen.col(K.YEL_L).px(sx, 58).px(sx - 1, 59).px(sx, 59).px(sx + 1, 59).px(sx, 60);
+        }
         F.textCenter(ctx, 'FESTA ENCERRADA!', 160, 62, K.YEL_L, { scale: 2, shadow: K.RED_D });
         if (Math.floor(clock * 1.5) % 2 === 0) {
           F.textCenter(ctx, 'APERTE UM NÚMERO PARA RECOMEÇAR', 160, 92, K.WHITE, { shadow: K.BLACK });
@@ -849,15 +1026,15 @@ const SCENES = {
    Desenho compartilhado da sala de festa
    -------------------------------------------------------------------------- */
 
-/* Os convidados ficam ATRÁS da mesa: pés na linha do tampo, para o corpo
-   aparecer inteiro e os pés sumirem por trás do móvel. Por isso a sala é
-   desenhada em duas camadas, com os heróis no meio. */
-const GUEST_FOOT_Y = 118;
+/* Convidados na FRENTE da mesa do cenário, bem grandes — antes ficavam
+   miudinhos atrás do tampo da foto e quase sumiam. */
+const GUEST_FOOT_Y = 142;
+const GUEST_SCALE = 1.75;
 
 function layoutGuests(count) {
   const xs = [];
-  const spread = Math.min(34, 292 / Math.max(count, 1));
-  const start = 160 - ((count - 1) * spread) / 2;
+  const spread = Math.min(48, 260 / Math.max(count, 1));
+  const start = 168 - ((count - 1) * spread) / 2;
   for (let i = 0; i < count; i++) xs.push(Math.round(start + i * spread));
   return xs;
 }
@@ -866,41 +1043,160 @@ function layoutGuests(count) {
 function drawPartyBack(ctx) {
   const pen = new Pen(ctx);
 
-  // Geladeira
-  pen.col(K.BLACK).rect(8, 60, 34, 68);
-  pen.col(K.WHITE).rect(9, 61, 32, 66);
-  pen.col(K.GRAY_L).hline(9, 94, 32);
-  pen.col(K.GRAY_D).rect(36, 70, 3, 16).rect(36, 100, 3, 16);
+  // Geladeira com as compras visíveis
+  pen.col(K.BLACK).rect(7, 58, 36, 72);
+  pen.bevel(8, 59, 34, 70, K.WHITE, K.GRAY_L, K.GRAY);
+  pen.col(K.GRAY_L).hline(10, 92, 28);
+  pen.col(K.CYAN).rect(12, 64, 20, 22); // vidro freezer
+  pen.col(K.WHITE).hline(13, 65, 8);
+  pen.col(K.GRAY_D).rect(37, 70, 3, 14).rect(37, 104, 3, 14);
   if (S.fridgeFull) {
-    pen.col(K.RED).rect(14, 66, 6, 6);
-    pen.col(K.GRN).rect(24, 66, 6, 6);
-    pen.col(K.YEL).rect(19, 76, 6, 6);
+    const foods = boughtFoods();
+    let slot = 0;
+    for (const food of foods) {
+      const col = slot % 2;
+      const row = (slot / 2) | 0;
+      blitMid(ctx, SPR.food[food.id], 16 + col * 12, 98 + row * 10);
+      slot++;
+    }
+    if (foods.length === 0) {
+      pen.col(K.RED).rect(14, 98, 5, 5);
+      pen.col(K.GRN).rect(22, 98, 5, 5);
+    }
   }
 
-  // Faixa SURPRESA
+  // Faixa SURPRESA — cordas + serrilha
   if (S.bannerUp) {
-    pen.col(K.BLACK).rect(96, 14, 128, 22);
-    pen.bevel(97, 15, 126, 20, K.YEL, K.YEL_L, K.OCHRE);
-    F.textCenter(ctx, 'SURPRESA!', 160, 21, K.RED, { shadow: K.SAND });
+    const pulse = S.guestsIn > S.invited.length && Math.floor(clock * 2) % 2 === 0;
+    const bw = pulse ? 168 : 136;
+    const bh = pulse ? 26 : 20;
+    const bx = Math.round((W - bw) / 2);
+    // Cordas
+    pen.col(K.CREAM).line(bx - 8, 2, bx, 8).line(bx + bw, 8, bx + bw + 8, 2);
+    pen.col(K.BLACK).rect(bx - 2, 4, bw + 4, bh + 4);
+    pen.bevel(bx, 6, bw, bh, pulse ? K.YEL_L : K.YEL, K.WHITE, K.OCHRE);
+    // Serrilha inferior
+    for (let i = 0; i < bw; i += 6) {
+      pen.col(K.OCHRE).px(bx + i + 2, 6 + bh);
+      pen.col(K.YEL).px(bx + i + 3, 6 + bh);
+    }
+    F.textCenter(ctx, 'SURPRESA!', 160, pulse ? 10 : 11, K.RED, {
+      scale: pulse ? 2 : 1,
+      shadow: K.SAND
+    });
   }
 
+  // Balões nas laterais, sem atravessar a faixa nem as cabeças
   Sc.drawBalloons(ctx, S.balloonsHung, clock);
 }
 
-/** Camada da frente: o que está apoiado sobre a mesa, na frente dos heróis. */
+/** Bolo e presente nas laterais — não cobrem o meio onde estão os convidados. */
 function drawPartyFront(ctx) {
-  blitFoot(ctx, SPR.misc.cake, 62, 125);
-  if (S.presentDone && S.present) blitFoot(ctx, SPR.misc.gift, 262, 125);
+  const cakeBob = hop(clock, 2.4, 2);
+  blitFoot(ctx, SPR.misc.cake, 48, 128 - cakeBob);
+  if (S.presentDone && S.present) {
+    const giftBob = hop(clock, 2.1, 2, 1);
+    blitFoot(ctx, SPR.misc.gift, 278, 128 - giftBob);
+  }
 }
 
-function drawGuests(ctx, offsetX = 0) {
+/** Pratos do buffet na frente de cada convidado — todas as comidas ficam visíveis. */
+function drawGuestMeals(ctx, offsetX = 0) {
+  const pen = new Pen(ctx);
+  const menu = boughtFoods();
   for (let i = 0; i < S.guestsIn && i < S.guestX.length; i++) {
     const isHonoree = i >= S.invited.length;
     const hi = isHonoree ? S.honoree : S.invited[i];
-    const dance = isHonoree && S.guestsIn > S.invited.length
-      ? Math.round(3 * Math.sin(clock * 7 + i))
-      : 0;
-    blitFoot(ctx, SPR.hero[HEROES[hi].id], S.guestX[i] + offsetX, GUEST_FOOT_Y + dance);
+    const x = S.guestX[i] + offsetX;
+    const plateY = GUEST_FOOT_Y - 2;
+    const active = S.serveHero === hi;
+
+    // Pratinho
+    pen.col(K.BLACK).ellipse(x + 1, plateY + 1, 15, 5);
+    pen.col(active ? K.YEL_L : K.GRAY_L).ellipse(x, plateY, 14, 4);
+    pen.col(K.CREAM).ellipse(x, plateY, 11, 3);
+    if (active) {
+      // Marcador “é a vez deste herói”
+      pen.col(K.RED).px(x, plateY - 10).px(x - 1, plateY - 9).px(x + 1, plateY - 9);
+    }
+
+    const bag = S.served[hi] || {};
+    let slot = 0;
+    for (const food of menu) {
+      let qty = bag[food.id] || 0;
+      // Contagem ao vivo do item atual
+      if (hi === S.serveHero && food.id === S.serveFoodId && S.servePlacing > 0) {
+        qty = S.servePlacing;
+      }
+      if (qty <= 0) continue;
+      const fx = x - 10 + (slot % 3) * 8;
+      const fy = plateY - 1 - ((slot / 3) | 0) * 8;
+      blitMid(ctx, SPR.food[food.id], fx, fy);
+      if (qty > 1) {
+        F.text(ctx, String(qty), fx + 3, fy - 7, K.RED, { shadow: K.WHITE });
+      }
+      slot++;
+    }
+  }
+}
+
+/** Desenha sprite apoiado pelos pés, com escala (convidados maiores na festa). */
+function blitFootScaled(ctx, sprite, x, y, scale) {
+  if (!sprite) return;
+  const w = Math.round(sprite.w * scale);
+  const h = Math.round(sprite.h * scale);
+  ctx.drawImage(sprite.canvas, (x - (w >> 1)) | 0, (y - h) | 0, w, h);
+}
+
+function drawGuests(ctx, offsetX = 0) {
+  const pen = new Pen(ctx);
+  for (let i = 0; i < S.guestsIn && i < S.guestX.length; i++) {
+    const isHonoree = i >= S.invited.length;
+    const hi = isHonoree ? S.honoree : S.invited[i];
+    const hero = HEROES[hi];
+    const sprite = SPR.hero[hero.id];
+    const phase = i * 1.7;
+    const dancing = S.guestsIn > S.invited.length;
+    // Dança: salto + balanço lateral, defasada por convidado
+    const danceY = dancing
+      ? hop(clock, isHonoree ? 6.5 : 5.2, isHonoree ? 6 : 4, phase)
+      : hop(clock, 2.2, 1, phase);
+    const sway = dancing ? wave(clock, 3.4, 3, phase) : 0;
+    const x = S.guestX[i] + offsetX + sway;
+    const footY = GUEST_FOOT_Y + danceY;
+    const h = Math.round((sprite?.h || 56) * GUEST_SCALE);
+
+    // Sombra que encolhe no salto
+    const shadowW = Math.max(6, Math.round(16 * GUEST_SCALE / 1.5) - (danceY >> 1));
+    pen.col(K.BLACK).ellipse(x, GUEST_FOOT_Y + 1, shadowW, 3);
+
+    blitFootScaled(ctx, sprite, x, footY, GUEST_SCALE);
+
+    // Plaquinha com o nome ACIMA da cabeça (apontando pra baixo)
+    const serving = S.serveHero === hi;
+    const tagY = Math.max(4, footY - h - 12);
+    const label = hero.short;
+    const tw = F.measure(label, 1);
+    const tagW = tw + 8;
+    const tagX = x - (tagW >> 1);
+    pen.col(K.BLACK).rect(tagX - 1, tagY - 1, tagW + 2, 12);
+    pen.bevel(tagX, tagY, tagW, 10,
+      serving || isHonoree ? K.YEL : K.NAVY,
+      serving || isHonoree ? K.YEL_L : K.BLU,
+      serving || isHonoree ? K.OCHRE : K.NIGHT);
+    // Setinha
+    pen.col(serving || isHonoree ? K.YEL : K.NAVY).px(x - 1, tagY + 10).px(x, tagY + 11).px(x + 1, tagY + 10);
+    F.text(ctx, label, x - (tw >> 1), tagY + 2,
+      serving || isHonoree ? K.RED : K.YEL_L,
+      { shadow: K.BLACK });
+
+    if (isHonoree && dancing) {
+      const crownY = footY - h + 2;
+      const twinkle = hop(clock, 8, 1);
+      pen.col(K.BLACK).rect(x - 8, crownY - 2 - twinkle, 16, 6);
+      pen.col(K.YEL).rect(x - 7, crownY - 1 - twinkle, 14, 4);
+      pen.col(K.YEL_L).px(x - 7, crownY - 3 - twinkle).px(x, crownY - 4 - twinkle).px(x + 7, crownY - 3 - twinkle);
+    }
   }
 }
 
@@ -948,7 +1244,7 @@ export function handleNumber(n) {
 export function update(dt) {
   clock += dt;
   if (S.flash !== null && S.flashPop < 1) {
-    S.flashPop = Math.min(1, S.flashPop + dt * 7);
+    S.flashPop = Math.min(1, S.flashPop + dt * 5);
   }
   if (scene && scene.update) scene.update(dt);
 }

--- a/labs/ravi-123/index.html
+++ b/labs/ravi-123/index.html
@@ -18,7 +18,7 @@
     content="Conte de 1 a 9 e ajude o Ravi a convidar heróis para a maior festa surpresa do reino. Pixel art 320×200, tudo em vanilla.">
   <meta property="og:locale" content="pt_BR">
 
-  <link rel="stylesheet" href="style.css?v=6">
+  <link rel="stylesheet" href="style.css?v=18">
 </head>
 
 <body>
@@ -46,7 +46,7 @@
     </p>
   </noscript>
 
-  <script type="module" src="main.js?v=6"></script>
+  <script type="module" src="main.js?v=18"></script>
 </body>
 
 </html>

--- a/labs/ravi-123/scenes.js
+++ b/labs/ravi-123/scenes.js
@@ -10,12 +10,55 @@
 import { W, H, makeSurface } from './screen.js';
 import { K, Pen, blit, blitMid, IMG } from './assets.js';
 import * as F from './font.js';
-import { SPR, TOYS, VEHICLES, HEROES } from './sprites.js';
+import { SPR, TOYS, VEHICLES, HEROES, FOODS } from './sprites.js';
+import { bounceOut, wave, hop, wrap } from './anim.js';
 
 export const STAGE_H = 166;  // altura da área de jogo (o resto é a barra de fala)
 
 /** Cache de cenários já assados. */
 const baked = new Map();
+
+/* --------------------------------------------------------------------------
+   Peças de UI diegética (pixel) — tudo reutiliza a mesma “ferragem”
+   -------------------------------------------------------------------------- */
+
+/** Sombra + chanfro elevado. */
+function raised(pen, x, y, w, h, face, light, dark) {
+  pen.col(K.BLACK).rect(x + 1, y + 1, w, h);
+  pen.bevel(x, y, w, h, face, light, dark);
+  // Brilho interno de 1px no topo
+  pen.col(light).hline(x + 2, y + 2, Math.max(0, w - 4));
+}
+
+/** Chanfro afundado (tecla / poço). */
+function sunk(pen, x, y, w, h, face, light, dark) {
+  pen.col(K.BLACK).rect(x, y, w, h);
+  pen.inset(x + 1, y + 1, w - 2, h - 2, face, light, dark);
+}
+
+/** Rebite metálico. */
+function rivet(pen, x, y) {
+  pen.col(K.BLACK).px(x, y).px(x + 1, y).px(x, y + 1);
+  pen.col(K.GRAY_L).px(x, y);
+  pen.col(K.GRAY).px(x + 1, y).px(x, y + 1);
+}
+
+/** Estrelinha de 5 px — ornamento de título/flashcard. */
+function spark(pen, x, y, c = K.YEL_L) {
+  pen.col(c).px(x, y - 1).px(x - 1, y).px(x, y).px(x + 1, y).px(x, y + 1);
+}
+
+/** Badge numérico com fundo creme (contraste em madeira/azul). */
+function numBadge(ctx, pen, n, cx, cy, scale = 2, fg = K.RED, face = K.CREAM) {
+  const label = String(n);
+  const tw = F.measure(label, scale);
+  const bw = tw + 6;
+  const bh = 7 * scale + 2;
+  const bx = Math.round(cx - bw / 2);
+  const by = Math.round(cy - bh / 2);
+  raised(pen, bx, by, bw, bh, face, face === K.CREAM ? K.WHITE : K.YEL_L, face === K.CREAM ? K.GRAY_D : K.RED_D);
+  F.text(ctx, label, Math.round(cx - tw / 2), by + 2, fg, { scale, shadow: face === K.CREAM ? K.SAND : K.RED_D });
+}
 
 /**
  * Devolve o canvas do cenário, assando na primeira vez que for pedido.
@@ -56,48 +99,71 @@ export function backdrop(id) {
    Chrome: barra de fala e flashcard
    -------------------------------------------------------------------------- */
 
-/** Barra de narração no rodapé, no lugar do balão de vidro antigo. */
+/** Barra de narração no rodapé — cromada, com filete dourado e ícone. */
 export function speechBar(ctx, message) {
   const pen = new Pen(ctx);
   const y = STAGE_H;
   const h = H - STAGE_H;
+
+  // Base preta + face navy com chanfro
   pen.col(K.BLACK).rect(0, y, W, h);
-  pen.col(K.NAVY).rect(1, y + 1, W - 2, h - 2);
-  pen.col(K.BLU).hline(1, y + 1, W - 2).vline(1, y + 1, h - 2);
-  pen.col(K.NIGHT).hline(1, H - 2, W - 2).vline(W - 2, y + 1, h - 2);
+  pen.bevel(1, y + 1, W - 2, h - 2, K.NAVY, K.BLU, K.NIGHT);
+  // Filete dourado no topo (como moldura de CRT educativo)
+  pen.col(K.OCHRE).hline(2, y + 1, W - 4);
+  pen.col(K.YEL).hline(2, y + 2, W - 4);
+  pen.col(K.NIGHT).hline(2, H - 2, W - 4);
+
+  // Ícone de fala (boquinha) à esquerda
+  pen.col(K.YEL_L).ellipse(12, y + (h >> 1), 5, 4);
+  pen.col(K.NAVY).ellipse(12, y + (h >> 1), 3, 2);
+  pen.col(K.YEL).px(17, y + (h >> 1) - 1).px(18, y + (h >> 1)).px(17, y + (h >> 1) + 1);
 
   if (!message) return;
-  const lines = F.wrap(message, W - 16);
-  const startY = y + (h - (lines.length * F.LINE - 2)) / 2;
+  const lines = F.wrap(message, W - 36);
+  const startY = y + (h - (lines.length * F.LINE - 2)) / 2 + 1;
   for (let i = 0; i < lines.length; i++) {
-    F.textCenter(ctx, lines[i], W / 2, Math.round(startY + i * F.LINE), K.YEL_L, { shadow: K.BLACK });
+    F.textCenter(ctx, lines[i], W / 2 + 4, Math.round(startY + i * F.LINE), K.YEL_L, { shadow: K.BLACK });
   }
 }
 
 /**
- * Flashcard do numeral — o elemento de ensino do jogo original.
- * `pop` (0..1) é usado para a animação de entrada.
+ * Flashcard do numeral — cartão de ensino com moldura vermelha e brilho.
+ * `pop` (0..1) anima a entrada com bounce.
  */
 export function flashcard(ctx, n, pop = 1) {
   if (n === null || n === undefined) return;
   const pen = new Pen(ctx);
   const scale = 3;
-  const w = 44;
-  const h = 58;
-  const grow = Math.min(1, Math.max(0, pop));
-  const cw = Math.round(w * (0.6 + grow * 0.4));
-  const chh = Math.round(h * (0.6 + grow * 0.4));
+  const w = 52;
+  const h = 66;
+  const grow = bounceOut(Math.min(1, Math.max(0, pop)));
+  const cw = Math.round(w * (0.55 + grow * 0.45));
+  const chh = Math.round(h * (0.55 + grow * 0.45));
   const x = Math.round((W - cw) / 2);
-  const y = Math.round(26 - (chh - h) / 2);
+  const y = Math.round(18 - (chh - h) / 2 - (1 - grow) * 12);
 
+  // Sombra elíptica
+  pen.col(K.BLACK).ellipse(W / 2, y + chh + 5, Math.round(cw * 0.38), 4);
+  // Cartão
   pen.col(K.BLACK).rect(x + 3, y + 3, cw, chh);
   pen.bevel(x, y, cw, chh, K.CREAM, K.WHITE, K.GRAY);
-  pen.col(K.RED).frame(x + 3, y + 3, cw - 6, chh - 6);
+  pen.col(K.WHITE).hline(x + 3, y + 3, Math.max(0, cw - 6));
+  // Moldura dupla vermelha
+  pen.col(K.RED_D).frame(x + 3, y + 3, cw - 6, chh - 6);
+  pen.col(K.RED).frame(x + 4, y + 4, cw - 8, chh - 8);
+  pen.col(K.RED_L).frame(x + 5, y + 5, cw - 10, chh - 10);
+  // Cantos decorativos
+  if (grow > 0.4) {
+    spark(pen, x + 8, y + 10, K.YEL);
+    spark(pen, x + cw - 9, y + 10, K.YEL);
+    spark(pen, x + 8, y + chh - 10, K.ORANGE);
+    spark(pen, x + cw - 9, y + chh - 10, K.ORANGE);
+  }
 
-  if (grow > 0.7) {
+  if (grow > 0.55) {
     const label = String(n);
     const tw = F.measure(label, scale);
-    F.text(ctx, label, Math.round(x + (cw - tw) / 2), y + 13, K.RED, { scale, shadow: K.RED_D });
+    F.text(ctx, label, Math.round(x + (cw - tw) / 2), y + 16, K.RED, { scale, shadow: K.RED_D });
   }
 }
 
@@ -111,8 +177,9 @@ function cell(ctx, spot, opts = {}) {
   const { x, y, w, h } = spot;
   const disabled = opts.done || opts.locked;
 
-  pen.col(K.BLACK).rect(x, y, w, h);
-  pen.bevel(x + 1, y + 1, w - 2, h - 2, disabled ? K.GRAY : K.CREAM, K.WHITE, K.GRAY_D);
+  sunk(pen, x, y, w, h, disabled ? K.GRAY : K.CREAM, K.WHITE, K.GRAY_D);
+  // Filete interno creme
+  if (!disabled) pen.col(K.WHITE).hline(x + 3, y + 2, w - 6);
 
   if (opts.icon) blitMid(ctx, opts.icon, x + 13, y + h / 2);
   else if (opts.label) F.text(ctx, opts.label, x + 4, y + (h - 7) / 2, K.GRAY_XD);
@@ -120,10 +187,15 @@ function cell(ctx, spot, opts = {}) {
   const numColor = opts.locked ? K.GRAY_D : opts.done ? K.GRN_D : K.RED;
   const label = String(spot.n);
   const tw = F.measure(label, 2);
-  F.text(ctx, label, Math.round(x + w - tw - 8), Math.round(y + (h - 14) / 2), numColor, { scale: 2 });
+  F.text(ctx, label, Math.round(x + w - tw - 6), Math.round(y + (h - 14) / 2), numColor, {
+    scale: 2,
+    shadow: K.SAND
+  });
 
   if (opts.done) {
-    pen.col(K.GRN_L).line(x + 5, y + h / 2, x + 9, y + h - 4).line(x + 9, y + h - 4, x + 19, y + 3);
+    pen.col(K.BLACK).rect(x + 4, y + 3, 14, 12);
+    pen.col(K.GRN).rect(x + 5, y + 4, 12, 10);
+    pen.col(K.GRN_L).line(x + 7, y + 9, x + 10, y + 12).line(x + 10, y + 12, x + 16, y + 5);
   }
   if (opts.locked) {
     pen.col(K.GRAY_XD).rect(x + 9, y + h / 2 - 2, 8, 7);
@@ -176,16 +248,21 @@ export function drawMachinePanel(ctx, spots, active) {
   const first = spots[0];
   const last = spots[spots.length - 1];
   const width = last.x + last.w - first.x;
-  // Carcaça do painel, com espaço para o rótulo acima das teclas
-  pen.col(K.BLACK).rect(first.x - 7, first.y - 12, width + 14, first.h + 20);
-  pen.bevel(first.x - 6, first.y - 11, width + 12, first.h + 18, K.GRAY, K.GRAY_L, K.GRAY_D);
+  // Carcaça do painel
+  raised(pen, first.x - 7, first.y - 14, width + 14, first.h + 22, K.GRAY, K.GRAY_L, K.GRAY_D);
+  rivet(pen, first.x - 4, first.y - 11);
+  rivet(pen, first.x + width + 2, first.y - 11);
+  rivet(pen, first.x - 4, first.y + first.h + 2);
+  rivet(pen, first.x + width + 2, first.y + first.h + 2);
+  // Plaquinha do rótulo
+  raised(pen, Math.round(W / 2 - 36), first.y - 12, 72, 10, K.NAVY, K.BLU, K.NIGHT);
   F.textCenter(ctx, 'MOLDADORA', W / 2, first.y - 10, K.YEL_L, { shadow: K.BLACK });
 
   for (const spot of spots) {
     const on = spot.n === active;
-    pen.col(K.BLACK).rect(spot.x, spot.y, spot.w, spot.h);
-    pen.bevel(spot.x + 1, spot.y + 1, spot.w - 2, spot.h - 2,
+    sunk(pen, spot.x, spot.y, spot.w, spot.h,
       on ? K.YEL : K.BLU, on ? K.YEL_L : K.BLU_L, on ? K.OCHRE : K.BLU_D);
+    if (on) pen.col(K.WHITE).hline(spot.x + 2, spot.y + 2, spot.w - 4);
     const label = String(spot.n);
     const tw = F.measure(label, 2);
     F.text(ctx, label, Math.round(spot.x + (spot.w - tw) / 2), spot.y + 3,
@@ -208,29 +285,42 @@ export function drawSignpost(ctx, spots, state) {
   const names = ['FÁBRICA', 'MERCADO', 'CORREIOS', 'A FESTA!'];
   const done = [state.presentDone, state.marketDone, state.inviteDone, false];
 
-  // Poste
-  pen.col(K.BLACK).rect(148, 20, 12, 108);
-  pen.col(K.WOOD_D).rect(149, 21, 10, 106);
-  pen.col(K.OCHRE).vline(150, 21, 106);
+  // Poste com veios de madeira
+  pen.col(K.BLACK).rect(148, 18, 14, 112);
+  pen.col(K.WOOD_D).rect(149, 19, 12, 110);
+  pen.col(K.OCHRE).vline(151, 19, 110);
+  pen.col(K.SAND).vline(152, 22, 20).vline(152, 55, 18).vline(152, 90, 16);
+  // Base do poste
+  pen.col(K.BLACK).rect(142, 126, 26, 6);
+  pen.col(K.WOOD_D).rect(143, 127, 24, 4);
 
   for (const spot of spots) {
     const i = spot.n - 1;
     const party = i === 3;
-    pen.col(K.BLACK).rect(spot.x, spot.y, spot.w, spot.h);
-    pen.bevel(spot.x + 1, spot.y + 1, spot.w - 2, spot.h - 2,
+    raised(pen, spot.x, spot.y, spot.w, spot.h,
       party ? K.YEL : K.OCHRE, party ? K.YEL_L : K.SAND, K.WOOD_D);
+    // Veios horizontais leves
+    if (!party) {
+      pen.col(K.SAND).hline(spot.x + 4, spot.y + 5, spot.w - 14);
+      pen.col(K.WOOD_D).hline(spot.x + 4, spot.y + spot.h - 4, spot.w - 14);
+    }
     // Ponta de seta
     pen.col(K.BLACK);
-    for (let k = 0; k < 8; k++) pen.vline(spot.x + spot.w + k, spot.y + k, spot.h - k * 2);
+    for (let k = 0; k < 9; k++) pen.vline(spot.x + spot.w + k, spot.y + k, spot.h - k * 2);
     pen.col(party ? K.YEL : K.OCHRE);
-    for (let k = 0; k < 7; k++) pen.vline(spot.x + spot.w + k, spot.y + 1 + k, spot.h - 2 - k * 2);
+    for (let k = 0; k < 8; k++) pen.vline(spot.x + spot.w + k, spot.y + 1 + k, spot.h - 2 - k * 2);
+    pen.col(party ? K.YEL_L : K.SAND).vline(spot.x + spot.w, spot.y + 2, spot.h - 4);
 
-    const label = String(spot.n);
-    F.text(ctx, label, spot.x + 5, spot.y + 3, party ? K.RED : K.RED_D, { scale: 2, shadow: K.SAND });
-    F.text(ctx, names[i], spot.x + 22, spot.y + 6, K.WOOD_D);
+    // Badge do número (vermelho, bem legível)
+    numBadge(ctx, pen, spot.n, spot.x + 14, spot.y + (spot.h >> 1), 2, K.YEL_L, K.RED);
+    F.text(ctx, names[i], spot.x + 28, spot.y + 6, K.WOOD_D, { shadow: party ? K.OCHRE : K.SAND });
+
     if (done[i]) {
-      pen.col(K.GRN).line(spot.x + 108, spot.y + 9, spot.x + 112, spot.y + 14)
-        .line(spot.x + 112, spot.y + 14, spot.x + 120, spot.y + 4);
+      pen.col(K.BLACK).rect(spot.x + 106, spot.y + 4, 14, 12);
+      pen.col(K.GRN).rect(spot.x + 107, spot.y + 5, 12, 10);
+      pen.col(K.GRN_L)
+        .line(spot.x + 109, spot.y + 10, spot.x + 112, spot.y + 13)
+        .line(spot.x + 112, spot.y + 13, spot.x + 118, spot.y + 6);
     }
   }
 }
@@ -246,16 +336,51 @@ export function vehicleSpots() {
   return spots;
 }
 
+/** Faixa compacta 0–9 para trocar de veículo durante a viagem. */
+export function travelSwapSpots() {
+  const spots = [];
+  const bw = 28;
+  const gap = 2;
+  const total = 10 * bw + 9 * gap;
+  const x0 = Math.round((W - total) / 2);
+  for (let i = 0; i < 10; i++) {
+    spots.push({ n: i, x: x0 + i * (bw + gap), y: 4, w: bw, h: 18 });
+  }
+  return spots;
+}
+
+export function drawTravelSwap(ctx, spots, activeN) {
+  const pen = new Pen(ctx);
+  const first = spots[0];
+  const last = spots[spots.length - 1];
+  const width = last.x + last.w - first.x;
+  // Trilho cromado atrás das teclas
+  raised(pen, first.x - 4, first.y - 3, width + 8, first.h + 6, K.NAVY, K.BLU, K.NIGHT);
+
+  for (const spot of spots) {
+    const on = spot.n === activeN;
+    sunk(pen, spot.x, spot.y, spot.w, spot.h,
+      on ? K.YEL : K.CREAM, on ? K.YEL_L : K.WHITE, on ? K.OCHRE : K.GRAY_D);
+    const label = String(spot.n);
+    const tw = F.measure(label, 2);
+    F.text(ctx, label, Math.round(spot.x + (spot.w - tw) / 2), spot.y + 2,
+      on ? K.RED : K.GRAY_XD, { scale: 2, shadow: on ? K.SAND : undefined });
+  }
+}
+
 export function drawVehicleRack(ctx, spots) {
   const pen = new Pen(ctx);
   for (const spot of spots) {
     const v = VEHICLES[spot.n];
-    pen.col(K.BLACK).rect(spot.x, spot.y, spot.w, spot.h);
-    pen.bevel(spot.x + 1, spot.y + 1, spot.w - 2, spot.h - 2, K.CREAM, K.WHITE, K.GRAY_D);
+    raised(pen, spot.x, spot.y, spot.w, spot.h, K.CREAM, K.WHITE, K.GRAY_D);
+    // Faixa superior colorida
+    pen.col(K.NAVY).rect(spot.x + 2, spot.y + 2, spot.w - 4, 10);
+    pen.col(K.BLU).hline(spot.x + 2, spot.y + 2, spot.w - 4);
+    const twN = F.measure(String(spot.n), 2);
+    F.text(ctx, String(spot.n), Math.round(spot.x + (spot.w - twN) / 2), spot.y + 2,
+      K.YEL_L, { scale: 2, shadow: K.BLACK });
 
-    /* Veículos mais largos que o cartão entram pela metade. A contagem de
-       rodas de verdade acontece na cena da viagem, com o veículo em tamanho
-       cheio e o flashcard — aqui é só a vitrine de escolha. */
+    /* Veículos mais largos que o cartão entram pela metade. */
     const sprite = v.wheels === 0 ? SPR.ravi.idle : SPR.vehicle[v.id];
     const half = sprite.w > spot.w - 6 || sprite.h > 26;
     const dw = half ? Math.round(sprite.w / 2) : sprite.w;
@@ -263,14 +388,16 @@ export function drawVehicleRack(ctx, spots) {
     ctx.drawImage(
       sprite.canvas,
       Math.round(spot.x + (spot.w - dw) / 2),
-      Math.round(spot.y + 16 - dh / 2),
+      Math.round(spot.y + 28 - dh / 2),
       dw, dh
     );
 
-    F.textCenter(ctx, v.name, spot.x + spot.w / 2, spot.y + 32, K.GRAY_XD);
-    const label = String(spot.n);
-    const tw = F.measure(label, 2);
-    F.text(ctx, label, Math.round(spot.x + (spot.w - tw) / 2), spot.y + 43, K.RED, { scale: 2, shadow: K.SAND });
+    F.textCenter(ctx, v.name, spot.x + spot.w / 2, spot.y + 42, K.GRAY_XD);
+    // Chip de rodas
+    const chip = `${v.wheels}`;
+    const cw = F.measure(chip, 1) + 10;
+    raised(pen, Math.round(spot.x + (spot.w - cw) / 2), spot.y + spot.h - 13, cw, 10, K.YEL, K.YEL_L, K.OCHRE);
+    F.textCenter(ctx, chip + 'R', spot.x + spot.w / 2, spot.y + spot.h - 11, K.RED_D);
   }
 }
 
@@ -280,23 +407,59 @@ export function quantitySpots() {
   for (let i = 0; i < 9; i++) {
     const col = i % 3;
     const row = (i / 3) | 0;
-    spots.push({ n: i + 1, x: 210 + col * 34, y: 18 + row * 32, w: 30, h: 28 });
+    spots.push({ n: i + 1, x: 210 + col * 34, y: 24 + row * 28, w: 30, h: 26 });
   }
   return spots;
 }
 
 export function drawQuantityBoard(ctx, spots, title) {
   const pen = new Pen(ctx);
-  pen.col(K.BLACK).rect(202, 4, 112, 106);
-  pen.bevel(203, 5, 110, 104, K.WOOD_D, K.OCHRE, K.GRAY_XD);
+  raised(pen, 202, 4, 112, 106, K.WOOD_D, K.OCHRE, K.GRAY_XD);
+  rivet(pen, 206, 8);
+  rivet(pen, 306, 8);
+  rivet(pen, 206, 100);
+  rivet(pen, 306, 100);
+  // Faixa do título
+  raised(pen, 210, 8, 96, 12, K.NAVY, K.BLU, K.NIGHT);
   F.textCenter(ctx, title, 258, 10, K.YEL_L, { shadow: K.BLACK });
 
   for (const spot of spots) {
-    pen.col(K.BLACK).rect(spot.x, spot.y, spot.w, spot.h);
-    pen.bevel(spot.x + 1, spot.y + 1, spot.w - 2, spot.h - 2, K.CREAM, K.WHITE, K.GRAY_D);
+    sunk(pen, spot.x, spot.y, spot.w, spot.h, K.CREAM, K.WHITE, K.GRAY_D);
+    pen.col(K.WHITE).hline(spot.x + 3, spot.y + 2, spot.w - 6);
     const label = String(spot.n);
     const tw = F.measure(label, 3);
-    F.text(ctx, label, Math.round(spot.x + (spot.w - tw) / 2), spot.y + 4, K.RED, { scale: 3 });
+    F.text(ctx, label, Math.round(spot.x + (spot.w - tw) / 2), spot.y + 4, K.RED, {
+      scale: 3,
+      shadow: K.SAND
+    });
+  }
+}
+
+/**
+ * Carrinho de compras com os itens já escolhidos dentro do cesto.
+ * `cart` é o mapa { foodId: qty } do estado do jogo.
+ */
+export function drawShoppingCart(ctx, cart, footX = 150, footY = 158, t = 0) {
+  const body = SPR.misc.cart;
+  if (!body) return;
+  const wobble = t ? wave(t, 6, 1) : 0;
+  const bx = Math.round(footX - body.w / 2) + wobble;
+  const by = footY - body.h;
+  blit(ctx, body, bx, by);
+
+  // Miolo creme do cesto — os itens empilham aqui, bem visíveis
+  const originX = bx + 16;
+  const originY = by + 16;
+  const cols = 4;
+  let slot = 0;
+  for (const food of FOODS) {
+    const qty = cart[food.id] || 0;
+    for (let i = 0; i < qty && slot < 12; i++, slot++) {
+      const col = slot % cols;
+      const row = (slot / cols) | 0;
+      const jiggle = t ? hop(t, 5 + (slot % 3), 1, slot) : 0;
+      blitMid(ctx, SPR.food[food.id], originX + col * 11, originY + row * 9 - jiggle);
+    }
   }
 }
 
@@ -316,12 +479,10 @@ export function drawMailboxes(ctx, spots, state) {
   const pen = new Pen(ctx);
   for (const spot of spots) {
     if (spot.n === 0) {
-      pen.col(K.BLACK).rect(spot.x, spot.y, spot.w, spot.h);
-      pen.bevel(spot.x + 1, spot.y + 1, spot.w - 2, spot.h - 2, K.GRN, K.GRN_L, K.GRN_D);
-      F.textCenter(ctx, 'VOLTAR', spot.x + spot.w / 2, spot.y + 8, K.WHITE, { shadow: K.GRN_D });
-      F.textCenter(ctx, 'À PLACA', spot.x + spot.w / 2, spot.y + 18, K.WHITE, { shadow: K.GRN_D });
-      const tw = F.measure('0', 2);
-      F.text(ctx, '0', Math.round(spot.x + (spot.w - tw) / 2), spot.y + 26, K.YEL_L, { scale: 2, shadow: K.GRN_D });
+      raised(pen, spot.x, spot.y, spot.w, spot.h, K.GRN, K.GRN_L, K.GRN_D);
+      F.textCenter(ctx, 'VOLTAR', spot.x + spot.w / 2, spot.y + 6, K.WHITE, { shadow: K.GRN_D });
+      F.textCenter(ctx, 'À PLACA', spot.x + spot.w / 2, spot.y + 16, K.WHITE, { shadow: K.GRN_D });
+      numBadge(ctx, pen, 0, spot.x + spot.w / 2, spot.y + 30, 2, K.RED);
       continue;
     }
 
@@ -330,15 +491,13 @@ export function drawMailboxes(ctx, spots, state) {
     const locked = idx === state.honoree;
     const invited = state.invited.includes(idx);
 
-    pen.col(K.BLACK).rect(spot.x, spot.y, spot.w, spot.h);
-    pen.bevel(spot.x + 1, spot.y + 1, spot.w - 2, spot.h - 2,
-      locked ? K.GRAY : invited ? K.GRN_D : K.BLU_D, K.GRAY_L, K.GRAY_XD);
+    raised(pen, spot.x, spot.y, spot.w, spot.h,
+      locked ? K.GRAY : invited ? K.GRN_D : K.BLU_D,
+      locked ? K.GRAY_L : invited ? K.GRN_L : K.BLU_L,
+      K.GRAY_XD);
 
-    /* Portinha com o herói espiando. O recorte mostra da cabeça ao tronco:
-       o sprite tem folga no topo para elmos e chapéus, então ele entra
-       deslocado para que o rosto fique centrado na janelinha. */
-    pen.col(K.BLACK).rect(spot.x + 3, spot.y + 3, 20, 32);
-    pen.col(locked ? K.GRAY_D : K.CREAM).rect(spot.x + 4, spot.y + 4, 18, 30);
+    /* Portinha com o herói espiando. */
+    sunk(pen, spot.x + 3, spot.y + 3, 20, 32, locked ? K.GRAY_D : K.CREAM, K.WHITE, K.GRAY_XD);
     if (!locked) {
       ctx.save();
       ctx.beginPath();
@@ -351,14 +510,21 @@ export function drawMailboxes(ctx, spots, state) {
       pen.col(K.YEL).ring(spot.x + 13, spot.y + 15, 3);
     }
 
+    // Placa de latão com o número
+    raised(pen, spot.x + 26, spot.y + 4, 26, 16, K.YEL, K.YEL_L, K.OCHRE);
     const label = String(spot.n);
-    F.text(ctx, label, spot.x + 27, spot.y + 5, locked ? K.GRAY_L : K.YEL_L,
-      { scale: 2, shadow: K.BLACK });
-    F.text(ctx, hero.short, spot.x + 25, spot.y + 24, locked ? K.GRAY_L : K.WHITE,
+    const tw = F.measure(label, 2);
+    F.text(ctx, label, Math.round(spot.x + 39 - tw / 2), spot.y + 5,
+      locked ? K.GRAY_XD : K.RED, { scale: 2, shadow: K.SAND });
+
+    F.text(ctx, hero.short, spot.x + 25, spot.y + 26, locked ? K.GRAY_L : K.WHITE,
       { shadow: K.BLACK });
     if (invited) {
-      pen.col(K.GRN_L).line(spot.x + 44, spot.y + 10, spot.x + 47, spot.y + 15)
-        .line(spot.x + 47, spot.y + 15, spot.x + 53, spot.y + 4);
+      pen.col(K.BLACK).rect(spot.x + 44, spot.y + 24, 10, 10);
+      pen.col(K.GRN).rect(spot.x + 45, spot.y + 25, 8, 8);
+      pen.col(K.GRN_L)
+        .line(spot.x + 46, spot.y + 29, spot.x + 48, spot.y + 31)
+        .line(spot.x + 48, spot.y + 31, spot.x + 52, spot.y + 26);
     }
   }
 }
@@ -366,25 +532,31 @@ export function drawMailboxes(ctx, spots, state) {
 /** Pratos numerados da mesa da festa. */
 export function plateSpots() {
   const spots = [];
-  // Começa em x=44 para deixar o canto esquerdo livre para o Ravi
+  // Fileira baixa, abaixo dos convidados (pés ~142) e acima da barra de fala
   for (let i = 0; i < 9; i++) {
-    spots.push({ n: i + 1, x: 44 + i * 30, y: 128, w: 28, h: 30 });
+    spots.push({ n: i + 1, x: 44 + i * 30, y: 148, w: 28, h: 16 });
   }
   return spots;
 }
 
-/** Pratos: comida à esquerda, numeral à direita — sem um cobrir o outro. */
+/** Pratos: oval creme + numeral + miniatura da comida da vez (Mickey 123). */
 export function drawPlates(ctx, spots, food) {
   const pen = new Pen(ctx);
-  const icon = food ? SPR.food[food.id] : null;
   for (const spot of spots) {
     const cx = Math.round(spot.x + spot.w / 2);
     const cy = Math.round(spot.y + spot.h / 2);
-    pen.col(K.BLACK).ellipse(cx, cy, 13, 10);
-    pen.col(K.WHITE).ellipse(cx, cy, 12, 9);
-    pen.col(K.GRAY_L).ellipse(cx, cy, 9, 6);
-    if (icon) blitMid(ctx, icon, cx - 6, cy);
-    F.text(ctx, String(spot.n), cx + 2, cy - 7, K.RED, { scale: 2 });
+    // Prato oval com borda
+    pen.col(K.BLACK).ellipse(cx + 1, cy + 1, 12, 7);
+    pen.col(K.GRAY).ellipse(cx, cy, 12, 7);
+    pen.col(K.CREAM).ellipse(cx, cy, 10, 5);
+    pen.col(K.WHITE).ellipse(cx - 2, cy - 1, 3, 2);
+    if (food) blitMid(ctx, SPR.food[food.id], cx - 5, cy - 2);
+    // Badge do número por cima, bem legível
+    const label = String(spot.n);
+    const tw = F.measure(label, 2);
+    pen.col(K.BLACK).rect(cx - (tw >> 1) - 2, spot.y - 3, tw + 4, 11);
+    pen.bevel(cx - (tw >> 1) - 1, spot.y - 2, tw + 2, 9, K.YEL, K.YEL_L, K.OCHRE);
+    F.text(ctx, label, Math.round(cx - tw / 2), spot.y - 1, K.RED, { scale: 2 });
   }
 }
 
@@ -407,15 +579,20 @@ export function hitTest(spots, x, y, pad = 3) {
   return null;
 }
 
-/** Confete da festa — posições fixas, animadas por tempo. */
+/** Confete da festa — formas variadas, sem alocar no draw. */
 export function makeConfetti(count) {
   const arr = [];
+  const colors = [K.RED, K.YEL, K.GRN, K.BLU, K.PINK, K.CYAN, K.ORANGE, K.PUR];
   for (let i = 0; i < count; i++) {
     arr.push({
-      x: (i * 53 + 11) % W,
-      y: (i * 29) % STAGE_H,
-      speed: 14 + (i % 5) * 6,
-      color: [K.RED, K.YEL, K.GRN, K.BLU, K.PINK, K.CYAN][i % 6]
+      x: (i * 47 + 13) % W,
+      y: (i * 31 + 7) % STAGE_H,
+      speed: 18 + (i % 7) * 5,
+      drift: 1 + (i % 4),
+      spin: 3 + (i % 5),
+      size: 2 + (i % 3),
+      shape: i % 3, // 0 rect, 1 tall, 2 diamond-ish
+      color: colors[i % colors.length]
     });
   }
   return arr;
@@ -424,20 +601,47 @@ export function makeConfetti(count) {
 export function drawConfetti(ctx, arr, t) {
   const pen = new Pen(ctx);
   for (const p of arr) {
-    const y = (p.y + t * p.speed) % STAGE_H;
-    const x = p.x + Math.round(3 * Math.sin(t * 2 + p.x));
-    pen.col(p.color).rect(x, y | 0, 2, 2);
+    const y = wrap(p.y + t * p.speed, STAGE_H);
+    const x = p.x + wave(t, p.drift, 5, p.x);
+    const flip = ((t * p.spin + p.x) | 0) & 1;
+    pen.col(p.color);
+    if (p.shape === 0) {
+      pen.rect(x, y | 0, p.size + flip, p.size + (1 - flip));
+    } else if (p.shape === 1) {
+      pen.rect(x, y | 0, 1 + flip, p.size + 2);
+    } else {
+      pen.px(x, y | 0).px(x + 1, (y | 0) + 1).px(x - 1, (y | 0) + 1).px(x, (y | 0) + 2);
+    }
   }
 }
 
-/** Balões pendurados na parede da festa, abaixo da faixa. */
+/** Balões nas laterais da festa — flutuam e balançam o fio. */
 export function drawBalloons(ctx, count, t) {
   const pen = new Pen(ctx);
-  const step = Math.min(32, 272 / Math.max(count, 1));
+  const palette = [K.RED, K.YEL, K.BLU, K.PINK, K.GRN, K.ORANGE, K.PUR, K.CYAN];
   for (let i = 0; i < count; i++) {
-    const x = Math.round(24 + i * step);
-    const y = 48 + Math.round(3 * Math.sin(t * 1.6 + i));
-    blitMid(ctx, SPR.food.balloon, x, y);
-    pen.col(K.CREAM).vline(x, y + 8, 14);
+    const left = i % 2 === 0;
+    const slot = (i / 2) | 0;
+    const baseX = left
+      ? Math.round(18 + slot * 16)
+      : Math.round(W - 18 - slot * 16);
+    const sway = wave(t, 1.4 + i * 0.07, 3, i * 1.3);
+    const bob = wave(t, 1.8 + i * 0.11, 4, i);
+    const x = baseX + sway;
+    const y = 38 + bob;
+    // Fio curvado
+    pen.col(K.CREAM);
+    pen.px(baseX, y + 10);
+    pen.px(baseX + (sway >> 1), y + 16);
+    pen.vline(x, y + 8, 4);
+    // Sombra + balão
+    pen.col(K.BLACK).ellipse(x + 1, y + 1, 7, 8);
+    if (SPR.food.balloon) blitMid(ctx, SPR.food.balloon, x, y);
+    else {
+      pen.col(K.BLACK).ellipse(x, y, 7, 8);
+      pen.col(palette[i % palette.length]).ellipse(x, y, 6, 7);
+    }
+    pen.col(K.WHITE).ellipse(x - 2, y - 3, 2, 2);
+    pen.col(palette[i % palette.length]).px(x, y + 8);
   }
 }

--- a/labs/ravi-123/sprites.js
+++ b/labs/ravi-123/sprites.js
@@ -1,36 +1,39 @@
 /* ==========================================================================
    Ravi 1·2·3 — sprites do elenco, brinquedos, comidas e veículos
    --------------------------------------------------------------------------
-   Tudo é assado uma única vez no boot, em canvas fora de tela. Em tempo de
-   execução o render só faz drawImage — nenhum path, nenhuma alocação.
+   Heróis e Ravi vêm das folhas com chroma key. Brinquedos, comidas e veículos
+   são pixel art procedural — cada um com silhueta própria, como no Mickey's
+   123 original (nenhuma vitrine pode repetir o mesmo desenho).
    ========================================================================== */
 
 import { K, bakeSprite, sliceSpriteSheet } from './assets.js';
 
 /* --------------------------------------------------------------------------
-   Dados (nomes e propriedades vêm do jogo antigo, a arte é nova)
+   Dados (nomes alinhados ao Mickey's 123; a arte é original)
    -------------------------------------------------------------------------- */
 
 /* `short` é o rótulo que cabe na caixa postal dos correios (5 chars no máximo);
-   `name` é o usado na narração falada. */
+   `name` é o usado na narração falada.
+   Ordem alinhada à folha heroes_sprites (3×3, idle = 1ª pose de cada herói). */
 export const HEROES = [
   { id: 'bolt', name: 'Sir Bolt', short: 'BOLT', title: 'Cavaleiro', color: K.BLU, dark: K.BLU_D },
-  { id: 'luna', name: 'Luna', short: 'LUNA', title: 'Feiticeira', color: K.PUR, dark: K.PUR_L },
-  { id: 'freya', name: 'Freya', short: 'FREYA', title: 'Arqueira', color: K.GRN, dark: K.GRN_D },
-  { id: 'kenzo', name: 'Kenzo', short: 'KENZO', title: 'Samurai', color: K.RED, dark: K.RED_D },
-  { id: 'bjorn', name: 'Bjorn', short: 'BJORN', title: 'Viking', color: K.ORANGE, dark: K.OCHRE },
   { id: 'shade', name: 'Shade', short: 'SHADE', title: 'Ninja', color: K.GRAY_D, dark: K.GRAY_XD },
-  { id: 'max', name: 'Maximus', short: 'MAX', title: 'Gladiador', color: K.OCHRE, dark: K.WOOD_D },
-  { id: 'ember', name: 'Ember', short: 'EMBER', title: 'Dragão', color: K.RED_L, dark: K.RED },
-  { id: 'aria', name: 'Aria', short: 'ARIA', title: 'Princesa', color: K.PINK, dark: K.PUR }
+  { id: 'luna', name: 'Luna', short: 'LUNA', title: 'Feiticeira', color: K.PUR, dark: K.PUR_L },
+  { id: 'ember', name: 'Ember', short: 'EMBER', title: 'Dragão', color: K.GRN, dark: K.GRN_D },
+  { id: 'aria', name: 'Aria', short: 'ARIA', title: 'Princesa', color: K.PINK, dark: K.PUR },
+  { id: 'max', name: 'Maximus', short: 'MAX', title: 'Robô', color: K.GRAY, dark: K.GRAY_D },
+  { id: 'freya', name: 'Freya', short: 'FREYA', title: 'Fada', color: K.GRN_L, dark: K.GRN },
+  { id: 'kenzo', name: 'Kenzo', short: 'KENZO', title: 'Samurai', color: K.RED, dark: K.RED_D },
+  { id: 'bjorn', name: 'Bjorn', short: 'BJORN', title: 'Arqueiro', color: K.GRN_D, dark: K.WOOD_D }
 ];
 
+/* Ordem = Mickey's 123: urso, boneca, dino, foguete, trator, robô, trombeta, bola, boneco. */
 export const TOYS = [
   { id: 'urso', name: 'Urso' },
-  { id: 'palhaco', name: 'Palhaço' },
+  { id: 'boneca', name: 'Boneca' },
   { id: 'dino', name: 'Dinossauro' },
-  { id: 'barco', name: 'Barco' },
-  { id: 'trem', name: 'Trenzinho' },
+  { id: 'foguete', name: 'Foguete' },
+  { id: 'trator', name: 'Trator' },
   { id: 'robo', name: 'Robô' },
   { id: 'trombeta', name: 'Trombeta' },
   { id: 'bola', name: 'Bola' },
@@ -38,23 +41,24 @@ export const TOYS = [
 ];
 
 export const FOODS = [
-  { id: 'burger', name: 'Hambúrguer' },
-  { id: 'fries', name: 'Batata frita' },
-  { id: 'apple', name: 'Maçã' },
-  { id: 'milk', name: 'Leite' },
-  { id: 'balloon', name: 'Balão' }
+  { id: 'burger', name: 'Hambúrguer', ask: 'hambúrgueres', how: 'Quantos' },
+  { id: 'fries', name: 'Batata frita', ask: 'porções de batata', how: 'Quantas' },
+  { id: 'apple', name: 'Maçã', ask: 'maçãs', how: 'Quantas' },
+  { id: 'milk', name: 'Leite', ask: 'caixas de leite', how: 'Quantas' },
+  { id: 'balloon', name: 'Balão', ask: 'balões', how: 'Quantos' }
 ];
 
+/* Rodas = número da tecla (0–9), como no original: a criança conta o que vê. */
 export const VEHICLES = [
   { id: 'walk', name: 'A pé', wheels: 0, w: 26 },
   { id: 'uni', name: 'Monociclo', wheels: 1, w: 26 },
   { id: 'moto', name: 'Moto', wheels: 2, w: 42 },
   { id: 'tri', name: 'Triciclo', wheels: 3, w: 44 },
   { id: 'car', name: 'Carrinho', wheels: 4, w: 52 },
-  { id: 'jipe', name: 'Jipe', wheels: 5, w: 58 },
+  { id: 'spare', name: 'Estepe', wheels: 5, w: 58 },
   { id: 'van', name: 'Van', wheels: 6, w: 64 },
-  { id: 'trator', name: 'Trator', wheels: 7, w: 70 },
-  { id: 'bus', name: 'Ônibus', wheels: 8, w: 78 },
+  { id: 'van7', name: 'Van+', wheels: 7, w: 70 },
+  { id: 'skates', name: 'Patins', wheels: 8, w: 54 },
   { id: 'truck', name: 'Caminhão', wheels: 9, w: 86 }
 ];
 
@@ -69,61 +73,410 @@ export const SPR = {
   misc: {}
 };
 
+/* --------------------------------------------------------------------------
+   Helpers de forma
+   -------------------------------------------------------------------------- */
+
+function blob(pen, cx, cy, rx, ry, fill) {
+  pen.col(K.BLACK).ellipse(cx, cy, rx + 1, ry + 1);
+  pen.col(fill).ellipse(cx, cy, rx, ry);
+}
+
+function box(pen, x, y, w, h, fill) {
+  pen.col(K.BLACK).rect(x - 1, y - 1, w + 2, h + 2);
+  pen.col(fill).rect(x, y, w, h);
+}
+
+/* --------------------------------------------------------------------------
+   Brinquedos — ícones 16×16 (cada um com silhueta única)
+   -------------------------------------------------------------------------- */
+
+const TOY_PAINTERS = {
+  urso(pen) {
+    blob(pen, 4, 4, 2, 2, K.WOOD_D);
+    blob(pen, 11, 4, 2, 2, K.WOOD_D);
+    blob(pen, 8, 6, 5, 4, K.OCHRE);
+    blob(pen, 8, 12, 5, 4, K.OCHRE);
+    pen.col(K.BLACK).px(6, 5).px(10, 5).px(8, 7);
+    pen.col(K.SAND).ellipse(8, 12, 2, 2);
+  },
+  boneca(pen) {
+    blob(pen, 8, 4, 3, 3, K.SKIN);
+    pen.col(K.YEL).ellipse(8, 2, 5, 2);
+    pen.col(K.PINK).rect(5, 7, 7, 6);
+    pen.col(K.WHITE).hline(5, 10, 7);
+    pen.col(K.BLACK).px(7, 4).px(9, 4);
+    pen.col(K.PINK).px(8, 5);
+    pen.col(K.SKIN).px(3, 9).px(12, 9);
+    pen.col(K.PINK).rect(5, 13, 3, 2).rect(9, 13, 3, 2);
+  },
+  dino(pen) {
+    blob(pen, 7, 10, 6, 4, K.GRN);
+    blob(pen, 12, 5, 3, 3, K.GRN);
+    pen.col(K.GRN_D).px(4, 6).px(6, 5).px(8, 5).px(10, 5);
+    pen.col(K.BLACK).px(13, 4);
+    pen.col(K.GRN_D).rect(1, 11, 3, 2);
+    pen.col(K.GRN_D).rect(5, 13, 2, 2).rect(9, 13, 2, 2);
+  },
+  foguete(pen) {
+    pen.col(K.BLACK).ellipse(8, 7, 4, 7);
+    pen.col(K.WHITE).ellipse(8, 7, 3, 6);
+    pen.col(K.RED).ellipse(8, 2, 2, 2);
+    pen.col(K.CYAN).ellipse(8, 6, 2, 2);
+    pen.col(K.RED).rect(3, 10, 3, 4).rect(11, 10, 3, 4);
+    pen.col(K.ORANGE).px(7, 14).px(8, 15).px(9, 14);
+    pen.col(K.YEL).px(8, 13);
+  },
+  trator(pen) {
+    // Trator: cabine alta + chassi curto + roda grande atrás
+    box(pen, 1, 9, 8, 4, K.GRN);
+    box(pen, 7, 3, 6, 10, K.GRN_D);
+    pen.col(K.CYAN).rect(8, 5, 4, 3);
+    pen.col(K.BLACK).ellipse(4, 14, 2, 2);
+    pen.col(K.BLACK).ellipse(12, 13, 3, 3);
+    pen.col(K.GRAY).ellipse(4, 14, 1, 1).ellipse(12, 13, 1, 1);
+    pen.col(K.YEL).rect(0, 7, 2, 2);
+    pen.col(K.GRAY_XD).rect(3, 6, 2, 3);
+  },
+  robo(pen) {
+    box(pen, 4, 5, 8, 8, K.GRAY_L);
+    box(pen, 5, 1, 6, 4, K.GRAY);
+    pen.col(K.RED).px(7, 2).px(9, 2);
+    pen.col(K.GRAY).rect(1, 6, 3, 2).rect(12, 6, 3, 2);
+    pen.col(K.CYAN).rect(6, 8, 4, 3);
+    pen.col(K.YEL).px(3, 0).px(12, 0);
+  },
+  trombeta(pen) {
+    pen.col(K.YEL).rect(3, 7, 8, 3);
+    pen.col(K.BLACK).frame(2, 6, 10, 5);
+    pen.col(K.YEL).ellipse(13, 8, 2, 4);
+    pen.col(K.BLACK).ring(13, 8, 4);
+    pen.col(K.OCHRE).px(5, 5).px(7, 5).px(9, 5);
+    pen.col(K.BLACK).px(5, 4).px(7, 4).px(9, 4);
+  },
+  bola(pen) {
+    blob(pen, 8, 8, 6, 6, K.WHITE);
+    pen.col(K.RED).ellipse(8, 5, 5, 2);
+    pen.col(K.BLU).ellipse(8, 11, 5, 2);
+    pen.col(K.WHITE).ellipse(6, 6, 1, 1);
+  },
+  boneco(pen) {
+    blob(pen, 8, 4, 3, 3, K.SKIN);
+    pen.col(K.WOOD_D).hline(6, 1, 5);
+    pen.col(K.BLACK).px(7, 4).px(9, 4);
+    box(pen, 5, 7, 7, 5, K.BLU);
+    pen.col(K.RED).rect(5, 12, 7, 2);
+    pen.col(K.YEL).px(5, 14).px(11, 14);
+    pen.col(K.SKIN).px(3, 8).px(12, 8);
+  }
+};
+
+/* --------------------------------------------------------------------------
+   Comidas / balão — ícones 14×16
+   -------------------------------------------------------------------------- */
+
+const FOOD_PAINTERS = {
+  burger(pen) {
+    pen.col(K.OCHRE).ellipse(7, 6, 6, 3);
+    pen.col(K.SAND).ellipse(7, 5, 5, 2);
+    pen.col(K.GRN).rect(1, 8, 12, 2);
+    pen.col(K.WOOD_D).rect(1, 10, 12, 2);
+    pen.col(K.OCHRE).ellipse(7, 12, 6, 2);
+    pen.col(K.BLACK).px(5, 4).px(9, 3);
+  },
+  fries(pen) {
+    pen.col(K.YEL).rect(3, 2, 2, 6).rect(6, 1, 2, 7).rect(9, 3, 2, 5);
+    pen.col(K.YEL_L).vline(3, 2, 6).vline(6, 1, 7);
+    pen.col(K.RED).rect(2, 7, 10, 8);
+    pen.col(K.RED_D).hline(2, 14, 10);
+    pen.col(K.WHITE).rect(4, 9, 6, 3);
+    pen.col(K.BLACK).frame(1, 6, 12, 10);
+  },
+  apple(pen) {
+    blob(pen, 7, 9, 5, 5, K.RED);
+    pen.col(K.RED_L).ellipse(5, 7, 1, 2);
+    pen.col(K.WOOD_D).vline(7, 2, 3);
+    pen.col(K.GRN).ellipse(10, 3, 2, 1);
+  },
+  milk(pen) {
+    box(pen, 4, 4, 7, 11, K.WHITE);
+    pen.col(K.BLU).rect(4, 4, 7, 3);
+    pen.col(K.BLACK).line(4, 4, 7, 1).line(11, 4, 7, 1);
+    pen.col(K.WHITE).px(7, 2).px(8, 3);
+    pen.col(K.BLU_L).rect(5, 9, 5, 4);
+  },
+  balloon(pen) {
+    blob(pen, 7, 6, 5, 6, K.PINK);
+    pen.col(K.WHITE).ellipse(5, 4, 1, 2);
+    pen.col(K.PINK).px(7, 12).px(6, 13).px(8, 13);
+    pen.col(K.CREAM).line(7, 13, 7, 15);
+  }
+};
+
+/* --------------------------------------------------------------------------
+   Veículos — silhuetas distintas; rodas alinhadas para contar
+   -------------------------------------------------------------------------- */
+
+function wheel(pen, cx, cy, r) {
+  pen.col(K.BLACK).ellipse(cx, cy, r, r);
+  pen.col(K.GRAY_L).ellipse(cx, cy, Math.max(1, r - 2), Math.max(1, r - 2));
+  pen.col(K.GRAY_D).ellipse(cx, cy, 1, 1);
+}
+
+function drawVehicle(pen, v, w) {
+  const groundY = 23;
+  const r = v.wheels >= 8 ? 3 : v.wheels >= 5 ? 4 : 5;
+  const wheelY = groundY - r;
+
+  switch (v.id) {
+    case 'walk':
+      break;
+    case 'uni':
+      pen.col(K.GRAY_XD).vline(w >> 1, 8, 8);
+      pen.col(K.WOOD_D).hline((w >> 1) - 4, 8, 9);
+      break;
+    case 'moto':
+      // Motocicleta de perfil: guidão, banco e duas rodas bem separadas
+      pen.col(K.RED).rect(14, 11, 16, 5);
+      pen.col(K.BLACK).frame(13, 10, 18, 7);
+      pen.col(K.GRAY_XD).line(14, 11, 8, 6).line(8, 6, 5, 6);
+      pen.col(K.GRAY_L).hline(3, 5, 6);
+      pen.col(K.GRAY).rect(22, 8, 6, 3);
+      pen.col(K.YEL).rect(28, 12, 2, 2);
+      break;
+    case 'tri':
+      pen.col(K.BLU).rect(8, 11, 26, 6);
+      pen.col(K.BLACK).frame(7, 10, 28, 8);
+      pen.col(K.GRAY_XD).line(10, 11, 7, 6);
+      pen.col(K.RED).rect(22, 7, 8, 4);
+      break;
+    case 'car': {
+      const y = groundY - r - 12;
+      pen.col(K.BLACK).rect(3, y + 4, w - 6, 10);
+      pen.col(K.RED).rect(4, y + 5, w - 8, 8);
+      pen.col(K.RED_D).hline(4, y + 12, w - 8);
+      pen.col(K.BLACK).rect(14, y - 4, w - 30, 9);
+      pen.col(K.RED_L).rect(15, y - 3, w - 32, 7);
+      pen.col(K.CYAN).rect(17, y - 1, (w - 36) / 2, 4).rect(19 + (w - 36) / 2, y - 1, (w - 36) / 2, 4);
+      pen.col(K.YEL_L).rect(w - 6, y + 7, 2, 3);
+      break;
+    }
+    case 'spare': {
+      // Carrinho + estepe no teto (5 rodas)
+      const y = groundY - r - 12;
+      pen.col(K.BLACK).rect(3, y + 4, w - 6, 10);
+      pen.col(K.BLU).rect(4, y + 5, w - 8, 8);
+      pen.col(K.BLU_D).hline(4, y + 12, w - 8);
+      pen.col(K.BLACK).rect(14, y - 4, w - 30, 9);
+      pen.col(K.BLU_L).rect(15, y - 3, w - 32, 7);
+      pen.col(K.CYAN).rect(17, y - 1, (w - 36) / 2, 4).rect(19 + (w - 36) / 2, y - 1, (w - 36) / 2, 4);
+      // Estepe no teto
+      wheel(pen, w >> 1, y - 2, 4);
+      pen.col(K.YEL_L).rect(w - 6, y + 7, 2, 3);
+      break;
+    }
+    case 'van': {
+      const bodyH = 14;
+      const bodyY = groundY - r - bodyH - 1;
+      pen.col(K.BLACK).rect(2, bodyY - 1, w - 4, bodyH + 2);
+      pen.col(K.GRN).rect(3, bodyY, w - 6, bodyH);
+      pen.col(K.GRN_D).hline(3, bodyY + bodyH - 1, w - 6);
+      pen.col(K.CYAN);
+      for (let x = 7; x < w - 10; x += 12) pen.rect(x, bodyY + 3, 8, 6);
+      pen.col(K.BLACK);
+      for (let x = 7; x < w - 10; x += 12) pen.frame(x - 1, bodyY + 2, 10, 8);
+      pen.col(K.YEL_L).rect(w - 5, bodyY + bodyH - 5, 2, 3);
+      break;
+    }
+    case 'van7': {
+      // Van + estepe lateral (7 rodas)
+      const bodyH = 14;
+      const bodyY = groundY - r - bodyH - 1;
+      pen.col(K.BLACK).rect(2, bodyY - 1, w - 4, bodyH + 2);
+      pen.col(K.PUR).rect(3, bodyY, w - 6, bodyH);
+      pen.col(K.PUR_L).hline(3, bodyY + bodyH - 1, w - 6);
+      pen.col(K.CYAN);
+      for (let x = 7; x < w - 14; x += 12) pen.rect(x, bodyY + 3, 8, 6);
+      pen.col(K.BLACK);
+      for (let x = 7; x < w - 14; x += 12) pen.frame(x - 1, bodyY + 2, 10, 8);
+      wheel(pen, w - 10, bodyY + 6, 4);
+      pen.col(K.YEL_L).rect(w - 5, bodyY + bodyH - 5, 2, 3);
+      break;
+    }
+    case 'skates': {
+      // Dois patins com 4 rodinhas cada = 8
+      pen.col(K.RED).rect(4, 10, 18, 5);
+      pen.col(K.BLU).rect(32, 10, 18, 5);
+      pen.col(K.BLACK).frame(3, 9, 20, 7).frame(31, 9, 20, 7);
+      pen.col(K.CREAM).rect(8, 6, 10, 4).rect(36, 6, 10, 4);
+      pen.col(K.GRAY_XD).vline(13, 4, 3).vline(41, 4, 3);
+      break;
+    }
+    case 'truck': {
+      const bodyH = 14;
+      const bodyY = groundY - r - bodyH - 1;
+      pen.col(K.BLACK).rect(2, bodyY + 3, w - 30, bodyH - 2);
+      pen.col(K.GRAY_L).rect(3, bodyY + 4, w - 32, bodyH - 4);
+      pen.col(K.GRAY_D).hline(3, bodyY + bodyH - 1, w - 32);
+      pen.col(K.BLACK).rect(w - 28, bodyY - 1, 26, bodyH + 2);
+      pen.col(K.ORANGE).rect(w - 27, bodyY, 24, bodyH);
+      pen.col(K.OCHRE).hline(w - 27, bodyY + bodyH - 1, 24);
+      pen.col(K.CYAN).rect(w - 24, bodyY + 3, 12, 6);
+      pen.col(K.BLACK).frame(w - 25, bodyY + 2, 14, 8);
+      pen.col(K.YEL_L).rect(w - 5, bodyY + bodyH - 5, 2, 3);
+      break;
+    }
+    default:
+      break;
+  }
+
+  const n = v.wheels;
+  if (n === 1) {
+    wheel(pen, w >> 1, groundY - 7, 7);
+  } else if (n > 1) {
+    // Patins: 4+4 em dois grupos; demais: fila única contável
+    if (v.id === 'skates') {
+      for (let i = 0; i < 4; i++) wheel(pen, 6 + i * 5, wheelY, 3);
+      for (let i = 0; i < 4; i++) wheel(pen, 34 + i * 5, wheelY, 3);
+    } else {
+      const margin = r + 2;
+      const span = w - margin * 2;
+      for (let i = 0; i < n; i++) {
+        const x = margin + Math.round((i * span) / (n - 1));
+        wheel(pen, x, wheelY, r);
+      }
+    }
+  }
+}
+
+/* --------------------------------------------------------------------------
+   Diversos
+   -------------------------------------------------------------------------- */
+
+function drawSheep(pen) {
+  blob(pen, 11, 8, 8, 5, K.WHITE);
+  pen.col(K.GRAY_L).ellipse(6, 6, 2, 2).ellipse(11, 5, 2, 2).ellipse(16, 6, 2, 2);
+  blob(pen, 19, 6, 3, 3, K.GRAY_XD);
+  pen.col(K.WHITE).px(19, 5);
+  pen.col(K.BLACK).px(20, 6);
+  pen.col(K.GRAY_XD).vline(6, 12, 3).vline(10, 12, 3).vline(14, 12, 3).vline(17, 12, 3);
+}
+
+function drawMailman(pen) {
+  pen.col(K.BLACK).ring(8, 24, 6).ring(26, 24, 6);
+  pen.col(K.GRAY).ring(8, 24, 3).ring(26, 24, 3);
+  pen.col(K.GRAY_XD).line(8, 24, 17, 14).line(26, 24, 17, 14).line(17, 14, 17, 9);
+  pen.col(K.BLU_D).hline(13, 9, 9);
+  box(pen, 12, 12, 10, 9, K.BLU);
+  blob(pen, 17, 7, 5, 5, K.SKIN);
+  pen.col(K.BLACK).px(15, 6).px(19, 6);
+  pen.col(K.BLU_D).rect(11, 1, 13, 3);
+  pen.col(K.BLACK).frame(10, 0, 15, 5);
+  box(pen, 22, 15, 8, 6, K.CREAM);
+  pen.col(K.RED).px(26, 17);
+}
+
+function drawEnvelope(pen) {
+  box(pen, 0, 0, 13, 9, K.CREAM);
+  pen.col(K.BLACK).line(0, 0, 6, 5).line(12, 0, 6, 5);
+  pen.col(K.RED).px(11, 7).px(10, 7);
+}
+
+function drawGift(pen) {
+  box(pen, 1, 6, 18, 13, K.RED);
+  pen.col(K.YEL).rect(8, 6, 4, 13);
+  pen.col(K.YEL).hline(1, 11, 18);
+  pen.col(K.YEL).ellipse(7, 4, 3, 3).ellipse(13, 4, 3, 3);
+  pen.col(K.BLACK).ring(7, 4, 4).ring(13, 4, 4);
+}
+
+function drawCake(pen) {
+  pen.col(K.BLACK).rect(1, 12, 30, 12);
+  pen.col(K.CREAM).rect(2, 13, 28, 10);
+  pen.col(K.PINK).hline(2, 13, 28).hline(2, 14, 28);
+  pen.col(K.BLACK).rect(6, 4, 20, 9);
+  pen.col(K.WHITE).rect(7, 5, 18, 7);
+  pen.col(K.PINK).hline(7, 5, 18);
+  pen.col(K.BLU).vline(11, 0, 5).vline(16, 0, 5).vline(21, 0, 5);
+  pen.col(K.YEL_L).px(11, -1).px(16, -1).px(21, -1);
+  pen.col(K.ORANGE).px(11, 0).px(16, 0).px(21, 0);
+}
+
+/** Carrinho de supermercado — cesto aberto para as compras ficarem visíveis. */
+function drawCart(pen) {
+  // Alça (lado esquerdo, onde o Ravi empurra)
+  pen.col(K.BLACK).line(1, 18, 8, 4).line(8, 4, 16, 4);
+  pen.col(K.GRAY_L).line(2, 18, 8, 5).line(8, 5, 15, 5);
+  // Cesto: fundo escuro para os itens contrastarem
+  pen.col(K.BLACK).rect(10, 10, 50, 26);
+  pen.col(K.GRAY_XD).rect(11, 11, 48, 24);
+  // Interior (chão do cesto)
+  pen.col(K.CREAM).rect(13, 14, 44, 18);
+  // Grades laterais (não cobrem o miolo)
+  pen.col(K.GRAY);
+  for (let x = 13; x <= 55; x += 7) {
+    pen.vline(x, 11, 3);
+    pen.vline(x, 29, 5);
+  }
+  pen.col(K.GRAY_L).hline(11, 11, 48).hline(11, 33, 48);
+  // Borda superior
+  pen.col(K.BLACK).rect(9, 8, 52, 3);
+  pen.col(K.GRAY).rect(10, 9, 50, 1);
+  // Base
+  pen.col(K.BLACK).rect(16, 35, 38, 3);
+  pen.col(K.GRAY_D).rect(17, 36, 36, 1);
+  // Rodas
+  pen.col(K.BLACK).ellipse(20, 43, 6, 6).ellipse(50, 43, 6, 6);
+  pen.col(K.GRAY_XD).ellipse(20, 43, 4, 4).ellipse(50, 43, 4, 4);
+  pen.col(K.GRAY_L).ellipse(20, 43, 1, 1).ellipse(50, 43, 1, 1);
+}
+
+/* --------------------------------------------------------------------------
+   Boot
+   -------------------------------------------------------------------------- */
+
 let built = false;
+
 export async function buildSprites() {
   if (built) return SPR;
   built = true;
 
-  // O fatiador retorna todos os sprites encontrados na folha em ordem.
-  // Como são gerados via IA, os índices dependem da quantidade gerada.
   const raviSlices = sliceSpriteSheet('ravi_sprites', 56);
   const poses = ['idle', 'walk0', 'walk1', 'wave', 'cheer', 'sleep', 'sit'];
   for (let i = 0; i < poses.length; i++) {
-    // Usamos o sprite correspondente ou o primeiro se faltar (fallback para IA imperfeita)
     SPR.ravi[poses[i]] = raviSlices[i] || raviSlices[0];
   }
 
-  const heroSlices = sliceSpriteSheet('heroes_sprites', 56);
+  // Folha com dezenas de poses: fica só com silhuetas de personagem (sem faixas largas / texto)
+  // e pega a 1ª pose de cada bloco para os 9 heróis.
+  const heroSlices = sliceSpriteSheet('heroes_sprites', 56)
+    .filter((s) => s.w >= 28 && s.w <= 58 && s.w / s.h <= 1.1);
+  const step = Math.max(1, Math.floor(heroSlices.length / HEROES.length) || 1);
   for (let i = 0; i < HEROES.length; i++) {
-    SPR.hero[HEROES[i].id] = heroSlices[i] || heroSlices[0];
+    SPR.hero[HEROES[i].id] = heroSlices[Math.min(i * step, heroSlices.length - 1)] || heroSlices[0];
   }
-
-  const itemSlices = sliceSpriteSheet('items_sprites', 24);
-  const vehicleSlices = sliceSpriteSheet('items_sprites', 36);
-  
-  const toyIcon = itemSlices[0] || itemSlices[0];
-  const dinoIcon = itemSlices[1] || itemSlices[0];
-  const carIcon = vehicleSlices[2] || vehicleSlices[0]; // Veículo maior!
-  const foodIcon = itemSlices[3] || itemSlices[0];
-  const appleIcon = itemSlices[4] || itemSlices[0];
-  const balloonIcon = itemSlices[5] || itemSlices[0];
 
   for (const toy of TOYS) {
-    SPR.toy[toy.id] = toy.id === 'dino' ? dinoIcon : toyIcon;
-  }
-  for (const food of FOODS) {
-    if (food.id === 'balloon') SPR.food[food.id] = balloonIcon;
-    else if (food.id === 'apple') SPR.food[food.id] = appleIcon;
-    else SPR.food[food.id] = foodIcon;
-  }
-  for (const v of VEHICLES) {
-    SPR.vehicle[v.id] = carIcon;
+    SPR.toy[toy.id] = bakeSprite(16, 16, (pen) => TOY_PAINTERS[toy.id](pen));
   }
 
-  SPR.misc.sheep = heroSlices[0] || toyIcon;
-  SPR.misc.mailman = heroSlices[1] || toyIcon;
-  SPR.misc.envelope = bakeSprite(14, 10, (pen) => {
-    pen.col(K.CREAM).rect(0, 0, 14, 10);
-    pen.col(K.BLACK).frame(0, 0, 14, 10);
-  });
-  SPR.misc.gift = bakeSprite(21, 21, (pen) => {
-    pen.col(K.RED).rect(0, 0, 21, 21);
-    pen.col(K.YEL).rect(8, 0, 5, 21);
-    pen.col(K.YEL).rect(0, 8, 21, 5);
-  });
+  for (const food of FOODS) {
+    SPR.food[food.id] = bakeSprite(14, 16, (pen) => FOOD_PAINTERS[food.id](pen));
+  }
+
+  for (const v of VEHICLES) {
+    SPR.vehicle[v.id] = bakeSprite(v.w, 26, (pen) => drawVehicle(pen, v, v.w));
+  }
+
+  SPR.misc.sheep = bakeSprite(24, 16, drawSheep);
+  SPR.misc.mailman = bakeSprite(34, 31, drawMailman);
+  SPR.misc.envelope = bakeSprite(14, 10, drawEnvelope);
+  SPR.misc.gift = bakeSprite(21, 21, drawGift);
   SPR.misc.cake = bakeSprite(32, 27, (pen) => {
-    pen.col(K.PINK).rect(0, 10, 32, 17);
+    pen.ctx.translate(0, 2);
+    drawCake(pen);
   });
+  SPR.misc.cart = bakeSprite(64, 50, drawCart);
 
   return SPR;
 }

--- a/labs/ravi-123/style.css
+++ b/labs/ravi-123/style.css
@@ -10,7 +10,10 @@
 :root {
   --sw: 320px;   /* largura escalada, calculada por screen.js */
   --sh: 200px;   /* altura escalada */
-  --hud: #cbd5e1;
+  --hud: #f8e8a0;
+  --hud-face: #1a2458;
+  --hud-edge: #f0c040;
+  --hud-ink: #f8f0d0;
 }
 
 *,
@@ -26,9 +29,11 @@ body {
   width: 100%;
   height: 100%;
   overflow: hidden;
-  background: #000;
+  /* Letterbox com vinheta suave — casa com a paleta navy/noite do jogo */
+  background:
+    radial-gradient(ellipse 80% 70% at 50% 45%, #142048 0%, #050814 70%, #000 100%);
   color: var(--hud);
-  font: 600 14px/1.4 system-ui, -apple-system, "Segoe UI", sans-serif;
+  font: 600 14px/1.4 "Trebuchet MS", "Segoe UI", system-ui, sans-serif;
   touch-action: manipulation;
   user-select: none;
   -webkit-user-select: none;
@@ -47,6 +52,13 @@ body {
   width: var(--sw);
   height: var(--sh);
   line-height: 0;
+  /* Moldura fina dourada ao redor do CRT */
+  box-shadow:
+    0 0 0 2px #0a1028,
+    0 0 0 4px #c89830,
+    0 0 0 6px #1a2458,
+    0 12px 40px rgba(0, 0, 0, 0.55);
+  border-radius: 2px;
 }
 
 /* O canvas mantém o backing store em 320×200; quem amplia é o navegador,
@@ -71,6 +83,7 @@ body {
   padding-right: calc(12px + env(safe-area-inset-right, 0px));
   padding-left: calc(12px + env(safe-area-inset-left, 0px));
   pointer-events: none;
+  z-index: 2;
 }
 
 .hud-spacer {
@@ -79,12 +92,13 @@ body {
 
 .hud-btn {
   pointer-events: auto;
-  width: 36px;
-  height: 36px;
-  border: 2px solid #334155;
-  border-radius: 8px;
-  background: rgba(15, 23, 42, 0.72);
-  color: var(--hud);
+  width: 38px;
+  height: 38px;
+  border: 2px solid var(--hud-edge);
+  border-radius: 6px;
+  background:
+    linear-gradient(180deg, #2a3878 0%, var(--hud-face) 55%, #0e1638 100%);
+  color: var(--hud-ink);
   font: inherit;
   font-size: 1.05rem;
   line-height: 1;
@@ -92,23 +106,37 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: background 120ms linear, border-color 120ms linear;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.22),
+    inset 0 -2px 0 rgba(0, 0, 0, 0.35),
+    0 2px 0 #0a1028;
+  transition: filter 120ms linear, border-color 120ms linear, transform 80ms linear;
 }
 
 .hud-btn:hover,
 .hud-btn:focus-visible {
-  background: rgba(30, 41, 59, 0.92);
-  border-color: #64748b;
+  filter: brightness(1.12);
+  border-color: #ffe080;
   outline: none;
 }
 
 .hud-btn:active {
   transform: translateY(1px);
+  box-shadow:
+    inset 0 2px 0 rgba(0, 0, 0, 0.35),
+    0 1px 0 #0a1028;
 }
 
 .hud-btn[aria-pressed="true"] {
-  color: #64748b;
-  border-color: #1e293b;
+  /* som ligado: nota dourada */
+  color: #ffe080;
+}
+
+.hud-btn[aria-pressed="false"] {
+  /* som mudo */
+  color: #7a8498;
+  border-color: #4a5578;
+  filter: saturate(0.7);
 }
 
 #rotate-hint {
@@ -120,7 +148,8 @@ body {
   text-align: center;
   padding: 0 16px;
   font-size: 0.85rem;
-  color: #94a3b8;
+  color: #b8c4e0;
+  text-shadow: 0 1px 2px #000;
 }
 
 /* Em celular de pé o palco 320×200 vira uma faixa estreita: vale avisar. */


### PR DESCRIPTION
## Summary
- Alinha o lab ao Mickey 123: timings mais calmos, brinquedos/veículos distintos, carrinho de compras e convidados legíveis na festa
- Animações baratas (`anim.js`) + UI diegética (barra de fala, flashcard, placas, teclas, HUD/CSS)
- Festa no molde original: cada convidado (e o aniversariante) recebe **cada** comida comprada, com pratinhos acumulando os itens

## Test plan
- [ ] Abrir `/labs/ravi-123/?v=18` (hard refresh) e iniciar com um número
- [ ] Mercado: comprar várias comidas + balões; ver itens no carrinho
- [ ] Correios: convidar ≥1 herói; fábrica: fazer um presente
- [ ] Ir à festa: faixa, balões, SURPRESA, convidados grandes com plaquinhas
- [ ] Servir: para cada herói, passar por **todas** as comidas; itens ficam no pratinho
- [ ] Confirmar dança final e restart com um número

Made with [Cursor](https://cursor.com)