### PR TITLE
feat(river-knight): casco sólido e canhões com mira automática

### DIFF
--- a/labs/river-knight/index.html
+++ b/labs/river-knight/index.html
@@ -16,7 +16,7 @@
     <meta property="og:url" content="https://diogopaulino.com.br/labs/river-knight/">
     <meta property="og:title" content="River Knight">
     <meta property="og:description"
-        content="Aventura medieval 3D no navegador: rio com ondas de Gerstner, drakkar, machados de arremesso e um castelo à espera.">
+        content="Aventura medieval 3D no navegador: rio com ondas de Gerstner, drakkar com canhões e um castelo à espera.">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="River Knight">
     <meta name="twitter:description" content="Navegue, lute e resgate a princesa. Aventura medieval 3D em three.js.">
@@ -27,7 +27,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;600;700;800&family=Outfit:wght@300;400;500;600;700&display=swap"
         rel="stylesheet">
     <link rel="stylesheet" href="/labs/shared.css?v=4">
-    <link rel="stylesheet" href="style.css?v=1">
+    <link rel="stylesheet" href="style.css?v=4">
 
     <script type="importmap">
     {
@@ -95,6 +95,15 @@
 
             <p id="message" class="message" role="status" aria-live="polite"></p>
 
+            <div id="reticle" class="reticle" aria-hidden="true">
+                <span class="reticle-ring"></span>
+                <span class="reticle-dot"></span>
+                <span id="reticleLabel" class="reticle-label"></span>
+            </div>
+            <div class="throw-meter" title="Canhão pronto">
+                <i id="throwFill"></i>
+            </div>
+
             <div class="hud-actions">
                 <button id="soundButton" class="icon-button" type="button" aria-pressed="true"
                     title="Som (M)" aria-label="Alternar som">♪</button>
@@ -110,7 +119,7 @@
                 </div>
                 <div class="touch-buttons">
                     <button type="button" class="pad pad-boost" data-control="boost" aria-label="Acelerar">REMAR</button>
-                    <button type="button" class="pad pad-throw" data-control="throw" aria-label="Arremessar machado">🪓</button>
+                    <button type="button" class="pad pad-throw" data-control="throw" aria-label="Disparar canhão">🔥</button>
                 </div>
             </div>
         </div>
@@ -148,9 +157,9 @@
                     <section class="menu-section">
                         <h2>Comandos</h2>
                         <div class="keys">
-                            <span><kbd>A</kbd><kbd>D</kbd> ou <kbd>←</kbd><kbd>→</kbd> navegar</span>
+                            <span><kbd>A</kbd><kbd>D</kbd> ou <kbd>←</kbd><kbd>→</kbd> governar o navio</span>
                             <span><kbd>W</kbd> remar forte · <kbd>S</kbd> segurar</span>
-                            <span><kbd>Espaço</kbd> ou <kbd>clique</kbd> arremessar machado</span>
+                            <span><kbd>Espaço</kbd> / <kbd>clique</kbd> canhão (mira automática)</span>
                             <span><kbd>C</kbd> câmera · <kbd>P</kbd> pausa · <kbd>M</kbd> som</span>
                         </div>
                     </section>
@@ -239,7 +248,7 @@
     </main>
 
     <script src="/labs/shared.js?v=5" defer></script>
-    <script type="module" src="src/main.js?v=1"></script>
+    <script type="module" src="src/main.js?v=13"></script>
 </body>
 
 </html>

--- a/labs/river-knight/src/audio.js
+++ b/labs/river-knight/src/audio.js
@@ -374,6 +374,25 @@ export class GameAudio {
                 this._noiseBurst(t, { duration: 0.22, freq: 1800, endFreq: 420, q: 3, gain: 0.22 * intensity });
                 this._tone(t, { freq: 620, endFreq: 240, duration: 0.16, gain: 0.1, type: 'triangle' });
                 break;
+            case 'cannon':
+                this._noiseBurst(t, {
+                    duration: 0.55,
+                    type: 'lowpass',
+                    freq: 900,
+                    endFreq: 80,
+                    gain: 0.72 * intensity
+                });
+                this._tone(t, { freq: 70, endFreq: 28, duration: 0.55, gain: 0.48 * intensity, type: 'sine' });
+                this._tone(t, { freq: 180, endFreq: 55, duration: 0.28, gain: 0.18 * intensity, type: 'triangle' });
+                this._noiseBurst(t + 0.04, {
+                    duration: 0.35,
+                    type: 'bandpass',
+                    freq: 1400,
+                    endFreq: 400,
+                    q: 1.2,
+                    gain: 0.22 * intensity
+                });
+                break;
             case 'hitWood':
                 this._noiseBurst(t, { duration: 0.14, type: 'lowpass', freq: 1400, endFreq: 300, gain: 0.32 });
                 this._tone(t, { freq: 180, endFreq: 90, duration: 0.18, gain: 0.22, type: 'square' });

--- a/labs/river-knight/src/config.js
+++ b/labs/river-knight/src/config.js
@@ -22,19 +22,29 @@ export const BOAT = {
     strafeSpeed: 15.5,
     strafeAccel: 46,
     maxHull: 5,
-    throwCooldown: 0.42,
-    furyCooldown: 0.16,
+    /** Recarga de canhão (uma salva). */
+    throwCooldown: 0.78,
+    furyCooldown: 0.34,
     invulnAfterHit: 1.4,
     bankLimitPadding: 3.4
 };
 
-export const AXE = {
-    speed: 78,
-    gravity: 16,
-    life: 2.6,
+/** Canhão de bordo — mira automática (estilo jogos de navio). */
+export const CANNON = {
+    speed: 108,
+    gravity: 11,
+    life: 3.4,
     damage: 1,
-    spin: 22
+    /** Alcance de trava automática. */
+    assistRange: 155,
+    /** Cone bem amplo (~87°): só precisa apontar o navio. */
+    assistCone: 0.05,
+    loft: 6.2,
+    ballRadius: 1.85
 };
+
+/** Alias legado — alguns módulos ainda referenciam AXE. */
+export const AXE = CANNON;
 
 export const DIFFICULTY = {
     squire: {
@@ -116,7 +126,7 @@ export const QUALITY = {
     high: {
         id: 'high',
         label: 'Cinemática',
-        pixelRatio: 2,
+        pixelRatio: 1.5,
         antialias: true,
         shadows: true,
         shadowSize: 2048,

--- a/labs/river-knight/src/effects.js
+++ b/labs/river-knight/src/effects.js
@@ -19,6 +19,7 @@ class ParticleSystem {
     constructor({ texture, max = 600, blending = THREE.AdditiveBlending, depthWrite = false }) {
         this.max = max;
         this.cursor = 0;
+        this._wasAlive = false;
 
         this.positions = new Float32Array(max * 3);
         this.colors = new Float32Array(max * 3);
@@ -115,6 +116,7 @@ class ParticleSystem {
 
     update(dt) {
         const { positions, vel, life, maxLife, alphas, sizes, gravity, drag, grow, baseSize } = this;
+        let alive = 0;
         for (let i = 0; i < this.max; i++) {
             if (life[i] <= 0) {
                 if (alphas[i] !== 0) alphas[i] = 0;
@@ -125,6 +127,7 @@ class ParticleSystem {
                 alphas[i] = 0;
                 continue;
             }
+            alive++;
             const d = Math.exp(-drag[i] * dt);
             vel[i * 3] *= d;
             vel[i * 3 + 1] = vel[i * 3 + 1] * d - gravity[i] * dt;
@@ -139,15 +142,19 @@ class ParticleSystem {
             sizes[i] = baseSize[i] * (1 + grow[i] * (1 - t));
         }
 
-        this.geometry.attributes.position.needsUpdate = true;
-        this.geometry.attributes.aAlpha.needsUpdate = true;
-        this.geometry.attributes.aSize.needsUpdate = true;
-        this.geometry.attributes.aColor.needsUpdate = true;
+        if (alive > 0 || this._wasAlive) {
+            this.geometry.attributes.position.needsUpdate = true;
+            this.geometry.attributes.aAlpha.needsUpdate = true;
+            this.geometry.attributes.aSize.needsUpdate = true;
+            this.geometry.attributes.aColor.needsUpdate = true;
+        }
+        this._wasAlive = alive > 0;
     }
 
     reset() {
         this.life.fill(0);
         this.alphas.fill(0);
+        this._wasAlive = false;
         this.geometry.attributes.aAlpha.needsUpdate = true;
     }
 }
@@ -215,7 +222,8 @@ class Wake {
 
         this.mesh = new THREE.Mesh(geo, material);
         this.mesh.frustumCulled = false;
-        this.mesh.renderOrder = 6;
+        this.mesh.renderOrder = 3;
+        this.mesh.material.depthTest = true;
         this.material = material;
     }
 
@@ -234,8 +242,8 @@ class Wake {
         const trail = this.trail;
         for (let i = trail.length - 1; i >= 0; i--) {
             trail[i].age += dt;
-            trail[i].width += dt * 1.5;
-            if (trail[i].age > 2.6) trail.splice(i, 1);
+            trail[i].width += dt * 1.95;
+            if (trail[i].age > 3.3) trail.splice(i, 1);
         }
 
         const n = this.samples;
@@ -262,8 +270,8 @@ class Wake {
             const px = -dz;
             const pz = dx;
 
-            const w = s.width;
-            const y = waterHeight(s.x, s.z, time) + 0.07;
+            const w = Math.min(s.width, 4.2);
+            const y = waterHeight(s.x, s.z, time) + 0.04;
             this.positions[a] = s.x - px * w;
             this.positions[a + 1] = y;
             this.positions[a + 2] = s.z - pz * w;
@@ -277,7 +285,7 @@ class Wake {
             this.uvs[u + 3] = idx / this.samples;
 
             const headFade = Math.min(1, s.age / 0.35);
-            const fade = Math.max(0, 1 - s.age / 2.6) ** 1.6 * s.strength * 0.62 * headFade;
+            const fade = Math.max(0, 1 - s.age / 3.3) ** 1.45 * s.strength * 0.7 * headFade;
             this.alphas[i * 2] = fade;
             this.alphas[i * 2 + 1] = fade;
         }
@@ -365,8 +373,8 @@ export class Effects {
         const scale = quality.id === 'low' ? 0.5 : 1;
 
         this.spray = new ParticleSystem({
-            texture: sparkTexture(),
-            max: Math.round(520 * scale),
+            texture: smokeTexture(),
+            max: Math.round(420 * scale),
             blending: THREE.NormalBlending
         });
         this.embers = new ParticleSystem({
@@ -412,10 +420,10 @@ export class Effects {
                 {
                     life: 0.45 + Math.random() * 0.5,
                     size: 0.2 + Math.random() * 0.38,
-                    color: tmpColor.setRGB(0.86, 0.92, 0.96),
+                    color: tmpColor.setRGB(0.9, 0.95, 0.98),
                     gravity: 11,
                     drag: 0.9,
-                    grow: 1.3
+                    grow: 1.5
                 }
             );
         }

--- a/labs/river-knight/src/entities.js
+++ b/labs/river-knight/src/entities.js
@@ -1,6 +1,6 @@
 /**
  * Entidades do rio: barcos inimigos, torres, barricadas, rochas, redemoinhos,
- * itens, flechas e machados.
+ * itens, flechas e balas de canhão.
  *
  * Todas vivem em pools de tamanho fixo criados no início da partida. Durante o
  * jogo nada é instanciado: objetos apenas alternam entre ativo e inativo.
@@ -14,12 +14,12 @@ import {
     buildRockGeometry,
     buildPickup,
     buildArrowMesh,
-    buildAxeMesh,
+    buildCannonballMesh,
     plainMaterial
-} from './models.js';
+} from './models.js?v=12';
 import { waterHeight, waterSlope } from './water.js';
 import { centerX, halfWidth, terrainHeight } from './river.js';
-import { AXE, SCORE } from './config.js';
+import { CANNON, SCORE } from './config.js?v=12';
 import { clamp, damp, randRange } from './utils.js';
 
 const tmpSlope = { dx: 0, dz: 0 };
@@ -492,35 +492,32 @@ class Arrow extends Entity {
     }
 }
 
-class Axe extends Entity {
+class Cannonball extends Entity {
     constructor() {
-        super(buildAxeMesh(1));
-        this.kind = 'axe';
-        this.radius = 1.4;
+        super(buildCannonballMesh(1));
+        this.kind = 'shot';
+        this.radius = CANNON.ballRadius;
         this.velocity = new THREE.Vector3();
         this.life = 0;
-        this.spin = 0;
     }
 
-    spawn(x, y, z, dirX, dirZ, speed = AXE.speed) {
+    spawn(x, y, z, dirX, dirZ, speed = CANNON.speed, loft = CANNON.loft) {
         this.group.position.set(x, y, z);
-        this.velocity.set(dirX * speed, 6.5, dirZ * speed);
-        this.life = AXE.life;
-        this.spin = 0;
+        this.velocity.set(dirX * speed, loft, dirZ * speed);
+        this.life = CANNON.life;
         this.activate();
     }
 
     update(dt, ctx) {
-        this.velocity.y -= AXE.gravity * dt;
+        this.velocity.y -= CANNON.gravity * dt;
         this.group.position.addScaledVector(this.velocity, dt);
-        this.spin += AXE.spin * dt;
-        this.group.rotation.set(this.spin, 0.2, Math.PI * 0.12);
         this.life -= dt;
 
         const pos = this.group.position;
-        if (pos.y < waterHeight(pos.x, pos.z, ctx.time) - 0.2) {
-            ctx.effects.splash(pos.x, 0.1, pos.z, 10, 0.8);
-            ctx.audio.sfx('splash', 0.5);
+        if (pos.y < waterHeight(pos.x, pos.z, ctx.time) - 0.15) {
+            ctx.effects.splash(pos.x, 0.15, pos.z, 18, 1.25);
+            ctx.effects.smokePuff(pos.x, 0.4, pos.z, 4, 0.7);
+            ctx.audio.sfx('splash', 0.7);
             this.deactivate();
             return;
         }
@@ -540,7 +537,7 @@ const POOL_SIZES = {
     whirlpools: 3,
     pickups: 16,
     arrows: 46,
-    axes: 22
+    shots: 24
 };
 
 export class Entities {
@@ -566,7 +563,7 @@ export class Entities {
         make('whirlpools', () => new Whirlpool(), POOL_SIZES.whirlpools);
         make('pickups', () => new PickupItem(), POOL_SIZES.pickups);
         make('arrows', () => new Arrow(), POOL_SIZES.arrows);
-        make('axes', () => new Axe(), POOL_SIZES.axes);
+        make('shots', () => new Cannonball(), POOL_SIZES.shots);
 
         this.targets = ['enemyShips', 'towers', 'barricades', 'rocks', 'whirlpools'];
     }
@@ -617,10 +614,71 @@ export class Entities {
         return e;
     }
 
-    throwAxe(x, y, z, dirX, dirZ, speed) {
-        const e = this._free('axes');
-        e?.spawn(x, y, z, dirX, dirZ, speed);
+    fireShot(x, y, z, dirX, dirZ, speed, loft) {
+        const e = this._free('shots');
+        e?.spawn(x, y, z, dirX, dirZ, speed, loft);
         return e;
+    }
+
+    /** @deprecated use fireShot */
+    throwAxe(x, y, z, dirX, dirZ, speed, loft) {
+        return this.fireShot(x, y, z, dirX, dirZ, speed, loft);
+    }
+
+    /**
+     * Alvo automático para canhão: prioriza torre, depois barco, no hemisfério à frente.
+     * Cone largo — o jogador só precisa apontar o navio grosso modo.
+     */
+    findCannonTarget(originX, originY, originZ, forwardX, forwardZ, range = CANNON.assistRange) {
+        let best = null;
+        let bestScore = Infinity;
+        const keys = ['towers', 'enemyShips', 'barricades'];
+        const range2 = range * range;
+        const fLen = Math.hypot(forwardX, forwardZ) || 1;
+        const fx = forwardX / fLen;
+        const fz = forwardZ / fLen;
+
+        for (const key of keys) {
+            for (const target of this.pools[key]) {
+                if (!target.active || target.indestructible || target.sinking > 0 || target.crumble > 0) continue;
+                const dx = target.position.x - originX;
+                const dz = target.position.z - originZ;
+                const dist2 = dx * dx + dz * dz;
+                if (dist2 < 9 || dist2 > range2) continue;
+                const dist = Math.sqrt(dist2);
+                const ndx = dx / dist;
+                const ndz = dz / dist;
+                const dot = ndx * fx + ndz * fz;
+                if (dot < CANNON.assistCone) continue;
+
+                const kindBias = key === 'towers' ? 0.55 : key === 'enemyShips' ? 0.7 : 1;
+                const score = (dist / range) * kindBias + (1 - dot) * 0.85;
+                if (score < bestScore) {
+                    bestScore = score;
+                    const aimY = key === 'towers' ? target.position.y + 7 : target.position.y + 1.8;
+                    // Antecipação simples para barcos em movimento.
+                    let leadX = target.position.x;
+                    let leadZ = target.position.z;
+                    if (key === 'enemyShips' && target.speed) {
+                        const tFlight = dist / CANNON.speed;
+                        leadZ -= target.speed * tFlight;
+                    }
+                    best = {
+                        kind: key,
+                        x: leadX,
+                        y: aimY,
+                        z: leadZ,
+                        dist,
+                        entity: target
+                    };
+                }
+            }
+        }
+        return best;
+    }
+
+    findThrowTarget(originX, originY, originZ, forwardX, forwardZ, range) {
+        return this.findCannonTarget(originX, originY, originZ, forwardX, forwardZ, range);
     }
 
     /** Atualiza todas as entidades ativas. */
@@ -632,24 +690,32 @@ export class Entities {
         }
     }
 
-    /** Colisão dos machados do jogador com alvos destrutíveis. */
+    /** Colisão das balas de canhão com alvos destrutíveis. */
     resolveAxeHits(ctx) {
-        for (const axe of this.pools.axes) {
-            if (!axe.active) continue;
-            const ap = axe.group.position;
+        for (const shot of this.pools.shots) {
+            if (!shot.active) continue;
+            const ap = shot.group.position;
 
             for (const key of this.targets) {
                 for (const target of this.pools[key]) {
                     if (!target.active || target.indestructible || target.sinking > 0 || target.crumble > 0) continue;
                     const dx = target.position.x - ap.x;
                     const dz = target.position.z - ap.z;
-                    const dy = target.position.y - ap.y;
-                    const r = target.radius + axe.radius;
+                    const r = target.radius + shot.radius;
                     if (dx * dx + dz * dz > r * r) continue;
-                    if (Math.abs(dy) > (key === 'towers' ? 12 : 5)) continue;
 
-                    const killed = target.hit(AXE.damage, ctx);
-                    axe.deactivate();
+                    if (key === 'towers') {
+                        const baseY = target.position.y;
+                        if (ap.y < baseY - 1.5 || ap.y > baseY + 14) continue;
+                    } else {
+                        const dy = target.position.y - ap.y;
+                        if (Math.abs(dy) > 5.5) continue;
+                    }
+
+                    const killed = target.hit(CANNON.damage, ctx);
+                    ctx.effects.explosion(ap.x, ap.y, ap.z, 0.55, 0.35);
+                    ctx.audio.sfx('explosion', 0.35);
+                    shot.deactivate();
                     if (killed) {
                         const points =
                             key === 'enemyShips' ? SCORE.enemyShip : key === 'towers' ? SCORE.tower : SCORE.barricade;
@@ -660,13 +726,12 @@ export class Entities {
             }
         }
 
-        // Machados também derrubam flechas em voo (defesa de última hora).
-        for (const axe of this.pools.axes) {
-            if (!axe.active) continue;
+        for (const shot of this.pools.shots) {
+            if (!shot.active) continue;
             for (const arrow of this.pools.arrows) {
                 if (!arrow.active) continue;
-                const d = axe.group.position.distanceToSquared(arrow.group.position);
-                if (d < 6) {
+                const d = shot.group.position.distanceToSquared(arrow.group.position);
+                if (d < 8) {
                     ctx.effects.impact(arrow.group.position.x, arrow.group.position.y, arrow.group.position.z, 0xffc987);
                     ctx.audio.sfx('hitMetal');
                     arrow.deactivate();
@@ -686,4 +751,4 @@ export class Entities {
     }
 }
 
-export { EnemyShip, Tower, Barricade, RockObstacle, Whirlpool, PickupItem, Arrow, Axe };
+export { EnemyShip, Tower, Barricade, RockObstacle, Whirlpool, PickupItem, Arrow, Cannonball };

--- a/labs/river-knight/src/hud.js
+++ b/labs/river-knight/src/hud.js
@@ -30,6 +30,9 @@ export class Hud {
             steerZone: $('steerZone'),
             soundButton: $('soundButton'),
             pauseButton: $('pauseButton'),
+            reticle: $('reticle'),
+            reticleLabel: $('reticleLabel'),
+            throwFill: $('throwFill'),
 
             loading: $('loadingOverlay'),
             loadingFill: $('loadingFill'),
@@ -174,6 +177,26 @@ export class Hud {
         this.flashTimer = setTimeout(() => {
             el.dataset.show = 'false';
         }, 90);
+    }
+
+    /** Mira: trava visual quando há torre/inimigo no cone. */
+    setAim(lock) {
+        if (!this.el.reticle) return;
+        const locked = Boolean(lock);
+        this.el.reticle.dataset.lock = String(locked);
+        if (!this.el.reticleLabel) return;
+        if (!locked) {
+            this.el.reticleLabel.textContent = '';
+            return;
+        }
+        const labels = { towers: 'Torre', enemyShips: 'Navio', barricades: 'Barricada' };
+        this.el.reticleLabel.textContent = labels[lock.kind] || 'Alvo';
+    }
+
+    /** 0 = recarregando, 1 = canhão pronto. */
+    setThrowReady(ratio) {
+        if (!this.el.throwFill) return;
+        this.el.throwFill.style.width = `${Math.max(0, Math.min(1, ratio)) * 100}%`;
     }
 
     /* ---------------------------- overlays ------------------------------ */

--- a/labs/river-knight/src/main.js
+++ b/labs/river-knight/src/main.js
@@ -12,28 +12,29 @@ import {
     COURSE_LENGTH,
     CASTLE_Z,
     BOSS_Z,
-    STORAGE_KEY
-} from './config.js';
+    STORAGE_KEY,
+    BOAT
+} from './config.js?v=12';
 import { createSky, createSkyUniforms, sampleSkyPalette, applySkyPalette } from './sky.js';
 import { createWater, waterHeight } from './water.js';
 import { createTerrain } from './terrain.js';
-import { Effects } from './effects.js';
-import { Entities } from './entities.js';
+import { Effects } from './effects.js?v=12';
+import { Entities } from './entities.js?v=12';
 import { World } from './world.js';
-import { Player } from './player.js';
+import { Player } from './player.js?v=12';
 import { createCastle, BossBarge } from './castle.js';
 import { Hud } from './hud.js';
 import { Input } from './input.js';
-import { GameAudio } from './audio.js';
-import { updateCloth } from './models.js';
+import { GameAudio } from './audio.js?v=12';
+import { updateCloth } from './models.js?v=12';
 import { centerX, halfWidth } from './river.js';
 import { clamp, damp, detectMobile, formatTime, randRange } from './utils.js';
 
 const WHITE = new THREE.Color(1, 1, 1);
 
 const CAMERA_MODES = [
-    { name: 'perseguição', offset: new THREE.Vector3(0, 9.6, 22), look: new THREE.Vector3(0, 2.6, -17) },
-    { name: 'proa', offset: new THREE.Vector3(0, 6.2, 14.5), look: new THREE.Vector3(0, 2.2, -22) },
+    { name: 'perseguição', offset: new THREE.Vector3(0, 9.4, 20.5), look: new THREE.Vector3(0, 4.8, -12) },
+    { name: 'proa', offset: new THREE.Vector3(0, 7.2, 15.5), look: new THREE.Vector3(0, 3.6, -22) },
     { name: 'aérea', offset: new THREE.Vector3(0, 17, 30), look: new THREE.Vector3(0, 1.5, -12) }
 ];
 
@@ -193,7 +194,7 @@ class Game {
         this.boss = new BossBarge(this.scene);
 
         this.hud.setLoading(0.92, 'Preparando o guerreiro…');
-        this.player = new Player(this.scene);
+        this.player = new Player(this.scene, quality);
 
         this.audio = new GameAudio();
         this.audio.enabled = !this.settings.muted;
@@ -398,7 +399,7 @@ class Game {
         this.hud.setScore(0);
         this.hud.setCombo(1);
         this.hud.setTime(0);
-        this.hud.message('Rume ao castelo!', 'gold', 2600);
+        this.hud.message('Rumo ao castelo!', 'gold', 1800);
 
         this.updateCamera(1, true);
     }
@@ -560,7 +561,7 @@ class Game {
         p.z -= dt * 7;
         p.x = damp(p.x, centerX(p.z), 1.2, dt);
         const wy = waterHeight(p.x, p.z, this.time);
-        p.root.position.set(p.x, wy + 0.62, p.z);
+        p.root.position.set(p.x, wy + 0.42, p.z);
         p.root.rotation.z = Math.sin(this.time * 0.7) * 0.035;
         p.root.rotation.x = Math.sin(this.time * 0.5) * 0.02;
 
@@ -572,7 +573,7 @@ class Game {
         p.wParts.armR.rotation.x = -0.25 + Math.sin(this.time * 1.2) * 0.08;
         p.wParts.torso.rotation.z = Math.sin(this.time * 1.4) * 0.05;
 
-        this.effects.wake.push(p.x, p.z + 6.5, 1.5, 0.5);
+        this.effects.wake.push(p.x, p.z + 6.5, 2.0, 0.55);
         if (Math.random() < 0.4) this.effects.splash(p.x, wy, p.z - 6.5, 2, 0.4);
 
         const radius = 26;
@@ -629,10 +630,24 @@ class Game {
         ctx.speedScale = this.bossStarted && this.boss.active && this.boss.dying <= 0 ? 0.92 : 1;
 
         if (this.input.consumeFire() || (this.player.hasFury && this.input.firing)) {
-            if (this.player.throwAxe(this.entities, ctx)) this.audio.sfx('throw');
+            if (this.player.fireCannons(this.entities, ctx)) {
+                this.audio.sfx('cannon', this.player.hasFury ? 1.15 : 1);
+                const lock = this.player._lastLock;
+                if (lock?.kind === 'towers') this.hud.message('Canhão na torre!', 'gold', 900);
+                else if (lock?.kind === 'enemyShips') this.hud.message('Bordo a bordo!', 'gold', 800);
+            }
         }
 
         this.player.update(dt, ctx);
+
+        // Mira automática — só aponta o navio; a retícula trava sozinha.
+        {
+            const lock = this.player.getAimLock(this.entities);
+            this.hud.setAim(lock);
+            const cd = this.player.hasFury ? BOAT.furyCooldown : BOAT.throwCooldown;
+            const ready = 1 - clamp(this.player.throwTimer / cd, 0, 1);
+            this.hud.setThrowReady(ready);
+        }
 
         // O chefe fecha o rio: não dá para passar por ele.
         if (this.boss.active && this.boss.dying <= 0) {
@@ -715,15 +730,23 @@ class Game {
         boss.update(dt, ctx);
 
         if (boss.dying <= 0) {
-            // Machados contra o chefe.
-            for (const axe of this.entities.pools.axes) {
-                if (!axe.active) continue;
-                const dx = axe.group.position.x - boss.group.position.x;
-                const dz = axe.group.position.z - boss.group.position.z;
-                const dy = axe.group.position.y - boss.group.position.y;
-                if (Math.abs(dx) < 7 && Math.abs(dz) < 17 && dy < 9 && dy > -3) {
-                    axe.deactivate();
+            // Balas de canhão contra o chefe.
+            for (const shot of this.entities.pools.shots) {
+                if (!shot.active) continue;
+                const dx = shot.group.position.x - boss.group.position.x;
+                const dz = shot.group.position.z - boss.group.position.z;
+                const dy = shot.group.position.y - boss.group.position.y;
+                if (Math.abs(dx) < 8 && Math.abs(dz) < 18 && dy < 10 && dy > -3) {
+                    shot.deactivate();
                     boss.hit(1, ctx);
+                    this.effects.explosion(
+                        shot.group.position.x,
+                        shot.group.position.y,
+                        shot.group.position.z,
+                        0.7,
+                        0.3
+                    );
+                    this.audio.sfx('explosion', 0.45);
                     this.hud.setBossHealth(boss.healthRatio);
                 }
             }

--- a/labs/river-knight/src/models.js
+++ b/labs/river-knight/src/models.js
@@ -133,9 +133,20 @@ export function updateCloth(time) {
 /* Casco                                                               */
 /* ------------------------------------------------------------------ */
 
+/** Perfil do casco em t ∈ [-1, 1] (−1 popa, +1 proa). */
+function hullShapeAt(t, { length = 15, beam = 3.6, depth = 1.6, rise = 1.9 } = {}) {
+    const taper = Math.pow(Math.max(0, 1 - t * t), 0.42);
+    return {
+        hw: Math.max(0.09, (beam / 2) * taper),
+        dep: depth * (0.55 + 0.45 * taper),
+        sheer: rise * Math.pow(Math.abs(t), 2.6),
+        z: (t * length) / 2
+    };
+}
+
 /**
- * Gera o casco por seções transversais.
- * @param {object} o dimensões do barco
+ * Gera só a casca do casco (loft em U). O convés é mesh separada —
+ * ver `buildDeckGeometry`.
  */
 export function buildHullGeometry({
     length = 15,
@@ -148,21 +159,11 @@ export function buildHullGeometry({
     const positions = [];
     const uvs = [];
     const indices = [];
-
-    const shapeAt = (t) => {
-        // t ∈ [-1, 1]: -1 popa, +1 proa.
-        const taper = Math.pow(Math.max(0, 1 - t * t), 0.42);
-        return {
-            hw: Math.max(0.09, (beam / 2) * taper),
-            dep: depth * (0.55 + 0.45 * taper),
-            sheer: rise * Math.pow(Math.abs(t), 2.6),
-            z: (t * length) / 2
-        };
-    };
+    const dims = { length, beam, depth, rise };
 
     for (let r = 0; r <= rings; r++) {
         const t = (r / rings) * 2 - 1;
-        const { hw, dep, sheer, z } = shapeAt(t);
+        const { hw, dep, sheer, z } = hullShapeAt(t, dims);
         for (let a = 0; a <= arcSteps; a++) {
             const s = a / arcSteps;
             const ang = -Math.PI / 2 + s * Math.PI;
@@ -184,22 +185,76 @@ export function buildHullGeometry({
         }
     }
 
-    // Convés: liga bordo a bordo um pouco abaixo da amurada.
-    const deckStart = positions.length / 3;
+    // Tampas da proa e da popa — fecham o U para a câmera não ver a água
+    // através do túnel do casco.
+    const midArc = Math.floor(arcSteps / 2);
+    for (const end of [0, rings]) {
+        const base = end * perRing;
+        const keel = base + midArc;
+        // Fan a partir da quilha cobrindo o arco (normals para fora do barco).
+        for (let a = 0; a < arcSteps; a++) {
+            const iA = base + a;
+            const iB = base + a + 1;
+            if (end === 0) indices.push(keel, iB, iA); // popa (−Z): normal −Z
+            else indices.push(keel, iA, iB); // proa (+Z): normal +Z
+        }
+    }
+
+    const geo = new THREE.BufferGeometry();
+    geo.setAttribute('position', new THREE.Float32BufferAttribute(positions, 3));
+    geo.setAttribute('uv', new THREE.Float32BufferAttribute(uvs, 2));
+    geo.setIndex(indices);
+    geo.computeVertexNormals();
+    geo.computeBoundingSphere();
+    return geo;
+}
+
+/**
+ * Convés com espessura e normals para cima (visível da câmera de perseguição).
+ * Topo em sheer − drop; fundo em topo − thickness.
+ */
+export function buildDeckGeometry({
+    length = 15,
+    beam = 3.6,
+    rise = 1.9,
+    rings = 28,
+    drop = 0.28,
+    thickness = 0.14,
+    inset = 0.995
+} = {}) {
+    const positions = [];
+    const uvs = [];
+    const indices = [];
+    const dims = { length, beam, rise };
+
+    // Ordem por anel: L-top, R-top, L-bot, R-bot.
     for (let r = 0; r <= rings; r++) {
         const t = (r / rings) * 2 - 1;
-        const { hw, sheer, z } = shapeAt(t);
-        const y = sheer - 0.42;
-        positions.push(-hw * 0.94, y, z, hw * 0.94, y, z);
-        uvs.push(0, (r / rings) * 3.2, 1, (r / rings) * 3.2);
+        const { hw, sheer, z } = hullShapeAt(t, dims);
+        const x = Math.max(0.08, hw * inset);
+        const yTop = sheer - drop;
+        const yBot = yTop - thickness;
+        const v = (r / rings) * 3.2;
+        positions.push(-x, yTop, z, x, yTop, z, -x, yBot, z, x, yBot, z);
+        uvs.push(0, v, 1, v, 0, v, 1, v);
     }
+
     for (let r = 0; r < rings; r++) {
-        const i0 = deckStart + r * 2;
-        const i1 = i0 + 1;
-        const i2 = i0 + 2;
-        const i3 = i0 + 3;
-        indices.push(i0, i1, i2, i1, i3, i2);
+        const b = r * 4;
+        const n = b + 4;
+        // Topo: winding CCW visto de cima → normal +Y.
+        indices.push(b, n, b + 1, b + 1, n, n + 1);
+        // Fundo: normal −Y.
+        indices.push(b + 2, b + 3, n + 2, b + 3, n + 3, n + 2);
+        // Bordas laterais (fecha a espessura).
+        indices.push(b, b + 2, n, n, b + 2, n + 2);
+        indices.push(b + 1, n + 1, b + 3, b + 3, n + 1, n + 3);
     }
+
+    // Tampas do convés nas pontas.
+    const last = rings * 4;
+    indices.push(0, 1, 3, 0, 3, 2);
+    indices.push(last, last + 3, last + 1, last, last + 2, last + 3);
 
     const geo = new THREE.BufferGeometry();
     geo.setAttribute('position', new THREE.Float32BufferAttribute(positions, 3));
@@ -262,16 +317,187 @@ export function buildLongship({
     shields = true,
     oars = true,
     dragon = true,
-    lantern = true
+    lantern = true,
+    lanternLight = true,
+    cannons = false
 } = {}) {
     const group = new THREE.Group();
-    const parts = { oars: [], shields: [], lights: [] };
+    const parts = { oars: [], shields: [], lights: [], cannons: [] };
+    const deckDrop = 0.22;
+    const deckThickness = 0.18;
 
-    const hull = new THREE.Mesh(buildHullGeometry({ length, beam }), woodMaterial(false, hullColor));
+    const hull = new THREE.Mesh(buildHullGeometry({ length, beam }), woodMaterial(false, hullColor).clone());
     hull.castShadow = true;
     hull.receiveShadow = true;
+    hull.material.side = THREE.DoubleSide;
+    hull.material.color.multiplyScalar(0.88);
     group.add(hull);
     parts.hull = hull;
+
+    // Porão sólido que segue o afilamento do casco — a água nunca “entra”.
+    const bilgeMat = new THREE.MeshStandardMaterial({
+        color: 0x120d09,
+        roughness: 1,
+        metalness: 0,
+        flatShading: false
+    });
+    const bilgeRoot = new THREE.Group();
+    bilgeRoot.raycast = () => {};
+    const bilgeSegs = 14;
+    for (let i = 0; i < bilgeSegs; i++) {
+        const t0 = -0.98 + (i / bilgeSegs) * 1.96;
+        const t1 = -0.98 + ((i + 1) / bilgeSegs) * 1.96;
+        const t = (t0 + t1) * 0.5;
+        const { hw, dep, sheer, z } = hullShapeAt(t, { length, beam });
+        const topY = sheer - deckDrop + 0.06;
+        const botY = sheer - dep * 0.98 - 0.08;
+        const h = Math.max(0.55, topY - botY);
+        const segLen = Math.abs(((t1 - t0) * length) / 2) * 1.08;
+        const plug = new THREE.Mesh(
+            new THREE.BoxGeometry(Math.max(0.28, hw * 2.08), h, segLen),
+            bilgeMat
+        );
+        plug.position.set(0, (topY + botY) * 0.5, z);
+        plug.raycast = () => {};
+        bilgeRoot.add(plug);
+    }
+    group.add(bilgeRoot);
+    parts.bilge = bilgeRoot;
+
+    // Convés separado: madeira escura, espesso, normals para cima.
+    const deckMat = woodMaterial(true, 0x6a4a32).clone();
+    deckMat.polygonOffset = true;
+    deckMat.polygonOffsetFactor = 1;
+    deckMat.polygonOffsetUnits = 1;
+    const deck = new THREE.Mesh(
+        buildDeckGeometry({
+            length,
+            beam,
+            drop: deckDrop,
+            thickness: Math.max(deckThickness, 0.26),
+            inset: 0.992
+        }),
+        deckMat
+    );
+    deck.castShadow = true;
+    deck.receiveShadow = true;
+    group.add(deck);
+    parts.deck = deck;
+
+    // Ripas do piso — leitura de prancha, fecha visualmente o vão residual.
+    const plankMat = woodMaterial(true, 0x4a3222);
+    for (let i = -2; i <= 2; i++) {
+        if (i === 0) continue;
+        const plank = new THREE.Mesh(new THREE.BoxGeometry(0.08, 0.03, length * 0.82), plankMat);
+        plank.position.set(i * beam * 0.14, -deckDrop + 0.02, 0);
+        group.add(plank);
+    }
+
+    // Anteparas na proa/popa (bem nas pontas) — bloqueiam o túnel para a água.
+    const bulkMat = woodMaterial(true, 0x2e1c12);
+    for (const t of [-0.94, -0.55, 0.55, 0.94]) {
+        const { hw, sheer, dep, z } = hullShapeAt(t, { length, beam });
+        const deckY = sheer - deckDrop;
+        const bilge = sheer - dep * 0.85;
+        const h = Math.max(0.55, deckY - bilge + 0.35);
+        const bulk = new THREE.Mesh(new THREE.BoxGeometry(hw * 1.85, h, 0.11), bulkMat);
+        bulk.position.set(0, bilge + h * 0.5, z);
+        bulk.castShadow = true;
+        group.add(bulk);
+    }
+
+    // Espelho de popa/proa — a câmera de perseguição olha para dentro do U;
+    // sem painel sólido a água atravessa o casco.
+    for (const t of [-0.995, 0.995]) {
+        const { hw, sheer, dep, z } = hullShapeAt(t, { length, beam });
+        const bilge = sheer - dep;
+        const h = Math.max(1.15, sheer - bilge + 0.6);
+        const panel = new THREE.Mesh(
+            new THREE.BoxGeometry(Math.max(0.65, hw * 2.15), h, 0.2),
+            bulkMat
+        );
+        panel.position.set(0, bilge + h * 0.52, z);
+        panel.castShadow = true;
+        group.add(panel);
+    }
+
+    // Plataforma de popa (guerreiro) — fecha o túnel que a câmera vê.
+    {
+        const sternMat = woodMaterial(true, 0x4a3222);
+        const sternDark = woodMaterial(true, 0x2a1a12);
+
+        // Bloco único da quilha ao peitoril, da popa até midships.
+        // Centro alto o bastante para o topo ficar acima da linha d'água.
+        const sternPlug = new THREE.Mesh(
+            new THREE.BoxGeometry(beam * 0.98, 2.4, length * 0.52),
+            sternDark
+        );
+        sternPlug.position.set(0, 0.05, -length * 0.24);
+        sternPlug.raycast = () => {};
+        group.add(sternPlug);
+
+        const platform = new THREE.Mesh(
+            new THREE.BoxGeometry(beam * 0.98, 0.32, length * 0.52),
+            sternMat
+        );
+        platform.position.set(0, -deckDrop + 0.55, -length * 0.2);
+        platform.castShadow = true;
+        platform.receiveShadow = true;
+        group.add(platform);
+        parts.sternPlatform = platform;
+
+        // Convés elevado contínuo (leitura de madeira, não de vazio).
+        const aftDeck = new THREE.Mesh(
+            new THREE.BoxGeometry(beam * 1.0, 0.18, length * 0.54),
+            woodMaterial(true, 0x5c3d28)
+        );
+        aftDeck.position.set(0, -deckDrop + 0.7, -length * 0.18);
+        aftDeck.receiveShadow = true;
+        group.add(aftDeck);
+
+        const rail = new THREE.Mesh(
+            new THREE.BoxGeometry(beam * 0.96, 0.48, 0.18),
+            woodMaterial(true, 0x3a2618)
+        );
+        rail.position.set(0, -deckDrop + 0.98, -length * 0.44);
+        group.add(rail);
+
+        for (const side of [-1, 1]) {
+            const cheek = new THREE.Mesh(
+                new THREE.BoxGeometry(0.22, 1.35, length * 0.5),
+                woodMaterial(true, 0x3a2618)
+            );
+            cheek.position.set(side * beam * 0.46, -deckDrop + 0.35, -length * 0.2);
+            group.add(cheek);
+        }
+
+        // Tampa de popa alta — silhueta fechada vista da câmera de perseguição.
+        const transom = new THREE.Mesh(
+            new THREE.BoxGeometry(beam * 0.98, 1.75, 0.32),
+            woodMaterial(true, 0x2e1c12)
+        );
+        transom.position.set(0, 0.15, -length * 0.48);
+        transom.castShadow = true;
+        group.add(transom);
+    }
+
+    // Sombra de contato na superfície da água (o corpo d'água é opaco).
+    // root.y ≈ water + 0.42 → y local ≈ −0.36 fica logo acima da água.
+    const contact = new THREE.Mesh(
+        new THREE.CircleGeometry(beam * 0.42, 20),
+        new THREE.MeshBasicMaterial({
+            color: 0x030a12,
+            transparent: true,
+            opacity: 0.38,
+            depthWrite: false
+        })
+    );
+    contact.rotation.x = -Math.PI / 2;
+    contact.position.y = -0.36;
+    contact.scale.set(1.2, 3.1, 1);
+    contact.renderOrder = 3;
+    group.add(contact);
+    parts.contactShadow = contact;
 
     // Amurada (borda superior) — dois "trilhos" curvos de madeira escura.
     const railMat = woodMaterial(true, hullColor);
@@ -280,10 +506,8 @@ export function buildLongship({
         const pts = [];
         for (let i = 0; i <= railSteps; i++) {
             const t = (i / railSteps) * 2 - 1;
-            const taper = Math.pow(Math.max(0, 1 - t * t), 0.42);
-            const hw = Math.max(0.09, (beam / 2) * taper);
-            const sheer = 1.9 * Math.pow(Math.abs(t), 2.6);
-            pts.push(new THREE.Vector3(side * hw, sheer + 0.03, (t * length) / 2));
+            const { hw, sheer, z } = hullShapeAt(t, { length, beam });
+            pts.push(new THREE.Vector3(side * hw, sheer + 0.03, z));
         }
         const rail = new THREE.Mesh(
             new THREE.TubeGeometry(new THREE.CatmullRomCurve3(pts), railSteps, 0.11, 6, false),
@@ -297,6 +521,40 @@ export function buildLongship({
     const keel = new THREE.Mesh(new THREE.BoxGeometry(0.16, 0.22, length * 0.98), railMat);
     keel.position.y = -1.35;
     group.add(keel);
+
+    // Faixa molhada na linha d'água (leitura do casco contra a água).
+    const waterlineMat = woodMaterial(true, 0x2a1a12);
+    for (const side of [-1, 1]) {
+        const pts = [];
+        for (let i = 0; i <= 20; i++) {
+            const t = (i / 20) * 2 - 1;
+            const { hw, z } = hullShapeAt(t, { length, beam });
+            pts.push(new THREE.Vector3(side * hw * 1.01, -0.95, z));
+        }
+        const band = new THREE.Mesh(
+            new THREE.TubeGeometry(new THREE.CatmullRomCurve3(pts), 20, 0.07, 5, false),
+            waterlineMat
+        );
+        group.add(band);
+    }
+
+    // Costelas internas (poucas, só para volume).
+    const ribMat = woodMaterial(true, 0x2e1d14);
+    const ribCount = 5;
+    for (let i = 0; i < ribCount; i++) {
+        const t = -0.55 + (i / (ribCount - 1)) * 1.1;
+        const { hw, sheer, z } = hullShapeAt(t, { length, beam });
+        const deckY = sheer - deckDrop;
+        const rib = new THREE.Mesh(new THREE.BoxGeometry(hw * 1.7, 0.08, 0.1), ribMat);
+        rib.position.set(0, deckY - 0.04, z);
+        group.add(rib);
+        const postL = new THREE.Mesh(new THREE.BoxGeometry(0.07, Math.max(0.2, sheer - deckY + 0.15), 0.07), ribMat);
+        postL.position.set(-hw * 0.88, (sheer + deckY) * 0.5, z);
+        group.add(postL);
+        const postR = postL.clone();
+        postR.position.x = hw * 0.88;
+        group.add(postR);
+    }
 
     if (dragon) {
         const head = buildDragonHead(hullColor);
@@ -312,13 +570,15 @@ export function buildLongship({
         group.add(tail);
     }
 
-    // Bancos de remo.
+    // Bancos de remo assentados no convés.
     const benchMat = woodMaterial(true, hullColor);
     const benchCount = 4;
     for (let i = 0; i < benchCount; i++) {
         const t = -0.5 + (i / (benchCount - 1)) * 1.0;
+        const { sheer, z } = hullShapeAt(t, { length, beam });
+        const deckY = sheer - deckDrop;
         const bench = new THREE.Mesh(new THREE.BoxGeometry(beam * 0.78, 0.12, 0.42), benchMat);
-        bench.position.set(0, 0.05, (t * length) / 2);
+        bench.position.set(0, deckY + 0.06, z);
         bench.castShadow = true;
         group.add(bench);
     }
@@ -427,6 +687,76 @@ export function buildLongship({
         }
     }
 
+    if (cannons) {
+        const bronze = metalMaterial(0x8f7340, 0.48);
+        const dark = metalMaterial(0x2e2924, 0.58);
+        const wood = woodMaterial(true, 0x4a3220);
+
+        const makeGun = (side, aim = 'broadside') => {
+            const gun = new THREE.Group();
+            const carriage = new THREE.Mesh(new THREE.BoxGeometry(0.62, 0.32, 0.48), wood);
+            carriage.position.y = -0.02;
+            gun.add(carriage);
+
+            const wheelGeo = new THREE.CylinderGeometry(0.16, 0.16, 0.08, 10);
+            for (const wx of [-0.22, 0.22]) {
+                const wheel = new THREE.Mesh(wheelGeo, dark);
+                wheel.rotation.z = Math.PI / 2;
+                wheel.position.set(wx, -0.18, 0.18);
+                gun.add(wheel);
+            }
+
+            const barrel = new THREE.Mesh(new THREE.CylinderGeometry(0.1, 0.145, 1.7, 12), bronze);
+            barrel.castShadow = true;
+            if (aim === 'bow') {
+                barrel.rotation.x = Math.PI / 2;
+                barrel.position.set(0, 0.18, 0.55);
+            } else {
+                barrel.rotation.z = Math.PI / 2;
+                barrel.rotation.y = side > 0 ? -0.08 : 0.08;
+                barrel.position.set(side * 0.42, 0.16, 0);
+            }
+            gun.add(barrel);
+
+            const ring = new THREE.Mesh(new THREE.TorusGeometry(0.115, 0.028, 6, 14), dark);
+            if (aim === 'bow') {
+                ring.position.set(0, 0.18, 1.35);
+            } else {
+                ring.rotation.y = Math.PI / 2;
+                ring.position.set(side * 1.22, 0.16, 0);
+            }
+            gun.add(ring);
+
+            gun.userData.side = side;
+            gun.userData.aim = aim;
+            gun.userData.muzzleLocal =
+                aim === 'bow'
+                    ? new THREE.Vector3(0, 0.2, 1.45)
+                    : new THREE.Vector3(side * 1.28, 0.18, 0);
+            return gun;
+        };
+
+        for (const side of [-1, 1]) {
+            for (let i = 0; i < 3; i++) {
+                const t = -0.34 + (i / 2) * 0.66;
+                const { hw, sheer, z } = hullShapeAt(t, { length, beam });
+                const gun = makeGun(side, 'broadside');
+                gun.position.set(side * (hw * 0.62), sheer - deckDrop + 0.22, z);
+                group.add(gun);
+                parts.cannons.push(gun);
+            }
+        }
+
+        // Canhão de proa — alvos à frente do rio.
+        {
+            const { sheer, z } = hullShapeAt(0.72, { length, beam });
+            const bowGun = makeGun(0, 'bow');
+            bowGun.position.set(0, sheer - deckDrop + 0.12, z);
+            group.add(bowGun);
+            parts.cannons.push(bowGun);
+        }
+    }
+
     if (lantern) {
         const lanternGroup = new THREE.Group();
         const cage = new THREE.Mesh(new THREE.CylinderGeometry(0.16, 0.2, 0.42, 8), metalMaterial(0x6b6257, 0.5));
@@ -436,14 +766,16 @@ export function buildLongship({
             plainMaterial(0xffd08a, 0.3, 0, 0xff9a3c, 1.4)
         );
         lanternGroup.add(flame);
-        const light = new THREE.PointLight(0xffa54a, 2.2, 9, 2);
-        light.position.y = 0.1;
-        lanternGroup.add(light);
+        if (lanternLight) {
+            const light = new THREE.PointLight(0xffa54a, 2.2, 9, 2);
+            light.position.y = 0.1;
+            lanternGroup.add(light);
+            parts.lights.push(light);
+        }
         lanternGroup.position.set(0, 1.85, -length / 2 + 0.9);
         group.add(lanternGroup);
         parts.lantern = lanternGroup;
         parts.lanternFlame = flame;
-        parts.lights.push(light);
     }
 
     group.userData.parts = parts;
@@ -617,6 +949,14 @@ export function buildAxeMesh(scale = 1) {
         c.castShadow = true;
     });
     return group;
+}
+
+/** Bala de canhão — projétil principal do jogador. */
+export function buildCannonballMesh(scale = 1) {
+    const mat = metalMaterial(0x2a2c30, 0.55);
+    const ball = new THREE.Mesh(new THREE.SphereGeometry(0.28 * scale, 12, 10), mat);
+    ball.castShadow = true;
+    return ball;
 }
 
 /** Flecha incendiária dos inimigos. */

--- a/labs/river-knight/src/player.js
+++ b/labs/river-knight/src/player.js
@@ -2,21 +2,23 @@
  * O drakkar do jogador e o guerreiro a bordo.
  *
  * Guarda a física da navegação (velocidade, deriva lateral, limites do rio),
- * a animação do casco sobre as ondas, os remos, o arremesso de machado e os
+ * a animação do casco sobre as ondas, os remos, os canhões de bordo e os
  * poderes temporários (escudo e fúria).
  */
 
 import * as THREE from 'three';
-import { buildLongship, buildWarrior } from './models.js';
+import { buildLongship, buildWarrior } from './models.js?v=12';
 import { waterHeight, waterSlope } from './water.js';
 import { centerX, halfWidth } from './river.js';
-import { BOAT, AXE } from './config.js';
+import { BOAT, CANNON } from './config.js?v=12';
 import { clamp, damp, lerp } from './utils.js';
 
 const tmpSlope = { dx: 0, dz: 0 };
+const tmpMuzzle = new THREE.Vector3();
+const tmpMuzzleWorld = new THREE.Vector3();
 
 export class Player {
-    constructor(scene) {
+    constructor(scene, quality = null) {
         this.root = new THREE.Group();
         scene.add(this.root);
 
@@ -28,7 +30,9 @@ export class Player {
             hullColor: 0x6b4429,
             sailBase: '#ded1b0',
             sailStripe: '#a02f2f',
-            emblem: 'cross'
+            emblem: 'cross',
+            lanternLight: quality?.id !== 'low',
+            cannons: true
         });
         ship.rotation.y = Math.PI;
         this.root.add(ship);
@@ -36,7 +40,8 @@ export class Player {
         this.parts = parts;
 
         const { group: warrior, parts: wParts } = buildWarrior({});
-        warrior.position.set(0, 0.32, -1.6);
+        // Pés no convés midship (sheer 0 − drop 0.26).
+        warrior.position.set(0, 0.95, -1.4);
         ship.add(warrior);
         this.warrior = warrior;
         this.wParts = wParts;
@@ -167,15 +172,19 @@ export class Player {
         const wy = waterHeight(this.x, this.z, time);
         waterSlope(this.x, this.z, time, tmpSlope);
 
-        this.root.position.set(this.x, wy + 0.62, this.z);
+        this.root.position.set(this.x, wy + 0.95, this.z);
 
         const steerYaw = clamp(-this.lateral / BOAT.strafeSpeed, -1, 1) * 0.26;
         this.yaw = damp(this.yaw, steerYaw, 6, dt);
-        this.roll = damp(this.roll, steerYaw * 1.5 - tmpSlope.dx * 1.4, 5, dt);
+        this.roll = damp(this.roll, clamp(steerYaw * 1.5 - tmpSlope.dx * 1.4, -0.22, 0.22), 5, dt);
 
         this.root.rotation.y = this.yaw;
         this.root.rotation.z = this.roll;
-        this.root.rotation.x = tmpSlope.dz * 1.1 + Math.sin(time * 1.3) * 0.012;
+        this.root.rotation.x = clamp(
+            tmpSlope.dz * 1.1 + Math.sin(time * 1.3) * 0.012,
+            -0.14,
+            0.14
+        );
 
         // --- remos ---
         const rowSpeed = 2.2 + (this.speed / BOAT.boostSpeed) * 3.4;
@@ -206,8 +215,8 @@ export class Player {
             this.wParts.torso.rotation.y = damp(this.wParts.torso.rotation.y, 0, 6, dt);
         }
 
-        // Machado da mão some enquanto está em voo.
-        this.wParts.axe.visible = this.throwTimer < (this.hasFury ? BOAT.furyCooldown : BOAT.throwCooldown) * 0.45;
+        // Ordem de fogo — braço aponta, canhão responde.
+        this.wParts.axe.visible = true;
 
         // --- lanterna e brasas ---
         if (this.parts.lanternFlame) {
@@ -215,14 +224,20 @@ export class Player {
             this.parts.lanternFlame.scale.set(s, s * 1.35, s);
         }
 
-        // --- espuma da proa e esteira ---
+        // --- espuma da proa e esteira (fora do casco, nunca sobre o convés) ---
         const speedRatio = this.speed / BOAT.boostSpeed;
-        effects.wake.push(this.x, this.z + 6.5, 1.5 + speedRatio * 1.4, 0.55 + speedRatio * 0.45);
+        const sternZ = this.z + 9.2;
+        effects.wake.push(this.x - 1.1, sternZ, 1.35 + speedRatio * 1.1, 0.55 + speedRatio * 0.4);
+        effects.wake.push(this.x + 1.1, sternZ, 1.35 + speedRatio * 1.1, 0.55 + speedRatio * 0.4);
 
-        if (Math.random() < 0.4 + speedRatio * 0.35) {
-            const bowX = this.x + Math.sin(this.yaw) * 6.5;
-            const bowZ = this.z - 6.8;
-            effects.splash(bowX, wy + 0.1, bowZ, 1, 0.3 + speedRatio * 0.35);
+        if (Math.random() < 0.22 + speedRatio * 0.22) {
+            const bowX = this.x + Math.sin(this.yaw) * 7.2;
+            const bowZ = this.z - 7.6;
+            effects.splash(bowX, wy + 0.05, bowZ, 1, 0.22 + speedRatio * 0.22);
+        }
+        if (Math.random() < 0.1 + speedRatio * 0.12) {
+            const side = Math.random() < 0.5 ? -1 : 1;
+            effects.splash(this.x + side * 3.4, wy + 0.02, this.z + 8.6, 1, 0.14 + speedRatio * 0.14);
         }
 
         // --- temporizadores ---
@@ -262,21 +277,137 @@ export class Player {
         return this.alive && this.throwTimer <= 0;
     }
 
-    /** Lança o machado a partir da mão do guerreiro. */
-    throwAxe(entities, ctx) {
+    /** Frente do navio no plano XZ (mundo). */
+    forwardXZ() {
+        return { x: Math.sin(this.yaw), z: -Math.cos(this.yaw) };
+    }
+
+    /** Alvo atual sob a mira automática (cone largo à frente). */
+    getAimLock(entities) {
+        const fwd = this.forwardXZ();
+        return entities.findCannonTarget(
+            this.x,
+            this.position.y + 1.4,
+            this.z,
+            fwd.x,
+            fwd.z
+        );
+    }
+
+    /**
+     * Dispara canhão com mira automática (estilo jogos de navio).
+     * Um botão: trava o melhor alvo no cone e escolhe o canhão certo.
+     * Em fúria: salva de bordo no mesmo lado.
+     */
+    fireCannons(entities, ctx) {
         if (!this.canThrow()) return false;
         this.throwTimer = this.hasFury ? BOAT.furyCooldown : BOAT.throwCooldown;
         this.throwAnim = 1;
 
-        const origin = new THREE.Vector3();
-        this.wParts.armR.getWorldPosition(origin);
+        const fwd = this.forwardXZ();
+        const target = entities.findCannonTarget(
+            this.x,
+            this.position.y + 1.4,
+            this.z,
+            fwd.x,
+            fwd.z
+        );
+        this._lastLock = target;
 
-        // Mira: levemente à frente, seguindo a inclinação do barco.
-        const dirX = Math.sin(this.yaw) * 0.55 + (ctx?.aimX ?? 0);
-        const dir = new THREE.Vector3(dirX, 0, -1).normalize();
+        let aimX = fwd.x;
+        let aimZ = fwd.z;
+        let aimY = this.position.y + 2.2;
+        if (target) {
+            aimX = target.x - this.x;
+            aimZ = target.z - this.z;
+            aimY = target.y;
+        } else {
+            // Sem trava: tiro curto à frente (ainda útil contra o que surgir).
+            aimX = fwd.x * 0.35 + (ctx?.input?.steer ?? 0) * 0.55;
+            aimZ = fwd.z;
+            aimY = this.position.y + 3.5;
+        }
+        const aimLen = Math.hypot(aimX, aimZ) || 1;
+        aimX /= aimLen;
+        aimZ /= aimLen;
 
-        entities.throwAxe(origin.x, origin.y + 0.3, origin.z - 1.2, dir.x, dir.z, AXE.speed);
-        return true;
+        // Lado no espaço local do modelo (já rotacionado 180° → inverte X mundo).
+        const rightX = Math.cos(this.yaw);
+        const rightZ = Math.sin(this.yaw);
+        const sideDot = aimX * rightX + aimZ * rightZ;
+        const preferSide = Math.abs(sideDot) < 0.25 ? 0 : sideDot > 0 ? -1 : 1;
+
+        const guns = this.parts.cannons || [];
+        const selected = [];
+        if (preferSide === 0) {
+            const bow = guns.find((g) => g.userData.aim === 'bow');
+            if (bow) selected.push(bow);
+        } else {
+            for (const gun of guns) {
+                if (gun.userData.aim === 'bow') continue;
+                if (gun.userData.side === preferSide) selected.push(gun);
+            }
+            // Ordena pela proximidade Z ao alvo — canhão do meio primeiro.
+            if (target && selected.length > 1) {
+                selected.sort((a, b) => {
+                    a.getWorldPosition(tmpMuzzle);
+                    const da = Math.hypot(target.x - tmpMuzzle.x, target.z - tmpMuzzle.z);
+                    b.getWorldPosition(tmpMuzzleWorld);
+                    const db = Math.hypot(target.x - tmpMuzzleWorld.x, target.z - tmpMuzzleWorld.z);
+                    return da - db;
+                });
+            }
+        }
+        if (!selected.length) {
+            const bow = guns.find((g) => g.userData.aim === 'bow');
+            if (bow) selected.push(bow);
+            else if (guns[0]) selected.push(guns[0]);
+        }
+        const toFire = this.hasFury ? selected : selected.slice(0, 1);
+        const speed = CANNON.speed * (this.hasFury ? 1.08 : 1);
+        let fired = 0;
+
+        for (let i = 0; i < toFire.length; i++) {
+            const gun = toFire[i];
+            tmpMuzzle.copy(gun.userData.muzzleLocal);
+            gun.localToWorld(tmpMuzzle);
+            tmpMuzzleWorld.copy(tmpMuzzle);
+
+            let dirX = aimX;
+            let dirZ = aimZ;
+            if (target) {
+                dirX = target.x - tmpMuzzleWorld.x;
+                dirZ = target.z - tmpMuzzleWorld.z;
+            }
+            const dLen = Math.hypot(dirX, dirZ) || 1;
+            dirX /= dLen;
+            dirZ /= dLen;
+
+            const dist = target ? Math.hypot(target.x - tmpMuzzleWorld.x, target.z - tmpMuzzleWorld.z) : 55;
+            const dy = (target ? target.y : aimY) - tmpMuzzleWorld.y;
+            const tFlight = dist / speed;
+            let loft = dy / Math.max(0.2, tFlight) + 0.5 * CANNON.gravity * tFlight;
+            loft = clamp(loft, 4.5, 28);
+
+            // Pequeno atraso entre bocas na salva.
+            const stagger = i * 0.04;
+            const ox = tmpMuzzleWorld.x + dirX * stagger * speed * 0.15;
+            const oz = tmpMuzzleWorld.z + dirZ * stagger * speed * 0.15;
+
+            if (entities.fireShot(ox, tmpMuzzleWorld.y, oz, dirX, dirZ, speed, loft)) {
+                fired += 1;
+                ctx.effects.explosion(tmpMuzzleWorld.x, tmpMuzzleWorld.y, tmpMuzzleWorld.z, 0.22, 0.12);
+                ctx.effects.smokePuff(tmpMuzzleWorld.x, tmpMuzzleWorld.y + 0.2, tmpMuzzleWorld.z, 5, 0.85);
+                ctx.effects.fire(tmpMuzzleWorld.x, tmpMuzzleWorld.y, tmpMuzzleWorld.z, 2, 0.9);
+            }
+        }
+
+        return fired > 0;
+    }
+
+    /** @deprecated use fireCannons */
+    throwAxe(entities, ctx) {
+        return this.fireCannons(entities, ctx);
     }
 
     damage(amount, ctx) {

--- a/labs/river-knight/src/terrain.js
+++ b/labs/river-knight/src/terrain.js
@@ -102,8 +102,10 @@ export function createTerrain(quality) {
                     col *= 0.78 + n1 * 0.38;
                     col *= 0.94 + n2 * 0.12;
 
-                    // Linha úmida junto à água.
-                    col *= mix(0.55, 1.0, smoothstep(-0.6, 1.1, h));
+                    // Faixa úmida / areia molhada junto à água.
+                    float wet = (1.0 - smoothstep(0.0, 1.55, h)) * smoothstep(-1.4, 0.35, h);
+                    col = mix(col, sand * vec3(0.52, 0.48, 0.40), wet * 0.55);
+                    col *= mix(0.42, 1.0, smoothstep(-0.35, 1.55, h));
                     return col;
                 }
                 `

--- a/labs/river-knight/src/water.js
+++ b/labs/river-knight/src/water.js
@@ -108,8 +108,8 @@ export function createWater(skyUniforms, quality) {
         uFoam: { value: foamTexture() },
         uFogColor: { value: new THREE.Color(0.7, 0.7, 0.75) },
         uFogDensity: { value: quality.fogDensity },
-        uShallow: { value: new THREE.Color(0.15, 0.33, 0.29) },
-        uDeep: { value: new THREE.Color(0.022, 0.062, 0.095) }
+        uShallow: { value: new THREE.Color(0.22, 0.44, 0.36) },
+        uDeep: { value: new THREE.Color(0.01, 0.03, 0.06) }
     };
 
     const material = new THREE.ShaderMaterial({
@@ -197,20 +197,21 @@ export function createWater(skyUniforms, quality) {
 
                 // Brilho especular do sol na crista das ondas.
                 vec3 H = normalize(V + uSunDir);
-                float spec = pow(max(dot(N, H), 0.0), 380.0);
-                float sparkle = pow(max(dot(N, H), 0.0), 60.0) *
+                float spec = pow(max(dot(N, H), 0.0), 420.0);
+                float sparkle = pow(max(dot(N, H), 0.0), 72.0) *
                     smoothstep(0.55, 1.0, rkValueNoise(rp * 3.1 + uTime * 0.6));
-                col += uSunColor * (spec * 3.4 + sparkle * 0.5);
+                col += uSunColor * (spec * 2.2 + sparkle * 0.28);
 
                 // Espuma junto às margens e nas cristas mais altas.
                 float shore = rkShoreDist(vWorld.x, vWorld.z);
                 // smoothstep exige edge0 < edge1 (fora disso o resultado é indefinido em GLSL).
-                float band = smoothstep(-9.0, -4.0, shore) * (1.0 - smoothstep(-3.2, 0.5, shore));
-                float crest = smoothstep(1.35, 2.35, vPhase);
-                vec2 fuv = vWorld.xz * 0.05 + vec2(uTime * 0.006, uTime * 0.009);
+                float band = smoothstep(-12.5, -2.8, shore) * (1.0 - smoothstep(-2.0, 1.4, shore));
+                float crest = smoothstep(1.15, 2.15, vPhase);
+                // Corrente sutil no eixo do rio (Z negativo ≈ descida).
+                vec2 fuv = vWorld.xz * 0.046 + vec2(uTime * 0.0035, uTime * 0.045);
                 float ftex = texture2D(uFoam, fuv).a;
-                float foam = clamp(band * 1.05 + crest * 0.16, 0.0, 1.0) * smoothstep(0.08, 0.55, ftex);
-                col = mix(col, vec3(0.88, 0.93, 0.96), clamp(foam, 0.0, 1.0) * 0.85);
+                float foam = clamp(band * 1.35 + crest * 0.24, 0.0, 1.0) * smoothstep(0.05, 0.5, ftex);
+                col = mix(col, vec3(0.92, 0.96, 0.99), clamp(foam, 0.0, 1.0) * 0.92);
 
                 // Névoa exponencial casada com o céu.
                 float dist = length(cameraPosition - vWorld);

--- a/labs/river-knight/src/world.js
+++ b/labs/river-knight/src/world.js
@@ -17,7 +17,15 @@ const RECYCLE_BEHIND = 90;
 /* ------------------------------------------------------------------ */
 
 class Scatter {
-    constructor(scene, geometry, count, { minDist, maxDist, scale, sink = 0.6, tint = null }) {
+    constructor(scene, geometry, count, {
+        minDist,
+        maxDist,
+        scale,
+        sink = 0.6,
+        tint = null,
+        minHeight = 0.8,
+        maxSlope = 1.35
+    }) {
         const material = new THREE.MeshStandardMaterial({
             vertexColors: !tint,
             color: tint || 0xffffff,
@@ -37,6 +45,8 @@ class Scatter {
         this.maxDist = maxDist;
         this.scaleRange = scale;
         this.sink = sink;
+        this.minHeight = minHeight;
+        this.maxSlope = maxSlope;
         this.items = new Array(count);
         this.dummy = new THREE.Object3D();
 
@@ -48,16 +58,25 @@ class Scatter {
     /** Sorteia uma posição válida na margem, na frente do jogador. */
     _place(item, z) {
         const side = Math.random() < 0.5 ? -1 : 1;
-        const dist = randRange(this.minDist, this.maxDist);
+        // Viés para perto da margem (mais densidade visual na beira do rio).
+        const u = Math.pow(Math.random(), 1.55);
+        const dist = this.minDist + u * (this.maxDist - this.minDist);
         const x = centerX(z) + side * (halfWidth(z) + dist);
         const y = terrainHeight(x, z);
+        // Amostra vizinhos: evita “flutuadores” em encostas muito íngremes.
+        const eps = 1.4;
+        const yL = terrainHeight(x - eps, z);
+        const yR = terrainHeight(x + eps, z);
+        const yD = terrainHeight(x, z - eps);
+        const yU = terrainHeight(x, z + eps);
+        const slope = Math.max(Math.abs(yL - yR), Math.abs(yD - yU)) / (2 * eps);
         item.x = x;
         item.y = y - this.sink;
         item.z = z;
         item.scale = randRange(this.scaleRange[0], this.scaleRange[1]);
         item.rot = randRange(0, Math.PI * 2);
         item.tilt = randRange(-0.06, 0.06);
-        item.valid = y > 0.4;
+        item.valid = y > this.minHeight && slope < this.maxSlope;
     }
 
     /** Distribui tudo de uma vez ao (re)iniciar a partida. */
@@ -147,21 +166,27 @@ export class World {
     constructor(scene, quality) {
         const s = quality.scatterScale;
         this.pines = new Scatter(scene, buildPineGeometry(), Math.round(150 * s), {
-            minDist: 1.5,
-            maxDist: 120,
-            scale: [0.75, 1.5]
+            minDist: 1.2,
+            maxDist: 95,
+            scale: [0.75, 1.5],
+            minHeight: 1.2,
+            maxSlope: 1.15
         });
         this.oaks = new Scatter(scene, buildOakGeometry(), Math.round(70 * s), {
-            minDist: 2,
-            maxDist: 95,
-            scale: [0.7, 1.35]
+            minDist: 1.6,
+            maxDist: 78,
+            scale: [0.7, 1.35],
+            minHeight: 1.2,
+            maxSlope: 1.1
         });
-        this.bankRocks = new Scatter(scene, buildRockGeometry(5), Math.round(80 * s), {
-            minDist: -2.5,
-            maxDist: 70,
-            scale: [0.8, 2.6],
-            sink: 0.9,
-            tint: 0x54504a
+        this.bankRocks = new Scatter(scene, buildRockGeometry(5), Math.round(110 * s), {
+            minDist: 0.2,
+            maxDist: 18,
+            scale: [0.7, 2.4],
+            sink: 1.25,
+            tint: 0x54504a,
+            minHeight: 0.45,
+            maxSlope: 1.95
         });
 
         this.birds = quality.id === 'low' ? null : new Birds(scene, 12);
@@ -211,7 +236,7 @@ export class World {
             ['rock', 26 - progress * 10],
             ['pickup', 20 - progress * 6],
             ['enemyShip', 6 + progress * 26],
-            ['tower', 4 + progress * 20],
+            ['tower', 8 + progress * 24],
             ['barricade', 8 + progress * 12],
             ['whirlpool', 4 + progress * 8]
         ];
@@ -267,7 +292,8 @@ export class World {
             }
             case 'tower': {
                 const side = Math.random() < 0.5 ? -1 : 1;
-                const x = cx + side * (hw + randRange(3, 11));
+                // Mais perto da água — alcançáveis com canhão assistido.
+                const x = cx + side * (hw + randRange(1.6, 6.5));
                 entities.spawnTower(x, z, { fireRate: (3.6 - progress * 1.3) / difficulty.enemyFireScale });
                 break;
             }

--- a/labs/river-knight/style.css
+++ b/labs/river-knight/style.css
@@ -476,6 +476,99 @@ body[data-state="playing"] .game-shell > header .app-logo {
 .message[data-tone="danger"] { color: oklch(78% 0.16 28); }
 .message[data-tone="gold"] { color: var(--gold); }
 
+/* --- mira / arremesso --- */
+.reticle {
+    position: absolute;
+    left: 50%;
+    top: 46%;
+    width: 2.6rem;
+    height: 2.6rem;
+    transform: translate(-50%, -50%);
+    pointer-events: none;
+    opacity: 0.55;
+    transition: opacity 0.2s ease, color 0.2s ease;
+    color: oklch(88% 0.04 90);
+    z-index: 4;
+}
+
+.reticle[data-lock="true"] {
+    opacity: 0.95;
+    color: oklch(78% 0.14 75);
+}
+
+.reticle-ring {
+    position: absolute;
+    inset: 0;
+    border: 1.5px solid currentColor;
+    border-radius: 50%;
+    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.35), 0 0 18px rgba(0, 0, 0, 0.25);
+    opacity: 0.75;
+}
+
+.reticle-dot {
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    width: 4px;
+    height: 4px;
+    margin: -2px 0 0 -2px;
+    border-radius: 50%;
+    background: currentColor;
+    box-shadow: 0 0 8px currentColor;
+}
+
+.reticle-label {
+    position: absolute;
+    left: 50%;
+    top: calc(100% + 0.45rem);
+    transform: translateX(-50%);
+    font-family: 'Cinzel', Georgia, serif;
+    font-size: 0.68rem;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    white-space: nowrap;
+    text-shadow: 0 1px 10px rgba(0, 0, 0, 0.85);
+    opacity: 0;
+    transition: opacity 0.2s ease;
+}
+
+.reticle[data-lock="true"] .reticle-label {
+    opacity: 1;
+}
+
+.throw-meter {
+    position: absolute;
+    left: 50%;
+    top: calc(46% + 1.85rem);
+    width: 3.4rem;
+    height: 3px;
+    transform: translateX(-50%);
+    border-radius: 999px;
+    background: rgba(12, 10, 8, 0.45);
+    overflow: hidden;
+    pointer-events: none;
+    z-index: 4;
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+}
+
+.throw-meter > i {
+    display: block;
+    height: 100%;
+    width: 0%;
+    background: linear-gradient(90deg, oklch(72% 0.12 75), oklch(86% 0.1 95));
+    transition: width 0.08s linear;
+}
+
+body[data-state="playing"] .reticle,
+body[data-state="playing"] .throw-meter {
+    display: block;
+}
+
+body:not([data-state="playing"]) .reticle,
+body:not([data-state="playing"]) .throw-meter {
+    display: none;
+}
+
 /* --- ações --- */
 .hud-actions {
     grid-row: 3;


### PR DESCRIPTION
## Summary
- Fecha o porão e a popa do drakkar (volume opaco + convés/tampas) para a água não atravessar o casco na câmera de perseguição.
- Substitui o machado por canhões de bordo/proa com mira automática larga (estilo jogos de navio), balística, fumaça/clarão e SFX.
- Ajusta esteira/respingos, HUD de trava, UI de comandos e feedback de combate para um tom mais realista e divertido.

## Test plan
- [ ] Abrir `/labs/river-knight/` com hard refresh e zarpar
- [ ] Confirmar que, vivo e na câmera de perseguição, o casco/popa não mostram água “dentro” do navio
- [ ] Governar o navio e disparar (Espaço/clique): retícula trava em torre/navio sem mirar fino
- [ ] Acertar torre e barco inimigo; verificar explosão, som de canhão e mensagem de feedback
- [ ] Em fúria, confirmar salva no mesmo lado
- [ ] Derrotar a barcaça negra com balas de canhão e completar até o castelo


Made with [Cursor](https://cursor.com)