### PR TITLE
feat(santos-games): remake California Games estilo emulador Mega Drive

### DIFF
--- a/labs/santos-games/index.html
+++ b/labs/santos-games/index.html
@@ -4,47 +4,43 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover, user-scalable=no">
-    <title>Santos Games — seis provas de praia 16-bit | Labs</title>
+    <title>Santos Games — Mega Drive / California Games | Labs</title>
     <meta name="description"
-        content="Homenagem 16-bit ao California Games ambientada em Santos: surfe no Quebra-Mar, skate no bowl da orla, altinha no Gonzaga, BMX na ciclovia, frescobol no José Menino e canoa havaiana na baía.">
-    <meta name="theme-color" content="#0d0a1a">
-    <link rel="canonical" href="https://diogopaulino.com.br/labs/santos-vice-city/">
+        content="Homenagem ao California Games (Mega Drive) em Santos: surfe, skate, altinha, BMX, frescobol e canoa. Pixel art 16-bit limpo no navegador.">
+    <meta name="theme-color" content="#101018">
+    <link rel="canonical" href="https://diogopaulino.com.br/labs/santos-games/">
 
     <meta property="og:type" content="website">
     <meta property="og:title" content="Santos Games">
-    <meta property="og:description"
-        content="Seis provas de praia em pixel art 16-bit gerada 100% em código, com patrocinadores, medalhas e pódio. Uma homenagem ao California Games, mas caiçara.">
+    <meta property="og:description" content="California Games, mas caiçara. Seis provas 16-bit no estilo Mega Drive.">
     <meta property="og:url" content="https://diogopaulino.com.br/labs/santos-games/">
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Santos Games">
-    <meta name="twitter:description" content="California Games, mas em Santos. Seis provas 16-bit no navegador.">
 
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Bungee&family=Nunito:wght@500;700;800&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/labs/shared.css?v=4">
-    <link rel="stylesheet" href="style.css?v=3">
+    <link rel="stylesheet" href="style.css?v=7">
 </head>
 
 <body>
-    <div class="svc-background" style="background-image: url('assets/bg.jpg');"></div>
-    <div class="svc-layout">
-        <header data-lab-header data-title="Santos Games" class="glass-header">
+    <div class="sg-bg" aria-hidden="true"></div>
+
+    <div class="sg-layout">
+        <header data-lab-header data-title="Santos Games" class="sg-header">
             <template data-slot="logo">
                 <div class="app-logo">
-                    <span class="brand-mark" aria-hidden="true">🌇</span>
+                    <span class="brand-mark" aria-hidden="true">🏖</span>
                     <span>Santos Games</span>
                 </div>
             </template>
         </header>
 
-        <main class="svc-shell">
-            <section class="svc-stage" aria-label="Área do jogo">
-                <div class="svc-screen-wrap" id="svcWrap">
+        <main class="sg-shell">
+            <section class="sg-stage" aria-label="Área do jogo">
+                <div class="sg-emu" id="svcWrap">
                     <canvas id="svcStage" width="320" height="224" hidden></canvas>
                     <canvas id="svcScreen" role="img"
-                        aria-label="Santos Vice Games — jogo de esportes de praia em pixel art 16-bit"></canvas>
-                    <div class="svc-vignette" aria-hidden="true"></div>
+                        aria-label="Santos Games — esportes de praia em pixel art 16-bit"></canvas>
 
                     <div class="svc-touch tp--hidden" id="svcTouch" aria-label="Controles por toque">
                         <div class="tp-dpad">
@@ -63,52 +59,49 @@
                 <p class="sr-only" aria-live="polite" id="svcAnnouncer"></p>
             </section>
 
-            <aside class="svc-side glass-panel" aria-label="Sobre o jogo">
-                <div class="svc-side-block">
-                    <span class="svc-kicker">Santos Games</span>
-                    <h2>California Games, mas caiçara</h2>
-                    <p>Seis provas de praia num campeonato só: escolha o patrocinador, dispute
-                        surfe, skate, altinha, BMX, frescobol e canoa havaiana, e veja se sobra
-                        lugar no pódio. Pixel art e trilha gerados 100&nbsp;% em código.</p>
+            <aside class="sg-side" aria-label="Sobre o jogo">
+                <div class="sg-side-block">
+                    <span class="sg-kicker">Mega Drive · 320×224</span>
+                    <h2>California Games,<br>mas caiçara</h2>
+                    <p>Escolha o patrocinador, dispute seis provas na orla de Santos e dispute o pódio.</p>
                 </div>
 
-                <ol class="svc-events">
+                <ol class="sg-events">
                     <li><b>Surfe</b><span>Quebra-Mar</span></li>
                     <li><b>Skate Vert</b><span>Bowl da Orla</span></li>
-                    <li><b>Altinha</b><span>Areia do Gonzaga</span></li>
-                    <li><b>BMX</b><span>Ciclovia da Orla</span></li>
+                    <li><b>Altinha</b><span>Gonzaga</span></li>
+                    <li><b>BMX</b><span>Ciclovia</span></li>
                     <li><b>Frescobol</b><span>José Menino</span></li>
-                    <li><b>Canoa havaiana</b><span>Baía de Santos</span></li>
+                    <li><b>Canoa</b><span>Baía</span></li>
                 </ol>
 
-                <div class="svc-side-block">
-                    <span class="svc-kicker">Controles</span>
-                    <div class="svc-key-row"><kbd>↑↓←→</kbd><span>Mover</span></div>
-                    <div class="svc-key-row"><kbd>Z</kbd><span>Botão A</span></div>
-                    <div class="svc-key-row"><kbd>X</kbd><span>Botão B</span></div>
-                    <div class="svc-key-row"><kbd>Enter</kbd><span>Start / pausa</span></div>
-                    <div class="svc-key-row"><kbd>M</kbd><span>Mudo</span></div>
-                    <p class="svc-note">Também funciona com gamepad e, no celular, com os
-                        botões na tela.</p>
+                <div class="sg-side-block">
+                    <span class="sg-kicker">Controles</span>
+                    <div class="sg-key-row"><kbd>↑↓←→</kbd><span>Mover</span></div>
+                    <div class="sg-key-row"><kbd>Z</kbd><span>Botão A</span></div>
+                    <div class="sg-key-row"><kbd>X</kbd><span>Botão B</span></div>
+                    <div class="sg-key-row"><kbd>Enter</kbd><span>Start / pausa</span></div>
+                    <div class="sg-key-row"><kbd>M</kbd><span>Mudo</span></div>
+                    <p class="sg-note">Gamepad e botões na tela no celular.</p>
                 </div>
 
-                <div class="svc-actions">
-                    <button id="svcSoundToggle" class="svc-btn" type="button" aria-pressed="true">
+                <div class="sg-actions">
+                    <button id="svcSoundToggle" class="sg-btn" type="button" aria-pressed="true">
                         <span aria-hidden="true" data-icon>◉</span>
                         <span data-label>Som ativado</span>
                     </button>
-                    <button id="svcResetBtn" class="svc-btn svc-btn--ghost" type="button">
+                    <button id="svcResetBtn" class="sg-btn sg-btn--ghost" type="button">
                         Apagar recordes
                     </button>
                 </div>
             </aside>
         </main>
 
-        <footer data-lab-footer data-home-href="/" class="glass-footer"></footer>
+        <footer data-lab-footer data-home-href="/" class="sg-footer"></footer>
     </div>
 
     <script src="/labs/shared.js?v=5" defer></script>
-    <script type="module" src="src/main.js?v=2"></script>
+    <script type="module" src="src/main.js?v=7"></script>
 </body>
 
 </html>

--- a/labs/santos-games/src/art/figure.js
+++ b/labs/santos-games/src/art/figure.js
@@ -1,18 +1,8 @@
-// art/figure.js — compositor procedural de atleta 16-bit.
-//
-// Autorar à mão todas as poses de seis modalidades (surfe, skate, altinha, BMX, frescobol e
-// remo) em string-art daria centenas de sprites e um inferno de manutenção. Em vez disso o
-// atleta é montado a partir de um esqueleto simples: quadril -> tronco -> cabeça, mais quatro
-// membros descritos por ângulo/comprimento. Cada pose vira ~6 números, e trocar o uniforme do
-// patrocinador é só trocar duas cores da paleta.
+// art/figure.js — atleta 16-bit limpo (contorno + silhueta legível estilo California Games).
 
 import { SVC } from '../core/palette.js';
 import { makeBuf, fillRect, fillDisc, line, tip, toRows, flipRows, put } from './raster.js';
 
-/**
- * Desenha um membro de dois segmentos (braço: ombro/cotovelo/mão; perna: quadril/joelho/pé).
- * Ângulos são absolutos em graus; devolve a ponta para pendurar equipamento nela.
- */
 function twoBone(buf, ox, oy, a1, l1, a2, l2, thick, ch) {
     const joint = tip(ox, oy, a1, l1);
     line(buf, ox, oy, joint.x, joint.y, thick, ch);
@@ -21,15 +11,35 @@ function twoBone(buf, ox, oy, a1, l1, a2, l2, thick, ch) {
     return { joint, end };
 }
 
-/**
- * Postura neutra. Ângulos em graus no plano cartesiano (0 = direita, 90 = cima).
- * Uma pose só precisa declarar o que muda em relação a isto.
- */
+/** Contorno preto 1px ao redor de pixels opacos — leitura MD clássica. */
+function outline(buf, ink = '0') {
+    const { w, h, data } = buf;
+    const mark = new Uint8Array(w * h);
+    for (let i = 0; i < data.length; i++) {
+        if (data[i] && data[i] !== ' ' && data[i] !== '.') mark[i] = 1;
+    }
+    for (let y = 0; y < h; y++) {
+        for (let x = 0; x < w; x++) {
+            if (mark[y * w + x]) continue;
+            let near = false;
+            for (let dy = -1; dy <= 1 && !near; dy++) {
+                for (let dx = -1; dx <= 1; dx++) {
+                    if (!dx && !dy) continue;
+                    const nx = x + dx, ny = y + dy;
+                    if (nx < 0 || ny < 0 || nx >= w || ny >= h) continue;
+                    if (mark[ny * w + nx]) { near = true; break; }
+                }
+            }
+            if (near) put(buf, x, y, ink);
+        }
+    }
+}
+
 const NEUTRAL = {
-    lean: 0,               // inclinação do tronco (graus, + = para trás)
-    crouch: 0,             // quanto o quadril desce (px)
-    headTilt: 0,           // deslocamento horizontal da cabeça (px)
-    armFront: [-60, -70],  // [ângulo do braço, ângulo do antebraço]
+    lean: 0,
+    crouch: 0,
+    headTilt: 0,
+    armFront: [-60, -70],
     armBack: [-115, -95],
     legFront: [-70, -85],
     legBack: [-100, -88],
@@ -39,16 +49,8 @@ const NEUTRAL = {
 };
 
 export const FIGURE_W = 26;
-// Altura folgada de propósito: as poses mais esticadas (perna estendida do chute, corpo
-// esparramado da queda) precisam caber inteiras, senão o desenho é cortado no meio.
 export const FIGURE_H = 36;
 
-/**
- * Rasteriza um atleta e devolve { rows, pal, anchors } no formato de `core/sprites.bake`.
- * @param {object} pose  desvios da postura neutra
- * @param {object} kit   { shirt, trim, skin, hair } em chars da paleta mestra
- * @param {object} opts  { flip }
- */
 export function buildFigure(pose = {}, kit = {}, opts = {}) {
     const p = { ...NEUTRAL, ...pose };
     const buf = makeBuf(FIGURE_W, FIGURE_H);
@@ -57,25 +59,32 @@ export function buildFigure(pose = {}, kit = {}, opts = {}) {
     const trim = kit.trim || 'y';
     const skin = kit.skin || 'u';
     const hair = kit.hair || '0';
+    const shorts = kit.shorts || '2';
 
-    // Âncora: quadril no centro-baixo, deixando espaço embaixo para prancha/skate/bicicleta.
     const hipX = FIGURE_W / 2;
     const hipY = FIGURE_H - 18 + p.crouch;
 
     const torsoAngle = 90 + p.lean;
     const chest = tip(hipX, hipY, torsoAngle, 9);
 
-    // Membros de trás primeiro: ficam por baixo do tronco na sobreposição.
+    // pernas
     twoBone(buf, hipX, hipY, p.legBack[0], p.legLen[0], p.legBack[1], p.legLen[1], 3, skin);
+    const legF = twoBone(buf, hipX, hipY, p.legFront[0], p.legLen[0], p.legFront[1], p.legLen[1], 3, skin);
+    // bermuda
+    fillRect(buf, hipX - 4, hipY - 1, 8, 4, shorts);
+    fillRect(buf, hipX - 3, hipY, 6, 2, shirt);
+
+    // braço de trás
     twoBone(buf, chest.x, chest.y - 1, p.armBack[0], p.armLen[0], p.armBack[1], p.armLen[1], 2, skin);
 
-    // Tronco: camisa do patrocinador com uma faixa mais clara no meio.
+    // tronco
     line(buf, hipX, hipY, chest.x, chest.y, 6, shirt);
-    line(buf, hipX, hipY, chest.x, chest.y, 2, trim);
+    line(buf, hipX, hipY - 1, chest.x, chest.y - 1, 2, trim);
 
-    // Cabeça + cabelo (meia-lua superior).
+    // cabeça
     const headC = tip(chest.x + p.headTilt, chest.y, torsoAngle, 4);
     fillDisc(buf, headC.x, headC.y, 3, skin);
+    put(buf, headC.x + (opts.flip ? -1 : 1), headC.y, '0');
     if (p.hair !== 'none') {
         for (let i = -3; i <= 3; i++) {
             for (let j = -3; j <= 0; j++) {
@@ -85,29 +94,25 @@ export function buildFigure(pose = {}, kit = {}, opts = {}) {
         if (p.hair === 'long') fillRect(buf, headC.x - 3, headC.y, 2, 5, hair);
     }
 
-    // Membros da frente por cima.
-    const legF = twoBone(buf, hipX, hipY, p.legFront[0], p.legLen[0], p.legFront[1], p.legLen[1], 3, skin);
     const armF = twoBone(buf, chest.x, chest.y - 1, p.armFront[0], p.armLen[0], p.armFront[1], p.armLen[1], 2, skin);
+
+    outline(buf, '0');
 
     const rows = opts.flip ? flipRows(toRows(buf)) : toRows(buf);
 
-    // Linha mais baixa com tinta: é ela, e não a altura do buffer, que define onde ficam os
-    // "pés" do sprite. Ancorar pela altura fixa fazia o atleta flutuar em umas poses e afundar
-    // em outras, porque cada pose ocupa uma fatia diferente do buffer.
     let bottom = FIGURE_H - 1;
     for (let y = FIGURE_H - 1; y >= 0; y--) {
         if (rows[y].trim() !== '') { bottom = y; break; }
     }
 
     const pal = { ' ': null };
-    for (const ch of [shirt, trim, skin, hair]) pal[ch] = SVC[ch];
+    for (const ch of [shirt, trim, skin, hair, shorts, '0']) pal[ch] = SVC[ch];
 
     const mirror = (pt) => (opts.flip ? { x: FIGURE_W - 1 - pt.x, y: pt.y } : pt);
     return {
         rows,
         pal,
         bottom,
-        // Pontos de ancoragem em coordenadas do sprite — quem chama pendura raquete/remo aqui.
         anchors: {
             hand: mirror(armF.end),
             foot: mirror(legF.end),
@@ -117,40 +122,33 @@ export function buildFigure(pose = {}, kit = {}, opts = {}) {
     };
 }
 
-/** Poses das seis provas. Os nomes descrevem a leitura em tela, não o esqueleto. */
 export const POSES = {
-    // --- surfe: base baixa, braços abertos para equilíbrio ---
     surfCrouch: { crouch: 3, lean: -14, armFront: [-20, 10], armBack: [-160, 170], legFront: [-55, -110], legBack: [-125, -70] },
     surfCarve: { crouch: 4, lean: -30, armFront: [0, 30], armBack: [-170, 150], legFront: [-45, -115], legBack: [-135, -60] },
     surfAir: { crouch: 1, lean: 10, armFront: [30, 60], armBack: [150, 120], legFront: [-60, -40], legBack: [-110, -50], armLen: [7, 7] },
     surfTube: { crouch: 6, lean: -8, armFront: [10, 40], armBack: [-165, -150], legFront: [-60, -115], legBack: [-120, -75] },
     surfWipe: { crouch: -4, lean: 60, armFront: [80, 130], armBack: [110, 60], legFront: [-20, 30], legBack: [-150, -170] },
 
-    // --- skate ---
     skatePump: { crouch: 4, lean: -16, armFront: [-30, -10], armBack: [-150, -170], legFront: [-60, -110], legBack: [-120, -70] },
     skateAir: { crouch: 2, lean: 0, armFront: [40, 80], armBack: [140, 100], legFront: [-70, -30], legBack: [-110, -40] },
     skateGrab: { crouch: 6, lean: -20, armFront: [-55, -100], armBack: [140, 110], legFront: [-70, -105], legBack: [-115, -80] },
     skateLand: { crouch: 5, lean: -10, armFront: [-10, 20], armBack: [-170, 160], legFront: [-65, -105], legBack: [-115, -75] },
     skateBail: { crouch: -3, lean: 45, armFront: [70, 120], armBack: [120, 80], legFront: [-30, 20], legBack: [-160, 170] },
 
-    // --- altinha ---
     ballIdle: { crouch: 0, lean: -4, armFront: [-50, -30], armBack: [-130, -150], legFront: [-80, -88], legBack: [-100, -90] },
     ballKick: { crouch: 1, lean: -18, armFront: [-20, 20], armBack: [-160, 160], legFront: [-25, -5], legBack: [-115, -85] },
     ballHead: { crouch: -2, lean: 18, armFront: [40, 70], armBack: [140, 110], legFront: [-75, -95], legBack: [-105, -85] },
     ballChest: { crouch: 1, lean: 12, armFront: [-10, 40], armBack: [-170, 140], legFront: [-80, -90], legBack: [-100, -88] },
 
-    // --- BMX (tronco bem à frente, mãos no guidão) ---
     bikeRide: { crouch: 3, lean: -34, armFront: [-14, -8], armBack: [-24, -12], legFront: [-70, -100], legBack: [-110, -80] },
     bikeAir: { crouch: 2, lean: -26, armFront: [-10, -5], armBack: [-20, -10], legFront: [-55, -70], legBack: [-125, -60] },
     bikeTrick: { crouch: 0, lean: -10, armFront: [10, 30], armBack: [-30, -20], legFront: [-40, 10], legBack: [-140, -160] },
     bikeCrash: { crouch: -5, lean: 55, armFront: [90, 140], armBack: [110, 70], legFront: [-10, 40], legBack: [-170, 160] },
 
-    // --- frescobol ---
     racketReady: { crouch: 1, lean: -6, armFront: [-40, -10], armBack: [-140, -160], legFront: [-72, -92], legBack: [-108, -88] },
     racketSwing: { crouch: 2, lean: -20, armFront: [25, 55], armBack: [-150, -170], legFront: [-60, -100], legBack: [-120, -80] },
     racketReach: { crouch: -1, lean: -10, armFront: [60, 85], armBack: [-140, -160], legFront: [-70, -85], legBack: [-105, -95] },
 
-    // --- canoa (sentado, remando) ---
     rowCatch: { crouch: 8, lean: -40, armFront: [-5, 20], armBack: [-25, 5], legFront: [-30, -60], legBack: [-40, -70], armLen: [8, 7] },
     rowPull: { crouch: 8, lean: -66, armFront: [-160, -140], armBack: [-175, -155], legFront: [-30, -60], legBack: [-40, -70], armLen: [8, 7] }
 };

--- a/labs/santos-games/src/art/scenery.js
+++ b/labs/santos-games/src/art/scenery.js
@@ -1,16 +1,4 @@
-// art/scenery.js — camadas de fundo pré-renderizadas.
-//
-// Os fundos são gradientes ditherizados e silhuetas com muito detalhe por pixel: redesenhar
-// isso a cada frame custaria caro. Cada camada é rasterizada UMA vez para um canvas offscreen
-// no boot e depois só é blitada com deslocamento de parallax — o custo por frame vira um
-// punhado de drawImage.
-//
-// Referências locais são de propósito: os prédios tortos da Ponta da Praia, o Monte Serrat com
-// o funicular, o Quebra-Mar avançando na água. É Santos, não uma praia genérica.
-//
-// Tudo que é "brilho do sol" (a coluna cintilante no mar, o reflexo na areia molhada) nasce da
-// mesma constante SUN_X. Antes cada camada escolhia a sua e o resultado era uma coluna amarela
-// solta no meio da água, sem sol nenhum acima dela.
+// art/scenery.js — fundos pré-renderizados: Santos ensolarado estilo California Games MD.
 
 import { SVC, SUN_X, ditherGradient } from '../core/palette.js';
 import { W, H } from '../core/pixel.js';
@@ -30,77 +18,60 @@ function px(g, x, y, w, h, ch) {
     g.fillRect(x | 0, y | 0, Math.max(1, w | 0), Math.max(1, h | 0));
 }
 
-/** Gerador determinístico local — cada camada tem a sua semente e sai igual todo boot. */
 function seeded(seed) {
     let s = seed >>> 0;
     return () => { s = (s * 1103515245 + 12345) & 0x7fffffff; return s / 0x7fffffff; };
 }
 
-// ---------------------------------------------------------------------------
-// Céu
-// ---------------------------------------------------------------------------
-
-/**
- * Céu de pôr do sol "vice": rampa noite -> magenta -> laranja -> creme, com o sol listrado
- * característico do visual outrun e bancos de nuvem em duas tintas.
- */
-function makeSky(sunY = 118, sunR = 34) {
+/** Céu diurno com sol listrado (cartucho 16-bit). */
+function makeSky(sunY = 52, sunR = 28) {
     const { cv, g } = canvas(W, H);
-    ditherGradient(g, 0, 0, W, sunY + sunR + 24, ['1', '2', '3', '4', '5', '6', '7', '8'], SVC);
+    ditherGradient(g, 0, 0, W, sunY + sunR + 36, ['3', '4', '5', '5', '7', '8', 'h'], SVC);
 
     const cx = Math.round(W * SUN_X);
 
-    // halo: o sol não corta o céu num círculo duro, ele sangra em volta
-    for (let r = sunR + 14; r > sunR; r--) {
-        const ch = r > sunR + 9 ? '5' : r > sunR + 4 ? '6' : '7';
-        for (let a = 0; a < 360; a += 3) {
+    for (let r = sunR + 12; r > sunR; r--) {
+        const ch = r > sunR + 8 ? '7' : r > sunR + 4 ? '8' : 'h';
+        for (let a = 0; a < 360; a += 4) {
             const rad = a * Math.PI / 180;
             px(g, cx + Math.cos(rad) * r, sunY - Math.sin(rad) * r, 1, 1, ch);
         }
     }
 
-    // disco com faixas horizontais: finas em cima, grossas embaixo
     for (let dy = -sunR; dy <= sunR; dy++) {
         const halfW = Math.sqrt(Math.max(0, sunR * sunR - dy * dy));
         const yy = sunY + dy;
         const t = (dy + sunR) / (2 * sunR);
-        const band = Math.floor((yy + 400) / (3 + t * 6)) % 2 === 0;
-        if (t > 0.45 && band) continue;
-        const ch = t < 0.26 ? 'h' : t < 0.44 ? '8' : t < 0.68 ? '7' : '6';
+        const band = Math.floor((yy + 400) / (3 + t * 5)) % 2 === 0;
+        if (t > 0.4 && band) continue;
+        const ch = t < 0.28 ? 'h' : t < 0.5 ? '8' : t < 0.72 ? '7' : '6';
         px(g, cx - halfW, yy, halfW * 2, 1, ch);
     }
 
-    // Nuvens: quatro linhas de larguras diferentes empilhadas formam um banco achatado, com o
-    // topo aceso pelo sol e a barriga na sombra. Barras retas de 2 px, que era o desenho
-    // anterior, liam como riscos horizontais soltos no céu — não como nuvem.
+    // nuvens brancas empilhadas
     const rnd = seeded(4242);
-    const bands = [[18, 96, '3', '5'], [38, 74, '3', '6'], [62, 124, '4', '7'], [86, 58, '4', '7']];
-    for (const [y, len, dark, lit] of bands) {
-        for (let i = 0; i < 5; i++) {
-            const x = Math.round(rnd() * W);
-            const w = Math.round(len * (0.45 + rnd() * 0.5));
-            const bulge = Math.round(w * (0.25 + rnd() * 0.2));
-            px(g, x + bulge, y - 2, w - bulge * 2, 1, lit);
-            px(g, x + Math.round(bulge * 0.5), y - 1, w - bulge, 1, lit);
-            px(g, x, y, w, 1, dark);
-            px(g, x + 3, y + 1, w - 6, 1, dark);
-            px(g, x + Math.round(w * 0.35), y + 2, Math.round(w * 0.3), 1, dark);
-        }
+    for (let i = 0; i < 7; i++) {
+        const x = Math.round(rnd() * W);
+        const y = 10 + Math.round(rnd() * 36);
+        const w = 28 + Math.round(rnd() * 42);
+        px(g, x + 6, y - 2, w - 12, 1, 'r');
+        px(g, x + 2, y, w - 4, 2, 'r');
+        px(g, x, y + 2, w, 2, 'q');
+        px(g, x + 8, y + 4, w - 16, 1, 'p');
     }
     return cv;
 }
 
-/** Céu noturno com estrelas — usado no pódio e na tela de título. */
+/** Céu de pódio / noite suave (teal profundo + estrelas). */
 function makeStarfield(width = W, height = 120) {
     const { cv, g } = canvas(width, height);
     ditherGradient(g, 0, 0, width, height, ['0', '1', '2', '3'], SVC);
     const rnd = seeded(5);
-    for (let i = 0; i < 130; i++) {
+    for (let i = 0; i < 110; i++) {
         const x = Math.floor(rnd() * width);
         const y = Math.floor(rnd() * height * 0.82);
         const r = rnd();
         px(g, x, y, 1, 1, r < 0.2 ? 'E' : r < 0.55 ? 'q' : 'o');
-        // as mais brilhantes ganham um cruzamento de 1 px, que é o que faz "estrela"
         if (r < 0.06) {
             px(g, x - 1, y, 1, 1, 'p'); px(g, x + 1, y, 1, 1, 'p');
             px(g, x, y - 1, 1, 1, 'p'); px(g, x, y + 1, 1, 1, 'p');
@@ -109,16 +80,10 @@ function makeStarfield(width = W, height = 120) {
     return cv;
 }
 
-// ---------------------------------------------------------------------------
-// Cidade
-// ---------------------------------------------------------------------------
-
 /**
- * Skyline de Santos em silhueta, tileável na horizontal.
- * Alguns prédios saem propositalmente inclinados — os "prédios tortos" da Ponta da Praia,
- * que afundaram em solo de areia sem fundação profunda e viraram cartão-postal involuntário.
+ * Skyline diurno de Santos — prédios claros da orla, alguns inclinados (Ponta da Praia).
  */
-function makeSkyline(width = 640, height = 78, tint = '2', tintTop = '3', seed = 7) {
+function makeSkyline(width = 640, height = 78, body = 'q', edge = 'r', seed = 7) {
     const { cv, g } = canvas(width, height);
     let x = 0;
     const rnd = seeded(seed);
@@ -126,29 +91,28 @@ function makeSkyline(width = 640, height = 78, tint = '2', tintTop = '3', seed =
     while (x < width) {
         const bw = 12 + Math.floor(rnd() * 22);
         const bh = 22 + Math.floor(rnd() * (height - 26));
-        const lean = rnd() < 0.22 ? (rnd() < 0.5 ? -1 : 1) : 0;   // ~1 em 5 prédios inclina
+        const lean = rnd() < 0.2 ? (rnd() < 0.5 ? -1 : 1) : 0;
 
         for (let row = 0; row < bh; row++) {
             const y = height - 1 - row;
             const shift = lean ? Math.round(lean * row * 0.14) : 0;
-            px(g, x + shift, y, bw, 1, row > bh - 6 ? tintTop : tint);
-            // aresta iluminada no lado que dá para o sol
-            px(g, x + shift + bw - 1, y, 1, 1, tintTop);
+            const shade = row > bh - 5 ? edge : (row % 7 === 0 ? 'p' : body);
+            px(g, x + shift, y, bw, 1, shade);
+            px(g, x + shift + bw - 1, y, 1, 1, edge);
         }
 
-        // coroamento: caixa d'água, casa de máquinas ou antena
         const topY = height - bh;
         const crown = rnd();
-        if (crown < 0.34) px(g, x + 3, topY - 4, 5, 4, tintTop);
-        else if (crown < 0.6) px(g, x + Math.floor(bw / 2), topY - 7, 1, 7, tintTop);
+        if (crown < 0.34) px(g, x + 3, topY - 4, 5, 4, edge);
+        else if (crown < 0.6) px(g, x + Math.floor(bw / 2), topY - 7, 1, 7, 'o');
 
-        // janelas acesas
+        // janelas escuras de dia + algumas com ar-condicionado
         for (let wy = 4; wy < bh - 6; wy += 5) {
             for (let wx = 2; wx < bw - 2; wx += 4) {
-                if (rnd() < 0.42) {
+                if (rnd() < 0.55) {
                     const y = height - 1 - wy;
                     const shift = lean ? Math.round(lean * wy * 0.14) : 0;
-                    px(g, x + wx + shift, y, 2, 2, rnd() < 0.7 ? '8' : 'A');
+                    px(g, x + wx + shift, y, 2, 2, rnd() < 0.15 ? 'y' : '3');
                 }
             }
         }
@@ -157,59 +121,41 @@ function makeSkyline(width = 640, height = 78, tint = '2', tintTop = '3', seed =
     return cv;
 }
 
-/** Monte Serrat: silhueta do morro com o traçado do funicular e a capela no topo. */
 function makeMorro(width = 320, height = 96) {
     const { cv, g } = canvas(width, height);
     const peak = width * 0.5;
     const rnd = seeded(19);
     for (let x = 0; x < width; x++) {
         const d = Math.abs(x - peak) / (width * 0.5);
-        // ruído baixo no contorno: um morro perfeitamente parabólico lê como colina de desenho
         const bump = Math.sin(x * 0.13) * 2 + Math.sin(x * 0.041) * 3;
         const top = Math.round(height - (1 - d * d) * (height - 8) - 4 - bump);
         for (let y = top; y < height; y++) {
             const rel = y - top;
-            // O corpo do morro continua sendo mata, só que na sombra. Fechar o miolo em roxo
-            // escuro, como antes, fazia o Monte Serrat parecer um buraco atrás da cidade.
-            const shade = rel < 3 ? 'k' : rel < 10 ? 'j' : rel < 30 ? 'i' : 'i';
+            const shade = rel < 3 ? 'k' : rel < 10 ? 'j' : 'i';
             px(g, x, y, 1, 1, shade);
         }
-        // sombra na base, onde o morro encontra a cidade
         px(g, x, height - 6, 1, 6, '1');
-        // manchas de mata mais clara na encosta virada para o sol
-        if (rnd() < 0.16) px(g, x, top + 4 + Math.floor(rnd() * 12), 1, 2, 'j');
+        if (rnd() < 0.16) px(g, x, top + 4 + Math.floor(rnd() * 12), 1, 2, 'l');
     }
-    // trilho do funicular subindo pela encosta direita
     for (let t = 0; t < 46; t++) {
         const x = Math.round(peak + 10 + t * 1.5);
         const y = Math.round(height - 6 - t * 1.55);
         px(g, x, y, 2, 1, 'p');
         if (t % 6 === 0) px(g, x - 1, y - 1, 4, 1, 'o');
     }
-    // capela no topo
     const capY = Math.round(height * 0.06);
-    px(g, peak - 4, capY + 2, 9, 7, 'q');
-    px(g, peak - 4, capY + 2, 9, 1, 'r');
+    px(g, peak - 4, capY + 2, 9, 7, 'r');
+    px(g, peak - 4, capY + 2, 9, 1, 'E');
     px(g, peak - 1, capY - 3, 2, 6, 'q');
     px(g, peak - 3, capY - 1, 6, 1, 'q');
     return cv;
 }
 
-// ---------------------------------------------------------------------------
-// Mar e areia
-// ---------------------------------------------------------------------------
-
-/**
- * Faixa de mar: gradiente ditherizado + cristas horizontais + a coluna de reflexo do sol.
- * O reflexo é feito de traços que encurtam e escurecem conforme descem — é isso que dá a
- * leitura de "caminho de luz na água" em vez de uma barra amarela colada por cima.
- */
 function makeSea(width = W, height = 70) {
     const { cv, g } = canvas(width, height);
     ditherGradient(g, 0, 0, width, height, ['9', 'a', 'b', 'c'], SVC);
 
     const rnd = seeded(77);
-    // cristas: quanto mais perto do observador, mais longas e espaçadas
     for (let y = 2; y < height; y += 3) {
         const t = y / height;
         const count = Math.round(6 + t * 10);
@@ -220,14 +166,11 @@ function makeSea(width = W, height = 70) {
         }
     }
 
-    // Reflexo do sol, alinhado à mesma coluna do disco no céu. Ele entra por fade nas
-    // primeiras linhas: começar em cheio na borda de cima deixava um degrau visível bem no
-    // encontro com o horizonte.
     const cx = Math.round(width * SUN_X);
     for (let y = 0; y < height; y++) {
         const t = y / height;
         const fadeIn = Math.min(1, y / 10);
-        if (rnd() < 0.25 + t * 0.25 + (1 - fadeIn) * 0.6) continue;   // buracos: a luz pisca
+        if (rnd() < 0.25 + t * 0.25 + (1 - fadeIn) * 0.6) continue;
         const spread = 2 + t * 13;
         const len = Math.max(1, Math.round((1 - t * 0.55) * (2 + rnd() * 5)));
         const x = cx + Math.round((rnd() - 0.5) * spread * 2) - len / 2;
@@ -236,28 +179,24 @@ function makeSea(width = W, height = 70) {
     return cv;
 }
 
-/** Faixa de areia: bandas + granulado fino + conchinhas, com a barra molhada no topo. */
 function makeSand(width = W, height = 60) {
     const { cv, g } = canvas(width, height);
     ditherGradient(g, 0, 6, width, height - 6, ['h', 'g', 'f', 'e'], SVC);
 
-    // faixa molhada onde a água acabou de subir — escura e brilhante
     const rnd = seeded(91);
     px(g, 0, 0, width, 6, 'R');
     for (let x = 0; x < width; x++) {
         const wob = Math.round(Math.sin(x * 0.09) * 1.5 + Math.sin(x * 0.31) * 1);
         px(g, x, 0, 1, 3 + wob, 'Q');
         px(g, x, 5 + wob, 1, 2, 'g');
-        if (rnd() < 0.1) px(g, x, 1 + wob, 1, 1, 'd');   // brilho de água na areia
+        if (rnd() < 0.1) px(g, x, 1 + wob, 1, 1, 'd');
     }
 
-    // granulado: pares de pixels claros/escuros dão textura sem virar chuvisco
     for (let i = 0; i < width * 2.2; i++) {
         const x = Math.floor(rnd() * width);
         const y = 7 + Math.floor(rnd() * (height - 8));
         px(g, x, y, 1, 1, rnd() < 0.5 ? 'e' : 'h');
     }
-    // pedrinhas e conchas esparsas
     for (let i = 0; i < 26; i++) {
         const x = Math.floor(rnd() * width);
         const y = 12 + Math.floor(rnd() * (height - 16));
@@ -267,7 +206,6 @@ function makeSand(width = W, height = 60) {
     return cv;
 }
 
-/** Quebra-Mar: espinha de pedras entrando no mar, em perspectiva. */
 function makeBreakwater(width = 200, height = 40) {
     const { cv, g } = canvas(width, height);
     const rnd = seeded(33);
@@ -277,49 +215,56 @@ function makeBreakwater(width = 200, height = 40) {
         const y = Math.round(height - h - t * 6);
         for (let j = 0; j < h; j++) {
             const r = rnd();
-            // blocos de pedra: topo claro, corpo médio, base na sombra
             const ch = j === 0 ? 'p' : j < h * 0.4 ? (r < 0.4 ? 'o' : 'n') : (r < 0.4 ? 'n' : 'm');
             px(g, x, y + j, 1, 1, ch);
         }
-        // arrebentação batendo no costão
         if (rnd() < 0.12) px(g, x, y + h - 1, 2, 2, 'P');
     }
     return cv;
 }
 
-// ---------------------------------------------------------------------------
-// Elementos animados (desenhados por frame, não pré-renderizados)
-// ---------------------------------------------------------------------------
-
 /**
- * Grade neon em perspectiva (piso do título/pódio). Devolve uma função de desenho em vez de
- * um canvas porque ela anima: as linhas horizontais rolam em direção ao observador.
+ * Faixa de calçadão limpa (poucas linhas) — leitura Mega Drive, sem grade synthwave.
  */
-export function drawNeonGrid(ctx, y0, h, t, colorH = 'x', colorV = 'z') {
+export function drawBoardwalk(ctx, y0, h, t, colorH = 'y', colorV = 'c') {
     const horizonY = y0;
-    ctx.strokeStyle = SVC[colorV];
+    ctx.fillStyle = SVC['g'];
+    ctx.fillRect(0, horizonY, W, h);
+
+    // ciclovia vermelha
+    ctx.fillStyle = SVC['B'];
+    ctx.beginPath();
+    ctx.moveTo(W / 2 - 3, horizonY);
+    ctx.lineTo(W / 2 - 36, y0 + h);
+    ctx.lineTo(W / 2 + 36, y0 + h);
+    ctx.lineTo(W / 2 + 3, horizonY);
+    ctx.closePath();
+    ctx.fill();
+
+    // linhas de perspectiva (poucas, limpas)
+    ctx.strokeStyle = SVC['e'];
     ctx.lineWidth = 1;
     ctx.beginPath();
-    for (let i = -10; i <= 10; i++) {
-        ctx.moveTo(W / 2 + i * 3 + 0.5, horizonY + 0.5);
-        ctx.lineTo(W / 2 + i * 46 + 0.5, y0 + h + 0.5);
+    for (let i = -6; i <= 6; i++) {
+        if (i === 0) continue;
+        ctx.moveTo(W / 2 + i * 4 + 0.5, horizonY + 0.5);
+        ctx.lineTo(W / 2 + i * 40 + 0.5, y0 + h + 0.5);
     }
     ctx.stroke();
 
-    for (let i = 0; i < 14; i++) {
-        const p = ((i / 14) + (t * 0.25 % 1)) % 1;
-        const yy = horizonY + Math.pow(p, 2.2) * h;
-        // as linhas próximas engrossam: é o que dá a sensação de vir na direção do jogador
-        const thick = p > 0.72 ? 2 : 1;
-        ctx.fillStyle = SVC[p > 0.5 ? colorH : colorV];
-        ctx.fillRect(0, Math.round(yy), W, thick);
+    for (let i = 0; i < 8; i++) {
+        const p = ((i / 8) + (t * 0.15 % 1)) % 1;
+        const yy = horizonY + Math.pow(p, 2.1) * h;
+        ctx.fillStyle = SVC[p > 0.55 ? colorH : colorV];
+        ctx.fillRect(0, Math.round(yy), W, 1);
     }
 }
 
-/**
- * Faixa de água animada, para as provas que precisam de mar vivo em vez de bloco chapado.
- * Bandas de profundidade + marolas que correm — barato o suficiente para rodar por frame.
- */
+/** Alias legado — menus antigos ainda importam drawNeonGrid. */
+export function drawNeonGrid(ctx, y0, h, t, colorH = 'y', colorV = 'c') {
+    drawBoardwalk(ctx, y0, h, t, colorH, colorV);
+}
+
 export function drawWater(px2, x, y, w, h, t, scroll = 0) {
     const bands = ['b', 'a', '9', 'O'];
     for (let i = 0; i < h; i++) {
@@ -327,7 +272,6 @@ export function drawWater(px2, x, y, w, h, t, scroll = 0) {
         const idx = Math.min(bands.length - 1, Math.floor(p * bands.length));
         px2.rect(x, y + i, w, 1, SVC[bands[idx]]);
     }
-    // marolas: linhas curtas que descem devagar e correm para trás
     for (let i = 0; i < 22; i++) {
         const p = ((i * 0.137 + t * 0.05) % 1);
         const yy = y + Math.round(p * p * h);
@@ -337,7 +281,6 @@ export function drawWater(px2, x, y, w, h, t, scroll = 0) {
     }
 }
 
-/** Linha de espuma quebrando na areia — usada pelas provas de praia. */
 export function drawShoreFoam(px2, y, t, width = W) {
     for (let x = 0; x < width; x++) {
         const wob = Math.sin(x * 0.11 + t * 1.6) * 2 + Math.sin(x * 0.037 - t) * 1.5;
@@ -347,10 +290,6 @@ export function drawShoreFoam(px2, y, t, width = W) {
     }
 }
 
-/**
- * Sombra elíptica achatada no chão. Um sprite sem sombra flutua; com ela, o mesmo sprite
- * ganha peso — é o retoque mais barato de todos e o que mais muda a leitura.
- */
 export function drawShadow(px2, cx, cy, rx, alpha = 0.4) {
     const ctx = px2.ctx;
     ctx.globalAlpha = alpha;
@@ -360,16 +299,12 @@ export function drawShadow(px2, cx, cy, rx, alpha = 0.4) {
     ctx.globalAlpha = 1;
 }
 
-/**
- * Constrói e memoiza todas as camadas. Chamado uma vez no boot; cada prova escolhe as
- * camadas que usa e o parallax que aplica.
- */
 export function buildScenery() {
     return {
         sky: makeSky(),
         skyNight: makeStarfield(W, 140),
-        skyline: makeSkyline(640, 78, '2', '3', 7),
-        skylineFar: makeSkyline(640, 54, '1', '2', 23),
+        skyline: makeSkyline(640, 78, 'q', 'r', 7),
+        skylineFar: makeSkyline(640, 54, 'p', 'q', 23),
         morro: makeMorro(320, 96),
         sea: makeSea(W, 70),
         seaFar: makeSea(W, 40),
@@ -378,7 +313,6 @@ export function buildScenery() {
     };
 }
 
-/** Blit tileável horizontal — usado pelas camadas de parallax. */
 export function tile(ctx, image, offsetX, y, width = W) {
     const iw = image.width;
     let x = -(((offsetX % iw) + iw) % iw);

--- a/labs/santos-games/src/art/songs.js
+++ b/labs/santos-games/src/art/songs.js
@@ -8,7 +8,7 @@
 // suingue de samba, a ciclovia corre, o frescobol é leve e a baía é remada cadenciada.
 
 export const SONGS = {
-    // --- tela de título: synthwave em Am, o "vice" do nome ---
+    // --- tela de título: tema de orla em Am ---
     tema: {
         bpm: 104,
         rows: 16,

--- a/labs/santos-games/src/core/palette.js
+++ b/labs/santos-games/src/core/palette.js
@@ -1,62 +1,52 @@
-// core/palette.js — paleta mestra 16-bit (48 cores) indexada por char, + matriz de dithering.
-// Teto: ~120 linhas.
+// core/palette.js — paleta Mega Drive limpa (cores saturadas, contraste alto, poucos tons mudos).
 
-/** Paleta mestra "SVC" — pôr do sol vice-city, mar, areia, verde, concreto, pele, neon. */
+/** Paleta mestra — California Games / Santos, leitura clara em 320×224. */
 export const SVC = {
-    ' ': null, '.': null, // transparente
+    ' ': null, '.': null,
 
-    // noite / contorno
-    '0': '#080512', '1': '#170b2b', '2': '#2d114c',
+    // preto / painéis (cinza-azul frio, sem roxo)
+    '0': '#000000', '1': '#101820', '2': '#203040',
 
-    // rampa pôr do sol (a "vice" ramp) - Mais vibrante e puro
-    '3': '#661f77', '4': '#ad207a', '5': '#f53874',
-    '6': '#ff6f3b', '7': '#ffac30', '8': '#ffe866',
+    // céu diurno (azul limpo → sol)
+    '3': '#2868a0', '4': '#4890c8', '5': '#78c0e8',
+    '6': '#f07828', '7': '#f0a830', '8': '#f0d848',
 
-    // mar - Mais contraste e azul profundo
-    '9': '#062d4e', 'a': '#0a4b7a', 'b': '#007999', 'c': '#1faac1', 'd': '#73f0e8',
+    // mar
+    '9': '#003858', 'a': '#006888', 'b': '#0090a8', 'c': '#20c0b0', 'd': '#68e0d0',
 
     // areia
-    'e': '#7a5638', 'f': '#b98a52', 'g': '#e0bd82', 'h': '#f5e3b6',
+    'e': '#805028', 'f': '#c08840', 'g': '#e0b868', 'h': '#f0e0b0',
 
-    // verde (jardins, morro) - Mais vivo
-    'i': '#05301a', 'j': '#095e29', 'k': '#119b35', 'l': '#46db3e',
+    // verde
+    'i': '#084018', 'j': '#187028', 'k': '#28a830', 'l': '#58e040',
 
-    // concreto / cidade
-    'm': '#2a2a38', 'n': '#454a5c', 'o': '#6b7386', 'p': '#9aa3b5', 'q': '#cdd3e0', 'r': '#f2f4fb',
+    // cidade / UI cinza
+    'm': '#282838', 'n': '#484858', 'o': '#707088', 'p': '#a0a0b8', 'q': '#d0d0e0', 'r': '#f0f0f8',
 
-    // pele (5 tons)
-    's': '#5a3320', 't': '#8a5334', 'u': '#c08457', 'v': '#e8b088', 'w': '#f6d8bd',
+    // pele
+    's': '#603020', 't': '#905038', 'u': '#c88858', 'v': '#e8b080', 'w': '#f0d0b0',
 
-    // neon
-    'x': '#ff2fa0', 'y': '#00f0ff', 'z': '#b74dff', 'A': '#ffe600',
+    // acentos (coral / teal / ouro)
+    'x': '#f05040', 'y': '#38c8b8', 'z': '#f0c040', 'A': '#f0e020',
 
     // utilitários
-    'B': '#e03a2f', 'C': '#2b6ad6', 'D': '#3a2417', 'E': '#ffffff', 'F': '#000000',
-    'G': '#ff9dc4', 'H': '#7cf0a0', 'I': '#c8382f', 'J': '#f0f0ff',
+    'B': '#e02820', 'C': '#2868d0', 'D': '#382818', 'E': '#ffffff', 'F': '#000000',
+    'G': '#f090b0', 'H': '#60e880', 'I': '#c02820', 'J': '#e8e8f8',
 
-    // extra utilitário para roupas/variação
-    'K': '#f4a300', 'L': '#00897b', 'M': '#6d4c41', 'N': '#8e24aa',
+    'K': '#f09800', 'L': '#089880', 'M': '#684838', 'N': '#f06848',
 
-    // rampas complementares abertas na revisão 16-bit: mar profundo, espuma, areia molhada,
-    // sombra de sprite e dois neons secundários para o HUD
-    'O': '#062a42', 'P': '#c9f5ef', 'Q': '#5c4630', 'R': '#9d7047',
-    'S': '#1a1626', 'T': '#3a2f52', 'U': '#ff5d8f', 'V': '#6ef2c0'
+    'O': '#002838', 'P': '#c0f0e8', 'Q': '#584830', 'R': '#987048',
+    'S': '#080810', 'T': '#182838', 'U': '#f06848', 'V': '#58e8b0'
 };
 
-/** Coluna do sol no céu — mar, reflexo e brilhos se alinham a ela. */
-export const SUN_X = 0.62;
+export const SUN_X = 0.7;
 
-/**
- * Constrói um sub-conjunto de paleta com aliases legíveis para um sprite específico.
- * Ex.: sub({ o:'g', b:'f', s:'6', k:'0' }) -> mapeia char 'o' para a cor SVC['g'], etc.
- */
 export function sub(map) {
     const pal = { ' ': null, '.': null };
     for (const k in map) pal[k] = SVC[map[k]];
     return pal;
 }
 
-/** Matriz Bayer 4x4 normalizada em [0,1) — para dithering de gradientes/transições. */
 export const BAYER4 = [
     [0, 8, 2, 10],
     [12, 4, 14, 6],
@@ -68,10 +58,6 @@ export function bayerThreshold(x, y) {
     return BAYER4[y & 3][x & 3];
 }
 
-/**
- * Desenha um gradiente vertical ditherizado dentro de (x,y,w,h) usando uma rampa de chars.
- * ramp: array de chars da paleta em ordem (escuro -> claro).
- */
 export function ditherGradient(ctx, x, y, w, h, ramp, pal) {
     const steps = ramp.length - 1;
     for (let ry = 0; ry < h; ry++) {
@@ -79,11 +65,11 @@ export function ditherGradient(ctx, x, y, w, h, ramp, pal) {
         const pos = t * steps;
         const idx = Math.min(steps - 1, Math.floor(pos));
         const frac = pos - idx;
+        const a = ramp[idx];
+        const b = ramp[idx + 1] || a;
         for (let rx = 0; rx < w; rx++) {
-            const thresh = bayerThreshold(rx, ry);
-            const useUpper = frac > thresh;
-            const ch = ramp[useUpper ? idx + 1 : idx];
-            const col = pal ? pal[ch] : SVC[ch];
+            const pick = bayerThreshold(x + rx, y + ry) < frac ? b : a;
+            const col = pal[pick];
             if (!col) continue;
             ctx.fillStyle = col;
             ctx.fillRect(x + rx, y + ry, 1, 1);

--- a/labs/santos-games/src/core/pixel.js
+++ b/labs/santos-games/src/core/pixel.js
@@ -31,7 +31,9 @@ export class PixelSurface {
         this._buildDitherPatterns();
 
         this._ro = new ResizeObserver(() => this._scheduleFit());
-        this._ro.observe(this.wrap);
+        // observa o palco pai — o wrap muda de tamanho por nós (escala inteira)
+        const stage = this.wrap.parentElement || this.wrap;
+        this._ro.observe(stage);
         this._fitPending = false;
         this.fit();
     }
@@ -43,33 +45,24 @@ export class PixelSurface {
     }
 
     fit() {
-        // A caixa útil é a área interna do wrap: o padding é a "moldura" do gabinete e não
-        // pode entrar na conta, senão a tela vaza por baixo dela.
-        const cs = getComputedStyle(this.wrap);
-        const padX = parseFloat(cs.paddingLeft) + parseFloat(cs.paddingRight);
-        const padY = parseFloat(cs.paddingTop) + parseFloat(cs.paddingBottom);
-        const availW = this.wrap.clientWidth - padX;
-        const availH = this.wrap.clientHeight - padY;
-        if (availW < 4 || availH < 4) return;
+        // Escala INTEIRA estilo emulador Mega Drive / Genesis.
+        const stage = this.wrap.parentElement;
+        const maxW = Math.max(32, (stage?.clientWidth || 320) - 4);
+        const maxH = Math.max(32, (stage?.clientHeight || 224) - 4);
 
-        const dpr = Math.min(window.devicePixelRatio || 1, 2);
-        const raw = Math.min(availW / W, availH / H);
-        if (!(raw > 0)) return;
+        const dpr = Math.min(window.devicePixelRatio || 1, 3);
+        const cssScale = Math.max(1, Math.floor(Math.min(maxW / W, maxH / H)));
+        this.wrap.style.width = `${W * cssScale}px`;
+        this.wrap.style.height = `${H * cssScale}px`;
 
-        // O tamanho em CSS preenche a moldura via flexbox e aspect-ratio, mas o buffer de trás é
-        // sempre um múltiplo inteiro de 320x224. Com `image-rendering: pixelated` o navegador
-        // faz a ampliação final por vizinho mais próximo — pixels continuam duros e nenhum
-        // espaço da moldura fica sobrando.
-        // As larguras visuais ficam por conta do CSS puro.
-        const cssScale = raw;
-
-        const back = clamp(Math.ceil(cssScale * dpr), 1, MAX_BACK_SCALE);
+        const back = clamp(Math.max(cssScale, Math.round(cssScale * dpr)), 1, MAX_BACK_SCALE);
         if (this.screen.width !== W * back || this.screen.height !== H * back) {
             this.screen.width = W * back;
             this.screen.height = H * back;
             this.sctx.imageSmoothingEnabled = false;
         }
         this.back = back;
+        this.cssScale = cssScale;
     }
 
     setTheme(theme) { this.theme = theme; }
@@ -179,7 +172,7 @@ export class PixelSurface {
     }
 
     /** Fade ditherizado (0..1) sobre o stage inteiro, na cor dada. */
-    ditherFade(t, color = '#0d0a1a') {
+    ditherFade(t, color = '#000000') {
         if (t <= 0) return;
         const idx = Math.min(4, Math.floor(t * 4.999));
         const ctx = this.ctx;
@@ -193,7 +186,7 @@ export class PixelSurface {
     }
 
     /** Wipe diagonal (0..1) — barras verticais cobrindo a tela da esquerda pra direita. */
-    wipe(t, color = '#0d0a1a', bars = 10) {
+    wipe(t, color = '#000000', bars = 10) {
         if (t <= 0) return;
         const ctx = this.ctx;
         ctx.fillStyle = color;

--- a/labs/santos-games/src/core/store.js
+++ b/labs/santos-games/src/core/store.js
@@ -3,8 +3,8 @@
 
 import { EVENT_ORDER } from '../game/config.js';
 
-const KEY = 'svg.save.v2';
-const VERSION = 2;
+const KEY = 'svg.save.v3';
+const VERSION = 3;
 
 function defaults() {
     const best = {};
@@ -13,7 +13,7 @@ function defaults() {
         v: VERSION,
         best,
         champ: { best: 0, place: 0, sponsor: null, date: 0, golds: 0 },
-        opts: { mute: false, vol: 0.7, scanlines: true, shake: true, touch: null },
+        opts: { mute: false, vol: 0.7, scanlines: false, shake: true, touch: null },
         seen: { intro: false, sponsor: null }
     };
 }

--- a/labs/santos-games/src/events/altinha.js
+++ b/labs/santos-games/src/events/altinha.js
@@ -13,8 +13,8 @@ import { drawShoreFoam, drawShadow } from '../art/scenery.js';
 import { panel, needleGauge } from '../game/hud.js';
 
 const SAND_Y = 176;
-const GRAVITY = 250; // Reduzido para mais tempo aéreo
-const HIT_RANGE_X = 34; // Mais tolerância horizontal
+const GRAVITY = 220;
+const HIT_RANGE_X = 38;
 
 /** Tipos de toque: alcance vertical, impulso e pontuação-base de cada um. */
 const TOUCHES = {
@@ -41,6 +41,7 @@ export class AltinhaEvent extends EventBase {
         this.serveT = 1.0;
         this.ball = { x: W / 2, y: 60, vx: 0, vy: 0, spin: 0, live: false };
         this.shadowPulse = 0;
+        this._varietyShown = false;
         // figurantes da roda, parados na areia atrás
         this.roda = [
             { x: 52, kit: 0 }, { x: 108, kit: 1 }, { x: 214, kit: 2 }, { x: 272, kit: 3 }
@@ -69,7 +70,7 @@ export class AltinhaEvent extends EventBase {
         // --- atleta ---
         const vx = input.axisX();
         if (vx !== 0) this.facing = vx;
-        this.playerX = clamp(this.playerX + vx * 160 * dt, 20, W - 20); // Mais veloz
+        this.playerX = clamp(this.playerX + vx * 175 * dt, 20, W - 20); // Mais veloz
 
         if (this.serveT > 0) {
             this.serveT -= dt;
@@ -107,7 +108,8 @@ export class AltinhaEvent extends EventBase {
         const dx = Math.abs(b.x - this.playerX);
         const height = SAND_Y - b.y;
 
-        if (dx > HIT_RANGE_X) {
+        const reach = b.vy > 0 ? HIT_RANGE_X + 4 : HIT_RANGE_X;
+        if (dx > reach) {
             this.float.push('LONGE', this.playerX, SAND_Y - 60, 'o', 500);
             audio.play('ui_deny');
             return;
@@ -147,15 +149,22 @@ export class AltinhaEvent extends EventBase {
         this.score += pts;
         this.variety.add(key);
         this.lastTouch = key;
+        if (this.variety.size === 4 && !this._varietyShown) {
+            this._varietyShown = true;
+            this.float.push('VARIEDADE x1.5!', W / 2, 54, 'z', 1100);
+            audio.play('coin');
+        }
         this.pose = t.pose;
         this.poseT = 0.28;
 
-        this.float.push(`${t.name} +${pts}`, this.playerX, SAND_Y - 70, repeated ? 'p' : 'A', 750);
-        if (this.combo > 0 && this.combo % 10 === 0) {
+        this.float.push(`${t.name} +${pts}`, this.playerX, SAND_Y - 70, repeated ? 'p' : 'z', 750);
+        if (this.combo > 0 && this.combo % 5 === 0) {
             this.float.push(`${this.combo} TOQUES!`, W / 2, 70, 'x', 1200);
-            this.score += 50;
-            audio.play('coin');
-            px.shake(1, 120);
+            if (this.combo % 10 === 0) {
+                this.score += 50;
+                audio.play('coin');
+                px.shake(1, 120);
+            }
         }
         this.app.audio.play(t.sfx);
     }
@@ -166,6 +175,7 @@ export class AltinhaEvent extends EventBase {
         this.drops++;
         this.combo = 0;
         this.variety.clear();
+        this._varietyShown = false;
         this.serveT = 1.2;
         audio.play('drop');
         px.shake(2, 180);
@@ -214,9 +224,9 @@ export class AltinhaEvent extends EventBase {
         if (this.ball.live && this.ball.vy > 0 && Math.abs(this.ball.x - this.playerX) < HIT_RANGE_X + 16) {
             const glow = Math.abs(this.ball.x - this.playerX) < HIT_RANGE_X;
             ctx.globalAlpha = 0.55;
-            px.rect(this.playerX - HIT_RANGE_X, SAND_Y - 1, HIT_RANGE_X * 2, 2, SVC[glow ? 'H' : 'o']);
-            px.rect(this.playerX - HIT_RANGE_X, SAND_Y - 4, 1, 4, SVC[glow ? 'H' : 'o']);
-            px.rect(this.playerX + HIT_RANGE_X - 1, SAND_Y - 4, 1, 4, SVC[glow ? 'H' : 'o']);
+            px.rect(this.playerX - HIT_RANGE_X, SAND_Y - 1, HIT_RANGE_X * 2, 2, SVC[glow ? 'y' : 'o']);
+            px.rect(this.playerX - HIT_RANGE_X, SAND_Y - 4, 1, 4, SVC[glow ? 'y' : 'o']);
+            px.rect(this.playerX + HIT_RANGE_X - 1, SAND_Y - 4, 1, 4, SVC[glow ? 'y' : 'o']);
             ctx.globalAlpha = 1;
         }
 
@@ -246,14 +256,14 @@ export class AltinhaEvent extends EventBase {
             const on = this.variety.has(key);
             const x = x0 + i * (boxW + gap);
             panel(px, x, 16, boxW, 14, {
-                fill: on ? 'j' : '1', border: '0', light: on ? 'H' : 'n', dark: '0', shadow: false
+                fill: on ? 'j' : '1', border: '0', light: on ? 'y' : 'n', dark: '0', shadow: false
             });
             font.text(px.ctx, letter, x + boxW / 2, 19, {
                 color: on ? 'P' : 'n', align: 'center', mono: true
             });
         });
         if (this.variety.size >= 4) {
-            font.text(px.ctx, 'x1.5', x0 - 26, 19, { color: 'A', mono: true, outline: '0' });
+            font.text(px.ctx, 'x1.5', x0 - 26, 19, { color: 'z', mono: true, outline: '0' });
         }
     }
 }

--- a/labs/santos-games/src/events/bmx.js
+++ b/labs/santos-games/src/events/bmx.js
@@ -15,7 +15,7 @@ import { gauge } from '../game/hud.js';
 const GROUND_Y = 182;
 // Janela de "coyote time": por um instante depois de sair do chão o pulo ainda é aceito.
 // Sem isso, saltar no fim de uma rampa exigia precisão de frame e a prova parecia injusta.
-const COYOTE_SEC = 0.12;
+const COYOTE_SEC = 0.14;
 const COURSE_LEN = 5200;      // px de ciclovia até a linha de chegada
 const GRAVITY = 1050;
 const MAX_SPEED = 320;
@@ -94,8 +94,8 @@ export class BmxEvent extends EventBase {
 
         // --- aceleração ---
         const ax = input.axisX();
-        if (ax > 0) this.speed += 180 * dt;
-        else if (ax < 0) this.speed -= 250 * dt;
+        if (ax > 0) this.speed += 200 * dt;
+        else if (ax < 0) this.speed -= 260 * dt;
         else this.speed -= 20 * dt;
         this.speed = clamp(this.speed, 50, MAX_SPEED);
 
@@ -158,6 +158,7 @@ export class BmxEvent extends EventBase {
                 this.vy = 250 + this.speed * 1.15;
                 this.grounded = false;
                 audio.play('jump');
+                this.float.push('RAMP!', 96, GROUND_Y - this.y - 36, 'y', 500);
                 px.shake(1, 80);
             }
         }
@@ -184,7 +185,7 @@ export class BmxEvent extends EventBase {
                 p.taken = true;
                 this.cocos++;
                 this.score += 40;
-                this.float.push('+40', 96, GROUND_Y - this.y - 30, 'A', 600);
+                this.float.push('COCO +40', 96, GROUND_Y - this.y - 30, 'z', 600);
                 audio.play('coin');
             }
         }
@@ -217,6 +218,9 @@ export class BmxEvent extends EventBase {
         const t = this.elapsed;
         this.timeBonus = Math.max(0, Math.round((78 - t) * 12));
         this.score += this.timeBonus;
+        if (this.timeBonus > 0) {
+            this.float.push(`TEMPO +${this.timeBonus}`, W / 2, 100, 'z', 1400);
+        }
         this.detail = `${t.toFixed(1)}s · ${this.tricks} manobras · ${this.crashes} quedas`;
         this.app.audio.play('record');
         this.finish(this.detail);
@@ -343,7 +347,7 @@ export class BmxEvent extends EventBase {
     renderOverlay() {
         const { px, font } = this.app;
 
-        gauge(px, font, 4, 16, 104, 'VEL', this.speed / MAX_SPEED, { fill: 'A', glow: '8' });
+        gauge(px, font, 4, 16, 104, 'VEL', this.speed / MAX_SPEED, { fill: 'z', glow: '7' });
 
         // barra de percurso com a posição relativa — a leitura de "quanto falta"
         gauge(px, font, W - 116, 16, 112, 'PISTA', this.dist / COURSE_LEN, { fill: 'k', glow: 'l' });

--- a/labs/santos-games/src/events/canoa.js
+++ b/labs/santos-games/src/events/canoa.js
@@ -16,7 +16,7 @@ const RACE_LEN = 4200;
 const LANES = [126, 148, 170, 192];   // y de cada raia, do fundo para a frente
 const PLAYER_SCREEN_X = 92;
 const BEAT_SEC = 0.52;                // intervalo entre remadas na cadência ideal
-const GOOD_WINDOW = 0.16;             // tolerância em segundos para uma remada "no tempo"
+const GOOD_WINDOW = 0.18;             // tolerância em segundos para uma remada "no tempo"
 
 export class CanoaEvent extends EventBase {
     setup() {
@@ -33,6 +33,7 @@ export class CanoaEvent extends EventBase {
         this.broken = 0;
         this.rowPhase = 0;
         this.finished = false;
+        this.perfectStreak = 0;
         this.wake = [];
 
         const { rng } = this.app;
@@ -73,6 +74,7 @@ export class CanoaEvent extends EventBase {
             // perdeu a batida inteira
             this.beatT += BEAT_SEC;
             this.cadence = Math.max(0, this.cadence - 0.22);
+            this.perfectStreak = 0;
             this.broken++;
         }
 
@@ -86,6 +88,7 @@ export class CanoaEvent extends EventBase {
                 // remar do lado errado desequilibra a canoa
                 this.cadence = Math.max(0, this.cadence - 0.3);
                 this.broken++;
+                this.perfectStreak = 0;
                 this.speed *= 0.94;
                 audio.play('ui_deny');
                 this.float.push('FORA DE LADO', PLAYER_SCREEN_X, this.laneY - 34, 'B', 700);
@@ -96,24 +99,32 @@ export class CanoaEvent extends EventBase {
                 this.strokes++;
                 if (quality > 0.7) {
                     this.perfect++;
+                    this.perfectStreak++;
                     this.score += 12;
-                    this.float.push('NO TEMPO', PLAYER_SCREEN_X, this.laneY - 34, 'H', 500);
+                    this.float.push(`NO TEMPO +12`, PLAYER_SCREEN_X, this.laneY - 34, 'z', 550);
+                    if (this.perfectStreak >= 5 && this.perfectStreak % 5 === 0) {
+                        this.float.push(`${this.perfectStreak} SEGUIDAS!`, PLAYER_SCREEN_X, this.laneY - 50, 'x', 800);
+                        this.speed += 18;
+                    }
                 } else {
+                    this.perfectStreak = 0;
                     this.score += 5;
                 }
+                this.pushWake(side);
                 this.nextSide = side === 'a' ? 'b' : 'a';
                 this.beatT = BEAT_SEC;
                 this.rowPhase = 0;
                 audio.play('stroke');
-                this.pushWake();
             } else {
                 // remada fora da janela: entra, mas mata o embalo
                 this.cadence = Math.max(0, this.cadence - 0.14);
+                this.perfectStreak = 0;
                 this.speed += 8;
                 this.strokes++;
                 this.nextSide = side === 'a' ? 'b' : 'a';
                 this.beatT = BEAT_SEC;
                 audio.play('stroke');
+                this.float.push('FORA DO TEMPO', PLAYER_SCREEN_X, this.laneY - 34, 'o', 450);
             }
         }
 
@@ -155,8 +166,8 @@ export class CanoaEvent extends EventBase {
         if (this.dist >= RACE_LEN) this.arrive();
     }
 
-    pushWake() {
-        this.wake.push({ x: PLAYER_SCREEN_X - 30, y: this.laneY + 6, life: 0.7, side: this.nextSide });
+    pushWake(side) {
+        this.wake.push({ x: PLAYER_SCREEN_X - 30, y: this.laneY + 6, life: 0.7, side });
         if (this.wake.length > 20) this.wake.shift();
     }
 
@@ -170,6 +181,7 @@ export class CanoaEvent extends EventBase {
     }
 
     arrive() {
+        if (this.finished) return;
         this.finished = true;
         const placeBonus = [320, 200, 110, 50][this.place - 1] ?? 20;
         const timeBonus = Math.max(0, Math.round((70 - this.elapsed) * 6));
@@ -254,7 +266,7 @@ export class CanoaEvent extends EventBase {
 
         // --- sincronia acumulada e velocidade, nas beiradas ---
         gauge(px, font, 4, 16, 84, 'SINC', this.cadence, {
-            fill: this.cadence > 0.6 ? 'H' : 'c', glow: 'd'
+            fill: this.cadence > 0.6 ? 'y' : 'c', glow: 'd'
         });
         gauge(px, font, W - 88, 16, 84, 'RITMO', this.speed / 240, { fill: 'b', glow: 'c' });
 
@@ -271,15 +283,15 @@ export class CanoaEvent extends EventBase {
         const goodW = Math.round(trackW * (GOOD_WINDOW * 2 / BEAT_SEC));
         px.rect(Math.round(trackX + trackW / 2 - goodW / 2), 29, goodW, 6, SVC['j']);
         px.rect(Math.round(trackX + trackW / 2 - goodW / 2), 29, goodW, 1, SVC['k']);
-        px.rect(Math.round(trackX + trackW / 2) - 1, 27, 2, 10, SVC['A']);
+        px.rect(Math.round(trackX + trackW / 2) - 1, 27, 2, 10, SVC['z']);
 
         const p = clamp(this.beatT / BEAT_SEC, -0.4, 1);
         const markX = trackX + trackW / 2 + p * (trackW / 2);
-        px.rect(Math.round(markX) - 1, 26, 3, 12, SVC[Math.abs(this.beatT) <= GOOD_WINDOW ? 'H' : 'r']);
+        px.rect(Math.round(markX) - 1, 26, 3, 12, SVC[Math.abs(this.beatT) <= GOOD_WINDOW ? 'y' : 'r']);
 
         // qual botão vem agora, dentro da própria caixa da cadência
         font.text(px.ctx, this.nextSide === 'a' ? 'Z' : 'X', boxX + boxW - 6, 18, {
-            color: 'A', align: 'right', mono: true
+            color: 'z', align: 'right', mono: true
         });
 
         // --- trilho da regata: onde cada canoa está no percurso ---
@@ -292,6 +304,6 @@ export class CanoaEvent extends EventBase {
             px.rect(railX + Math.round(railW * t) - 1, railY - 2, 3, 3, SVC['o']);
         }
         const pt = clamp(this.dist / RACE_LEN, 0, 1);
-        px.rect(railX + Math.round(railW * pt) - 2, railY - 3, 5, 8, SVC['A']);
+        px.rect(railX + Math.round(railW * pt) - 2, railY - 3, 5, 8, SVC['z']);
     }
 }

--- a/labs/santos-games/src/events/frescobol.js
+++ b/labs/santos-games/src/events/frescobol.js
@@ -16,7 +16,7 @@ const NEAR_Y = 196;      // linha do jogador
 const FAR_Y = 126;       // linha do parceiro
 const NEAR_SPREAD = 118; // meia-largura da quadra perto
 const FAR_SPREAD = 58;   // meia-largura longe
-const HIT_WINDOW = 0.22; // faixa de z em que o rebate é possível (Aumentado)
+const HIT_WINDOW = 0.24; // faixa de z em que o rebate é possível
 const REACH = 44;        // alcance lateral da raquete (Aumentado)
 
 const screenY = (z, h) => lerp(NEAR_Y, FAR_Y, z) - h * lerp(1, 0.55, z);
@@ -71,7 +71,7 @@ export class FrescobolEvent extends EventBase {
         }
 
         // --- posição do jogador ---
-        this.playerX = clamp(this.playerX + input.axisX() * 1.9 * dt, -1, 1);
+        this.playerX = clamp(this.playerX + input.axisX() * 2.3 * dt, -1, 1);
 
         // --- carga do rebate: segurar A acumula força, soltar/apertar rebate ---
         if (input.state.a.down) this.charge = Math.min(1, this.charge + dt * 2.8);
@@ -150,7 +150,8 @@ export class FrescobolEvent extends EventBase {
 
         audio.play('hit');
         const label = quality > 0.8 ? 'NO CHEIO!' : quality > 0.45 ? 'BOA' : 'RASPOU';
-        this.float.push(`${label} +${pts}`, screenX(this.playerX, 0), NEAR_Y - 44, quality > 0.8 ? 'A' : 'r', 750);
+        this.float.push(`${label} +${pts}`, screenX(this.playerX, 0), NEAR_Y - 44, quality > 0.8 ? 'z' : 'y', 750);
+        if (charge > 0.75) this.float.push('FORTE!', screenX(this.playerX, 0), NEAR_Y - 58, 'x', 550);
         if (this.rally > 0 && this.rally % 10 === 0) {
             this.score += 60;
             this.float.push(`${this.rally} TROCAS!`, W / 2, 84, 'x', 1200);
@@ -182,7 +183,7 @@ export class FrescobolEvent extends EventBase {
         this.misses++;
         this.rally = 0;
         this.charge = 0;
-        this.pauseT = 1.1;
+        this.pauseT = 0.95;
         audio.play('miss');
         px.shake(2, 160);
         this.float.push(reason, W / 2, 150, 'B', 1000);
@@ -251,7 +252,7 @@ export class FrescobolEvent extends EventBase {
             // posicionamento vira adivinhação de trajetória em perspectiva falsa
             if (b.owner === 'player' && b.vz < 0) {
                 const landX = screenX(b.x + b.vx * Math.max(0, b.h / 46), 0);
-                const blink = Math.sin(this.elapsed * 14) > 0 ? 'A' : '8';
+                const blink = Math.sin(this.elapsed * 14) > 0 ? 'z' : '8';
                 px.rect(landX - 5, NEAR_Y - 1, 11, 1, SVC[blink]);
                 px.rect(landX, NEAR_Y - 3, 1, 5, SVC[blink]);
             }
@@ -276,7 +277,7 @@ export class FrescobolEvent extends EventBase {
         if (this.ball.live && this.ball.owner === 'player' && this.ball.z < 0.45) {
             const inRange = Math.abs(screenX(this.ball.x, this.ball.z) - playerSX) <= REACH;
             ctx.globalAlpha = 0.45;
-            px.rect(playerSX - REACH, NEAR_Y + 1, REACH * 2, 2, SVC[inRange ? 'H' : 'o']);
+            px.rect(playerSX - REACH, NEAR_Y + 1, REACH * 2, 2, SVC[inRange ? 'y' : 'o']);
             ctx.globalAlpha = 1;
         }
 
@@ -292,12 +293,12 @@ export class FrescobolEvent extends EventBase {
 
         needleGauge(px, font, 4, 16, 92, 'VENTO', clamp(0.5 + this.wind, 0, 1), { color: 'y' });
         gauge(px, font, W - 96, 16, 92, 'FORÇA', this.charge, {
-            fill: this.charge > 0.8 ? 'B' : '6', glow: '8'
+            fill: this.charge > 0.8 ? 'x' : 'z', glow: '8'
         });
 
         if (this.rally > 0) {
             font.text(px.ctx, `TROCA ${this.rally}`, W / 2, 18, {
-                color: 'H', align: 'center', mono: true, outline: '0'
+                color: 'y', align: 'center', mono: true, outline: '0'
             });
         }
     }

--- a/labs/santos-games/src/events/skate.js
+++ b/labs/santos-games/src/events/skate.js
@@ -19,7 +19,7 @@ const R = 66;               // raio da transição
 const COPING_Y = FLOOR_Y - R;
 const S_MAX = HALF_FLAT + R * (Math.PI / 2);   // arco do fundo até o coping
 const GRAVITY = 750;
-const PUMP_ACCEL = 480;
+const PUMP_ACCEL = 540;
 const MIN_LAUNCH = 150;
 // Tolerância de alinhamento na aterrissagem, em graus. Era 42; com o mostrador de giro no HUD
 // o jogador finalmente enxerga o alvo, e 52 dá o respiro que faz a manobra parecer justa em
@@ -73,7 +73,7 @@ export class SkateEvent extends EventBase {
         this.usedGrabs = new Set();
         this.t = 0;
         // grafite do fundo do bowl, sorteado uma vez por run
-        this.tag = this.app.rng.pick(['SANTOS', 'CANAL 3', 'ORLA', 'VICE', 'CAIÇARA']);
+        this.tag = this.app.rng.pick(['SANTOS', 'CANAL 3', 'ORLA', 'GONZAGA', 'CAIÇARA']);
     }
 
     start() { this.app.audio.play('pump'); }
@@ -103,7 +103,7 @@ export class SkateEvent extends EventBase {
         const pt = surfaceAt(this.s);
         // componente da gravidade ao longo da superfície: freia subindo, empurra descendo
         this.v -= GRAVITY * Math.sin(pt.slope) * Math.sign(this.s || 1) * dt;
-        this.v *= 1 - 0.22 * dt;   // atrito
+        this.v *= 1 - 0.17 * dt;   // atrito
 
         // bombear: acelerar no sentido do movimento enquanto está na transição.
         // O ganho é proporcional à inclinação, então bombear no fundo reto não faz nada —
@@ -192,7 +192,10 @@ export class SkateEvent extends EventBase {
         if (this.grabName) this.usedGrabs.add(this.grabName);
 
         const label = spinPts > 0 ? `${Math.floor(spins * 2) * 180}°` : this.grabName || 'AIR';
-        this.float.push(`${label} +${Math.round(pts)}`, surfaceAt(this.s).x, COPING_Y - 30, 'A', 900);
+        this.float.push(`${label} +${Math.round(pts)}`, surfaceAt(this.s).x, COPING_Y - 30, 'z', 900);
+        if (norm < 20 && height >= 12) {
+            this.float.push('PERFEITO!', surfaceAt(this.s).x, COPING_Y - 54, 'y', 700);
+        }
         if (this.combo > 1) {
             this.float.push(`x${this.combo}`, surfaceAt(this.s).x, COPING_Y - 44, 'x', 700);
         }
@@ -346,14 +349,14 @@ export class SkateEvent extends EventBase {
         const { px, font } = this.app;
         gauge(px, font, 4, 16, 108, 'IMPULSO', Math.abs(this.v) / 420, {
             fill: Math.abs(this.v) > MIN_LAUNCH ? 'x' : 'n',
-            glow: 'G', mark: MIN_LAUNCH / 420, markColor: 'A'
+            glow: '8', mark: MIN_LAUNCH / 420, markColor: 'z'
         });
 
         if (this.state === 'air') {
             // Altura, nome do grab e — o que faltava — o alinhamento do giro. Sem esta leitura
             // a queda por rotação torta parecia aleatória; agora dá para fechar o giro no olho.
             font.text(px.ctx, `${Math.round(this.airY)} PX`, W / 2, 18,
-                { color: 'A', align: 'center', mono: true, outline: '0' });
+                { color: 'z', align: 'center', mono: true, outline: '0' });
 
             const norm = ((this.rotation % 360) + 360) % 360;
             const off = Math.min(norm, Math.abs(norm - 180), 360 - norm);
@@ -363,7 +366,7 @@ export class SkateEvent extends EventBase {
             px.rect(dialX + dialW / 2 - 1, 29, 2, 5, SVC['n']);
             const t = 1 - Math.min(1, off / 90);
             px.rect(dialX + Math.round((dialW - 3) * (0.5 + (norm > 180 ? -t : t) * 0.5)), 28, 3, 7,
-                SVC[ok ? 'H' : 'B']);
+                SVC[ok ? 'y' : 'B']);
 
             if (this.grabName) {
                 font.text(px.ctx, this.grabName, W / 2, 38,

--- a/labs/santos-games/src/events/surf.js
+++ b/labs/santos-games/src/events/surf.js
@@ -15,7 +15,7 @@ import { EventBase } from './base.js';
 import { W, H } from '../core/pixel.js';
 import { SVC } from '../core/palette.js';
 import { clamp, lerp } from '../core/util.js';
-import { tile, drawWater, drawShadow } from '../art/scenery.js';
+import { tile, drawWater, drawShoreFoam, drawShadow } from '../art/scenery.js';
 import { gauge, judgePanel } from '../game/hud.js';
 
 const START_X = 296;        // onde o pico nasce, perto da borda direita
@@ -40,7 +40,7 @@ export class SurfEvent extends EventBase {
     resetWave() {
         this.playerX = 170;
         this.face = 0.45;              // 0 = base da parede, 1 = lábio
-        this.speed = 70;               // mais rápido
+        this.speed = 78;               // mais rápido
         this.foamX = START_X;          // o pico (e a quebra) começam à direita e marcham
         this.foamSpeed = 22 + this.waveIndex * 6; // quebra mais agressiva (California Games style)
         this.state = 'ride';           // ride | air | tube | wipe
@@ -114,7 +114,7 @@ export class SurfEvent extends EventBase {
 
         // --- posição na linha (esquerda = fugir, direita = bolso) ---
         const vx = input.axisX();
-        this.playerX = clamp(this.playerX + vx * 70 * dt, 40, this.foamX - 6);
+        this.playerX = clamp(this.playerX + vx * 82 * dt, 40, this.foamX - 6);
 
         // --- a onda fecha ---
         this.foamX -= this.foamSpeed * dt;
@@ -126,7 +126,7 @@ export class SurfEvent extends EventBase {
         this.danger = clamp(1 - gap / 34, 0, 1);
 
         // --- manobras (com buffer: um toque logo antes do fim do cooldown ainda vale) ---
-        if (this.state === 'ride' && input.buffered('a', 130) && this.trickCooldown <= 0) {
+        if (this.state === 'ride' && input.buffered('a', 150) && this.trickCooldown <= 0) {
             input.consume('a');
             this.doTrick();
         }
@@ -194,13 +194,13 @@ export class SurfEvent extends EventBase {
             px.shake(2, 160);
         } else if (this.face > 0.55) {
             const pts = Math.round(30 + this.speed * 0.35);
-            this.addPoints(pts, 'RASGADA', 'A');
+            this.addPoints(pts, 'RASGADA', 'z');
             audio.play('carve');
             this.face = clamp(this.face - 0.22, 0, 1);
             this.speed *= 0.92;
         } else {
             const pts = Math.round(20 + this.speed * 0.2);
-            this.addPoints(pts, 'CUTBACK', 'H');
+            this.addPoints(pts, 'CUTBACK', 'y');
             audio.play('carve');
             // o cutback joga o surfista de volta pra dentro do bolso — risco e recompensa
             this.playerX = clamp(this.playerX + 22, 40, this.foamX - 6);
@@ -225,7 +225,8 @@ export class SurfEvent extends EventBase {
     closeWave() {
         this.state = 'wipe';
         this.wipeT = 0.9;
-        this.float.push('ONDA FECHOU', W / 2, 96, 'p', 1100);
+        const pts = Math.round(this.wavePoints);
+        this.float.push(`ONDA ${this.waveIndex + 1}  +${pts}`, W / 2, 88, 'z', 1200);
     }
 
     nextWave() {
@@ -288,6 +289,7 @@ export class SurfEvent extends EventBase {
 
         // --- oceano de fundo: horizonte com cintilância, depois o canal escuro na frente ---
         ctx.drawImage(scenery.seaFar, 0, SEA_Y);
+        drawShoreFoam(px, SEA_Y + 36, this.waveT);
         drawWater(px, 0, SEA_Y + 40, W, H - SEA_Y - 40, this.waveT, this.scroll);
         px.rect(0, TROUGH_Y, W, H - TROUGH_Y, SVC['a']);
         px.rect(0, TROUGH_Y + 14, W, H - TROUGH_Y - 14, SVC['9']);
@@ -378,7 +380,7 @@ export class SurfEvent extends EventBase {
             const pocketX = Math.round(this.foamX - 52);
             if (pocketX > 30 && pocketX < W - 10) {
                 const py = this.waterY(pocketX);
-                const blink = Math.sin(this.waveT * 8) > 0 ? 'A' : '8';
+                const blink = Math.sin(this.waveT * 8) > 0 ? 'z' : '8';
                 px.rect(pocketX - 4, py + 3, 9, 1, SVC[blink]);
                 px.rect(pocketX, py + 1, 1, 4, SVC[blink]);
             }
@@ -422,7 +424,7 @@ export class SurfEvent extends EventBase {
 
         const gap = clamp((this.foamX - this.playerX) / 120, 0, 1);
         gauge(px, font, W - 100, 16, 96, 'BOLSO', 1 - gap, {
-            fill: gap < 0.2 ? 'B' : 'x', glow: 'G', mark: 0.56, markColor: 'A'
+            fill: gap < 0.2 ? 'B' : 'x', glow: 'd', mark: 0.56, markColor: 'z'
         });
 
         if (this.phase === 'outro' && this.judges) {

--- a/labs/santos-games/src/game/config.js
+++ b/labs/santos-games/src/game/config.js
@@ -1,6 +1,6 @@
 // game/config.js — a "regra do jogo": catálogo de eventos, patrocinadores e rivais.
 //
-// SANTOS VICE GAMES é uma homenagem direta a California Games (Mega Drive): você escolhe um
+// SANTOS GAMES é uma homenagem direta a California Games (Mega Drive): você escolhe um
 // patrocinador, disputa uma sequência de provas de praia curtas e independentes, cada uma com
 // sua própria mecânica, e no fim sobe (ou não) ao pódio. Aqui a Califórnia vira a orla de
 // Santos e cada prova do original ganha um equivalente caiçara.

--- a/labs/santos-games/src/game/hud.js
+++ b/labs/santos-games/src/game/hud.js
@@ -194,8 +194,8 @@ export function countdown(px, font, secondsLeft) {
     px.ctx.globalAlpha = 0.45;
     px.rect(0, 66, W, 46, SVC['0']);
     px.ctx.globalAlpha = 1;
-    px.rect(0, 66, W, 1, SVC[n > 0 ? 'x' : 'H']);
-    px.rect(0, 111, W, 1, SVC[n > 0 ? 'x' : 'H']);
+    px.rect(0, 66, W, 1, SVC[n > 0 ? 'z' : 'H']);
+    px.rect(0, 111, W, 1, SVC[n > 0 ? 'z' : 'H']);
 
     font.textBig(px.ctx, label, W / 2, 74, {
         outlineColor: '0', align: 'center', scale,

--- a/labs/santos-games/src/game/menu.js
+++ b/labs/santos-games/src/game/menu.js
@@ -87,7 +87,7 @@ export class MenuList {
 
             if (active && !it.disabled) {
                 panel(px, x - halfW, iy - 4, halfW * 2, 15, {
-                    fill: '2', border: '0', light: 'z', dark: '1', shadow: false
+                    fill: '2', border: '0', light: 'y', dark: '1', accent: 'x', shadow: false
                 });
             }
             font.text(px.ctx, it.label, x, iy, {
@@ -130,8 +130,8 @@ export function scrim(px, y, h, alpha = 0.62) {
  */
 export function screenHeader(px, font, title, subtitle) {
     plate(px, 0, 0, W, 30, '0');
-    px.rect(0, 29, W, 1, SVC['x']);
-    px.rect(0, 30, W, 1, SVC['3']);
+    px.rect(0, 29, W, 1, SVC['y']);
+    px.rect(0, 30, W, 1, SVC['c']);
     font.textBig(px.ctx, title, W / 2, 5, {
         scale: 2, ramp: ['h', '8', '7', '6'], outlineColor: '0', align: 'center'
     });

--- a/labs/santos-games/src/game/scenes.js
+++ b/labs/santos-games/src/game/scenes.js
@@ -40,48 +40,54 @@ export const titleScene = {
         const { px, font, sprites, scenery, store } = this.ctx;
         const c = px.ctx;
 
-        c.drawImage(scenery.skyNight, 0, 0);
-        c.drawImage(scenery.sky, 0, 40);
-        drawNeonGrid(c, 150, 74, this.t);
-        c.drawImage(scenery.skyline, Math.round(-(this.t * 6) % 640), 96);
+        c.drawImage(scenery.sky, 0, 0);
+        c.drawImage(scenery.morro, 0, 28);
+        c.drawImage(scenery.sea, 0, 118);
+        drawNeonGrid(c, 148, 76, this.t);
+        c.drawImage(scenery.skyline, Math.round(-(this.t * 8) % 640), 88);
+        px.blitScreen(sprites.get('palm'), 28, 168);
+        px.blitScreen(sprites.get('palm'), W - 28, 172);
+        px.blitScreen(sprites.get('umbrella'), 70, 178);
 
-        // gaivotas cruzando o pôr do sol — a tela de título ganha uma vida que não custa nada
+        // gaivotas no céu claro
         for (let i = 0; i < 3; i++) {
             const gx = ((this.t * (9 + i * 4) + i * 130) % (W + 40)) - 20;
-            px.blitScreen(sprites.anim('gull', this.t + i, 4), gx, 30 + i * 13);
+            px.blitScreen(sprites.anim('gull', this.t + i, 4), gx, 18 + i * 10);
         }
 
-        // logotipo: SANTOS em degradê quente, VICE GAMES em neon frio, ambos com contorno grosso
+        // Logo estilo cartucho: marca grande + subtítulo — California Games vibes
         const bob = Math.sin(this.t * 1.6) * 2;
-        font.textBig(c, 'SANTOS', W / 2, 38 + bob, {
-            scale: 4, ramp: ['h', '8', '7', '6', '5'], outlineColor: '0', align: 'center'
+        font.textBig(c, 'SANTOS', W / 2, 22 + bob, {
+            scale: 4, ramp: ['h', '8', '7', '6'], outlineColor: '0', align: 'center'
         });
-        font.textBig(c, 'VICE GAMES', W / 2, 74 + bob, {
-            scale: 3, ramp: ['P', 'd', 'c', 'b'], outlineColor: '0', align: 'center'
-        });
-
-        scrim(px, 102, 14, 0.55);
-        font.text(c, 'SEIS PROVAS NA ORLA · UM CAMPEONATO', W / 2, 105, {
-            color: '8', align: 'center', mono: true, shadow: '0'
+        font.textBig(c, 'GAMES', W / 2, 56 + bob, {
+            scale: 4, ramp: ['P', 'd', 'c', 'b', 'a'], outlineColor: '0', align: 'center'
         });
 
-        // faixa escura atrás das chamadas de baixo — sem ela o texto some no skyline
-        scrim(px, 160, 64, 0.6);
-        px.rect(0, 160, W, 1, SVC['3']);
+        panel(px, 40, 92, W - 80, 16, { fill: '1', border: '0', light: 'y', dark: '0', accent: 'x', shadow: false });
+        font.text(c, 'SEIS PROVAS · ORLA DE SANTOS', W / 2, 96, {
+            color: 'A', align: 'center', mono: true
+        });
 
-        // "insira ficha"
+        // atleta + bola no calçadão
+        px.blitScreen(sprites.get('ballIdle'), W / 2 - 40, 170);
+        px.blitScreen(sprites.get(`cheer#${Math.floor(this.t * 2) % 4}`), W / 2 + 40, 170);
+        px.blitScreen(sprites.get('ballBig'), W / 2 - 40, 142);
+
         if (Math.floor(this.t * 1.8) % 2 === 0) {
-            font.text(c, 'APERTE START', W / 2, 170, {
+            font.text(c, 'APERTE START', W / 2, 188, {
                 color: 'A', align: 'center', mono: true, scale: 2, outline: '0'
             });
         }
 
         const career = store.careerTotal();
         if (career > 0) {
-            font.text(c, `CARREIRA ${String(career).padStart(5, '0')} PTS`, W / 2, 196,
-                { color: 'p', align: 'center', mono: true });
+            font.text(c, `CARREIRA ${String(career).padStart(5, '0')} PTS`, W / 2, 204,
+                { color: '0', align: 'center', mono: true, outline: 'E' });
         }
-        font.text(c, 'HOMENAGEM A CALIFORNIA GAMES', W / 2, 208, { color: 'o', align: 'center', mono: true });
+        font.text(c, 'HOMENAGEM A CALIFORNIA GAMES', W / 2, 214, {
+            color: '0', align: 'center', mono: true, outline: 'h'
+        });
     }
 };
 
@@ -126,7 +132,7 @@ export const menuScene = {
         c.drawImage(scenery.skyline, -40, 108);
 
         scrim(px, 31, 179);
-        screenHeader(px, font, 'SANTOS VICE GAMES', 'MENU PRINCIPAL');
+        screenHeader(px, font, 'SANTOS GAMES', 'MENU PRINCIPAL');
         this.menu.draw(px, font, sprites, W / 2, 62, {
             lineH: 20, time: this.t, hintY: 176, width: 176
         });
@@ -226,27 +232,25 @@ export const eventSelectScene = {
         this.ctx = ctx;
         this.mode = params.mode || 'single';
         this.t = 0;
-        this.menu = new MenuList(EVENT_ORDER.map((id) => {
-            const ev = EVENTS[id];
-            const best = ctx.store.getBest(id);
-            return {
-                label: ev.name,
-                value: id,
-                hint: `${ev.place} — ${ev.tagline}`,
-                best
-            };
-        }));
+        this.index = 0;
     },
     update(dtMs) {
         const ctx = this.ctx;
         this.t += dtMs / 1000;
-        const action = this.menu.update(ctx.input, ctx.audio, dtMs);
-        if (action === 'back') { ctx.goto(menuScene); return; }
-        if (action !== 'confirm') return;
-        const id = this.menu.current.value;
-        const champ = new Championship(this.mode, ctx.sponsor, ctx.rng, [id]);
-        ctx.champ = champ;
-        ctx.goto(briefingScene, { eventId: id, champ });
+        const { input, audio } = ctx;
+        const n = EVENT_ORDER.length;
+        if (input.state.left.pressed) { this.index = (this.index + n - 1) % n; audio.play('ui_move'); }
+        if (input.state.right.pressed) { this.index = (this.index + 1) % n; audio.play('ui_move'); }
+        if (input.state.up.pressed) { this.index = (this.index + n - 3) % n; audio.play('ui_move'); }
+        if (input.state.down.pressed) { this.index = (this.index + 3) % n; audio.play('ui_move'); }
+        if (input.state.b.pressed) { audio.play('ui_back'); ctx.goto(menuScene); return; }
+        if (input.state.a.pressed || input.state.start.pressed) {
+            audio.play('ui_confirm');
+            const id = EVENT_ORDER[this.index];
+            const champ = new Championship(this.mode, ctx.sponsor, ctx.rng, [id]);
+            ctx.champ = champ;
+            ctx.goto(briefingScene, { eventId: id, champ });
+        }
     },
     draw() {
         const { px, font, sprites, scenery, store } = this.ctx;
@@ -257,31 +261,40 @@ export const eventSelectScene = {
         scrim(px, 31, 179);
         screenHeader(px, font, this.mode === 'practice' ? 'TREINO' : 'PROVA ÚNICA', 'ESCOLHA A PROVA');
 
-        this.menu.items.forEach((it, i) => {
-            const active = i === this.menu.index;
-            const y = 46 + i * 20;
-            const ev = EVENTS[it.value];
-            if (active) panel(px, 10, y - 4, W - 20, 18, { fill: '2', border: '0', light: ev.tint, dark: '1' });
-            font.text(c, ev.name, 22, y, { color: active ? 'A' : 'q', mono: true });
-            font.text(c, ev.place, 118, y, { color: 'o', mono: true });
-            const best = store.getBest(it.value);
-            font.text(c, best.score ? String(best.score).padStart(4, '0') : '----', W - 42, y, {
-                color: best.score ? 'r' : 'n', align: 'right', mono: true
-            });
+        // Grade 3×2 estilo tela de eventos do California Games
+        const cols = 3, cellW = 96, cellH = 52;
+        const x0 = (W - cols * cellW) / 2;
+        const y0 = 38;
+        EVENT_ORDER.forEach((id, i) => {
+            const ev = EVENTS[id];
+            const cx = Math.round(x0 + (i % cols) * cellW + cellW / 2);
+            const cy = y0 + Math.floor(i / cols) * cellH;
+            const active = i === this.index;
+            if (active) {
+                panel(px, cx - 44, cy - 2, 88, 48, {
+                    fill: '2', border: '0', light: 'y', dark: '1', accent: ev.tint
+                });
+            } else {
+                panel(px, cx - 42, cy, 84, 44, { fill: '1', border: '0', light: 'n', dark: '0', shadow: false });
+            }
+            const logoKey = `logo_${SPONSORS.find((s) => s.boon === id)?.id || 'caicara'}`;
+            if (sprites.has(logoKey)) px.blitScreen(sprites.get(logoKey), cx, cy + 16);
+            font.text(c, ev.name, cx, cy + 30, { color: active ? 'A' : 'q', align: 'center', mono: true });
+            const best = store.getBest(id);
             if (best.medal) {
-                font.text(c, MEDAL_LABEL[best.medal][0], W - 22, y, {
-                    color: MEDAL_COLOR[best.medal], align: 'right', mono: true
+                font.text(c, MEDAL_LABEL[best.medal][0], cx + 34, cy + 6, {
+                    color: MEDAL_COLOR[best.medal], align: 'center', mono: true
                 });
             }
         });
 
-        const cur = this.menu.current;
-        if (cur) {
-            panel(px, 12, 172, W - 24, 30, { fill: '1', border: '0', light: 'n' });
-            font.text(c, EVENTS[cur.value].tagline, W / 2, 180, { color: 'p', align: 'center', mono: true });
-            font.text(c, EVENTS[cur.value].hint, W / 2, 191, { color: 'o', align: 'center', mono: true });
-        }
-        screenFooter(px, font, 'Z COMEÇA · X VOLTA');
+        const cur = EVENTS[EVENT_ORDER[this.index]];
+        panel(px, 12, 148, W - 24, 48, { fill: '1', border: '0', light: 'y', accent: cur.tint });
+        font.text(c, cur.place, W / 2, 154, { color: 'A', align: 'center', mono: true });
+        font.text(c, cur.tagline, W / 2, 166, { color: 'p', align: 'center', mono: true });
+        font.text(c, cur.hint, W / 2, 178, { color: 'o', align: 'center', mono: true });
+
+        screenFooter(px, font, 'SETAS ESCOLHEM · Z COMEÇA · X VOLTA');
     }
 };
 
@@ -601,7 +614,7 @@ export const podiumScene = {
         drawNeonGrid(c, 150, 74, this.t * 0.2);
 
         scrim(px, 31, 179, 0.45);
-        screenHeader(px, font, 'PÓDIO', 'CAMPEONATO SANTOS VICE GAMES');
+        screenHeader(px, font, 'PÓDIO', 'CAMPEONATO SANTOS GAMES');
 
         // três degraus
         const order = [1, 0, 2];   // prata, ouro, bronze — da esquerda para a direita
@@ -725,7 +738,7 @@ export const optionsScene = {
         const opts = this.ctx.store.getOpts();
         this.menu = new MenuList([
             { label: `SOM: ${opts.mute ? 'DESLIGADO' : 'LIGADO'}`, value: 'mute', hint: 'Também alterna com a tecla M.' },
-            { label: `SCANLINES: ${opts.scanlines ? 'LIGADAS' : 'DESLIGADAS'}`, value: 'scanlines', hint: 'Simula as linhas da TV de tubo.' },
+            { label: `SCANLINES: ${opts.scanlines ? 'LIGADAS' : 'DESLIGADAS'}`, value: 'scanlines', hint: 'Opcional. Desligado = visual limpo de emulador.' },
             { label: `TREMOR DE TELA: ${opts.shake ? 'LIGADO' : 'DESLIGADO'}`, value: 'shake', hint: 'Desligue se preferir imagem estável.' },
             {
                 label: this.confirmReset ? 'CONFIRMAR? Z APAGA' : 'APAGAR RECORDES',

--- a/labs/santos-games/src/main.js
+++ b/labs/santos-games/src/main.js
@@ -23,7 +23,7 @@ if (location.protocol === 'file:') {
     document.body.innerHTML =
         '<p style="font:16px system-ui;padding:2rem">Este laboratório usa ES Modules e precisa ser servido por HTTP.<br>' +
         'Rode <code>python3 -m http.server 8000</code> na raiz do repositório e abra ' +
-        '<code>http://localhost:8000/labs/santos-vice-city/</code>.</p>';
+        '<code>http://localhost:8000/labs/santos-games/</code>.</p>';
     throw new Error('file:// não suportado');
 }
 
@@ -39,7 +39,7 @@ const state = {
     acc: 0,
     last: 0,
     rafId: 0,
-    scanlines: true
+    scanlines: false
 };
 
 const SCENE_ANNOUNCE = {
@@ -142,7 +142,7 @@ function setSponsor(sponsor) {
 function applyOptions() {
     const opts = state.store.getOpts();
     state.audio.setMute(!!opts.mute);
-    state.scanlines = opts.scanlines !== false;
+    state.scanlines = !!opts.scanlines;
     state.px.shakeEnabled = opts.shake !== false;
     updateSoundButton();
 }
@@ -150,8 +150,9 @@ function applyOptions() {
 function setTouchLayout(layout) {
     const overlay = document.getElementById('svcTouch');
     if (!overlay) return;
-    const coarse = matchMedia('(pointer: coarse)').matches;
-    state.input.attachTouch(overlay, coarse ? (layout || 'FULL') : null);
+    // coarse pointer OU dispositivos sem hover (celulares/tablets) — o overlay some no desktop
+    const touchy = matchMedia('(pointer: coarse), (hover: none)').matches;
+    state.input.attachTouch(overlay, touchy ? (layout || 'FULL') : null);
 }
 
 function updateSoundButton() {
@@ -246,7 +247,7 @@ function boot() {
     const stage = document.getElementById('svcStage');
     const screen = document.getElementById('svcScreen');
     if (!wrap || !stage || !screen) {
-        console.error('Santos Vice Games: canvas não encontrado no HTML.');
+        console.error('Santos Games: canvas não encontrado no HTML.');
         return;
     }
 
@@ -304,14 +305,14 @@ function boot() {
 
     const resetBtn = document.getElementById('svcResetBtn');
     on(resetBtn, 'click', () => {
-        if (!window.confirm('Apagar todos os recordes e medalhas do Santos Vice Games?')) return;
+        if (!window.confirm('Apagar todos os recordes e medalhas do Santos Games?')) return;
         state.store.reset();
         applyOptions();
     });
 
     // UX Fix: tornar a lista lateral de eventos interativa. Se o usuário clicar
     // num item ali, ele pula direto para o briefing daquela prova no modo "Única".
-    const eventItems = document.querySelectorAll('.svc-events li');
+    const eventItems = document.querySelectorAll('.sg-events li');
     eventItems.forEach((li, i) => {
         li.style.cursor = 'pointer';
         li.title = 'Jogar esta prova';

--- a/labs/santos-games/style.css
+++ b/labs/santos-games/style.css
@@ -1,20 +1,29 @@
-/* Santos Games — CSS reescrito para layout premium fullscreen glassmorphism */
+/* Santos Games — shell limpo estilo emulador Mega Drive (sem CRT/TV) */
 
 :root {
-    --glass-bg: rgba(13, 10, 26, 0.45);
-    --glass-border: rgba(255, 255, 255, 0.1);
-    --glass-blur: blur(16px);
+    --sg-ink: #0c0c12;
+    --sg-panel: #14141c;
+    --sg-line: #2a2a36;
+    --sg-teal: #38c8b8;
+    --sg-coral: #f05040;
+    --sg-sun: #f0c040;
+    --sg-text: #e8e8f0;
+    --sg-muted: #9898a8;
+    --font-display: "Bungee", "Arial Black", sans-serif;
+    --font-ui: "Nunito", "Trebuchet MS", sans-serif;
 }
 
-body, html {
+html, body {
     margin: 0;
     padding: 0;
     width: 100%;
     height: 100%;
-    overflow: hidden; /* Evita scroll na página principal */
+    overflow: hidden;
+    font-family: var(--font-ui);
+    color: var(--sg-text);
+    background: var(--sg-ink);
 }
 
-/* O container base do lab não deve limitar o tamanho */
 .container {
     max-width: none !important;
     padding: 0 !important;
@@ -23,235 +32,232 @@ body, html {
     height: 100vh;
 }
 
-.svc-background {
+.sg-bg {
     position: fixed;
-    top: 0;
-    left: 0;
-    width: 100vw;
-    height: 100vh;
-    background-size: cover;
-    background-position: center;
-    background-repeat: no-repeat;
-    z-index: 1;
-    /* Animação sutil de escala para dar vida */
-    animation: bgPulse 30s infinite alternate ease-in-out;
+    inset: 0;
+    z-index: 0;
+    pointer-events: none;
+    background:
+        radial-gradient(ellipse 70% 50% at 50% 40%, #1a2430 0%, var(--sg-ink) 70%);
 }
 
-@keyframes bgPulse {
-    0% { transform: scale(1); }
-    100% { transform: scale(1.05); }
-}
-
-.svc-layout {
+.sg-layout {
     position: relative;
-    z-index: 2;
+    z-index: 1;
     display: flex;
     flex-direction: column;
     height: 100vh;
     width: 100vw;
 }
 
-/* Headers e footers glassmorphism */
-.glass-header, .glass-footer {
-    background: var(--glass-bg);
-    backdrop-filter: var(--glass-blur);
-    -webkit-backdrop-filter: var(--glass-blur);
-    border-bottom: 1px solid var(--glass-border);
-    padding: 1rem 2rem;
+.sg-header, .sg-footer {
+    background: var(--sg-panel);
+    border-bottom: 1px solid var(--sg-line);
+    padding: 0.65rem 1.1rem;
     display: flex;
     align-items: center;
-    color: white;
+    color: var(--sg-text);
 }
-.glass-footer {
+
+.sg-footer {
     border-bottom: none;
-    border-top: 1px solid var(--glass-border);
+    border-top: 1px solid var(--sg-line);
     margin-top: auto;
 }
 
-.svc-shell {
+.sg-shell {
     flex: 1;
     width: 100%;
-    max-width: 1600px;
+    max-width: 1400px;
     margin: 0 auto;
     display: flex;
-    flex-direction: row;
-    gap: 2rem;
-    padding: 2rem;
+    gap: 1.1rem;
+    padding: 0.85rem 1.1rem;
     align-items: stretch;
     box-sizing: border-box;
-    overflow: hidden; /* Evita que a página inteira role; o painel lateral que rolará */
+    min-height: 0;
+    overflow: hidden;
 }
 
-/* ---------- palco ---------- */
-.svc-stage {
+/* ---------- emulador: moldura fina, pixel integer ---------- */
+.sg-stage {
     flex: 1;
     display: flex;
     flex-direction: column;
     justify-content: center;
     align-items: center;
     min-width: 0;
-    min-height: 0; /* Essencial para flex-children não transbordarem */
-    height: 100%;
+    min-height: 0;
 }
 
-.svc-screen-wrap {
+.sg-emu {
     position: relative;
-    box-sizing: border-box;
-    aspect-ratio: 320 / 224;
-    max-width: 100%;
-    max-height: 100%;
-    width: auto;
-    height: auto;
+    box-sizing: content-box;
     display: flex;
     align-items: center;
     justify-content: center;
-    background: #0b0916;
-    border-radius: 12px;
-    padding: 0; /* sem padding para tela ocupar tudo */
-    border: 2px solid rgba(255, 255, 255, 0.15);
-    box-shadow: 
-        0 24px 60px -24px rgba(0, 0, 0, 0.8),
-        0 0 20px rgba(255, 47, 160, 0.4),
-        0 0 40px rgba(0, 240, 255, 0.2);
-    overflow: hidden;
-}
-
-/* scanlines intensificadas sobre o canvas */
-.svc-vignette {
-    position: absolute;
-    inset: 0;
-    pointer-events: none;
-    z-index: 2;
-    background: 
-        radial-gradient(ellipse at 50% 50%, transparent 60%, rgba(0, 0, 0, 0.6) 100%),
-        repeating-linear-gradient(0deg, rgba(0,0,0,0.15), rgba(0,0,0,0.15) 1px, transparent 1px, transparent 2px);
+    background: #000;
+    border: none;
+    outline: 1px solid var(--sg-line);
+    box-shadow: 0 8px 28px rgba(0, 0, 0, 0.45);
+    width: 320px;
+    height: 224px;
+    max-width: none;
+    max-height: none;
+    flex-shrink: 0;
 }
 
 #svcScreen {
     width: 100%;
     height: 100%;
-    object-fit: contain;
+    display: block;
     image-rendering: pixelated;
     image-rendering: crisp-edges;
-    background: #0d0a1a;
+    background: #000;
 }
 
-/* ---------- painel lateral (glassmorphism) ---------- */
-.glass-panel {
-    width: 340px;
+/* ---------- painel ---------- */
+.sg-side {
+    width: 280px;
     flex-shrink: 0;
-    background: var(--glass-bg);
-    backdrop-filter: var(--glass-blur);
-    -webkit-backdrop-filter: var(--glass-blur);
-    border: 1px solid var(--glass-border);
-    border-radius: 16px;
-    padding: 1.5rem;
-    color: white;
-    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+    background: var(--sg-panel);
+    border: 1px solid var(--sg-line);
+    border-radius: 10px;
+    padding: 1rem 1.05rem;
     display: flex;
     flex-direction: column;
-    gap: 1.5rem;
+    gap: 0.95rem;
     overflow-y: auto;
+    color: var(--sg-text);
 }
 
-.svc-side-block h2 {
-    font-size: 1.2rem;
-    font-weight: 700;
-    margin-bottom: 0.5rem;
-    color: #fff;
-    text-shadow: 0 2px 4px rgba(0,0,0,0.5);
-}
-
-.svc-side-block p {
-    font-size: 0.9rem;
-    line-height: 1.5;
-    color: rgba(255, 255, 255, 0.85);
-}
-
-.svc-kicker {
-    font-size: 0.7rem;
-    font-weight: 700;
-    letter-spacing: 0.15em;
-    text-transform: uppercase;
-    color: #00f0ff; /* Neon cyan */
-    margin-bottom: 0.5rem;
+.sg-kicker {
     display: block;
+    font-size: 0.65rem;
+    font-weight: 800;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--sg-teal);
+    margin-bottom: 0.3rem;
 }
 
-/* lista de eventos */
-.svc-events {
-    list-style: none;
-    counter-reset: prova;
-    background: rgba(0, 0, 0, 0.2);
-    border-radius: 12px;
-    padding: 0.8rem;
-    display: grid;
-    gap: 4px;
+.sg-side-block h2 {
+    font-family: var(--font-display);
+    font-size: 1.05rem;
+    line-height: 1.2;
+    font-weight: 400;
+    margin: 0 0 0.45rem;
+    color: var(--sg-sun);
 }
-.svc-events li {
+
+.sg-side-block p {
+    margin: 0;
+    font-size: 0.84rem;
+    line-height: 1.4;
+    color: var(--sg-muted);
+}
+
+.sg-events {
+    list-style: none;
+    margin: 0;
+    padding: 0.25rem;
+    display: grid;
+    gap: 2px;
+    background: #0c0c12;
+    border-radius: 8px;
+    border: 1px solid var(--sg-line);
+    counter-reset: prova;
+}
+
+.sg-events li {
     counter-increment: prova;
     display: flex;
     align-items: baseline;
-    gap: 0.5rem;
-    padding: 0.5rem;
-    border-radius: 8px;
-    font-size: 0.85rem;
-    transition: background 0.2s;
+    gap: 0.4rem;
+    padding: 0.4rem 0.5rem;
+    border-radius: 6px;
+    font-size: 0.82rem;
+    cursor: pointer;
+    transition: background 0.12s ease;
 }
-.svc-events li:hover {
-    background: rgba(255, 47, 160, 0.2);
-}
-.svc-events li::before {
-    content: counter(prova);
-    font-weight: 700;
-    color: #ff2fa0;
-    min-width: 1.2em;
-}
-.svc-events b { color: #fff; }
-.svc-events span { margin-left: auto; color: rgba(255,255,255,0.6); font-size: 0.75rem; }
 
-/* controles */
-.svc-key-row {
+.sg-events li:hover,
+.sg-events li:focus-visible {
+    background: rgba(56, 200, 184, 0.14);
+    outline: none;
+}
+
+.sg-events li::before {
+    content: counter(prova);
+    font-family: var(--font-display);
+    font-size: 0.68rem;
+    color: var(--sg-coral);
+    min-width: 1em;
+}
+
+.sg-events b { color: #fff; font-weight: 800; }
+.sg-events span {
+    margin-left: auto;
+    color: var(--sg-muted);
+    font-size: 0.7rem;
+}
+
+.sg-key-row {
     display: flex;
     align-items: center;
-    gap: 0.8rem;
-    padding: 0.3rem 0;
-    font-size: 0.85rem;
-    color: rgba(255,255,255,0.8);
+    gap: 0.65rem;
+    padding: 0.18rem 0;
+    font-size: 0.82rem;
+    color: var(--sg-muted);
 }
-.svc-key-row kbd {
-    min-width: 60px;
-    text-align: center;
-    font-family: monospace;
-    font-size: 0.75rem;
-    padding: 0.3rem 0.5rem;
-    border-radius: 4px;
-    background: rgba(255,255,255,0.1);
-    border: 1px solid rgba(255,255,255,0.2);
-    border-bottom-width: 2px;
-    color: #fff;
-}
-.svc-note { margin-top: 0.8rem; font-size: 0.75rem; color: rgba(255,255,255,0.5); }
 
-/* botoes */
-.svc-actions { display: flex; flex-direction: column; gap: 0.8rem; margin-top: auto; }
-.svc-btn {
-    padding: 0.8rem;
-    font-weight: 600;
-    color: #fff;
-    background: rgba(255, 47, 160, 0.8);
+.sg-key-row kbd {
+    min-width: 54px;
+    text-align: center;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 0.7rem;
+    padding: 0.22rem 0.4rem;
+    border-radius: 4px;
+    background: #0c0c12;
+    border: 1px solid var(--sg-line);
+    color: var(--sg-text);
+}
+
+.sg-note {
+    margin: 0.45rem 0 0;
+    font-size: 0.72rem;
+    color: #686878;
+}
+
+.sg-actions {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    margin-top: auto;
+}
+
+.sg-btn {
+    padding: 0.65rem 0.8rem;
+    font-family: var(--font-ui);
+    font-weight: 800;
+    font-size: 0.88rem;
+    color: #101018;
+    background: var(--sg-coral);
     border: none;
     border-radius: 8px;
     cursor: pointer;
-    transition: all 0.2s;
-    backdrop-filter: blur(4px);
 }
-.svc-btn:hover { background: #ff2fa0; transform: translateY(-2px); box-shadow: 0 4px 15px rgba(255, 47, 160, 0.4); }
-.svc-btn--ghost { background: rgba(255,255,255,0.1); }
-.svc-btn--ghost:hover { background: rgba(255,255,255,0.2); box-shadow: none; }
-.svc-btn[aria-pressed="false"] [data-icon] { opacity: 0.4; }
 
-/* ---------- controles de toque ---------- */
+.sg-btn:hover { filter: brightness(1.08); }
+.sg-btn--ghost {
+    color: var(--sg-text);
+    background: transparent;
+    border: 1px solid var(--sg-line);
+}
+.sg-btn--ghost:hover { background: rgba(255, 255, 255, 0.05); filter: none; }
+.sg-btn[aria-pressed="false"] [data-icon] { opacity: 0.4; }
+
+/* ---------- touch ---------- */
 .svc-touch { position: absolute; inset: 0; pointer-events: none; z-index: 10; }
 .svc-touch.tp--hidden { display: none; }
 .svc-touch button {
@@ -262,40 +268,51 @@ body, html {
     justify-content: center;
     font: inherit;
     font-size: 1rem;
-    font-weight: 700;
+    font-weight: 800;
     color: rgba(255, 255, 255, 0.92);
-    background: rgba(12, 10, 26, 0.58);
-    border: 1px solid rgba(255, 255, 255, 0.22);
+    background: rgba(16, 16, 24, 0.72);
+    border: 1px solid rgba(56, 200, 184, 0.45);
     border-radius: 50%;
-    box-shadow: 0 2px 0 rgba(0, 0, 0, 0.45), 0 1px 0 rgba(255, 255, 255, 0.15) inset;
-    backdrop-filter: blur(4px);
-    -webkit-backdrop-filter: blur(4px);
     touch-action: none;
     user-select: none;
-    transition: background 0.1s ease, transform 0.1s ease;
 }
-.svc-touch button:active { background: rgba(255, 47, 160, 0.7); transform: scale(0.94); box-shadow: 0 0 0 rgba(0, 0, 0, 0.45); }
+.svc-touch button:active {
+    background: rgba(240, 80, 64, 0.8);
+    transform: scale(0.94);
+}
 .tp-dpad button { width: 46px; height: 46px; border-radius: 8px; }
 .tp-up { left: 62px; bottom: 108px; }
 .tp-down { left: 62px; bottom: 12px; }
 .tp-left { left: 14px; bottom: 60px; }
 .tp-right { left: 110px; bottom: 60px; }
-.tp-actions button { width: 56px; height: 56px; font-size: 1.1rem; }
-.tp-a { right: 14px; bottom: 26px; }
-.tp-b { right: 76px; bottom: 62px; }
-.tp-start { width: 46px; height: 30px; border-radius: 15px !important; right: 50%; transform: translateX(50%); bottom: 10px; font-size: 0.8rem; }
-
-/* ---------- responsivo ---------- */
-@media (max-width: 960px) {
-    .svc-shell { flex-direction: column; padding: 1rem; overflow-y: auto; }
-    .svc-stage { min-height: 50vh; }
-    .glass-panel { width: 100%; }
-    .svc-side { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; }
-    .svc-actions { flex-direction: row; grid-column: 1 / -1; }
+.tp-actions button { width: 56px; height: 56px; }
+.tp-a { right: 14px; bottom: 26px; background: rgba(240, 80, 64, 0.55); }
+.tp-b { right: 76px; bottom: 62px; background: rgba(56, 200, 184, 0.4); }
+.tp-start {
+    width: 46px; height: 30px; border-radius: 14px !important;
+    right: 50%; transform: translateX(50%); bottom: 10px; font-size: 0.8rem;
 }
-@media (max-width: 700px) {
-    .svc-side { grid-template-columns: 1fr; }
-    .svc-actions { flex-direction: column; }
+
+@media (max-width: 980px) {
+    .sg-shell {
+        flex-direction: column;
+        padding: 0.65rem;
+        overflow-y: auto;
+    }
+    .sg-stage { min-height: 46vh; flex: none; }
+    .sg-side {
+        width: 100%;
+        max-height: none;
+        overflow: visible;
+    }
+    .sg-actions { flex-direction: row; flex-wrap: wrap; }
+    .sg-actions .sg-btn { flex: 1; min-width: 140px; }
+}
+
+@media (max-width: 640px) {
+    body, html { overflow: auto; }
+    .sg-layout { height: auto; min-height: 100vh; }
+    .sg-header, .sg-footer { padding: 0.55rem 0.75rem; }
     .tp-dpad button { width: 42px; height: 42px; }
     .tp-up { left: 54px; bottom: 96px; }
     .tp-down { left: 54px; bottom: 10px; }
@@ -303,8 +320,14 @@ body, html {
     .tp-right { left: 98px; bottom: 53px; }
     .tp-actions button { width: 50px; height: 50px; }
 }
+
 @media (max-height: 560px) and (orientation: landscape) {
-    .svc-shell { flex-direction: row; padding: 0.5rem; gap: 1rem; }
-    .glass-panel { width: 250px; }
-    .svc-screen-wrap { max-height: 85vh; }
+    .sg-shell { flex-direction: row; padding: 0.35rem; gap: 0.65rem; }
+    .sg-side { width: 210px; padding: 0.65rem; }
+    .sg-side-block h2 { font-size: 0.9rem; }
+    .sg-events span { display: none; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .sg-events li { transition: none; }
 }


### PR DESCRIPTION
## Summary
- Remake do **Santos Games** no clima California Games (Mega Drive): tema Santos ensolarado, sem “Vice”/neon
- Visual limpo de **emulador** (320×224 com escala inteira), sem CRT/TV/scanlines por padrão
- Paleta, personagens (contorno), menus, shell e as 6 provas polidos (jogabilidade mais ágil)

## Test plan
- [ ] Abrir `/labs/santos-games/` via HTTP
- [ ] Título → menu → patrocinador → campeonato
- [ ] Prova única: surfe, skate, altinha, BMX, frescobol, canoa
- [ ] Conferir pixels nítidos (escala inteira) e ausência de efeito de TV
- [ ] Mobile: layout em coluna + controles touch
- [ ] Opções: som, scanlines (opcional), apagar recordes


Made with [Cursor](https://cursor.com)