### PR TITLE
fix(labs): headers unificados e UI responsiva

### DIFF
--- a/labs/aurora-flow/index.html
+++ b/labs/aurora-flow/index.html
@@ -19,7 +19,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Oxanium:wght@400;600;700;800&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=4">
+    <link rel="stylesheet" href="/labs/shared.css?v=6">
     <link rel="stylesheet" href="style.css">
 </head>
 
@@ -160,7 +160,9 @@
         </div>
     </div>
 
-    <script src="/labs/shared.js?v=5" defer></script>
+    <footer data-lab-footer data-home-href="/"></footer>
+
+    <script src="/labs/shared.js?v=6" defer></script>
     <script src="script.js" defer></script>
 </body>
 

--- a/labs/aurora-flow/style.css
+++ b/labs/aurora-flow/style.css
@@ -74,7 +74,7 @@ header {
     left: 0;
     right: 0;
     z-index: 20;
-    padding: 1.1rem 1.35rem !important;
+    padding: max(1.1rem, env(safe-area-inset-top)) max(1.35rem, env(safe-area-inset-right)) 1.1rem max(1.35rem, env(safe-area-inset-left)) !important;
     background: linear-gradient(to bottom, rgba(0, 0, 0, 0.72), transparent);
     margin: 0 !important;
     display: grid !important;
@@ -94,6 +94,8 @@ header .back-link {
     background: rgba(255, 255, 255, 0.08);
     border: 1px solid var(--border);
     color: rgba(255, 255, 255, 0.82);
+    min-height: 44px;
+    min-width: 44px;
 }
 
 header .back-link:hover {

--- a/labs/calculator/index.html
+++ b/labs/calculator/index.html
@@ -16,7 +16,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Calculator">
     <meta name="twitter:description" content="Calculadora online com modos simples, científico e conversor de moedas em tempo real.">
-    <link rel="stylesheet" href="/labs/shared.css?v=4">
+    <link rel="stylesheet" href="/labs/shared.css?v=6">
     <link rel="stylesheet" href="style.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -187,7 +187,7 @@
 
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
-    <script src="/labs/shared.js?v=5" defer></script>
+    <script src="/labs/shared.js?v=6" defer></script>
     <script src="script.js" defer></script>
 </body>
 

--- a/labs/cyberos/index.html
+++ b/labs/cyberos/index.html
@@ -21,7 +21,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=VT323&display=swap"
     rel="stylesheet">
-  <link rel="stylesheet" href="/labs/shared.css?v=4">
+  <link rel="stylesheet" href="/labs/shared.css?v=6">
   <link rel="stylesheet" href="style.css?v=2">
 </head>
 
@@ -192,7 +192,7 @@
 
   <footer data-lab-footer data-home-href="/" class="cyber-lab-footer"></footer>
 
-  <script src="/labs/shared.js?v=5" defer></script>
+  <script src="/labs/shared.js?v=6" defer></script>
   <script src="script.js?v=2" defer></script>
 </body>
 

--- a/labs/english-duo/index.html
+++ b/labs/english-duo/index.html
@@ -15,7 +15,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Talk">
     <meta name="twitter:description" content="Aprenda idiomas de forma divertida e interativa com o Talk.">
-    <link rel="stylesheet" href="/labs/shared.css?v=4">
+    <link rel="stylesheet" href="/labs/shared.css?v=6">
     <link rel="stylesheet" href="style.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -364,7 +364,7 @@
     </div>
 
     <div id="toast-container" class="toast-container"></div>
-    <script src="/labs/shared.js?v=5" defer></script>
+    <script src="/labs/shared.js?v=6" defer></script>
     <script src="script.js" defer></script>
 </body>
 

--- a/labs/f1-racing/index.html
+++ b/labs/f1-racing/index.html
@@ -21,7 +21,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
-    <link rel="stylesheet" href="/labs/shared.css?v=4">
+    <link rel="stylesheet" href="/labs/shared.css?v=6">
     <link rel="stylesheet" href="style.css?v=13">
     <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700&family=Orbitron:wght@500;600;700;800;900&display=swap"
         rel="stylesheet">
@@ -287,7 +287,9 @@
         </section>
     </main>
 
-    <script src="/labs/shared.js?v=5" defer></script>
+    <footer data-lab-footer data-home-href="/"></footer>
+
+    <script src="/labs/shared.js?v=6" defer></script>
 
     <!--
         Boot watchdog (classic script on purpose): if the ES module never runs — CDN

--- a/labs/gravity/index.html
+++ b/labs/gravity/index.html
@@ -18,7 +18,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=4">
+    <link rel="stylesheet" href="/labs/shared.css?v=6">
     <link rel="stylesheet" href="style.css">
 </head>
 
@@ -287,7 +287,7 @@
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
 
-    <script src="/labs/shared.js?v=5" defer></script>
+    <script src="/labs/shared.js?v=6" defer></script>
     <script src="script.js" defer></script>
 </body>
 

--- a/labs/gravity/style.css
+++ b/labs/gravity/style.css
@@ -60,7 +60,7 @@ header {
     width: auto !important;
     max-width: none !important;
     z-index: 20;
-    padding: 1.25rem 1.5rem !important;
+    padding: max(1.1rem, env(safe-area-inset-top)) max(1.35rem, env(safe-area-inset-right)) 1.1rem max(1.35rem, env(safe-area-inset-left)) !important;
     background: linear-gradient(to bottom, rgba(0, 0, 0, 0.55), transparent);
     margin: 0 !important;
     display: grid !important;
@@ -80,6 +80,8 @@ header .back-link {
     background: rgba(255, 255, 255, 0.06);
     border: 1px solid var(--panel-border);
     color: var(--text-secondary);
+    min-height: 44px;
+    min-width: 44px;
 }
 
 header .back-link:hover {
@@ -817,7 +819,7 @@ body.fullscreen:hover header {
 
 @media (max-width: 420px) {
     header {
-        padding: 1rem !important;
+        padding: max(1rem, env(safe-area-inset-top)) max(1rem, env(safe-area-inset-right)) 1rem max(1rem, env(safe-area-inset-left)) !important;
     }
 
     .header-actions {

--- a/labs/image-editor/index.html
+++ b/labs/image-editor/index.html
@@ -15,7 +15,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Image Editor">
     <meta name="twitter:description" content="Editor de imagens no navegador: recorte, filtros, ajustes de brilho, contraste e saturação, tudo processado localmente sem enviar nada para servidor.">
-    <link rel="stylesheet" href="/labs/shared.css?v=4">
+    <link rel="stylesheet" href="/labs/shared.css?v=6">
     <link rel="stylesheet" href="style.css">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
 </head>
@@ -163,7 +163,7 @@
 
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
-    <script src="/labs/shared.js?v=5" defer></script>
+    <script src="/labs/shared.js?v=6" defer></script>
     <script src="script.js" defer></script>
 </body>
 

--- a/labs/image-editor/style.css
+++ b/labs/image-editor/style.css
@@ -380,7 +380,7 @@ input[type="range"]::-webkit-slider-thumb:hover {
         grid-template-columns: 1fr;
         grid-template-rows: 1fr auto;
         height: auto;
-        min-height: 80vh;
+        min-height: 0;
     }
 
     .controls-area {
@@ -390,6 +390,6 @@ input[type="range"]::-webkit-slider-thumb:hover {
     }
 
     .preview-area {
-        min-height: 300px;
+        min-height: min(50vh, 360px);
     }
 }

--- a/labs/image-optimizer/index.html
+++ b/labs/image-optimizer/index.html
@@ -15,7 +15,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Image Optimizer">
     <meta name="twitter:description" content="Otimize e converta suas imagens para JPG, PNG ou WEBP diretamente no navegador.">
-    <link rel="stylesheet" href="/labs/shared.css?v=4">
+    <link rel="stylesheet" href="/labs/shared.css?v=6">
     <link rel="stylesheet" href="style.css">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
 </head>
@@ -75,7 +75,7 @@
 
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
-    <script src="/labs/shared.js?v=5" defer></script>
+    <script src="/labs/shared.js?v=6" defer></script>
     <script src="script.js" defer></script>
 </body>
 

--- a/labs/index.html
+++ b/labs/index.html
@@ -20,7 +20,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@100..900&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="/labs/shared.css?v=4">
+  <link rel="stylesheet" href="/labs/shared.css?v=6">
   <link rel="stylesheet" href="/labs/style.css">
   <script type="application/ld+json">
   {
@@ -615,7 +615,7 @@
   </div>
   <footer data-lab-footer data-home-href="/"></footer>
   </div>
-  <script src="/labs/shared.js?v=5"></script>
+  <script src="/labs/shared.js?v=6"></script>
   <script src="/labs/index.js"></script>
 </body>
 

--- a/labs/jungle-run/index.html
+++ b/labs/jungle-run/index.html
@@ -15,7 +15,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@600;900&family=Plus+Jakarta+Sans:wght@400;500;700;800&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=4">
+    <link rel="stylesheet" href="/labs/shared.css?v=6">
     <link rel="stylesheet" href="style.css?v=3">
     <script src="https://pixijs.download/v8.6.6/pixi.min.js" defer></script>
 </head>
@@ -236,7 +236,7 @@
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
 
-    <script src="/labs/shared.js?v=5" defer></script>
+    <script src="/labs/shared.js?v=6" defer></script>
     <script src="script.js?v=4" defer></script>
 </body>
 

--- a/labs/lander/index.html
+++ b/labs/lander/index.html
@@ -15,7 +15,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Lander">
     <meta name="twitter:description" content="Pouso lunar com física realista: gravidade, inércia, consumo de combustível e terreno gerado por procedimento. Desça devagar e no ângulo certo.">
-    <link rel="stylesheet" href="/labs/shared.css?v=4">
+    <link rel="stylesheet" href="/labs/shared.css?v=6">
     <link rel="stylesheet" href="style.css?v=4">
     <!-- Courier Prime or VT323 for the retro feel -->
     <link href="https://fonts.googleapis.com/css2?family=VT323&display=swap" rel="stylesheet">
@@ -130,7 +130,7 @@
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
 
-    <script src="/labs/shared.js?v=5" defer></script>
+    <script src="/labs/shared.js?v=6" defer></script>
     <script src="script.js?v=3" defer></script>
 </body>
 

--- a/labs/matrix/index.html
+++ b/labs/matrix/index.html
@@ -20,7 +20,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Share+Tech+Mono&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=4">
+    <link rel="stylesheet" href="/labs/shared.css?v=6">
     <link rel="stylesheet" href="style.css">
 </head>
 
@@ -283,7 +283,7 @@
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
 
-    <script src="/labs/shared.js?v=5" defer></script>
+    <script src="/labs/shared.js?v=6" defer></script>
     <script src="script.js" defer></script>
 </body>
 

--- a/labs/minesweeper/index.html
+++ b/labs/minesweeper/index.html
@@ -15,7 +15,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Campo Minado 95">
     <meta name="twitter:description" content="Clássico jogo de Campo Minado estilo Windows 95.">
-    <link rel="stylesheet" href="/labs/shared.css?v=4">
+    <link rel="stylesheet" href="/labs/shared.css?v=6">
     <link rel="stylesheet" href="style.css">
 </head>
 
@@ -70,7 +70,7 @@
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
 
-    <script src="/labs/shared.js?v=5" defer></script>
+    <script src="/labs/shared.js?v=6" defer></script>
     <script src="script.js" defer></script>
 </body>
 

--- a/labs/minesweeper/script.js
+++ b/labs/minesweeper/script.js
@@ -22,6 +22,14 @@ document.addEventListener('DOMContentLoaded', () => {
     let timerInterval = null;
     let firstClick = true;
 
+    function updateCellSize() {
+        const available = Math.min(window.innerWidth - 48, 720);
+        const cell = Math.max(14, Math.min(24, Math.floor(available / COLS)));
+        document.documentElement.style.setProperty('--cell-size', cell + 'px');
+        boardElement.style.gridTemplateColumns = `repeat(${COLS}, var(--cell-size))`;
+        boardElement.style.gridTemplateRows = `repeat(${ROWS}, var(--cell-size))`;
+    }
+
     function initGame() {
         // Set difficulty
         const difficulty = difficultySelect.value;
@@ -30,9 +38,8 @@ document.addEventListener('DOMContentLoaded', () => {
         COLS = config.cols;
         MINES = config.mines;
 
-        // Update Grid CSS
-        boardElement.style.gridTemplateColumns = `repeat(${COLS}, 24px)`;
-        boardElement.style.gridTemplateRows = `repeat(${ROWS}, 24px)`;
+        // Update Grid CSS (fluid cell size for small viewports)
+        updateCellSize();
 
         // Reset state
         board = [];
@@ -299,6 +306,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     resetBtn.addEventListener('click', initGame);
     difficultySelect.addEventListener('change', initGame);
+    window.addEventListener('resize', updateCellSize);
 
     initGame();
 });

--- a/labs/minesweeper/style.css
+++ b/labs/minesweeper/style.css
@@ -7,13 +7,13 @@
     --win-light: #ffffff;
     --win-black: #000000;
     --win-blue: #000080;
+    --cell-size: 24px;
 }
 
 /* Shared CSS handles body background and text color */
 body {
     font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-    overflow: hidden;
-    /* Prevent scrolling */
+    overflow: auto;
 }
 
 .container {
@@ -31,8 +31,9 @@ body {
     padding: 3px;
     box-shadow: 4px 4px 10px rgba(0, 0, 0, 0.5);
     min-width: 200px;
-    max-width: 100vw;
+    max-width: min(100%, 100vw - 1.5rem);
     overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
 }
 
 .title-bar {
@@ -133,8 +134,8 @@ body {
 }
 
 .cell {
-    width: 24px;
-    height: 24px;
+    width: var(--cell-size);
+    height: var(--cell-size);
     background: var(--win-gray);
     border: 2px solid;
     border-color: var(--win-light) var(--win-dark) var(--win-dark) var(--win-light);
@@ -263,4 +264,34 @@ body {
     border-radius: 4px;
     font-weight: bold;
     border: 1px solid rgba(255, 255, 255, 0.3);
+}
+
+@media (max-width: 480px) {
+    .counter {
+        font-size: 14px;
+        min-width: 48px;
+        padding: 2px 3px;
+    }
+
+    .status-bar {
+        padding: 3px 5px;
+    }
+
+    .face-btn {
+        width: 24px;
+        height: 24px;
+        font-size: 16px;
+    }
+
+    .title-bar-text {
+        font-size: 12px;
+    }
+
+    .cell {
+        font-size: 12px;
+    }
+
+    #difficulty-select {
+        font-size: 11px;
+    }
 }

--- a/labs/paint/index.html
+++ b/labs/paint/index.html
@@ -17,7 +17,7 @@
     <meta property="og:locale" content="pt_BR">
     <meta property="og:image" content="https://diogopaulino.com.br/labs/paint/og-paint.jpg">
     <meta name="twitter:card" content="summary_large_image">
-    <link rel="stylesheet" href="/labs/shared.css?v=4">
+    <link rel="stylesheet" href="/labs/shared.css?v=6">
     <link rel="stylesheet" href="style.css?v=2">
 </head>
 
@@ -250,7 +250,7 @@
 
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
-    <script src="/labs/shared.js?v=5" defer></script>
+    <script src="/labs/shared.js?v=6" defer></script>
     <script src="script.js?v=2" defer></script>
 </body>
 

--- a/labs/paint/style.css
+++ b/labs/paint/style.css
@@ -57,23 +57,6 @@ body {
     gap: 16px;
 }
 
-/* Back Link overrides for toolbar context */
-.back-link {
-    position: static !important;
-    box-shadow: none !important;
-    border: none !important;
-    background: transparent !important;
-    padding: 0 !important;
-    color: var(--text-secondary);
-    font-size: 16px;
-}
-
-.back-link:hover {
-    background: var(--surface-hover) !important;
-    color: var(--text-primary) !important;
-    transform: none !important;
-}
-
 .logo {
     display: flex;
     align-items: center;
@@ -308,11 +291,58 @@ input[type="range"]::-webkit-slider-thumb {
         overflow-x: auto;
         border-right: none;
         border-bottom: 1px solid var(--border-color);
+        order: 1;
+    }
+
+    .canvas-container {
+        order: 2;
+        padding: 16px;
+        min-height: 0;
+        flex: 1;
     }
 
     .side-bar.right {
+        display: flex;
+        flex-direction: row;
+        flex-wrap: wrap;
+        width: 100%;
+        height: auto;
+        max-height: 120px;
+        overflow-x: auto;
+        overflow-y: auto;
+        align-items: center;
+        gap: 12px;
+        padding: 10px 12px;
+        border: none;
+        border-top: 1px solid var(--border-color);
+        border-left: none;
+        order: 3;
+    }
+
+    .side-bar.right .property-group {
+        margin-bottom: 0;
+        flex: 1 1 auto;
+        min-width: 120px;
+    }
+
+    .side-bar.right .property-group label {
+        margin-bottom: 6px;
+    }
+
+    .side-bar.right .color-picker-wrapper {
+        height: 32px;
+        margin-bottom: 6px;
+    }
+
+    .side-bar.right .color-palette {
+        grid-template-columns: repeat(9, 1fr);
+        gap: 4px;
+    }
+
+    .side-bar.right .separator,
+    .side-bar.right .shortcuts-hint,
+    .side-bar.right .shape-fill-group {
         display: none;
-        /* For mobile MVP, maybe hide or make modal */
     }
 
     .tool-group {

--- a/labs/partitura/index.html
+++ b/labs/partitura/index.html
@@ -20,7 +20,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;500;700;800&family=Space+Mono:wght@400;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="/labs/shared.css?v=4">
+  <link rel="stylesheet" href="/labs/shared.css?v=6">
   <link rel="stylesheet" href="style.css">
 </head>
 
@@ -222,7 +222,7 @@
     <footer data-lab-footer data-home-href="/" class="compact-footer"></footer>
   </div>
 
-  <script src="/labs/shared.js?v=5" defer></script>
+  <script src="/labs/shared.js?v=6" defer></script>
   <script src="script.js" defer></script>
 </body>
 

--- a/labs/piano/index.html
+++ b/labs/piano/index.html
@@ -17,7 +17,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Piano">
     <meta name="twitter:description" content="Piano minimalista com sons ultra realistas. 4 oitavas completas.">
-  <link rel="stylesheet" href="/labs/shared.css?v=4">
+  <link rel="stylesheet" href="/labs/shared.css?v=6">
   <link rel="stylesheet" href="style.css">
 </head>
 
@@ -80,7 +80,7 @@
     <footer data-lab-footer data-home-href="/"></footer>
   </div>
 
-  <script src="/labs/shared.js?v=5" defer></script>
+  <script src="/labs/shared.js?v=6" defer></script>
   <script src="script.js" defer></script>
 </body>
 

--- a/labs/piano/style.css
+++ b/labs/piano/style.css
@@ -34,6 +34,13 @@ body {
   -webkit-overflow-scrolling: touch;
   scrollbar-width: thin;
   scrollbar-color: #222 #000;
+  scroll-snap-type: x proximity;
+  mask-image: linear-gradient(to right, transparent, #000 12px, #000 calc(100% - 12px), transparent);
+  -webkit-mask-image: linear-gradient(to right, transparent, #000 12px, #000 calc(100% - 12px), transparent);
+}
+
+.piano-wrapper .key.white {
+  scroll-snap-align: start;
 }
 
 .piano-wrapper::-webkit-scrollbar {
@@ -328,11 +335,11 @@ body {
   }
 
   .key.white {
-    width: 44px;
+    width: 42px;
   }
 
   .key.black {
-    width: 30px;
+    width: 28px;
   }
 
   .controls {

--- a/labs/pomodoro/index.html
+++ b/labs/pomodoro/index.html
@@ -19,7 +19,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=4">
+    <link rel="stylesheet" href="/labs/shared.css?v=6">
     <link rel="stylesheet" href="style.css?v=3">
 </head>
 
@@ -304,7 +304,7 @@
     <div class="toast-region" id="toast-region" aria-live="polite" aria-atomic="false"></div>
     <p class="sr-only" id="live-region" role="status" aria-live="polite"></p>
 
-    <script src="/labs/shared.js?v=5" defer></script>
+    <script src="/labs/shared.js?v=6" defer></script>
     <script src="script.js?v=3" defer></script>
 </body>
 

--- a/labs/pulsar/index.html
+++ b/labs/pulsar/index.html
@@ -19,7 +19,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Oxanium:wght@400;600;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=4">
+    <link rel="stylesheet" href="/labs/shared.css?v=6">
     <link rel="stylesheet" href="style.css">
 </head>
 
@@ -110,7 +110,7 @@
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
 
-    <script src="/labs/shared.js?v=5" defer></script>
+    <script src="/labs/shared.js?v=6" defer></script>
     <script src="script.js" defer></script>
 </body>
 

--- a/labs/pulsar/style.css
+++ b/labs/pulsar/style.css
@@ -78,7 +78,7 @@ header {
     left: 0;
     right: 0;
     z-index: 20;
-    padding: 1.25rem 1.5rem !important;
+    padding: max(1.1rem, env(safe-area-inset-top)) max(1.35rem, env(safe-area-inset-right)) 1.1rem max(1.35rem, env(safe-area-inset-left)) !important;
     background: linear-gradient(to bottom, rgba(0, 0, 0, 0.7), transparent);
     margin: 0 !important;
     display: grid !important;
@@ -98,6 +98,8 @@ header .back-link {
     border: 1px solid rgba(255, 255, 255, 0.14);
     color: rgba(255, 255, 255, 0.85);
     transition: all 0.2s ease;
+    min-height: 44px;
+    min-width: 44px;
 }
 
 header .back-link:hover {
@@ -370,7 +372,7 @@ footer {
 }
 
 @media (max-width: 420px) {
-    header { padding: 1rem !important; }
+    header { padding: max(1rem, env(safe-area-inset-top)) max(1rem, env(safe-area-inset-right)) 1rem max(1rem, env(safe-area-inset-left)) !important; }
     header .app-logo { font-size: 1rem; }
     .floating-toolbar { bottom: 20px; width: calc(100% - 32px); justify-content: space-between; }
     .tool-btn .preset-name { max-width: 80px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }

--- a/labs/ravi-123/index.html
+++ b/labs/ravi-123/index.html
@@ -18,17 +18,19 @@
     content="Conte de 1 a 9 e ajude o Ravi a convidar heróis para a maior festa surpresa do reino. Pixel art 320×200, tudo em vanilla.">
   <meta property="og:locale" content="pt_BR">
 
+  <link rel="stylesheet" href="/labs/shared.css?v=6">
   <link rel="stylesheet" href="style.css?v=6">
 </head>
 
 <body>
+  <header data-lab-header data-title="Ravi 1·2·3" data-back-href="/labs/" data-back-label="Labs"></header>
+
   <main id="app">
     <div id="frame">
       <canvas id="screen" width="320" height="200" aria-label="Ravi 1·2·3: jogo de contagem"></canvas>
     </div>
 
     <nav id="hud" aria-label="Controles">
-      <button id="btn-back" class="hud-btn" type="button" title="Voltar aos labs" aria-label="Voltar aos labs">&#8592;</button>
       <span class="hud-spacer"></span>
       <button id="btn-sound" class="hud-btn" type="button" title="Som (M)" aria-label="Desligar o som"
         aria-pressed="true">&#9834;</button>
@@ -47,6 +49,7 @@
   </noscript>
 
   <script type="module" src="main.js?v=6"></script>
+  <script src="/labs/shared.js?v=6" defer></script>
 </body>
 
 </html>

--- a/labs/ravi-123/main.js
+++ b/labs/ravi-123/main.js
@@ -144,9 +144,6 @@ async function boot() {
       }
     });
 
-    document.getElementById('btn-back').addEventListener('click', () => {
-      window.location.href = '/labs/';
-    });
     document.getElementById('btn-sound').addEventListener('click', (event) => {
       Audio.init();
       syncSoundButton(event.currentTarget, Audio.toggleMute());

--- a/labs/ravi-123/style.css
+++ b/labs/ravi-123/style.css
@@ -3,7 +3,7 @@
    --------------------------------------------------------------------------
    Praticamente tudo que se vê é desenhado no canvas. O CSS só faz três
    coisas: pintar o letterbox, escalar o buffer 320×200 com nearest-neighbor
-   e posicionar os três botões de HUD.
+   e posicionar os botões de HUD (som / tela cheia).
    Sem web fonts, sem @import, sem backdrop-filter.
    ========================================================================== */
 
@@ -33,6 +33,49 @@ body {
   user-select: none;
   -webkit-user-select: none;
   -webkit-tap-highlight-color: transparent;
+}
+
+/* shared.css usa flex + padding; o jogo precisa de letterbox fullscreen preto */
+body {
+  position: relative;
+  padding: 0 !important;
+  display: block !important;
+  background-image: none !important;
+  align-items: stretch !important;
+}
+
+/* Shell compartilhado: faixa fina sobre o jogo, sem roubar cliques do canvas */
+header[data-lab-header] {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 40;
+  margin: 0 !important;
+  max-width: none !important;
+  padding: max(0.65rem, env(safe-area-inset-top)) 0.75rem 0.5rem !important;
+  grid-template-columns: auto 1fr auto !important;
+  background: linear-gradient(to bottom, rgba(0, 0, 0, 0.75), transparent);
+  pointer-events: none;
+}
+
+header[data-lab-header] > * {
+  pointer-events: auto;
+}
+
+header[data-lab-header] .back-link {
+  min-width: 44px;
+  min-height: 44px;
+}
+
+header[data-lab-header] .app-logo,
+header[data-lab-header] h1 {
+  font-size: 0.95rem !important;
+  color: #fff !important;
+}
+
+header[data-lab-header] .subtitle {
+  display: none;
 }
 
 #app {
@@ -65,9 +108,11 @@ body {
   top: 0;
   left: 0;
   right: 0;
+  z-index: 30;
   display: flex;
   gap: 8px;
-  padding: 10px 12px calc(10px + env(safe-area-inset-bottom, 0px));
+  /* abaixo do header compartilhado (voltar + tema) */
+  padding: calc(3.1rem + env(safe-area-inset-top, 0px)) 12px 10px;
   padding-right: calc(12px + env(safe-area-inset-right, 0px));
   padding-left: calc(12px + env(safe-area-inset-left, 0px));
   pointer-events: none;

--- a/labs/river-knight/index.html
+++ b/labs/river-knight/index.html
@@ -26,7 +26,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;600;700;800&family=Outfit:wght@300;400;500;600;700&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=4">
+    <link rel="stylesheet" href="/labs/shared.css?v=6">
     <link rel="stylesheet" href="style.css?v=1">
 
     <script type="importmap">
@@ -238,7 +238,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=5" defer></script>
+    <script src="/labs/shared.js?v=6" defer></script>
     <script type="module" src="src/main.js?v=1"></script>
 </body>
 

--- a/labs/river-knight/style.css
+++ b/labs/river-knight/style.css
@@ -154,7 +154,7 @@ button {
 }
 
 .game-shell > header .theme-switch-wrapper {
-    display: none;
+    display: flex;
 }
 
 .lab-foot {

--- a/labs/rock-kombat/index.html
+++ b/labs/rock-kombat/index.html
@@ -8,7 +8,7 @@
   <meta name="theme-color" content="#090a0c">
   <meta property="og:title" content="Rock Kombat — 2D Arcade Fight">
   <meta property="og:description" content="Escolha sua lenda. Leia a distância. Domine o palco.">
-  <link rel="stylesheet" href="/labs/shared.css?v=5">
+  <link rel="stylesheet" href="/labs/shared.css?v=6">
   <link rel="stylesheet" href="style.css?v=5">
 </head>
 <body>
@@ -168,7 +168,9 @@
     <div><p class="overline">INTERMISSION</p><h2>PAUSADO</h2><button class="cta" id="resume-button" type="button"><b>CONTINUAR</b></button><button class="quiet-button" id="quit-button" type="button">SAIR DA LUTA</button></div>
   </div>
 
-  <script src="/labs/shared.js?v=5" defer></script>
+  <footer data-lab-footer data-home-href="/"></footer>
+
+  <script src="/labs/shared.js?v=6" defer></script>
   <script type="module" src="main.js?v=1"></script>
 </body>
 </html>

--- a/labs/rock-kombat/style.css
+++ b/labs/rock-kombat/style.css
@@ -106,12 +106,14 @@ header .header-actions button {
   background: #08090b99 !important;
   padding: 9px 12px !important;
   text-decoration: none;
-  font-size: 10px !important;
+  font-size: 11px !important;
   font-weight: 800 !important;
   letter-spacing: 0.15em;
   border-radius: 0 !important;
   box-shadow: none !important;
   color: #cbc5bb !important;
+  min-height: 44px;
+  min-width: 44px;
 }
 
 header .back-link span {
@@ -1162,9 +1164,16 @@ dialog h2 {
     font-size: 14px;
   }
 
+  header .back-link,
   header .header-actions button {
     padding: 8px !important;
-    font-size: 8px !important;
+    font-size: 11px !important;
+    min-height: 44px;
+    min-width: 44px;
+  }
+
+  header .back-link span {
+    display: none;
   }
 
   #sound-button {
@@ -1204,7 +1213,7 @@ dialog h2 {
   }
 
   .hero-copy h1 {
-    font-size: 68px;
+    font-size: clamp(2.5rem, 14vw, 68px);
   }
 
   .hero-copy > p:not(.overline) {

--- a/labs/shared.css
+++ b/labs/shared.css
@@ -36,20 +36,31 @@
     border: 0;
 }
 
+html {
+    overflow-x: clip;
+}
+
 body {
     min-height: 100vh;
+    min-height: 100dvh;
     background: var(--bg-body);
     font-family: 'Outfit', -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
     color: var(--text-primary);
     display: flex;
     flex-direction: column;
     align-items: center;
-    padding: 2rem 1rem;
+    padding: max(2rem, env(safe-area-inset-top, 0px))
+        max(1rem, env(safe-area-inset-right, 0px))
+        max(2rem, env(safe-area-inset-bottom, 0px))
+        max(1rem, env(safe-area-inset-left, 0px));
     transition: background 0.4s cubic-bezier(0.4, 0, 0.2, 1), color 0.4s cubic-bezier(0.4, 0, 0.2, 1);
     background-image:
         radial-gradient(circle at 15% 50%, rgba(37, 99, 235, 0.03), transparent 25%),
         radial-gradient(circle at 85% 30%, rgba(96, 165, 250, 0.03), transparent 25%);
     background-attachment: fixed;
+    overflow-x: clip;
+    -webkit-text-size-adjust: 100%;
+    text-size-adjust: 100%;
 }
 
 .container {
@@ -60,6 +71,7 @@ body {
     display: flex;
     flex-direction: column;
     align-items: center;
+    min-width: 0;
 }
 
 /* Glassmorphism Utilities */
@@ -85,6 +97,7 @@ header {
     margin-bottom: 3rem;
     padding: 0 1rem;
     max-width: 1200px;
+    min-width: 0;
 }
 
 header .app-logo {
@@ -124,6 +137,7 @@ header .app-logo svg {
     text-decoration: none;
     font-size: 0.9rem;
     padding: 0.6rem 1.2rem;
+    min-height: 44px;
     border: 1px solid var(--border-subtle);
     border-radius: 2rem;
     transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
@@ -182,11 +196,13 @@ header h1 {
     justify-self: end;
     display: flex;
     align-items: center;
+    min-height: 44px;
 }
 
 .theme-toggle {
     width: 64px;
     height: 32px;
+    min-width: 64px;
     padding: 0;
     border-radius: 20px;
     border: 1px solid var(--border-subtle);
@@ -287,20 +303,24 @@ footer a:hover {
 /* Responsive */
 @media (max-width: 768px) {
     body {
-        padding: 1rem;
+        padding: max(1rem, env(safe-area-inset-top, 0px))
+            max(0.75rem, env(safe-area-inset-right, 0px))
+            max(1rem, env(safe-area-inset-bottom, 0px))
+            max(0.75rem, env(safe-area-inset-left, 0px));
     }
 
     header {
-        margin-bottom: 2rem;
+        margin-bottom: 1.5rem;
         padding: 0;
         grid-template-columns: auto minmax(0, 1fr) auto;
         gap: 0.5rem;
     }
 
     header .back-link {
-        padding: 0.5rem;
-        width: 36px;
-        height: 36px;
+        padding: 0;
+        width: 44px;
+        height: 44px;
+        min-height: 44px;
         justify-content: center;
         border-radius: 50%;
     }
@@ -309,13 +329,19 @@ footer a:hover {
         display: none;
     }
 
+    header h1,
     header .app-logo {
         justify-self: center;
-        font-size: 1.1rem;
+        font-size: clamp(1rem, 4.5vw, 1.35rem);
         max-width: 100%;
         min-width: 0;
         overflow: hidden;
         text-overflow: ellipsis;
+    }
+
+    header .subtitle {
+        font-size: 0.875rem;
+        padding: 0 0.25rem;
     }
 
     header .theme-toggle,
@@ -325,7 +351,9 @@ footer a:hover {
 
     footer {
         margin-top: 2rem;
-        padding: 1rem;
+        padding: 1rem max(1rem, env(safe-area-inset-right, 0px))
+            max(1rem, env(safe-area-inset-bottom, 0px))
+            max(1rem, env(safe-area-inset-left, 0px));
         font-size: 0.8rem;
         flex-direction: column;
         gap: 0.25rem;

--- a/labs/snake/index.html
+++ b/labs/snake/index.html
@@ -14,7 +14,7 @@
     <meta property="og:description"
         content="Snake retrô em um console portátil 8-bit: colete frutas, ganhe velocidade e bata o seu recorde.">
     <meta property="og:url" content="https://diogopaulino.com.br/labs/snake/">
-    <link rel="stylesheet" href="/labs/shared.css?v=4">
+    <link rel="stylesheet" href="/labs/shared.css?v=6">
     <link rel="stylesheet" href="style.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -115,7 +115,7 @@
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
 
-    <script src="/labs/shared.js?v=5" defer></script>
+    <script src="/labs/shared.js?v=6" defer></script>
     <script src="script.js?v=2" defer></script>
 </body>
 

--- a/labs/snake/style.css
+++ b/labs/snake/style.css
@@ -421,11 +421,12 @@ canvas {
     line-height: 1.5;
 }
 
-@media (max-width: 360px) {
+@media (max-width: 420px) {
     .handheld-device {
-        transform: scale(0.86);
+        /* Absolute-positioned controls break with height:auto; scale the shell instead. */
+        --device-scale: min(1, calc((100vw - 24px) / 320px));
+        transform: scale(var(--device-scale));
         transform-origin: top center;
-        margin-bottom: -78px;
-        /* Reclaims the space the scale transform leaves behind. */
+        margin-bottom: calc((var(--device-scale) - 1) * 562px);
     }
 }

--- a/labs/space-shooter/index.html
+++ b/labs/space-shooter/index.html
@@ -15,7 +15,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Neon Invaders">
     <meta name="twitter:description" content="Jogo de tiro espacial estilo arcade com gráficos neon.">
-    <link rel="stylesheet" href="/labs/shared.css?v=4">
+    <link rel="stylesheet" href="/labs/shared.css?v=6">
     <link rel="stylesheet" href="style.css?v=3">
     <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
 </head>
@@ -139,7 +139,7 @@
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
 
-    <script src="/labs/shared.js?v=5" defer></script>
+    <script src="/labs/shared.js?v=6" defer></script>
     <script src="script.js?v=3" defer></script>
 </body>
 

--- a/labs/space-shooter/style.css
+++ b/labs/space-shooter/style.css
@@ -552,7 +552,10 @@ footer a {
     }
 
     footer[data-lab-footer] {
-        display: none;
+        display: flex;
+        padding: 0.5rem;
+        font-size: 0.75rem;
+        margin-top: 0.5rem;
     }
 
     .quick-controls {

--- a/labs/style.css
+++ b/labs/style.css
@@ -228,6 +228,7 @@
     -webkit-overflow-scrolling: touch;
     flex-wrap: nowrap;
     scrollbar-width: thin;
+    mask-image: linear-gradient(90deg, #000 0%, #000 calc(100% - 28px), transparent 100%);
   }
 
   /* Sem isto os botões encolheriam para caber e o rótulo quebraria em duas linhas. */

--- a/labs/tamagotchi/index.html
+++ b/labs/tamagotchi/index.html
@@ -16,7 +16,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="RakuRaku Dinokun / Dinkie Dino (1997)">
     <meta name="twitter:description" content="Recriação pesquisada do RakuRaku Dinokun / Dinkie Dino: carcaça, LCD, controles e ciclo de cuidado em tempo real.">
-  <link rel="stylesheet" href="/labs/shared.css?v=4">
+  <link rel="stylesheet" href="/labs/shared.css?v=6">
   <link rel="stylesheet" href="style.css?v=12">
 </head>
 

--- a/labs/tamagotchi/style.css
+++ b/labs/tamagotchi/style.css
@@ -17,7 +17,11 @@
 body {
   min-width: 320px;
   overflow-x: hidden;
-  background-color: #ece9e2;
+  background-color: var(--bg-body, #ece9e2);
+}
+
+[data-theme="dark"] body {
+  background-color: var(--bg-body, #0a0a0a);
 }
 
 header {

--- a/labs/tetris/index.html
+++ b/labs/tetris/index.html
@@ -15,7 +15,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Tetris 90s">
     <meta name="twitter:description" content="Jogue Tetris clássico estilo anos 90 no seu navegador.">
-    <link rel="stylesheet" href="/labs/shared.css?v=4">
+    <link rel="stylesheet" href="/labs/shared.css?v=6">
     <link rel="stylesheet" href="style.css">
 </head>
 
@@ -93,7 +93,7 @@
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
 
-    <script src="/labs/shared.js?v=5" defer></script>
+    <script src="/labs/shared.js?v=6" defer></script>
     <script src="script.js" defer></script>
 </body>
 

--- a/labs/tetris/style.css
+++ b/labs/tetris/style.css
@@ -312,9 +312,12 @@ body {
     font-size: 0.9rem;
 }
 
-/* Responsive adjustments */
-@media (max-width: 400px) {
+/* Responsive adjustments — fit ~390px width with shared header + footer */
+@media (max-width: 420px) {
     .game-boy {
-        transform: scale(0.9);
+        --device-scale: min(1, calc((100vw - 24px) / 320px));
+        transform: scale(var(--device-scale));
+        transform-origin: top center;
+        margin-bottom: calc((var(--device-scale) - 1) * 540px);
     }
 }

--- a/labs/videogame/index.html
+++ b/labs/videogame/index.html
@@ -18,11 +18,11 @@
 
 
 
-    <link rel="stylesheet" href="/labs/shared.css?v=4">
+    <link rel="stylesheet" href="/labs/shared.css?v=6">
     <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="mobile.css">
     <script src="/labs/videogame/lib/nostalgist.umd.js" defer></script>
-    <script src="/labs/shared.js?v=5" defer></script>
+    <script src="/labs/shared.js?v=6" defer></script>
     <script src="games.js" defer></script>
     <script src="script.js" defer></script>
 </head>

--- a/labs/videogame/mobile.css
+++ b/labs/videogame/mobile.css
@@ -22,14 +22,15 @@
 
     /* --- PORTRAIT MODE: GameBoy Style --- */
     @media (orientation: portrait) {
+        /* Keep shared header (back button) reachable outside active play */
         #screen {
             position: fixed !important;
-            top: 0;
+            top: calc(56px + env(safe-area-inset-top, 0px));
             left: 0;
             width: 100% !important;
-            height: 48vh !important;
+            height: calc(48vh - 56px) !important;
             background: #000;
-            z-index: 50;
+            z-index: 40;
             padding: 0;
             border-bottom: 2px solid #333;
         }
@@ -43,7 +44,8 @@
         .mobile-controls {
             display: block;
             position: fixed;
-            top: 48vh;
+            /* Align with #screen bottom: (56px + safe) + (48vh - 56px) */
+            top: calc(48vh + env(safe-area-inset-top, 0px));
             left: 0;
             right: 0;
             bottom: 0;
@@ -54,6 +56,20 @@
             padding-bottom: env(safe-area-inset-bottom);
             padding-left: env(safe-area-inset-left);
             padding-right: env(safe-area-inset-right);
+        }
+
+        /* During play, hide shared chrome and reclaim the header strip */
+        body.game-mode [data-lab-header] {
+            display: none;
+        }
+
+        body.game-mode #screen {
+            top: 0;
+            height: 48vh !important;
+        }
+
+        body.game-mode .mobile-controls {
+            top: 48vh;
         }
 
         .controls-row {

--- a/labs/winamp/index.html
+++ b/labs/winamp/index.html
@@ -17,11 +17,14 @@
     <meta property="og:image" content="https://diogopaulino.com.br/assets/img/diogo.jpeg">
     <meta name="twitter:card" content="summary">
     <title>Winamp 2.91 — Diogo Labs</title>
+    <link rel="stylesheet" href="/labs/shared.css?v=6">
     <link rel="stylesheet" href="style.css?v=5">
 </head>
 
 <body>
     <a class="skip-link" href="#winamp-stage">Pular para o Winamp</a>
+
+    <header data-lab-header data-title="Winamp JS" data-back-href="/labs/" data-back-label="Labs"></header>
 
     <div class="desktop" id="desktop" data-skin="classic">
         <nav class="desktop-icons" aria-label="Atalhos da área de trabalho">
@@ -358,6 +361,7 @@
 
     <noscript>Ative o JavaScript para usar o player.</noscript>
     <script type="module" src="script.js?v=5"></script>
+    <script src="/labs/shared.js?v=6" defer></script>
 </body>
 
 </html>

--- a/labs/winamp/style.css
+++ b/labs/winamp/style.css
@@ -104,12 +104,67 @@ body {
 }
 
 body {
+    /* shared.css aplica flex/padding de labs; o desktop Win98 precisa ocupar a tela */
+    padding-top: 0 !important;
+    padding-right: 0 !important;
+    padding-bottom: 0 !important;
+    padding-left: 0 !important;
+    display: block !important;
+    align-items: stretch !important;
     background: var(--desktop);
+    background-image: none !important;
     color: #000;
     font-family: "MS Sans Serif", Tahoma, Geneva, sans-serif;
     font-size: 12px;
     -webkit-font-smoothing: none;
     image-rendering: pixelated;
+}
+
+/* Shell compartilhado: barra compacta estilo Win98 acima do desktop */
+header[data-lab-header] {
+    position: sticky;
+    top: 0;
+    z-index: 1000;
+    margin: 0 !important;
+    max-width: none !important;
+    width: 100%;
+    padding: max(0.5rem, env(safe-area-inset-top)) 0.75rem 0.5rem !important;
+    background: #000080;
+    border-bottom: 2px solid #fff;
+    color: #fff;
+}
+
+header[data-lab-header] .back-link {
+    background: #c0c0c0;
+    color: #000;
+    border-color: #fff #808080 #808080 #fff;
+    border-radius: 0;
+    min-height: 36px;
+    box-shadow: none;
+}
+
+header[data-lab-header] .back-link:hover {
+    transform: none;
+    color: #000;
+    border-color: #fff #808080 #808080 #fff;
+    box-shadow: none;
+}
+
+header[data-lab-header] .app-logo,
+header[data-lab-header] h1 {
+    color: #fff !important;
+    font-size: 1rem !important;
+}
+
+header[data-lab-header] .subtitle {
+    display: none;
+}
+
+header[data-lab-header] .theme-toggle {
+    border-radius: 0;
+    border-color: #fff #808080 #808080 #fff;
+    background: #c0c0c0;
+    box-shadow: none;
 }
 
 button,
@@ -145,8 +200,8 @@ a:focus-visible {
 .desktop {
     position: relative;
     width: 100%;
-    height: 100%;
-    min-height: 430px;
+    height: calc(100dvh - 52px);
+    min-height: max(430px, calc(100dvh - 52px));
     overflow: hidden;
     background:
         radial-gradient(circle at 82% 16%, rgba(255, 255, 255, 0.035) 0 1px, transparent 1px 100%),
@@ -937,14 +992,24 @@ a:focus-visible {
     transform: translateY(-50%);
 }
 
+/* Isola do `footer` genérico em shared.css */
+footer.wa-pl-footer,
 .wa-pl-footer {
     display: flex;
+    width: auto;
+    max-width: none;
     height: 30px;
     flex: 0 0 auto;
     align-items: center;
     justify-content: space-between;
     gap: 10px;
-    padding-top: 4px;
+    margin: 0;
+    padding: 4px 0 0;
+    border: 0;
+    background: transparent;
+    color: inherit;
+    font-size: inherit;
+    text-align: left;
 }
 
 .wa-pl-actions {
@@ -1007,6 +1072,8 @@ a:focus-visible {
     pointer-events: none;
 }
 
+/* Isola a taskbar do `footer` genérico em shared.css */
+footer.taskbar,
 .taskbar {
     position: absolute;
     z-index: 1000000;
@@ -1014,12 +1081,19 @@ a:focus-visible {
     bottom: 0;
     left: 0;
     display: flex;
+    width: 100%;
+    max-width: none;
     height: var(--taskbar-height);
     align-items: center;
+    justify-content: flex-start;
     gap: 4px;
+    margin: 0;
     padding: 3px 4px;
     border-top: 2px outset #fff;
     background: var(--win-gray);
+    color: #000;
+    font-size: 12px;
+    text-align: left;
 }
 
 .start-button,


### PR DESCRIPTION
## Summary
- Unifica o shell compartilhado (`shared.css`/`shared.js`) em todos os labs **exceto Santos Games**, incluindo Ravi 1·2·3 e Winamp, com safe-area, overflow control e alvos de toque ≥44px.
- Corrige conflitos de header (Paint, Rock Kombat, Videogame), completa footers faltantes e melhora layouts mobile (minesweeper fluido, paint sidebar, snake/tetris scale, piano scroll, image editor, tamagotchi theme).
- Validado no browser em ~390px e desktop: galeria, minesweeper, paint, ravi, winamp, snake, calculator e rock-kombat.

## Test plan
- [ ] Abrir `/labs/` em mobile (~390px): header circular + filtros scrolláveis + cards
- [ ] Conferir header consistente (voltar + título + tema) em paint, calculator, pomodoro, rock-kombat
- [ ] Minesweeper expert: células encolhem e o board não quebra a página
- [ ] Paint mobile: cores/tamanho acessíveis na faixa inferior
- [ ] Ravi e Winamp: header overlay sem quebrar o jogo/player
- [ ] Snake/Tetris: handheld cabe na largura com header/footer
- [ ] Santos Games permanece inalterado


Made with [Cursor](https://cursor.com)