### PR TITLE
feat(santos-games): kids-first tap gameplay and beach UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Um laboratório aberto onde guardo os experimentos e mini-projetos que fui crian
 | Projeto | O que é? |
 | :--- | :--- |
 | ⚔️ **[River Knight](https://diogopaulino.com.br/labs/river-knight/)** | Aventura medieval 3D em three.js — drakkar, machados e o resgate da princesa no castelo |
-| 🌇 **[Santos Games](https://diogopaulino.com.br/labs/santos-games/)** | California Games, mas caiçara — seis provas de praia 16-bit com patrocinador, medalhas e pódio |
+| 🌇 **[Santos Games](https://diogopaulino.com.br/labs/santos-games/)** | Praia de Santos para crianças — toque na tela e jogue surfe, skate, bola, bike, raquete e barco |
 | 🎈 **[Ravi 1·2·3](https://diogopaulino.com.br/labs/ravi-123/)** | Festa surpresa com heróis — conte 1 a 9 estilo Mickey's 123 |
 | 🥊 **[Rock Kombat](https://diogopaulino.com.br/labs/rock-kombat/)** | Luta 2D cinematográfica com lendas do rock |
 | 🕹️ **[Videogame](https://diogopaulino.com.br/labs/videogame/)** | Emulador de Mega Drive com filtro CRT |

--- a/labs/index.html
+++ b/labs/index.html
@@ -601,13 +601,11 @@
         </div>
         <div class="project-content">
           <h2>Santos Games</h2>
-          <p>California Games, mas caiçara: surfe no Quebra-Mar, skate no bowl da orla, altinha
-            no Gonzaga, BMX na ciclovia, frescobol no José Menino e canoa havaiana na baía —
-            com patrocinador, medalhas e pódio</p>
+          <p>Toque e brinque na praia de Santos: surfe, skate, bola, bike, raquete e barco.</p>
           <div class="project-tags">
-            <span class="tag">16-bit</span>
-            <span class="tag">6 provas</span>
-            <span class="tag">Pixel Art</span>
+            <span class="tag">Kids</span>
+            <span class="tag">Praia</span>
+            <span class="tag">Toque</span>
           </div>
         </div>
       </a>

--- a/labs/santos-games/index.html
+++ b/labs/santos-games/index.html
@@ -19,7 +19,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Fredoka:wght@500;600;700&family=Nunito:wght@700;800;900&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/labs/shared.css?v=6">
-    <link rel="stylesheet" href="style.css?v=8">
+    <link rel="stylesheet" href="style.css?v=9">
 </head>
 
 <body>
@@ -86,7 +86,7 @@
     </div>
 
     <script src="/labs/shared.js?v=5" defer></script>
-    <script type="module" src="src/main.js?v=8"></script>
+    <script type="module" src="src/main.js?v=9"></script>
 </body>
 
 </html>

--- a/labs/santos-games/index.html
+++ b/labs/santos-games/index.html
@@ -4,32 +4,33 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover, user-scalable=no">
-    <title>Santos Games — Mega Drive / California Games | Labs</title>
+    <title>Santos Games — praia para crianças | Labs</title>
     <meta name="description"
-        content="Homenagem ao California Games (Mega Drive) em Santos: surfe, skate, altinha, BMX, frescobol e canoa. Pixel art 16-bit limpo no navegador.">
-    <meta name="theme-color" content="#101018">
+        content="Seis brincadeiras da orla de Santos: surfe, skate, bola, bike, raquete e barco. Toque na tela para jogar — feito para crianças.">
+    <meta name="theme-color" content="#1aa7c4">
     <link rel="canonical" href="https://diogopaulino.com.br/labs/santos-games/">
 
     <meta property="og:type" content="website">
     <meta property="og:title" content="Santos Games">
-    <meta property="og:description" content="California Games, mas caiçara. Seis provas 16-bit no estilo Mega Drive.">
+    <meta property="og:description" content="Toque e brinque na praia de Santos: seis jogos coloridos.">
     <meta property="og:url" content="https://diogopaulino.com.br/labs/santos-games/">
 
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Bungee&family=Nunito:wght@500;700;800&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Fredoka:wght@500;600;700&family=Nunito:wght@700;800;900&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/labs/shared.css?v=6">
-    <link rel="stylesheet" href="style.css?v=7">
+    <link rel="stylesheet" href="style.css?v=8">
 </head>
 
 <body>
     <div class="sg-bg" aria-hidden="true"></div>
+    <div class="sg-sun" aria-hidden="true"></div>
 
     <div class="sg-layout">
         <header data-lab-header data-title="Santos Games" class="sg-header">
             <template data-slot="logo">
                 <div class="app-logo">
-                    <span class="brand-mark" aria-hidden="true">🏖</span>
+                    <span class="brand-mark" aria-hidden="true">🏖️</span>
                     <span>Santos Games</span>
                 </div>
             </template>
@@ -40,58 +41,42 @@
                 <div class="sg-emu" id="svcWrap">
                     <canvas id="svcStage" width="320" height="224" hidden></canvas>
                     <canvas id="svcScreen" role="img"
-                        aria-label="Santos Games — esportes de praia em pixel art 16-bit"></canvas>
+                        aria-label="Santos Games — toque na tela para brincar na praia"></canvas>
 
-                    <div class="svc-touch tp--hidden" id="svcTouch" aria-label="Controles por toque">
-                        <div class="tp-dpad">
-                            <button type="button" data-btn="up" aria-label="Cima" class="tp-up">▲</button>
-                            <button type="button" data-btn="left" aria-label="Esquerda" class="tp-left">◀</button>
-                            <button type="button" data-btn="right" aria-label="Direita" class="tp-right">▶</button>
-                            <button type="button" data-btn="down" aria-label="Baixo" class="tp-down">▼</button>
-                        </div>
-                        <div class="tp-actions">
-                            <button type="button" data-btn="b" aria-label="Botão B" class="tp-b">B</button>
-                            <button type="button" data-btn="a" aria-label="Botão A" class="tp-a">A</button>
-                        </div>
-                        <button type="button" data-btn="start" aria-label="Iniciar ou pausar" class="tp-start">II</button>
+                    <div class="svc-touch tp--hidden" id="svcTouch" aria-label="Toque para jogar">
+                        <button type="button" data-btn="left" aria-label="Esquerda" class="tp-left">◀</button>
+                        <button type="button" data-btn="right" aria-label="Direita" class="tp-right">▶</button>
+                        <button type="button" data-btn="a" aria-label="Toque" class="tp-tap">TOQUE</button>
+                        <button type="button" data-btn="start" aria-label="Pausa" class="tp-start">II</button>
                     </div>
                 </div>
+                <p class="sg-hint">Toque na tela. Quando a estrela brilhar, toque de novo!</p>
                 <p class="sr-only" aria-live="polite" id="svcAnnouncer"></p>
             </section>
 
-            <aside class="sg-side" aria-label="Sobre o jogo">
+            <aside class="sg-side" aria-label="Escolha o jogo">
                 <div class="sg-side-block">
-                    <span class="sg-kicker">Mega Drive · 320×224</span>
-                    <h2>California Games,<br>mas caiçara</h2>
-                    <p>Escolha o patrocinador, dispute seis provas na orla de Santos e dispute o pódio.</p>
+                    <span class="sg-kicker">Praia de Santos</span>
+                    <h2>Toque e brinque</h2>
+                    <p>Seis desenhos. Um toque. Estrela quando for a hora.</p>
                 </div>
 
                 <ol class="sg-events">
-                    <li><b>Surfe</b><span>Quebra-Mar</span></li>
-                    <li><b>Skate Vert</b><span>Bowl da Orla</span></li>
-                    <li><b>Altinha</b><span>Gonzaga</span></li>
-                    <li><b>BMX</b><span>Ciclovia</span></li>
-                    <li><b>Frescobol</b><span>José Menino</span></li>
-                    <li><b>Canoa</b><span>Baía</span></li>
+                    <li data-event="surf"><span class="sg-ico" aria-hidden="true">🌊</span><b>Surfe</b></li>
+                    <li data-event="skate"><span class="sg-ico" aria-hidden="true">🛹</span><b>Skate</b></li>
+                    <li data-event="altinha"><span class="sg-ico" aria-hidden="true">⚽</span><b>Bola</b></li>
+                    <li data-event="bmx"><span class="sg-ico" aria-hidden="true">🚲</span><b>Bike</b></li>
+                    <li data-event="frescobol"><span class="sg-ico" aria-hidden="true">🎾</span><b>Raquete</b></li>
+                    <li data-event="canoa"><span class="sg-ico" aria-hidden="true">🛶</span><b>Barco</b></li>
                 </ol>
-
-                <div class="sg-side-block">
-                    <span class="sg-kicker">Controles</span>
-                    <div class="sg-key-row"><kbd>↑↓←→</kbd><span>Mover</span></div>
-                    <div class="sg-key-row"><kbd>Z</kbd><span>Botão A</span></div>
-                    <div class="sg-key-row"><kbd>X</kbd><span>Botão B</span></div>
-                    <div class="sg-key-row"><kbd>Enter</kbd><span>Start / pausa</span></div>
-                    <div class="sg-key-row"><kbd>M</kbd><span>Mudo</span></div>
-                    <p class="sg-note">Gamepad e botões na tela no celular.</p>
-                </div>
 
                 <div class="sg-actions">
                     <button id="svcSoundToggle" class="sg-btn" type="button" aria-pressed="true">
-                        <span aria-hidden="true" data-icon>◉</span>
-                        <span data-label>Som ativado</span>
+                        <span aria-hidden="true" data-icon>🔊</span>
+                        <span data-label>Som ligado</span>
                     </button>
                     <button id="svcResetBtn" class="sg-btn sg-btn--ghost" type="button">
-                        Apagar recordes
+                        Apagar estrelas
                     </button>
                 </div>
             </aside>
@@ -101,7 +86,7 @@
     </div>
 
     <script src="/labs/shared.js?v=5" defer></script>
-    <script type="module" src="src/main.js?v=7"></script>
+    <script type="module" src="src/main.js?v=8"></script>
 </body>
 
 </html>

--- a/labs/santos-games/src/art/atlas.js
+++ b/labs/santos-games/src/art/atlas.js
@@ -52,6 +52,79 @@ function makeBall(r, main, spot) {
     const buf = makeBuf(size, size);
     fillDisc(buf, r, r, r, main);
     fillDisc(buf, r - Math.max(1, r / 3), r - Math.max(1, r / 3), Math.max(1, Math.floor(r / 2.4)), spot);
+    ring(buf, r, r, r, 1, '0');
+    put(buf, r + 1, r - 2, 'E');
+    return buf;
+}
+
+function makeCrab(frame) {
+    const buf = makeBuf(16, 10);
+    fillEllipse(buf, 8, 5, 5, 3, 'x');
+    fillEllipse(buf, 8, 5, 4, 2, 'N');
+    put(buf, 6, 4, '0');
+    put(buf, 10, 4, '0');
+    const lift = frame === 0 ? 0 : 1;
+    line(buf, 3, 5, 0, 3 + lift, 1, 'x');
+    line(buf, 13, 5, 15, 3 + (1 - lift), 1, 'x');
+    fillRect(buf, 4, 7 + lift, 2, 2, 'x');
+    fillRect(buf, 10, 7 + (1 - lift), 2, 2, 'x');
+    return buf;
+}
+
+function makeBalloon() {
+    const buf = makeBuf(12, 20);
+    fillDisc(buf, 6, 6, 5, 'B');
+    fillDisc(buf, 5, 5, 2, 'G');
+    put(buf, 4, 4, 'E');
+    fillRect(buf, 5, 11, 2, 2, 'x');
+    for (let y = 13; y < 20; y++) put(buf, 6 + ((y % 4) < 2 ? 0 : 1), y, 'p');
+    return buf;
+}
+
+function makeCloud() {
+    const buf = makeBuf(36, 14);
+    fillEllipse(buf, 12, 8, 10, 5, 'E');
+    fillEllipse(buf, 22, 8, 12, 6, 'E');
+    fillEllipse(buf, 18, 5, 8, 5, 'r');
+    return buf;
+}
+
+function makeHand() {
+    const buf = makeBuf(12, 14);
+    fillDisc(buf, 6, 9, 4, 'v');
+    fillRect(buf, 5, 2, 3, 7, 'v');
+    fillRect(buf, 8, 5, 3, 3, 'v');
+    put(buf, 6, 1, 'v');
+    return buf;
+}
+
+function makeSpark(n) {
+    const buf = makeBuf(7, 7);
+    put(buf, 3, 3, 'A');
+    if (n > 0) {
+        put(buf, 3, 1, '8');
+        put(buf, 3, 5, '8');
+        put(buf, 1, 3, '8');
+        put(buf, 5, 3, '8');
+    }
+    if (n > 1) {
+        put(buf, 1, 1, 'h');
+        put(buf, 5, 1, 'h');
+        put(buf, 1, 5, 'h');
+        put(buf, 5, 5, 'h');
+    }
+    return buf;
+}
+
+function makeHeart() {
+    const buf = makeBuf(11, 10);
+    fillDisc(buf, 3, 3, 3, 'B');
+    fillDisc(buf, 7, 3, 3, 'B');
+    fillRect(buf, 2, 4, 7, 3, 'B');
+    put(buf, 5, 8, 'B');
+    put(buf, 4, 7, 'B');
+    put(buf, 6, 7, 'B');
+    put(buf, 3, 2, 'G');
     return buf;
 }
 
@@ -334,10 +407,10 @@ export function buildAtlas(kit = {}) {
     for (const group of Object.keys(FIGURE_SET)) {
         for (const poseName of FIGURE_SET[group]) {
             const fig = buildFigure(POSES[poseName], playerKit);
-            reg.add('chars', poseName, fig.rows, fig.pal, { ox: 13, oy: fig.bottom + 1 });
+            reg.add('chars', poseName, fig.rows, fig.pal, { ox: 14, oy: fig.bottom + 1 });
             const flipped = buildFigure(POSES[poseName], playerKit, { flip: true });
             reg.add('chars', poseName + '_flip', flipped.rows, flipped.pal,
-                { ox: 13, oy: flipped.bottom + 1 });
+                { ox: 14, oy: flipped.bottom + 1 });
         }
     }
 
@@ -350,18 +423,18 @@ export function buildAtlas(kit = {}) {
     ];
     crowdKits.forEach((ck, i) => {
         const idle = buildFigure(POSES.ballIdle, ck);
-        reg.add('chars', `crowd#${i}`, idle.rows, idle.pal, { ox: 13, oy: idle.bottom + 1 });
+        reg.add('chars', `crowd#${i}`, idle.rows, idle.pal, { ox: 14, oy: idle.bottom + 1 });
         const cheer = buildFigure({ ...POSES.ballIdle, armFront: [70, 95], armBack: [110, 85] }, ck);
-        reg.add('chars', `cheer#${i}`, cheer.rows, cheer.pal, { ox: 13, oy: cheer.bottom + 1 });
+        reg.add('chars', `cheer#${i}`, cheer.rows, cheer.pal, { ox: 14, oy: cheer.bottom + 1 });
         const rowPose = buildFigure(POSES.rowPull, ck);
-        reg.add('chars', `rowRival#${i}`, rowPose.rows, rowPose.pal, { ox: 13, oy: rowPose.bottom + 1 });
+        reg.add('chars', `rowRival#${i}`, rowPose.rows, rowPose.pal, { ox: 14, oy: rowPose.bottom + 1 });
     });
 
     // --- equipamentos ---
     addBuf(reg, 'props', 'board', makeSurfboard('E', playerKit.shirt), { ox: 17, oy: 4, flip: true });
     addBuf(reg, 'props', 'deck', makeSkateDeck(), { ox: 12, oy: 4 });
-    addBuf(reg, 'props', 'ballBig', makeBall(6, 'E', 'x'), { ox: 6, oy: 6 });
-    addBuf(reg, 'props', 'ballSmall', makeBall(3, 'A', 'B'), { ox: 3, oy: 3 });
+    addBuf(reg, 'props', 'ballBig', makeBall(8, 'E', 'x'), { ox: 8, oy: 8 });
+    addBuf(reg, 'props', 'ballSmall', makeBall(4, 'A', 'B'), { ox: 4, oy: 4 });
     addBuf(reg, 'props', 'racket', makeRacket(), { ox: 6, oy: 17 });
     addBuf(reg, 'props', 'bike', makeBike(), { ox: 15, oy: 19 });
     addBuf(reg, 'props', 'canoe', makeCanoe(), { ox: 32, oy: 20 });
@@ -378,6 +451,10 @@ export function buildAtlas(kit = {}) {
     addBuf(reg, 'scene', 'pothole', makePothole(), { ox: 12, oy: 7 });
     addBuf(reg, 'scene', 'gull#0', makeGull(0), { ox: 7, oy: 4 });
     addBuf(reg, 'scene', 'gull#1', makeGull(1), { ox: 7, oy: 4 });
+    addBuf(reg, 'scene', 'crab#0', makeCrab(0), { ox: 8, oy: 10 });
+    addBuf(reg, 'scene', 'crab#1', makeCrab(1), { ox: 8, oy: 10 });
+    addBuf(reg, 'scene', 'balloon', makeBalloon(), { ox: 6, oy: 20 });
+    addBuf(reg, 'scene', 'cloud', makeCloud(), { ox: 18, oy: 12 });
 
     // --- partículas ---
     for (let i = 0; i < 3; i++) {
@@ -390,6 +467,11 @@ export function buildAtlas(kit = {}) {
     addBuf(reg, 'ui', 'medal_bronze', makeMedal('6'), { ox: 8, oy: 20 });
     addBuf(reg, 'ui', 'star', makeStar(), { ox: 5, oy: 5 });
     addBuf(reg, 'ui', 'cursor', makeCursor(), { ox: 0, oy: 5 });
+    addBuf(reg, 'ui', 'hand', makeHand(), { ox: 6, oy: 14 });
+    addBuf(reg, 'ui', 'heart', makeHeart(), { ox: 5, oy: 9 });
+    addBuf(reg, 'fx', 'spark#0', makeSpark(0), { ox: 3, oy: 3 });
+    addBuf(reg, 'fx', 'spark#1', makeSpark(1), { ox: 3, oy: 3 });
+    addBuf(reg, 'fx', 'spark#2', makeSpark(2), { ox: 3, oy: 3 });
 
     // Emblemas dos patrocinadores: cada um nas SUAS cores, não nas do uniforme atual —
     // a tela de escolha mostra os seis lado a lado e eles precisam se distinguir entre si.

--- a/labs/santos-games/src/art/figure.js
+++ b/labs/santos-games/src/art/figure.js
@@ -1,4 +1,4 @@
-// art/figure.js — atleta 16-bit limpo (contorno + silhueta legível estilo California Games).
+// art/figure.js — atleta chibi (cabeça grande, olho brilhante, sorriso) para leitura infantil.
 
 import { SVC } from '../core/palette.js';
 import { makeBuf, fillRect, fillDisc, line, tip, toRows, flipRows, put } from './raster.js';
@@ -11,7 +11,7 @@ function twoBone(buf, ox, oy, a1, l1, a2, l2, thick, ch) {
     return { joint, end };
 }
 
-/** Contorno preto 1px ao redor de pixels opacos — leitura MD clássica. */
+/** Contorno preto 1px ao redor de pixels opacos. */
 function outline(buf, ink = '0') {
     const { w, h, data } = buf;
     const mark = new Uint8Array(w * h);
@@ -35,6 +35,18 @@ function outline(buf, ink = '0') {
     }
 }
 
+function paintFace(buf, hx, hy) {
+    put(buf, hx - 2, hy, '0');
+    put(buf, hx + 2, hy, '0');
+    put(buf, hx - 2, hy - 1, 'E');
+    put(buf, hx + 2, hy - 1, 'E');
+    put(buf, hx - 1, hy + 2, '0');
+    put(buf, hx, hy + 3, '0');
+    put(buf, hx + 1, hy + 2, '0');
+    put(buf, hx - 4, hy + 1, 'G');
+    put(buf, hx + 4, hy + 1, 'G');
+}
+
 const NEUTRAL = {
     lean: 0,
     crouch: 0,
@@ -43,13 +55,13 @@ const NEUTRAL = {
     armBack: [-115, -95],
     legFront: [-70, -85],
     legBack: [-100, -88],
-    armLen: [7, 6],
-    legLen: [8, 7],
+    armLen: [6, 5],
+    legLen: [6, 5],
     hair: 'short'
 };
 
-export const FIGURE_W = 26;
-export const FIGURE_H = 36;
+export const FIGURE_W = 28;
+export const FIGURE_H = 42;
 
 export function buildFigure(pose = {}, kit = {}, opts = {}) {
     const p = { ...NEUTRAL, ...pose };
@@ -62,36 +74,33 @@ export function buildFigure(pose = {}, kit = {}, opts = {}) {
     const shorts = kit.shorts || '2';
 
     const hipX = FIGURE_W / 2;
-    const hipY = FIGURE_H - 18 + p.crouch;
+    const hipY = FIGURE_H - 16 + p.crouch;
 
     const torsoAngle = 90 + p.lean;
-    const chest = tip(hipX, hipY, torsoAngle, 9);
+    const chest = tip(hipX, hipY, torsoAngle, 8);
 
-    // pernas
     twoBone(buf, hipX, hipY, p.legBack[0], p.legLen[0], p.legBack[1], p.legLen[1], 3, skin);
     const legF = twoBone(buf, hipX, hipY, p.legFront[0], p.legLen[0], p.legFront[1], p.legLen[1], 3, skin);
-    // bermuda
-    fillRect(buf, hipX - 4, hipY - 1, 8, 4, shorts);
-    fillRect(buf, hipX - 3, hipY, 6, 2, shirt);
+    fillRect(buf, hipX - 5, hipY - 1, 10, 5, shorts);
+    fillRect(buf, hipX - 4, hipY, 8, 2, shirt);
 
-    // braço de trás
     twoBone(buf, chest.x, chest.y - 1, p.armBack[0], p.armLen[0], p.armBack[1], p.armLen[1], 2, skin);
 
-    // tronco
-    line(buf, hipX, hipY, chest.x, chest.y, 6, shirt);
+    line(buf, hipX, hipY, chest.x, chest.y, 7, shirt);
     line(buf, hipX, hipY - 1, chest.x, chest.y - 1, 2, trim);
 
-    // cabeça
-    const headC = tip(chest.x + p.headTilt, chest.y, torsoAngle, 4);
-    fillDisc(buf, headC.x, headC.y, 3, skin);
-    put(buf, headC.x + (opts.flip ? -1 : 1), headC.y, '0');
+    const headC = tip(chest.x + p.headTilt, chest.y, torsoAngle, 6);
+    fillDisc(buf, headC.x, headC.y, 5, skin);
+    paintFace(buf, headC.x, headC.y);
+
     if (p.hair !== 'none') {
-        for (let i = -3; i <= 3; i++) {
-            for (let j = -3; j <= 0; j++) {
-                if (i * i + j * j <= 10) put(buf, headC.x + i, headC.y + j, hair);
-            }
-        }
-        if (p.hair === 'long') fillRect(buf, headC.x - 3, headC.y, 2, 5, hair);
+        fillDisc(buf, headC.x, headC.y - 3, 5, hair);
+        fillRect(buf, headC.x - 5, headC.y - 1, 11, 3, skin);
+        paintFace(buf, headC.x, headC.y);
+        if (p.hair === 'long') fillRect(buf, headC.x - 5, headC.y, 3, 7, hair);
+        // tufo
+        put(buf, headC.x, headC.y - 6, hair);
+        put(buf, headC.x + 1, headC.y - 7, hair);
     }
 
     const armF = twoBone(buf, chest.x, chest.y - 1, p.armFront[0], p.armLen[0], p.armFront[1], p.armLen[1], 2, skin);
@@ -106,7 +115,7 @@ export function buildFigure(pose = {}, kit = {}, opts = {}) {
     }
 
     const pal = { ' ': null };
-    for (const ch of [shirt, trim, skin, hair, shorts, '0']) pal[ch] = SVC[ch];
+    for (const ch of [shirt, trim, skin, hair, shorts, '0', 'E', 'G']) pal[ch] = SVC[ch];
 
     const mirror = (pt) => (opts.flip ? { x: FIGURE_W - 1 - pt.x, y: pt.y } : pt);
     return {
@@ -125,15 +134,15 @@ export function buildFigure(pose = {}, kit = {}, opts = {}) {
 export const POSES = {
     surfCrouch: { crouch: 3, lean: -14, armFront: [-20, 10], armBack: [-160, 170], legFront: [-55, -110], legBack: [-125, -70] },
     surfCarve: { crouch: 4, lean: -30, armFront: [0, 30], armBack: [-170, 150], legFront: [-45, -115], legBack: [-135, -60] },
-    surfAir: { crouch: 1, lean: 10, armFront: [30, 60], armBack: [150, 120], legFront: [-60, -40], legBack: [-110, -50], armLen: [7, 7] },
+    surfAir: { crouch: 1, lean: 10, armFront: [30, 60], armBack: [150, 120], legFront: [-60, -40], legBack: [-110, -50], armLen: [7, 6] },
     surfTube: { crouch: 6, lean: -8, armFront: [10, 40], armBack: [-165, -150], legFront: [-60, -115], legBack: [-120, -75] },
-    surfWipe: { crouch: -4, lean: 60, armFront: [80, 130], armBack: [110, 60], legFront: [-20, 30], legBack: [-150, -170] },
+    surfWipe: { crouch: -2, lean: 50, armFront: [80, 130], armBack: [110, 60], legFront: [-20, 30], legBack: [-150, -170] },
 
     skatePump: { crouch: 4, lean: -16, armFront: [-30, -10], armBack: [-150, -170], legFront: [-60, -110], legBack: [-120, -70] },
     skateAir: { crouch: 2, lean: 0, armFront: [40, 80], armBack: [140, 100], legFront: [-70, -30], legBack: [-110, -40] },
     skateGrab: { crouch: 6, lean: -20, armFront: [-55, -100], armBack: [140, 110], legFront: [-70, -105], legBack: [-115, -80] },
     skateLand: { crouch: 5, lean: -10, armFront: [-10, 20], armBack: [-170, 160], legFront: [-65, -105], legBack: [-115, -75] },
-    skateBail: { crouch: -3, lean: 45, armFront: [70, 120], armBack: [120, 80], legFront: [-30, 20], legBack: [-160, 170] },
+    skateBail: { crouch: -2, lean: 40, armFront: [70, 120], armBack: [120, 80], legFront: [-30, 20], legBack: [-160, 170] },
 
     ballIdle: { crouch: 0, lean: -4, armFront: [-50, -30], armBack: [-130, -150], legFront: [-80, -88], legBack: [-100, -90] },
     ballKick: { crouch: 1, lean: -18, armFront: [-20, 20], armBack: [-160, 160], legFront: [-25, -5], legBack: [-115, -85] },
@@ -143,12 +152,12 @@ export const POSES = {
     bikeRide: { crouch: 3, lean: -34, armFront: [-14, -8], armBack: [-24, -12], legFront: [-70, -100], legBack: [-110, -80] },
     bikeAir: { crouch: 2, lean: -26, armFront: [-10, -5], armBack: [-20, -10], legFront: [-55, -70], legBack: [-125, -60] },
     bikeTrick: { crouch: 0, lean: -10, armFront: [10, 30], armBack: [-30, -20], legFront: [-40, 10], legBack: [-140, -160] },
-    bikeCrash: { crouch: -5, lean: 55, armFront: [90, 140], armBack: [110, 70], legFront: [-10, 40], legBack: [-170, 160] },
+    bikeCrash: { crouch: -3, lean: 48, armFront: [90, 140], armBack: [110, 70], legFront: [-10, 40], legBack: [-170, 160] },
 
     racketReady: { crouch: 1, lean: -6, armFront: [-40, -10], armBack: [-140, -160], legFront: [-72, -92], legBack: [-108, -88] },
     racketSwing: { crouch: 2, lean: -20, armFront: [25, 55], armBack: [-150, -170], legFront: [-60, -100], legBack: [-120, -80] },
     racketReach: { crouch: -1, lean: -10, armFront: [60, 85], armBack: [-140, -160], legFront: [-70, -85], legBack: [-105, -95] },
 
-    rowCatch: { crouch: 8, lean: -40, armFront: [-5, 20], armBack: [-25, 5], legFront: [-30, -60], legBack: [-40, -70], armLen: [8, 7] },
-    rowPull: { crouch: 8, lean: -66, armFront: [-160, -140], armBack: [-175, -155], legFront: [-30, -60], legBack: [-40, -70], armLen: [8, 7] }
+    rowCatch: { crouch: 8, lean: -40, armFront: [-5, 20], armBack: [-25, 5], legFront: [-30, -60], legBack: [-40, -70], armLen: [7, 6] },
+    rowPull: { crouch: 8, lean: -66, armFront: [-160, -140], armBack: [-175, -155], legFront: [-30, -60], legBack: [-40, -70], armLen: [7, 6] }
 };

--- a/labs/santos-games/src/core/input.js
+++ b/labs/santos-games/src/core/input.js
@@ -1,5 +1,6 @@
-// core/input.js — 8 ações canônicas: teclado + touch (overlay DOM) + gamepad, tudo por OR.
-// Teto: ~230 linhas.
+// core/input.js — 8 ações canônicas: teclado + toque + clique no canvas + gamepad.
+
+import { W, H } from './pixel.js';
 
 const ACTIONS = ['up', 'down', 'left', 'right', 'a', 'b', 'start', 'select'];
 
@@ -42,6 +43,41 @@ export class InputManager {
         this._bindWindow();
         this._touchLayout = null;
         this._touchButtons = [];
+        this.pointer = { x: W / 2, y: H / 2, down: false, clicked: false };
+        this._clickLatch = false;
+        this._pointerBound = false;
+    }
+
+    /** Clique/toque no canvas vira TAP (botão A) e guarda a posição em pixels do jogo. */
+    attachPointer(canvas) {
+        if (!canvas || this._pointerBound) return;
+        this._pointerBound = true;
+        const { signal } = this.ac;
+        const toGame = (e) => {
+            const r = canvas.getBoundingClientRect();
+            if (r.width < 1 || r.height < 1) return;
+            this.pointer.x = ((e.clientX - r.left) / r.width) * W;
+            this.pointer.y = ((e.clientY - r.top) / r.height) * H;
+        };
+        canvas.addEventListener('pointerdown', (e) => {
+            e.preventDefault();
+            toGame(e);
+            this.pointer.down = true;
+            this._clickLatch = true;
+            this._buffered.add('a');
+            this._touchDown.add('a');
+            try { canvas.setPointerCapture(e.pointerId); } catch { /* noop */ }
+        }, { signal });
+        canvas.addEventListener('pointermove', toGame, { signal });
+        const release = () => {
+            this.pointer.down = false;
+            this._touchDown.delete('a');
+        };
+        canvas.addEventListener('pointerup', release, { signal });
+        canvas.addEventListener('pointercancel', release, { signal });
+        canvas.addEventListener('lostpointercapture', release, { signal });
+        canvas.style.touchAction = 'none';
+        canvas.style.cursor = 'pointer';
     }
 
     onPause(cb) { this._pauseCb = cb; }
@@ -120,6 +156,8 @@ export class InputManager {
 
     /** Chamar uma vez por frame de update, com dt em ms. */
     update(dtMs) {
+        this.pointer.clicked = this._clickLatch;
+        this._clickLatch = false;
         this.pollGamepad();
         for (const a of ACTIONS) {
             const down = this._kbDown.has(a) || this._touchDown.has(a) ||

--- a/labs/santos-games/src/core/pixel.js
+++ b/labs/santos-games/src/core/pixel.js
@@ -102,9 +102,10 @@ export class PixelSurface {
     /** Desenha um sprite (mundo, sujeito à câmera + shake). */
     blit(sprite, wx, wy, opts = {}) {
         if (!sprite) return;
+        const s = opts.scale || 1;
         const so = this.shakeOffset || { x: 0, y: 0 };
-        const dx = Math.round(wx - this.cam.x - sprite.ox + so.x);
-        const dy = Math.round(wy - this.cam.y - sprite.oy + so.y);
+        const dx = Math.round(wx - this.cam.x - sprite.ox * s + so.x);
+        const dy = Math.round(wy - this.cam.y - sprite.oy * s + so.y);
         this._draw(sprite, dx, dy, opts);
     }
 
@@ -115,7 +116,8 @@ export class PixelSurface {
      */
     blitScreen(sprite, sx, sy, opts = {}) {
         if (!sprite) return;
-        this._draw(sprite, Math.round(sx - sprite.ox), Math.round(sy - sprite.oy), opts);
+        const s = opts.scale || 1;
+        this._draw(sprite, Math.round(sx - sprite.ox * s), Math.round(sy - sprite.oy * s), opts);
     }
 
     _draw(sprite, dx, dy, opts) {

--- a/labs/santos-games/src/events/altinha.js
+++ b/labs/santos-games/src/events/altinha.js
@@ -11,10 +11,11 @@ import { SVC } from '../core/palette.js';
 import { clamp } from '../core/util.js';
 import { drawShoreFoam, drawShadow } from '../art/scenery.js';
 import { panel, needleGauge } from '../game/hud.js';
+import { assistToward } from '../game/kids.js';
 
 const SAND_Y = 176;
 const GRAVITY = 220;
-const HIT_RANGE_X = 38;
+const HIT_RANGE_X = 56;
 
 /** Tipos de toque: alcance vertical, impulso e pontuação-base de cada um. */
 const TOUCHES = {
@@ -26,7 +27,7 @@ const TOUCHES = {
 
 export class AltinhaEvent extends EventBase {
     setup() {
-        this.duration = 70;
+        this.duration = 40;
         this.playerX = W / 2;
         this.facing = 1;
         this.pose = 'ballIdle';
@@ -69,8 +70,14 @@ export class AltinhaEvent extends EventBase {
 
         // --- atleta ---
         const vx = input.axisX();
-        if (vx !== 0) this.facing = vx;
-        this.playerX = clamp(this.playerX + vx * 175 * dt, 20, W - 20); // Mais veloz
+        if (vx !== 0) {
+            this.facing = vx;
+            this.playerX = clamp(this.playerX + vx * 175 * dt, 20, W - 20);
+        } else if (this.ball.live) {
+            this.playerX = clamp(assistToward(this.playerX, this.ball.x, 160, dt, 6), 20, W - 20);
+            if (this.ball.x < this.playerX - 4) this.facing = -1;
+            if (this.ball.x > this.playerX + 4) this.facing = 1;
+        }
 
         if (this.serveT > 0) {
             this.serveT -= dt;
@@ -93,7 +100,13 @@ export class AltinhaEvent extends EventBase {
 
         // --- toque ---
         // Buffer curto: apertar meio quadro antes da bola entrar no alcance continua valendo.
-        if (input.buffered('a', 110)) { input.consume('a'); this.tryTouch(); }
+        const height = SAND_Y - b.y;
+        const near = Math.abs(b.x - this.playerX) < HIT_RANGE_X + 10 && b.vy > 0 && height < 90;
+        this.cueReady = this.ball.live && near;
+        this.cueX = this.playerX;
+        this.cueY = SAND_Y - 70;
+
+        if (input.buffered('a', 160)) { input.consume('a'); this.tryTouch(); }
 
         // --- caiu na areia ---
         if (b.y >= SAND_Y - 4) {
@@ -110,7 +123,7 @@ export class AltinhaEvent extends EventBase {
 
         const reach = b.vy > 0 ? HIT_RANGE_X + 4 : HIT_RANGE_X;
         if (dx > reach) {
-            this.float.push('LONGE', this.playerX, SAND_Y - 60, 'o', 500);
+            this.float.push('OPS!', this.playerX, SAND_Y - 60, 'o', 500);
             audio.play('ui_deny');
             return;
         }
@@ -127,11 +140,7 @@ export class AltinhaEvent extends EventBase {
                 break;
             }
         }
-        if (!key) {
-            this.float.push('NÃO ALCANÇOU', this.playerX, SAND_Y - 60, 'o', 550);
-            audio.play('ui_deny');
-            return;
-        }
+        if (!key) key = height > 50 ? 'cabeca' : height > 28 ? 'coxa' : 'pe';
 
         const t = TOUCHES[key];
         // repetir o mesmo toque vale metade: a roda quer variedade
@@ -157,7 +166,7 @@ export class AltinhaEvent extends EventBase {
         this.pose = t.pose;
         this.poseT = 0.28;
 
-        this.float.push(`${t.name} +${pts}`, this.playerX, SAND_Y - 70, repeated ? 'p' : 'z', 750);
+        this.float.push(`BOA! +${pts}`, this.playerX, SAND_Y - 70, repeated ? 'p' : 'z', 750);
         if (this.combo > 0 && this.combo % 5 === 0) {
             this.float.push(`${this.combo} TOQUES!`, W / 2, 70, 'x', 1200);
             if (this.combo % 10 === 0) {
@@ -179,7 +188,7 @@ export class AltinhaEvent extends EventBase {
         this.serveT = 1.2;
         audio.play('drop');
         px.shake(2, 180);
-        this.float.push('CAIU NA AREIA', this.ball.x, SAND_Y - 30, 'B', 1100);
+        this.float.push('OPS!', this.ball.x, SAND_Y - 30, 'B', 1100);
     }
 
     finish(detail) {

--- a/labs/santos-games/src/events/altinha.js
+++ b/labs/santos-games/src/events/altinha.js
@@ -101,8 +101,8 @@ export class AltinhaEvent extends EventBase {
         // --- toque ---
         // Buffer curto: apertar meio quadro antes da bola entrar no alcance continua valendo.
         const height = SAND_Y - b.y;
-        const near = Math.abs(b.x - this.playerX) < HIT_RANGE_X + 10 && b.vy > 0 && height < 90;
-        this.cueReady = this.ball.live && near;
+        const near = this.ball.live && b.vy > 0 && height < 100;
+        this.cueReady = !!near;
         this.cueX = this.playerX;
         this.cueY = SAND_Y - 70;
 

--- a/labs/santos-games/src/events/base.js
+++ b/labs/santos-games/src/events/base.js
@@ -5,7 +5,7 @@
 // gameplay cuidando só da sua mecânica, e garante que as seis se comportem igual em pausa,
 // em `prefers-reduced-motion` e na entrega da pontuação.
 
-import { EVENTS } from '../game/config.js';
+import { EVENTS, KID_PICK } from '../game/config.js';
 import { FloatingText, topBar, countdown, controlHint } from '../game/hud.js';
 import { clamp } from '../core/util.js';
 import { tapped, consumeTap, drawTapCue, drawSparkles } from '../game/kids.js';
@@ -129,13 +129,12 @@ export class EventBase {
     draw() {
         this.render();
         topBar(this.app.px, this.app.font, {
-            title: this.def.name,
+            title: (KID_PICK[this.id] && KID_PICK[this.id].label) || this.def.name,
             score: Math.round(this.score),
-            middle: this.middleLabel(),
+            middle: this.cueReady ? '★' : this.middleLabel(),
             tint: this.def.tint
         });
         this.float.draw(this.app.px, this.app.font);
-        this.renderOverlay();
 
         if (this.phase === 'countdown') {
             countdown(this.app.px, this.app.font, this.phaseT - 0.2);

--- a/labs/santos-games/src/events/base.js
+++ b/labs/santos-games/src/events/base.js
@@ -8,10 +8,11 @@
 import { EVENTS } from '../game/config.js';
 import { FloatingText, topBar, countdown, controlHint } from '../game/hud.js';
 import { clamp } from '../core/util.js';
+import { tapped, consumeTap, drawTapCue, drawSparkles } from '../game/kids.js';
 
-const COUNTDOWN_SEC = 3.2;
-const OUTRO_SEC = 1.4;
-const HINT_SEC = 4.5;
+const COUNTDOWN_SEC = 2.4;
+const OUTRO_SEC = 1.1;
+const HINT_SEC = 6;
 
 export class EventBase {
     /**
@@ -33,7 +34,10 @@ export class EventBase {
         this.hintT = HINT_SEC;
         this.practice = false;
         /** Duração do miolo jogável; cada prova pode sobrescrever em `setup()`. */
-        this.duration = 60;
+        this.duration = 40;
+        this.cueReady = false;
+        this.cueX = 160;
+        this.cueY = 72;
     }
 
     // --- ganchos que cada prova implementa ---
@@ -79,6 +83,13 @@ export class EventBase {
         this.float.update(dtMs);
 
         if (this.phase === 'countdown') {
+            if (tapped(this.app.input)) {
+                consumeTap(this.app.input);
+                this.phase = 'play';
+                this.phaseT = 0;
+                this.start();
+                return null;
+            }
             this.phaseT -= dt;
             const prev = Math.ceil(this.phaseT + dt);
             const now = Math.ceil(this.phaseT);
@@ -128,6 +139,9 @@ export class EventBase {
 
         if (this.phase === 'countdown') {
             countdown(this.app.px, this.app.font, this.phaseT - 0.2);
+        } else if (this.phase === 'play' && this.cueReady) {
+            drawTapCue(this.app.px, this.app.font, this.app.sprites, this.cueX, this.cueY, this.elapsed);
+            drawSparkles(this.app.px, this.app.sprites, this.cueX, this.cueY, this.elapsed, 4);
         } else if (this.hintT > 0) {
             controlHint(this.app.px, this.app.font, this.def.hint, clamp(this.hintT / 1.2, 0, 1));
         }

--- a/labs/santos-games/src/events/bmx.js
+++ b/labs/santos-games/src/events/bmx.js
@@ -101,8 +101,8 @@ export class BmxEvent extends EventBase {
 
         this.coyote = this.grounded ? COYOTE_SEC : Math.max(0, (this.coyote || 0) - dt);
 
-        const nearObs = this.obstacles.find((o) => !o.hit && (o.x - this.dist) > 4 && (o.x - this.dist) < 70);
-        this.cueReady = this.grounded && !!nearObs;
+        const nearObs = this.obstacles.find((o) => !o.hit && (o.x - this.dist) > 4 && (o.x - this.dist) < 110);
+        this.cueReady = (this.grounded && !!nearObs) || (!this.grounded && this.y > 18);
         this.cueX = 96;
         this.cueY = GROUND_Y - 56;
 

--- a/labs/santos-games/src/events/bmx.js
+++ b/labs/santos-games/src/events/bmx.js
@@ -16,7 +16,7 @@ const GROUND_Y = 182;
 // Janela de "coyote time": por um instante depois de sair do chão o pulo ainda é aceito.
 // Sem isso, saltar no fim de uma rampa exigia precisão de frame e a prova parecia injusta.
 const COYOTE_SEC = 0.14;
-const COURSE_LEN = 5200;      // px de ciclovia até a linha de chegada
+const COURSE_LEN = 3400;      // px de ciclovia até a linha de chegada
 const GRAVITY = 1050;
 const MAX_SPEED = 320;
 
@@ -95,20 +95,26 @@ export class BmxEvent extends EventBase {
         // --- aceleração ---
         const ax = input.axisX();
         if (ax > 0) this.speed += 200 * dt;
-        else if (ax < 0) this.speed -= 260 * dt;
-        else this.speed -= 20 * dt;
-        this.speed = clamp(this.speed, 50, MAX_SPEED);
+        else if (ax < 0) this.speed -= 160 * dt;
+        else this.speed += 150 * dt;
+        this.speed = clamp(this.speed, 70, MAX_SPEED);
 
-        // --- salto ---
-        // Coyote time + buffer de toque: o pulo sai se o botão foi apertado pouco antes de
-        // encostar no chão OU pouco depois de sair dele.
         this.coyote = this.grounded ? COYOTE_SEC : Math.max(0, (this.coyote || 0) - dt);
-        if (this.coyote > 0 && input.buffered('a', 130)) {
-            input.consume('a');
+
+        const nearObs = this.obstacles.find((o) => !o.hit && (o.x - this.dist) > 4 && (o.x - this.dist) < 70);
+        this.cueReady = this.grounded && !!nearObs;
+        this.cueX = 96;
+        this.cueY = GROUND_Y - 56;
+
+        const wantJump = this.coyote > 0 && input.buffered('a', 180);
+        const autoHop = this.grounded && nearObs && (nearObs.x - this.dist) < 22;
+        if (wantJump || autoHop) {
+            if (wantJump) input.consume('a');
             this.vy = 300 + this.speed * 0.5;
             this.grounded = false;
             this.coyote = 0;
             audio.play('jump');
+            if (autoHop && !wantJump) this.float.push('PULO!', 96, GROUND_Y - 40, 'y', 400);
         }
 
         if (!this.grounded) {
@@ -116,7 +122,7 @@ export class BmxEvent extends EventBase {
             this.vy -= GRAVITY * dt;
 
             // manobra no ar: só vale com altura sobrando, senão vira queda
-            if (input.state.b.pressed && this.trickT <= 0 && this.y > 26) {
+            if (input.state.a.pressed && this.trickT <= 0 && this.y > 20) {
                 this.trickT = 0.55;
                 this.trickName = TRICKS[this.tricks % TRICKS.length];
                 this.trickRot = 0;
@@ -158,7 +164,7 @@ export class BmxEvent extends EventBase {
                 this.vy = 250 + this.speed * 1.15;
                 this.grounded = false;
                 audio.play('jump');
-                this.float.push('RAMP!', 96, GROUND_Y - this.y - 36, 'y', 500);
+                this.float.push('UAU!', 96, GROUND_Y - this.y - 36, 'y', 500);
                 px.shake(1, 80);
             }
         }
@@ -205,7 +211,7 @@ export class BmxEvent extends EventBase {
         this.speed *= 1 - damage;
         audio.play('crash');
         px.shake(4, 280);
-        this.float.push(label, 96, GROUND_Y - 50, 'B', 1100);
+        this.float.push('OPS!', 96, GROUND_Y - 50, 'B', 1100);
     }
 
     arrive() {

--- a/labs/santos-games/src/events/canoa.js
+++ b/labs/santos-games/src/events/canoa.js
@@ -12,11 +12,11 @@ import { clamp } from '../core/util.js';
 import { tile, drawWater } from '../art/scenery.js';
 import { panel, gauge } from '../game/hud.js';
 
-const RACE_LEN = 4200;
-const LANES = [126, 148, 170, 192];   // y de cada raia, do fundo para a frente
+const RACE_LEN = 2800;
+const LANES = [126, 148, 170, 192];
 const PLAYER_SCREEN_X = 92;
-const BEAT_SEC = 0.52;                // intervalo entre remadas na cadência ideal
-const GOOD_WINDOW = 0.18;             // tolerância em segundos para uma remada "no tempo"
+const BEAT_SEC = 0.58;
+const GOOD_WINDOW = 0.28;
 
 export class CanoaEvent extends EventBase {
     setup() {
@@ -82,7 +82,7 @@ export class CanoaEvent extends EventBase {
         const pressedA = input.state.a.pressed;
         const pressedB = input.state.b.pressed;
         if (pressedA || pressedB) {
-            const side = pressedA ? 'a' : 'b';
+            const side = this.nextSide;
             const offset = Math.abs(this.beatT);
             if (side !== this.nextSide) {
                 // remar do lado errado desequilibra a canoa
@@ -101,7 +101,7 @@ export class CanoaEvent extends EventBase {
                     this.perfect++;
                     this.perfectStreak++;
                     this.score += 12;
-                    this.float.push(`NO TEMPO +12`, PLAYER_SCREEN_X, this.laneY - 34, 'z', 550);
+                    this.float.push(`BOA! +12`, PLAYER_SCREEN_X, this.laneY - 34, 'z', 550);
                     if (this.perfectStreak >= 5 && this.perfectStreak % 5 === 0) {
                         this.float.push(`${this.perfectStreak} SEGUIDAS!`, PLAYER_SCREEN_X, this.laneY - 50, 'x', 800);
                         this.speed += 18;
@@ -124,19 +124,31 @@ export class CanoaEvent extends EventBase {
                 this.nextSide = side === 'a' ? 'b' : 'a';
                 this.beatT = BEAT_SEC;
                 audio.play('stroke');
-                this.float.push('FORA DO TEMPO', PLAYER_SCREEN_X, this.laneY - 34, 'o', 450);
+                this.float.push('REMA!', PLAYER_SCREEN_X, this.laneY - 34, 'o', 450);
             }
         }
 
         this.rowPhase += dt;
-        // arrasto: sem remar, a canoa perde tudo rápido (mas um pouco menos agora)
-        this.speed -= (20 + this.speed * 0.12) * dt;
-        this.speed = clamp(this.speed, 0, 240 + this.cadence * 50);
+        this.cueReady = Math.abs(this.beatT) <= GOOD_WINDOW + 0.08;
+        this.cueX = PLAYER_SCREEN_X + 24;
+        this.cueY = this.laneY - 42;
 
-        // --- leme: trocar de raia é discreto, um toque por raia (não é eixo contínuo) ---
         if (input.state.up.pressed && this.lane > 0) this.lane--;
         if (input.state.down.pressed && this.lane < LANES.length - 1) this.lane++;
+        // desvia sozinho da boia que vem na mesma raia
+        if (!input.state.up.down && !input.state.down.down) {
+            const danger = this.buoys.find((b) => !b.hit && b.lane === this.lane
+                && (b.dist - this.dist) > 20 && (b.dist - this.dist) < 90);
+            if (danger) {
+                const alt = danger.lane === 0 ? 1 : danger.lane === LANES.length - 1 ? danger.lane - 1
+                    : (this.lane > 1 ? this.lane - 1 : this.lane + 1);
+                this.lane = alt;
+            }
+        }
         this.laneY += (LANES[this.lane] - this.laneY) * Math.min(1, dt * 7);
+
+        this.speed -= (16 + this.speed * 0.1) * dt;
+        this.speed = clamp(this.speed, 20, 240 + this.cadence * 50);
 
         this.dist += this.speed * dt;
 
@@ -290,7 +302,7 @@ export class CanoaEvent extends EventBase {
         px.rect(Math.round(markX) - 1, 26, 3, 12, SVC[Math.abs(this.beatT) <= GOOD_WINDOW ? 'y' : 'r']);
 
         // qual botão vem agora, dentro da própria caixa da cadência
-        font.text(px.ctx, this.nextSide === 'a' ? 'Z' : 'X', boxX + boxW - 6, 18, {
+        font.text(px.ctx, 'TOQUE', boxX + boxW - 6, 18, {
             color: 'z', align: 'right', mono: true
         });
 

--- a/labs/santos-games/src/events/frescobol.js
+++ b/labs/santos-games/src/events/frescobol.js
@@ -11,13 +11,14 @@ import { SVC } from '../core/palette.js';
 import { clamp, lerp } from '../core/util.js';
 import { drawShoreFoam, drawShadow } from '../art/scenery.js';
 import { gauge, needleGauge } from '../game/hud.js';
+import { assistToward } from '../game/kids.js';
 
 const NEAR_Y = 196;      // linha do jogador
 const FAR_Y = 126;       // linha do parceiro
 const NEAR_SPREAD = 118; // meia-largura da quadra perto
 const FAR_SPREAD = 58;   // meia-largura longe
-const HIT_WINDOW = 0.24; // faixa de z em que o rebate é possível
-const REACH = 44;        // alcance lateral da raquete (Aumentado)
+const HIT_WINDOW = 0.38;
+const REACH = 64;
 
 const screenY = (z, h) => lerp(NEAR_Y, FAR_Y, z) - h * lerp(1, 0.55, z);
 const screenX = (x, z) => W / 2 + x * lerp(NEAR_SPREAD, FAR_SPREAD, z);
@@ -25,7 +26,7 @@ const groundY = (z) => lerp(NEAR_Y, FAR_Y, z);
 
 export class FrescobolEvent extends EventBase {
     setup() {
-        this.duration = 72;
+        this.duration = 40;
         this.playerX = 0;            // -1..1
         this.partnerX = 0;
         this.rally = 0;
@@ -71,7 +72,11 @@ export class FrescobolEvent extends EventBase {
         }
 
         // --- posição do jogador ---
-        this.playerX = clamp(this.playerX + input.axisX() * 2.3 * dt, -1, 1);
+        const ax = input.axisX();
+        if (ax !== 0) this.playerX = clamp(this.playerX + ax * 2.3 * dt, -1, 1);
+        else if (this.ball.live && this.ball.owner === 'player') {
+            this.playerX = assistToward(this.playerX, clamp(this.ball.x, -1, 1), 2.4, dt, 0.04);
+        }
 
         // --- carga do rebate: segurar A acumula força, soltar/apertar rebate ---
         if (input.state.a.down) this.charge = Math.min(1, this.charge + dt * 2.8);
@@ -93,7 +98,11 @@ export class FrescobolEvent extends EventBase {
         if (Math.abs(b.x) > 1.25) { this.miss('SAIU'); return; }
 
         // --- rebate do jogador ---
-        if (b.owner === 'player' && input.buffered('a', 110)) { input.consume('a'); this.tryHit(); }
+        this.cueReady = b.owner === 'player' && b.z < 0.5 && b.z > -0.08;
+        this.cueX = screenX(this.playerX, 0);
+        this.cueY = NEAR_Y - 58;
+
+        if (b.owner === 'player' && input.buffered('a', 180)) { input.consume('a'); this.tryHit(); }
 
         // --- chegou ao chão ---
         if (b.h <= 0) {
@@ -126,9 +135,14 @@ export class FrescobolEvent extends EventBase {
         const reachable = b.h < 62;
 
         if (!inZ || !inX || !reachable) {
-            audio.play('ui_deny');
-            this.float.push('ERROU O TEMPO', W / 2, 150, 'o', 600);
-            return;
+            // criança: ainda rebate se estiver perto o bastante
+            if (b.z < 0.55 && dx <= REACH + 24 && b.h < 80) {
+                /* segue o acerto */
+            } else {
+                audio.play('ui_deny');
+                this.float.push('OPS!', W / 2, 150, 'o', 600);
+                return;
+            }
         }
 
         // qualidade do timing: acertar no centro da janela vale mais
@@ -149,9 +163,8 @@ export class FrescobolEvent extends EventBase {
         b.h = Math.max(b.h, 6);
 
         audio.play('hit');
-        const label = quality > 0.8 ? 'NO CHEIO!' : quality > 0.45 ? 'BOA' : 'RASPOU';
+        const label = quality > 0.8 ? 'UAU!' : 'BOA!';
         this.float.push(`${label} +${pts}`, screenX(this.playerX, 0), NEAR_Y - 44, quality > 0.8 ? 'z' : 'y', 750);
-        if (charge > 0.75) this.float.push('FORTE!', screenX(this.playerX, 0), NEAR_Y - 58, 'x', 550);
         if (this.rally > 0 && this.rally % 10 === 0) {
             this.score += 60;
             this.float.push(`${this.rally} TROCAS!`, W / 2, 84, 'x', 1200);
@@ -186,7 +199,7 @@ export class FrescobolEvent extends EventBase {
         this.pauseT = 0.95;
         audio.play('miss');
         px.shake(2, 160);
-        this.float.push(reason, W / 2, 150, 'B', 1000);
+        this.float.push('OPS!', W / 2, 150, 'B', 1000);
     }
 
     finish(detail) {

--- a/labs/santos-games/src/events/skate.js
+++ b/labs/santos-games/src/events/skate.js
@@ -95,6 +95,10 @@ export class SkateEvent extends EventBase {
         }
 
         if (this.state === 'air') {
+            this.cueReady = true;
+            const lip = surfaceAt(this.s);
+            this.cueX = lip.x;
+            this.cueY = COPING_Y - this.airY - 28;
             this.stepAir(dt);
             return;
         }
@@ -118,7 +122,7 @@ export class SkateEvent extends EventBase {
         this.v = clamp(this.v, -420, 420);
         this.s += this.v * dt;
 
-        const nearLip = Math.abs(this.s) > S_MAX * 0.72 && Math.abs(this.v) > MIN_LAUNCH * 0.7;
+        const nearLip = Math.abs(this.s) > S_MAX * 0.55 && Math.abs(this.v) > MIN_LAUNCH * 0.45;
         this.cueReady = this.state === 'ride' && nearLip;
         const lip = surfaceAt(this.s);
         this.cueX = lip.x;

--- a/labs/santos-games/src/events/skate.js
+++ b/labs/santos-games/src/events/skate.js
@@ -54,7 +54,7 @@ const GRAB_NAMES = ['INDY', 'MELON', 'STALEFISH', 'MUTE'];
 
 export class SkateEvent extends EventBase {
     setup() {
-        this.duration = 62;
+        this.duration = 40;
         this.s = -12;
         this.v = 40;
         this.state = 'ride';        // ride | air | bail
@@ -109,12 +109,25 @@ export class SkateEvent extends EventBase {
         // O ganho é proporcional à inclinação, então bombear no fundo reto não faz nada —
         // é preciso pegar o tempo da parede, como no bowl de verdade.
         const dir = input.axisX();
-        if (dir !== 0 && Math.sign(dir) === Math.sign(this.v) && pt.slope > 0.12) {
-            this.v += PUMP_ACCEL * Math.sin(pt.slope) * Math.sign(this.v) * dt;
+        const pumping = dir !== 0 && Math.sign(dir) === Math.sign(this.v) && pt.slope > 0.12;
+        const autoPump = dir === 0 && pt.slope > 0.12 && Math.abs(this.v) > 8;
+        if (pumping || autoPump) {
+            this.v += PUMP_ACCEL * (autoPump ? 0.75 : 1) * Math.sin(pt.slope) * Math.sign(this.v) * dt;
             if (Math.random() < dt * 6) audio.play('pump');
         }
         this.v = clamp(this.v, -420, 420);
         this.s += this.v * dt;
+
+        const nearLip = Math.abs(this.s) > S_MAX * 0.72 && Math.abs(this.v) > MIN_LAUNCH * 0.7;
+        this.cueReady = this.state === 'ride' && nearLip;
+        const lip = surfaceAt(this.s);
+        this.cueX = lip.x;
+        this.cueY = lip.y - 40;
+
+        if (this.cueReady && input.buffered('a', 180)) {
+            input.consume('a');
+            this.v += Math.sign(this.v) * 80;
+        }
 
         // --- decolagem no coping ---
         if (Math.abs(this.s) >= S_MAX) {
@@ -172,8 +185,7 @@ export class SkateEvent extends EventBase {
         this.airY = 0;
         const spins = Math.abs(this.rotation) / 360;
         const norm = ((this.rotation % 360) + 360) % 360;
-        const aligned = norm < LAND_TOLERANCE || norm > 360 - LAND_TOLERANCE ||
-            (norm > 180 - LAND_TOLERANCE && norm < 180 + LAND_TOLERANCE);
+        const aligned = true;
 
         if (!aligned || this.bestAirThisJump() < 4) {
             this.bail();
@@ -194,7 +206,7 @@ export class SkateEvent extends EventBase {
         const label = spinPts > 0 ? `${Math.floor(spins * 2) * 180}°` : this.grabName || 'AIR';
         this.float.push(`${label} +${Math.round(pts)}`, surfaceAt(this.s).x, COPING_Y - 30, 'z', 900);
         if (norm < 20 && height >= 12) {
-            this.float.push('PERFEITO!', surfaceAt(this.s).x, COPING_Y - 54, 'y', 700);
+            this.float.push('UAU!', surfaceAt(this.s).x, COPING_Y - 54, 'y', 700);
         }
         if (this.combo > 1) {
             this.float.push(`x${this.combo}`, surfaceAt(this.s).x, COPING_Y - 44, 'x', 700);
@@ -224,7 +236,7 @@ export class SkateEvent extends EventBase {
         this.rotSpeed = 0;
         audio.play('crash');
         px.shake(4, 260);
-        this.float.push('CAIU!', surfaceAt(this.s).x, COPING_Y - 20, 'B', 1100);
+        this.float.push('OPS!', surfaceAt(this.s).x, COPING_Y - 20, 'B', 1100);
     }
 
     middleLabel() {

--- a/labs/santos-games/src/events/surf.js
+++ b/labs/santos-games/src/events/surf.js
@@ -17,6 +17,7 @@ import { SVC } from '../core/palette.js';
 import { clamp, lerp } from '../core/util.js';
 import { tile, drawWater, drawShoreFoam, drawShadow } from '../art/scenery.js';
 import { gauge, judgePanel } from '../game/hud.js';
+import { assistToward } from '../game/kids.js';
 
 const START_X = 296;        // onde o pico nasce, perto da borda direita
 const FACE_LEN = 186;       // extensão da parede para a esquerda do pico
@@ -25,7 +26,7 @@ const TROUGH_Y = 190;       // linha da base da onda
 const CREST_H = 92;         // altura da parede no pico
 const SHOULDER_H = 22;      // altura do ombro, lá na ponta esquerda da parede
 const SEA_Y = 124;          // horizonte da água
-const WAVES = 3;
+const WAVES = 2;
 
 export class SurfEvent extends EventBase {
     setup() {
@@ -104,17 +105,17 @@ export class SurfEvent extends EventBase {
         }
 
         // --- posição na parede ---
-        // Subir custa velocidade, descer ganha: é o bombeio que mantém a prancha viva.
         const vy = input.axisY();
         if (this.state === 'ride') {
-            this.face = clamp(this.face - vy * 0.95 * dt, 0, 1);
-            this.speed += (vy > 0 ? 52 : vy < 0 ? -26 : -6) * dt;
+            if (vy !== 0) this.face = clamp(this.face - vy * 0.95 * dt, 0, 1);
+            else this.face = assistToward(this.face, 0.68, 0.55, dt, 0.03);
+            this.speed += (vy > 0 ? 52 : vy < 0 ? -26 : 18) * dt;
         }
-        this.speed = clamp(this.speed, 26, 170);
+        this.speed = clamp(this.speed, 40, 170);
 
-        // --- posição na linha (esquerda = fugir, direita = bolso) ---
         const vx = input.axisX();
-        this.playerX = clamp(this.playerX + vx * 82 * dt, 40, this.foamX - 6);
+        if (vx !== 0) this.playerX = clamp(this.playerX + vx * 82 * dt, 40, this.foamX - 6);
+        else this.playerX = clamp(assistToward(this.playerX, this.foamX - 52, 70, dt, 4), 40, this.foamX - 8);
 
         // --- a onda fecha ---
         this.foamX -= this.foamSpeed * dt;
@@ -124,6 +125,9 @@ export class SurfEvent extends EventBase {
 
         const gap = this.foamX - this.playerX;
         this.danger = clamp(1 - gap / 34, 0, 1);
+        this.cueReady = this.state === 'ride' && this.trickCooldown <= 0 && this.face > 0.4;
+        this.cueX = this.playerX;
+        this.cueY = this.playerY() - 36;
 
         // --- manobras (com buffer: um toque logo antes do fim do cooldown ainda vale) ---
         if (this.state === 'ride' && input.buffered('a', 150) && this.trickCooldown <= 0) {
@@ -174,9 +178,11 @@ export class SurfEvent extends EventBase {
         // --- fim de onda ---
         // A margem de 2 px (em vez de 4) e o aviso visual de perigo dão ao jogador um quadro
         // inteiro para reagir: antes a queda vinha sem nenhum sinal.
-        if (gap < 2) {
-            this.wipeout();
-        } else if (this.foamX < 52 || this.waveT > 26) {
+        if (gap < 10) {
+            this.playerX = this.foamX - 22;
+            this.speed = Math.max(40, this.speed * 0.92);
+            if (this.state === 'ride') this.float.push('CUIDADO!', this.playerX, this.playerY() - 28, 'x', 500);
+        } else if (this.foamX < 52 || this.waveT > 22) {
             this.closeWave();
         }
     }
@@ -189,18 +195,18 @@ export class SurfEvent extends EventBase {
             this.airT = 0;
             this.airPeak = 0;
             const pts = Math.round(60 + this.speed * 0.7);
-            this.addPoints(pts, 'AÉREO!', 'x');
+            this.addPoints(pts, 'UAU!', 'x');
             audio.play('air');
             px.shake(2, 160);
         } else if (this.face > 0.55) {
             const pts = Math.round(30 + this.speed * 0.35);
-            this.addPoints(pts, 'RASGADA', 'z');
+            this.addPoints(pts, 'BOA!', 'z');
             audio.play('carve');
             this.face = clamp(this.face - 0.22, 0, 1);
             this.speed *= 0.92;
         } else {
             const pts = Math.round(20 + this.speed * 0.2);
-            this.addPoints(pts, 'CUTBACK', 'y');
+            this.addPoints(pts, 'BOA!', 'y');
             audio.play('carve');
             // o cutback joga o surfista de volta pra dentro do bolso — risco e recompensa
             this.playerX = clamp(this.playerX + 22, 40, this.foamX - 6);

--- a/labs/santos-games/src/game/config.js
+++ b/labs/santos-games/src/game/config.js
@@ -27,13 +27,12 @@ export const EVENTS = {
         judged: true,
         par: 620,
         song: 'mar',
-        tagline: 'Pegue a série, fique no bolso da onda e assine na parede.',
+        tagline: 'Toque quando a estrela brilhar!',
         brief: [
-            'A ondulação entra pelo canto do Quebra-Mar.',
-            'Suba e desça a parede para ganhar velocidade,',
-            'e assine manobras antes da onda fechar.'
+            'A onda leva você.',
+            'Quando a estrela aparecer, TOQUE!'
         ],
-        hint: 'CIMA/BAIXO SOBE A PAREDE · Z MANOBRA · X TUBO',
+        hint: 'TOQUE QUANDO BRILHAR',
         judgeNote: 'Jurados avaliam manobras, tubo e tempo na parede.'
     },
     skate: {
@@ -45,13 +44,12 @@ export const EVENTS = {
         judged: true,
         par: 560,
         song: 'bowl',
-        tagline: 'Bombeie o bowl, estoure o coping e caia de pé.',
+        tagline: 'Toque no alto para pular!',
         brief: [
-            'Bowl de concreto embaixo dos prédios tortos.',
-            'Bombeie no fundo para ganhar altura e solte',
-            'a manobra no ar — mas alinhe a aterrissagem.'
+            'O skate anda sozinho no bowl.',
+            'Quando brilhar no alto, TOQUE!'
         ],
-        hint: 'ESQ/DIR BOMBEIA · Z SOLTA O AR · DIR+Z GIRA · X GRAB',
+        hint: 'TOQUE NO ALTO',
         judgeNote: 'Jurados avaliam altura, variedade e aterrissagem.'
     },
     altinha: {
@@ -63,13 +61,12 @@ export const EVENTS = {
         judged: false,
         par: 480,
         song: 'areia',
-        tagline: 'A bola não pode cair. Simples assim.',
+        tagline: 'Não deixe a bola cair!',
         brief: [
-            'Roda de altinha na areia fofa do Gonzaga.',
-            'Fique embaixo da bola e toque no tempo certo.',
-            'Cada parte do corpo vale diferente — encadeie.'
+            'Corra até a bola.',
+            'TOQUE quando ela chegar perto!'
         ],
-        hint: 'ESQ/DIR ANDA · Z TOCA · CIMA+Z CABECEIA · BAIXO+Z PÉ',
+        hint: 'TOQUE A BOLA',
         judgeNote: ''
     },
     bmx: {
@@ -81,13 +78,12 @@ export const EVENTS = {
         judged: false,
         par: 700,
         song: 'orla',
-        tagline: 'Sete quilômetros de jardim, um relógio contra você.',
+        tagline: 'Toque para pular os obstáculos!',
         brief: [
-            'Descida pela ciclovia mais famosa do país.',
-            'Salte os obstáculos, use as rampas dos canteiros',
-            'e solte manobra no ar sem perder o ritmo.'
+            'A bike corre sozinha.',
+            'TOQUE para pular cone e buraco!'
         ],
-        hint: 'DIR ACELERA · ESQ FREIA · Z SALTA · X MANOBRA NO AR',
+        hint: 'TOQUE PARA PULAR',
         judgeNote: ''
     },
     frescobol: {
@@ -99,13 +95,12 @@ export const EVENTS = {
         judged: false,
         par: 520,
         song: 'peteca',
-        tagline: 'Sem ganhador, sem perdedor — só a bola no ar.',
+        tagline: 'Toque para devolver a bolinha!',
         brief: [
-            'Frescobol é jogo de cooperação: ninguém marca ponto,',
-            'a graça é a troca não cair. Leia a sombra da bola,',
-            'posicione-se e devolva no timing — o vento atrapalha.'
+            'A bolinha vem até você.',
+            'TOQUE para mandar de volta!'
         ],
-        hint: 'ESQ/DIR POSIÇÃO · Z REBATE · SEGURE Z PARA FORÇA',
+        hint: 'TOQUE PARA REBATER',
         judgeNote: ''
     },
     canoa: {
@@ -117,13 +112,12 @@ export const EVENTS = {
         judged: false,
         par: 640,
         song: 'baia',
-        tagline: 'Remada no ritmo certo vale mais que remada com raiva.',
+        tagline: 'Toque no ritmo para remar!',
         brief: [
-            'Largada na frente do Clube, boia de retorno lá longe.',
-            'Alterne as remadas no ritmo (Z, X, Z, X) para',
-            'manter a cadência e desvie do tráfego da baía.'
+            'Toque quando o barquinho brilhar.',
+            'Reme, reme, reme o barco!'
         ],
-        hint: 'Z E X ALTERNADOS NO TEMPO · CIMA/BAIXO TROCA DE RAIA',
+        hint: 'TOQUE NO BRILHO',
         judgeNote: ''
     }
 };
@@ -201,12 +195,22 @@ export const RIVALS = [
 /** Nome do atleta do jogador no placar. */
 export const PLAYER_NAME = 'VOCÊ';
 
+/** Nomes curtos e desenhos para o seletor infantil. */
+export const KID_PICK = {
+    surf: { label: 'SURFE', emoji: '🌊' },
+    skate: { label: 'SKATE', emoji: '🛹' },
+    altinha: { label: 'BOLA', emoji: '⚽' },
+    bmx: { label: 'BIKE', emoji: '🚲' },
+    frescobol: { label: 'RAQUETE', emoji: '🎾' },
+    canoa: { label: 'BARCO', emoji: '🛶' }
+};
+
 /**
  * Faixas de medalha, como fração do `par` do evento.
  * Deliberadamente generosas no bronze e duras no ouro: o California Games premiava a
  * tentativa, mas guardava o ouro pra quem entendeu a mecânica.
  */
-export const MEDAL_CUTS = { gold: 1.0, silver: 0.72, bronze: 0.45 };
+export const MEDAL_CUTS = { gold: 0.72, silver: 0.42, bronze: 0.18 };
 
 export function medalFor(eventId, score) {
     const ev = EVENTS[eventId];

--- a/labs/santos-games/src/game/hud.js
+++ b/labs/santos-games/src/game/hud.js
@@ -188,7 +188,7 @@ export function countdown(px, font, secondsLeft) {
     const n = Math.ceil(secondsLeft);
     const label = n > 0 ? String(n) : 'JÁ!';
     const frac = secondsLeft - Math.floor(secondsLeft);
-    const scale = n > 0 ? Math.round(4 + (1 - frac) * 2) : 5;
+    const scale = n > 0 ? Math.round(5 + (1 - frac) * 3) : 6;
 
     // anel de leitura atrás do número, para ele não sumir num fundo carregado
     px.ctx.globalAlpha = 0.45;
@@ -209,6 +209,6 @@ export function controlHint(px, font, text, alpha = 1) {
     px.ctx.globalAlpha = alpha;
     plate(px, 0, 209, W, 15, '0');
     px.rect(0, 209, W, 1, SVC['m']);
-    font.text(px.ctx, text, W / 2, 213, { color: 'p', align: 'center', mono: true });
+    font.text(px.ctx, text, W / 2, 211, { color: 'A', align: 'center', mono: true, scale: 2, outline: '0' });
     px.ctx.globalAlpha = 1;
 }

--- a/labs/santos-games/src/game/kids.js
+++ b/labs/santos-games/src/game/kids.js
@@ -126,8 +126,8 @@ export function drawBeachLife(px, sprites, scenery, t, extra = {}) {
     px.blitScreen(sprites.get('umbrella'), 78, 180);
 
     if (extra.balloons !== false && sprites.has('balloon')) {
-        px.blitScreen(sprites.get('balloon'), 16 + Math.sin(t * 1.2) * 4, 22 + Math.sin(t * 1.6) * 6);
-        px.blitScreen(sprites.get('balloon'), W - 18 + Math.sin(t * 1.1 + 1) * 4, 30 + Math.sin(t * 1.4) * 7);
+        px.blitScreen(sprites.get('balloon'), 10 + Math.sin(t * 1.2) * 3, 92 + Math.sin(t * 1.6) * 8);
+        px.blitScreen(sprites.get('balloon'), W - 12 + Math.sin(t * 1.1 + 1) * 3, 108 + Math.sin(t * 1.4) * 8);
     }
     if (extra.walkers !== false) {
         if (sprites.has('crab#0')) {

--- a/labs/santos-games/src/game/kids.js
+++ b/labs/santos-games/src/game/kids.js
@@ -1,0 +1,142 @@
+// game/kids.js — suco visual e ajuda para uma criança de 3–4 anos.
+// Uma ação só (TOQUE), personagens que se aproximam sozinhos do lance, e uma estrela
+// piscando no momento certo. Textos curtos: BOA, UAU, TOQUE, OPS.
+
+import { W } from '../core/pixel.js';
+import { SVC } from '../core/palette.js';
+import { clamp } from '../core/util.js';
+
+export function tapped(input) {
+    return input.buffered('a', 220) || input.buffered('b', 220) || input.state.start.pressed;
+}
+
+export function consumeTap(input) {
+    if (input.buffered('a', 220)) input.consume('a');
+    if (input.buffered('b', 220)) input.consume('b');
+}
+
+/** Anda sozinho até o alvo se o jogador não estiver empurrando o direcional. */
+export function assistToward(current, target, speed, dt, dead = 3) {
+    const d = target - current;
+    if (Math.abs(d) <= dead) return target;
+    const step = speed * dt;
+    if (Math.abs(d) <= step) return target;
+    return current + Math.sign(d) * step;
+}
+
+export function hitGrid(px, py, x0, y0, cols, rows, cellW, cellH) {
+    const col = Math.floor((px - x0) / cellW);
+    const row = Math.floor((py - y0) / cellH);
+    if (col < 0 || row < 0 || col >= cols || row >= rows) return -1;
+    return row * cols + col;
+}
+
+/** Estrela + palavra TOQUE no ponto em que a criança deve apertar. */
+export function drawTapCue(px, font, sprites, x, y, t) {
+    const pulse = 0.72 + Math.sin(t * 11) * 0.28;
+    const bob = Math.round(Math.sin(t * 8) * 3);
+    px.ctx.globalAlpha = pulse;
+    if (sprites.has('star')) px.blitScreen(sprites.get('star'), x - 14, y + bob - 2);
+    if (sprites.has('star')) px.blitScreen(sprites.get('star'), x + 14, y + bob + 2);
+    if (sprites.has('hand')) px.blitScreen(sprites.get('hand'), x, y + bob + 10);
+    px.ctx.globalAlpha = 1;
+    if (Math.floor(t * 4) % 2 === 0) {
+        font.text(px.ctx, 'TOQUE!', x, y + bob - 12, {
+            color: 'A', align: 'center', mono: true, scale: 2, outline: '0'
+        });
+    }
+}
+
+export function drawSparkles(px, sprites, x, y, t, n = 5) {
+    for (let i = 0; i < n; i++) {
+        const a = t * 3 + i * 1.26;
+        const r = 10 + (i % 3) * 6;
+        const sx = x + Math.cos(a) * r;
+        const sy = y + Math.sin(a * 1.3) * r * 0.6;
+        const key = `spark#${i % 3}`;
+        if (sprites.has(key)) {
+            px.ctx.globalAlpha = 0.45 + Math.sin(t * 9 + i) * 0.35;
+            px.blitScreen(sprites.get(key), sx, sy);
+            px.ctx.globalAlpha = 1;
+        }
+    }
+}
+
+export class Confetti {
+    constructor() { this.bits = []; }
+
+    burst(x, y, n = 28) {
+        for (let i = 0; i < n; i++) {
+            const a = Math.random() * Math.PI * 2;
+            const sp = 40 + Math.random() * 120;
+            this.bits.push({
+                x, y,
+                vx: Math.cos(a) * sp,
+                vy: Math.sin(a) * sp - 80,
+                life: 1.1 + Math.random() * 0.7,
+                ch: ['x', 'A', 'y', 'G', 'k', '8', 'B'][i % 7],
+                w: 2 + (i % 3)
+            });
+        }
+    }
+
+    update(dt) {
+        for (let i = this.bits.length - 1; i >= 0; i--) {
+            const b = this.bits[i];
+            b.x += b.vx * dt;
+            b.y += b.vy * dt;
+            b.vy += 220 * dt;
+            b.life -= dt;
+            if (b.life <= 0 || b.y > 230) this.bits.splice(i, 1);
+        }
+    }
+
+    draw(px) {
+        for (const b of this.bits) {
+            px.ctx.globalAlpha = clamp(b.life, 0, 1);
+            px.rect(b.x, b.y, b.w, b.w, SVC[b.ch]);
+            px.ctx.globalAlpha = 1;
+        }
+    }
+}
+
+/** Vida de fundo nas telas de menu: gaivotas, caranguejo, bola, balões. */
+export function drawBeachLife(px, sprites, scenery, t, extra = {}) {
+    const c = px.ctx;
+    c.drawImage(scenery.sky, 0, extra.skyY || 0);
+    if (extra.morro) c.drawImage(scenery.morro, extra.morroX || 0, extra.morroY || 28);
+    if (extra.sea !== false) c.drawImage(scenery.sea, 0, extra.seaY || 118);
+    if (extra.skyline !== false) {
+        c.drawImage(scenery.skyline, Math.round(-(t * extra.skySpeed || t * 10) % 640), extra.skylineY || 88);
+    }
+
+    for (let i = 0; i < 4; i++) {
+        const gx = ((t * (11 + i * 5) + i * 90) % (W + 50)) - 24;
+        px.blitScreen(sprites.anim('gull', t + i, 5), gx, 14 + i * 11);
+    }
+
+    if (sprites.has('cloud')) {
+        px.blitScreen(sprites.get('cloud'), (t * 8) % (W + 60) - 30, 22);
+        px.blitScreen(sprites.get('cloud'), (t * 5 + 160) % (W + 80) - 40, 36);
+    }
+
+    const palmSway = Math.round(Math.sin(t * 1.4) * 2);
+    px.blitScreen(sprites.get('palm'), 24 + palmSway, 172);
+    px.blitScreen(sprites.get('palm'), W - 22 - palmSway, 176);
+    px.blitScreen(sprites.get('umbrella'), 78, 180);
+
+    if (extra.balloons !== false && sprites.has('balloon')) {
+        px.blitScreen(sprites.get('balloon'), 16 + Math.sin(t * 1.2) * 4, 22 + Math.sin(t * 1.6) * 6);
+        px.blitScreen(sprites.get('balloon'), W - 18 + Math.sin(t * 1.1 + 1) * 4, 30 + Math.sin(t * 1.4) * 7);
+    }
+    if (extra.walkers !== false) {
+        if (sprites.has('crab#0')) {
+            const cx = ((t * 22) % (W + 30)) - 10;
+            px.blitScreen(sprites.anim('crab', t, 6), cx, 198);
+        }
+        if (sprites.has('dog')) {
+            const dx = ((t * 38) % (W + 40)) - 16;
+            px.blitScreen(sprites.get('dog'), dx, 200);
+        }
+    }
+}

--- a/labs/santos-games/src/game/scenes.js
+++ b/labs/santos-games/src/game/scenes.js
@@ -58,11 +58,10 @@ export const titleScene = {
 
         drawSparkles(px, sprites, W / 2, 44, this.t, 6);
 
-        if (Math.floor(this.t * 2.4) % 2 === 0) {
-            font.text(c, 'TOQUE PARA BRINCAR', W / 2, 96, {
-                color: 'A', align: 'center', mono: true, scale: 2, outline: '0'
-            });
-        }
+        font.text(c, 'TOQUE PARA BRINCAR', W / 2, 96, {
+            color: Math.floor(this.t * 3) % 2 === 0 ? 'A' : '8',
+            align: 'center', mono: true, scale: 2, outline: '0'
+        });
 
         const bounce = Math.abs(Math.sin(this.t * 4)) * 16;
         px.blitScreen(sprites.get('ballIdle'), W / 2 - 36, 178);
@@ -298,7 +297,7 @@ export const eventSelectScene = {
             const cx = Math.round(this.x0 + (i % this.cols) * this.cellW + this.cellW / 2);
             const cy = this.y0 + Math.floor(i / this.cols) * this.cellH;
             const active = i === this.index;
-            const bounce = active ? Math.round(Math.sin(this.t * 8) * 3) : 0;
+            const bounce = active ? Math.round(Math.sin(this.t * 8) * 4) : Math.round(Math.sin(this.t * 3 + i) * 1);
             panel(px, cx - 46, cy - 2, 92, 66, {
                 fill: active ? '2' : '1',
                 border: '0',
@@ -307,7 +306,7 @@ export const eventSelectScene = {
                 accent: ev.tint
             });
             const pose = PICK_POSE[id];
-            px.blitScreen(sprites.get(pose), cx, cy + 44 + bounce);
+            px.blitScreen(sprites.get(pose), cx, cy + 46 + bounce);
             const prop = PICK_PROP[id];
             if (sprites.has(prop) && id !== 'canoa') {
                 px.blitScreen(sprites.get(prop), cx + 16, cy + 48 + bounce);

--- a/labs/santos-games/src/game/scenes.js
+++ b/labs/santos-games/src/game/scenes.js
@@ -10,12 +10,13 @@
 import { W, H } from '../core/pixel.js';
 import { SVC } from '../core/palette.js';
 import { clamp, easeOutBack } from '../core/util.js';
-import { EVENTS, EVENT_ORDER, SPONSORS, MEDAL_LABEL, MEDAL_COLOR } from './config.js';
+import { EVENTS, EVENT_ORDER, SPONSORS, MEDAL_LABEL, MEDAL_COLOR, KID_PICK } from './config.js';
 import { Championship } from './championship.js';
 import { MenuList, screenHeader, screenFooter, scrim } from './menu.js';
 import { panel, judgePanel } from './hud.js';
 import { drawNeonGrid } from '../art/scenery.js';
 import { createEvent } from '../events/index.js';
+import { tapped, consumeTap, hitGrid, drawBeachLife, drawSparkles, Confetti } from './kids.js';
 
 // ---------------------------------------------------------------------------
 // Título
@@ -27,65 +28,50 @@ export const titleScene = {
         this.ctx = ctx;
         this.t = 0;
         this.ctx.audio.playSong('tema');
+        if (!ctx.sponsor) ctx.setSponsor(SPONSORS[0]);
     },
     update(dtMs) {
         const ctx = this.ctx;
         this.t += dtMs / 1000;
-        if (ctx.input.state.start.pressed || ctx.input.state.a.pressed) {
+        if (tapped(ctx.input)) {
+            consumeTap(ctx.input);
             ctx.audio.play('ui_confirm');
-            ctx.goto(menuScene);
+            ctx.goto(eventSelectScene, { mode: 'single' });
         }
     },
     draw() {
-        const { px, font, sprites, scenery, store } = this.ctx;
+        const { px, font, sprites, scenery } = this.ctx;
         const c = px.ctx;
 
-        c.drawImage(scenery.sky, 0, 0);
-        c.drawImage(scenery.morro, 0, 28);
-        c.drawImage(scenery.sea, 0, 118);
+        drawBeachLife(px, sprites, scenery, this.t, {
+            skyY: 0, morro: true, seaY: 118, skylineY: 88, walkers: false
+        });
         drawNeonGrid(c, 148, 76, this.t);
-        c.drawImage(scenery.skyline, Math.round(-(this.t * 8) % 640), 88);
-        px.blitScreen(sprites.get('palm'), 28, 168);
-        px.blitScreen(sprites.get('palm'), W - 28, 172);
-        px.blitScreen(sprites.get('umbrella'), 70, 178);
 
-        // gaivotas no céu claro
-        for (let i = 0; i < 3; i++) {
-            const gx = ((this.t * (9 + i * 4) + i * 130) % (W + 40)) - 20;
-            px.blitScreen(sprites.anim('gull', this.t + i, 4), gx, 18 + i * 10);
-        }
-
-        // Logo estilo cartucho: marca grande + subtítulo — California Games vibes
-        const bob = Math.sin(this.t * 1.6) * 2;
-        font.textBig(c, 'SANTOS', W / 2, 22 + bob, {
+        const bob = Math.sin(this.t * 2.2) * 3;
+        font.textBig(c, 'SANTOS', W / 2, 16 + bob, {
             scale: 4, ramp: ['h', '8', '7', '6'], outlineColor: '0', align: 'center'
         });
-        font.textBig(c, 'GAMES', W / 2, 56 + bob, {
+        font.textBig(c, 'GAMES', W / 2, 50 + bob, {
             scale: 4, ramp: ['P', 'd', 'c', 'b', 'a'], outlineColor: '0', align: 'center'
         });
 
-        panel(px, 40, 92, W - 80, 16, { fill: '1', border: '0', light: 'y', dark: '0', accent: 'x', shadow: false });
-        font.text(c, 'SEIS PROVAS · ORLA DE SANTOS', W / 2, 96, {
-            color: 'A', align: 'center', mono: true
-        });
+        drawSparkles(px, sprites, W / 2, 44, this.t, 6);
 
-        // atleta + bola no calçadão
-        px.blitScreen(sprites.get('ballIdle'), W / 2 - 40, 170);
-        px.blitScreen(sprites.get(`cheer#${Math.floor(this.t * 2) % 4}`), W / 2 + 40, 170);
-        px.blitScreen(sprites.get('ballBig'), W / 2 - 40, 142);
-
-        if (Math.floor(this.t * 1.8) % 2 === 0) {
-            font.text(c, 'APERTE START', W / 2, 188, {
+        if (Math.floor(this.t * 2.4) % 2 === 0) {
+            font.text(c, 'TOQUE PARA BRINCAR', W / 2, 96, {
                 color: 'A', align: 'center', mono: true, scale: 2, outline: '0'
             });
         }
 
-        const career = store.careerTotal();
-        if (career > 0) {
-            font.text(c, `CARREIRA ${String(career).padStart(5, '0')} PTS`, W / 2, 204,
-                { color: '0', align: 'center', mono: true, outline: 'E' });
+        const bounce = Math.abs(Math.sin(this.t * 4)) * 16;
+        px.blitScreen(sprites.get('ballIdle'), W / 2 - 36, 178);
+        px.blitScreen(sprites.get(`cheer#${Math.floor(this.t * 3) % 4}`), W / 2 + 44, 178);
+        px.blitScreen(sprites.get('ballBig'), W / 2 - 36, 148 - bounce);
+        if (sprites.has('crab#0')) {
+            px.blitScreen(sprites.anim('crab', this.t, 6), ((this.t * 28) % (W + 20)) - 8, 208);
         }
-        font.text(c, 'HOMENAGEM A CALIFORNIA GAMES', W / 2, 214, {
+        font.text(c, 'PRAIA DE SANTOS', W / 2, 214, {
             color: '0', align: 'center', mono: true, outline: 'h'
         });
     }
@@ -116,7 +102,11 @@ export const menuScene = {
         if (action !== 'confirm') return;
 
         switch (this.menu.current.value) {
-            case 'champ': ctx.goto(sponsorScene, { mode: 'champ' }); break;
+            case 'champ':
+                ctx.setSponsor(ctx.sponsor || SPONSORS[0]);
+                ctx.champ = new Championship('champ', ctx.sponsor, ctx.rng, EVENT_ORDER);
+                ctx.goto(briefingScene, { eventId: ctx.champ.currentEventId, champ: ctx.champ });
+                break;
             case 'single': ctx.goto(eventSelectScene, { mode: 'single' }); break;
             case 'practice': ctx.goto(eventSelectScene, { mode: 'practice' }); break;
             case 'records': ctx.goto(recordsScene); break;
@@ -226,6 +216,26 @@ export const sponsorScene = {
 // Seleção de prova (modo avulso e treino)
 // ---------------------------------------------------------------------------
 
+const PICK_POSE = {
+    surf: 'surfCarve', skate: 'skateAir', altinha: 'ballKick',
+    bmx: 'bikeAir', frescobol: 'racketSwing', canoa: 'rowPull'
+};
+const PICK_PROP = {
+    surf: 'board', skate: 'deck', altinha: 'ballBig',
+    bmx: 'bike', frescobol: 'racket', canoa: 'canoe'
+};
+
+function startPickedEvent(ctx, mode, eventIds) {
+    if (!ctx.sponsor) ctx.setSponsor(SPONSORS.find((s) => s.boon === eventIds[0]) || SPONSORS[0]);
+    else if (eventIds.length === 1) {
+        const sp = SPONSORS.find((s) => s.boon === eventIds[0]);
+        if (sp) ctx.setSponsor(sp);
+    }
+    const champ = new Championship(mode, ctx.sponsor, ctx.rng, eventIds);
+    ctx.champ = champ;
+    ctx.goto(briefingScene, { eventId: champ.currentEventId, champ });
+}
+
 export const eventSelectScene = {
     id: 'eventSelect',
     enter(ctx, params) {
@@ -233,74 +243,89 @@ export const eventSelectScene = {
         this.mode = params.mode || 'single';
         this.t = 0;
         this.index = 0;
+        this.cols = 3;
+        this.cellW = 100;
+        this.cellH = 72;
+        this.x0 = (W - this.cols * this.cellW) / 2;
+        this.y0 = 36;
+        if (!ctx.sponsor) ctx.setSponsor(SPONSORS[0]);
     },
     update(dtMs) {
         const ctx = this.ctx;
         this.t += dtMs / 1000;
         const { input, audio } = ctx;
-        const n = EVENT_ORDER.length;
+        const n = EVENT_ORDER.length + 1; // + JOGAR TUDO
+
+        const hover = hitGrid(input.pointer.x, input.pointer.y, this.x0, this.y0, this.cols, 2, this.cellW, this.cellH);
+        if (hover >= 0 && hover < 6 && hover !== this.index) {
+            this.index = hover;
+            audio.play('ui_move');
+        }
+        if (input.pointer.y > 178 && input.pointer.y < 204 && this.index !== 6) {
+            this.index = 6;
+            audio.play('ui_move');
+        }
+
         if (input.state.left.pressed) { this.index = (this.index + n - 1) % n; audio.play('ui_move'); }
         if (input.state.right.pressed) { this.index = (this.index + 1) % n; audio.play('ui_move'); }
-        if (input.state.up.pressed) { this.index = (this.index + n - 3) % n; audio.play('ui_move'); }
-        if (input.state.down.pressed) { this.index = (this.index + 3) % n; audio.play('ui_move'); }
-        if (input.state.b.pressed) { audio.play('ui_back'); ctx.goto(menuScene); return; }
-        if (input.state.a.pressed || input.state.start.pressed) {
+        if (input.state.up.pressed && this.index >= 3) { this.index -= 3; audio.play('ui_move'); }
+        if (input.state.down.pressed && this.index < 3) { this.index += 3; audio.play('ui_move'); }
+        if (input.state.b.pressed) { audio.play('ui_back'); ctx.goto(titleScene); return; }
+
+        if (tapped(input)) {
+            consumeTap(input);
             audio.play('ui_confirm');
-            const id = EVENT_ORDER[this.index];
-            const champ = new Championship(this.mode, ctx.sponsor, ctx.rng, [id]);
-            ctx.champ = champ;
-            ctx.goto(briefingScene, { eventId: id, champ });
+            if (this.index === 6) startPickedEvent(ctx, 'champ', EVENT_ORDER);
+            else startPickedEvent(ctx, this.mode, [EVENT_ORDER[this.index]]);
         }
     },
     draw() {
-        const { px, font, sprites, scenery, store } = this.ctx;
+        const { px, font, sprites, scenery } = this.ctx;
         const c = px.ctx;
-        c.drawImage(scenery.sky, 0, -10);
-        drawNeonGrid(c, 168, 56, this.t * 0.4);
+        c.drawImage(scenery.sky, 0, -8);
+        drawNeonGrid(c, 170, 54, this.t * 0.5);
+        for (let i = 0; i < 3; i++) {
+            px.blitScreen(sprites.anim('gull', this.t + i, 5),
+                ((this.t * (10 + i * 4) + i * 80) % (W + 40)) - 20, 18 + i * 8);
+        }
 
-        scrim(px, 31, 179);
-        screenHeader(px, font, this.mode === 'practice' ? 'TREINO' : 'PROVA ÚNICA', 'ESCOLHA A PROVA');
+        scrim(px, 28, 196, 0.55);
+        screenHeader(px, font, 'ESCOLHA', 'TOQUE NO DESENHO');
 
-        // Grade 3×2 estilo tela de eventos do California Games
-        const cols = 3, cellW = 96, cellH = 52;
-        const x0 = (W - cols * cellW) / 2;
-        const y0 = 38;
         EVENT_ORDER.forEach((id, i) => {
             const ev = EVENTS[id];
-            const cx = Math.round(x0 + (i % cols) * cellW + cellW / 2);
-            const cy = y0 + Math.floor(i / cols) * cellH;
+            const kid = KID_PICK[id];
+            const cx = Math.round(this.x0 + (i % this.cols) * this.cellW + this.cellW / 2);
+            const cy = this.y0 + Math.floor(i / this.cols) * this.cellH;
             const active = i === this.index;
-            if (active) {
-                panel(px, cx - 44, cy - 2, 88, 48, {
-                    fill: '2', border: '0', light: 'y', dark: '1', accent: ev.tint
-                });
-            } else {
-                panel(px, cx - 42, cy, 84, 44, { fill: '1', border: '0', light: 'n', dark: '0', shadow: false });
+            const bounce = active ? Math.round(Math.sin(this.t * 8) * 3) : 0;
+            panel(px, cx - 46, cy - 2, 92, 66, {
+                fill: active ? '2' : '1',
+                border: '0',
+                light: active ? 'A' : 'n',
+                dark: '0',
+                accent: ev.tint
+            });
+            const pose = PICK_POSE[id];
+            px.blitScreen(sprites.get(pose), cx, cy + 44 + bounce);
+            const prop = PICK_PROP[id];
+            if (sprites.has(prop) && id !== 'canoa') {
+                px.blitScreen(sprites.get(prop), cx + 16, cy + 48 + bounce);
             }
-            const logoKey = `logo_${SPONSORS.find((s) => s.boon === id)?.id || 'caicara'}`;
-            if (sprites.has(logoKey)) px.blitScreen(sprites.get(logoKey), cx, cy + 16);
-            font.text(c, ev.name, cx, cy + 30, { color: active ? 'A' : 'q', align: 'center', mono: true });
-            const best = store.getBest(id);
-            if (best.medal) {
-                font.text(c, MEDAL_LABEL[best.medal][0], cx + 34, cy + 6, {
-                    color: MEDAL_COLOR[best.medal], align: 'center', mono: true
-                });
-            }
+            font.text(c, kid.label, cx, cy + 4, {
+                color: active ? 'A' : 'r', align: 'center', mono: true, outline: '0'
+            });
         });
 
-        const cur = EVENTS[EVENT_ORDER[this.index]];
-        panel(px, 12, 148, W - 24, 48, { fill: '1', border: '0', light: 'y', accent: cur.tint });
-        font.text(c, cur.place, W / 2, 154, { color: 'A', align: 'center', mono: true });
-        font.text(c, cur.tagline, W / 2, 166, { color: 'p', align: 'center', mono: true });
-        font.text(c, cur.hint, W / 2, 178, { color: 'o', align: 'center', mono: true });
-
-        screenFooter(px, font, 'SETAS ESCOLHEM · Z COMEÇA · X VOLTA');
+        const allOn = this.index === 6;
+        panel(px, 24, 180, W - 48, 22, {
+            fill: allOn ? '2' : '1', border: '0', light: allOn ? 'A' : 'n', accent: 'x'
+        });
+        font.text(c, allOn ? '★  JOGAR TUDO  ★' : 'JOGAR TUDO', W / 2, 186, {
+            color: allOn ? 'A' : 'q', align: 'center', mono: true
+        });
     }
 };
-
-// ---------------------------------------------------------------------------
-// Briefing da prova
-// ---------------------------------------------------------------------------
 
 export const briefingScene = {
     id: 'briefing',
@@ -311,64 +336,47 @@ export const briefingScene = {
         this.def = EVENTS[this.eventId];
         this.t = 0;
         ctx.audio.playSong(this.def.song);
+        const sp = SPONSORS.find((s) => s.boon === this.eventId);
+        if (sp && this.champ.mode !== 'champ') ctx.setSponsor(sp);
     },
     update(dtMs) {
         const ctx = this.ctx;
         this.t += dtMs / 1000;
-        if (ctx.input.state.a.pressed || ctx.input.state.start.pressed) {
+        if (this.t > 0.35 && tapped(ctx.input)) {
+            consumeTap(ctx.input);
             ctx.audio.play('ui_confirm');
+            ctx.goto(playScene, { eventId: this.eventId, champ: this.champ });
+        }
+        if (this.t > 1.6) {
             ctx.goto(playScene, { eventId: this.eventId, champ: this.champ });
         }
         if (ctx.input.state.b.pressed) {
             ctx.audio.play('ui_back');
-            ctx.goto(this.champ.mode === 'champ' ? menuScene : eventSelectScene, { mode: this.champ.mode });
+            ctx.goto(eventSelectScene, { mode: this.champ.mode === 'champ' ? 'single' : this.champ.mode });
         }
     },
     draw() {
-        const { px, font, sprites, scenery, store, sponsor } = this.ctx;
+        const { px, font, sprites, scenery } = this.ctx;
         const c = px.ctx;
-        c.drawImage(scenery.sky, 0, -16);
-        c.drawImage(scenery.skyline, -80, 120);
+        c.drawImage(scenery.sky, 0, -10);
+        c.drawImage(scenery.skyline, -60, 100);
+        drawSparkles(px, sprites, W / 2, 70, this.t, 7);
 
-        scrim(px, 31, 179);
-        screenHeader(px, font, this.def.name, this.def.place);
-
-        panel(px, 14, 40, W - 28, 66, { fill: '1', border: '0', light: this.def.tint, accent: this.def.tint });
-        this.def.brief.forEach((linha, i) => {
-            font.text(c, linha, W / 2, 48 + i * 12, { color: 'q', align: 'center', mono: true });
+        scrim(px, 40, 150, 0.5);
+        font.textBig(c, KID_PICK[this.eventId]?.label || this.def.name, W / 2, 48, {
+            scale: 3, ramp: ['h', '8', '7'], outlineColor: '0', align: 'center'
         });
-        if (this.def.judgeNote) {
-            font.text(c, this.def.judgeNote, W / 2, 88, { color: 'y', align: 'center', mono: true });
-        }
-
-        // controles
-        panel(px, 14, 112, W - 28, 24, { fill: '2', border: '0', light: 'n' });
-        font.text(c, 'CONTROLES', W / 2, 116, { color: 'o', align: 'center', mono: true });
-        font.text(c, this.def.hint, W / 2, 126, { color: 'r', align: 'center', mono: true });
-
-        // recorde pessoal + bônus do patrocinador
-        const best = store.getBest(this.eventId);
-        panel(px, 14, 142, (W - 34) / 2, 26, { fill: '1', border: '0', light: 'n' });
-        font.text(c, 'SEU RECORDE', 20, 146, { color: 'o', mono: true });
-        font.text(c, best.score ? String(best.score) : '—', 20, 157, { color: 'A', mono: true });
-
-        panel(px, W / 2 + 3, 142, (W - 34) / 2, 26, { fill: '1', border: '0', light: 'n' });
-        const boon = sponsor && sponsor.boon === this.eventId;
-        font.text(c, 'PATROCÍNIO', W / 2 + 9, 146, { color: 'o', mono: true });
-        font.text(c, sponsor ? (boon ? `${sponsor.name} +12%` : sponsor.name) : 'SEM PATROCÍNIO', W / 2 + 9, 157, {
-            color: boon ? 'H' : 'p', mono: true
+        font.text(c, this.def.hint, W / 2, 88, {
+            color: 'A', align: 'center', mono: true, scale: 2, outline: '0'
         });
 
-        if (this.champ.mode === 'champ') {
-            font.text(c, `PROVA ${this.champ.progressLabel}`, W / 2, 176, {
-                color: 'x', align: 'center', mono: true
-            });
-        }
+        const pose = PICK_POSE[this.eventId];
+        const bob = Math.round(Math.sin(this.t * 8) * 4);
+        px.blitScreen(sprites.get(pose), W / 2, 168 + bob, { scale: 1.4 });
 
-        if (Math.floor(this.t * 2) % 2 === 0) {
-            font.text(c, 'Z PARA COMEÇAR', W / 2, 192, { color: 'A', align: 'center', mono: true, scale: 1 });
+        if (Math.floor(this.t * 3) % 2 === 0) {
+            font.text(c, 'TOQUE!', W / 2, 196, { color: 'A', align: 'center', mono: true, scale: 2, outline: '0' });
         }
-        screenFooter(px, font, 'Z COMEÇA · X VOLTA · ENTER PAUSA DURANTE A PROVA');
     }
 };
 
@@ -385,7 +393,7 @@ export const playScene = {
         this.event = createEvent(this.eventId, ctx);
         this.event.practice = this.champ.mode === 'practice';
         ctx.audio.playSong(EVENTS[this.eventId].song);
-        ctx.setTouchLayout('FULL');
+        ctx.setTouchLayout('PLAY');
     },
     update(dtMs) {
         const ctx = this.ctx;
@@ -426,8 +434,8 @@ export const pauseScene = {
         this.t = 0;
         this.menu = new MenuList([
             { label: 'CONTINUAR', value: 'resume' },
-            { label: 'RECOMEÇAR PROVA', value: 'restart' },
-            { label: 'SAIR PARA O MENU', value: 'quit' }
+            { label: 'DE NOVO', value: 'restart' },
+            { label: 'OUTRO JOGO', value: 'quit' }
         ]);
     },
     update(dtMs) {
@@ -440,7 +448,7 @@ export const pauseScene = {
         const value = this.menu.current.value;
         if (value === 'resume') ctx.popScene();
         else if (value === 'restart') ctx.restartEvent();
-        else ctx.goto(menuScene);
+        else ctx.goto(eventSelectScene, { mode: 'single' });
     },
     draw() {
         const { px, font, sprites } = this.ctx;
@@ -478,6 +486,8 @@ export const resultScene = {
         this.def = EVENTS[this.eventId];
         this.t = 0;
         this.isRecord = false;
+        this.confetti = new Confetti();
+        this.confetti.burst(W / 2, 90, 36);
 
         if (this.champ.mode !== 'practice') {
             this.isRecord = ctx.store.submitScore(
@@ -485,93 +495,74 @@ export const resultScene = {
             );
         }
         ctx.audio.playSong(this.entry.medal === 'gold' ? 'fanfarra_ouro'
-            : this.entry.medal ? 'fanfarra_menor' : 'falha');
+            : this.entry.medal ? 'fanfarra_menor' : 'fanfarra_menor');
         if (this.isRecord) ctx.audio.play('record');
+        ctx.audio.play('coin');
     },
     update(dtMs) {
         const ctx = this.ctx;
         this.t += dtMs / 1000;
-        if (this.t < 0.6) return;
-        if (ctx.input.state.a.pressed || ctx.input.state.start.pressed) {
+        this.confetti.update(dtMs / 1000);
+        if (this.t > 0.8 && Math.random() < 0.08) this.confetti.burst(40 + Math.random() * 240, 50, 6);
+        if (this.t < 0.55) return;
+        if (tapped(ctx.input)) {
+            consumeTap(ctx.input);
             ctx.audio.play('ui_confirm');
             if (this.champ.mode === 'champ') {
                 this.champ.advance();
                 if (this.champ.isFinished) ctx.goto(podiumScene, { champ: this.champ });
                 else ctx.goto(briefingScene, { eventId: this.champ.currentEventId, champ: this.champ });
             } else {
-                ctx.goto(eventSelectScene, { mode: this.champ.mode });
+                // criança ama repetir: toque joga a mesma prova de novo
+                startPickedEvent(ctx, this.champ.mode, [this.eventId]);
             }
         }
-        if (ctx.input.state.b.pressed && this.champ.mode !== 'champ') {
+        if (ctx.input.state.b.pressed) {
             ctx.audio.play('ui_back');
-            ctx.goto(menuScene);
+            ctx.goto(eventSelectScene, { mode: this.champ.mode === 'champ' ? 'single' : this.champ.mode });
         }
     },
     draw() {
         const { px, font, sprites, scenery } = this.ctx;
         const c = px.ctx;
-        c.drawImage(scenery.sky, 0, -30);
-        drawNeonGrid(c, 176, 48, this.t * 0.3);
+        c.drawImage(scenery.sky, 0, -20);
+        drawNeonGrid(c, 168, 56, this.t * 0.4);
+        this.confetti.draw(px);
 
-        scrim(px, 31, 179);
-        screenHeader(px, font, 'RESULTADO', `${this.def.name} · ${this.def.place}`);
-
-        // pontuação com contagem animada
-        const shown = Math.round(this.entry.score * clamp(this.t / 0.9, 0, 1));
-        font.textBig(c, String(shown).padStart(4, '0'), W / 2, 42, {
-            scale: 4, color: 'A', outlineColor: '0', align: 'center'
+        const wow = this.entry.medal === 'gold' ? 'UAU!'
+            : this.entry.medal ? 'BOA!' : 'LEGAL!';
+        font.textBig(c, wow, W / 2, 28, {
+            scale: 4, ramp: ['h', '8', 'A', 'x'], outlineColor: '0', align: 'center'
         });
 
-        if (this.entry.boon > 0) {
-            font.text(c, `+${this.entry.boon} DO PATROCINADOR`, W / 2, 80, {
-                color: 'H', align: 'center', mono: true
-            });
-        }
-        if (this.entry.detail) {
-            font.text(c, this.entry.detail, W / 2, 92, {
-                color: 'q', align: 'center', mono: true, outline: '0'
-            });
-        }
+        const shown = Math.round(this.entry.score * clamp(this.t / 0.7, 0, 1));
+        font.text(c, String(shown), W / 2, 72, {
+            color: 'A', align: 'center', mono: true, scale: 2, outline: '0'
+        });
 
-        // medalha
         if (this.entry.medal) {
-            const pop = easeOutBack(clamp((this.t - 0.9) / 0.5, 0, 1));
-            if (pop > 0) {
-                px.blitScreen(sprites.get(`medal_${this.entry.medal}`), 44, 132);
-                font.text(c, MEDAL_LABEL[this.entry.medal], 44, 136, {
-                    color: MEDAL_COLOR[this.entry.medal], align: 'center', mono: true, outline: '0'
-                });
-            }
+            px.blitScreen(sprites.get(`medal_${this.entry.medal}`), W / 2, 118, { scale: 1.6 });
+            font.text(c, MEDAL_LABEL[this.entry.medal], W / 2, 128, {
+                color: MEDAL_COLOR[this.entry.medal], align: 'center', mono: true, scale: 2, outline: '0'
+            });
         } else {
-            // contorno obrigatório: cinza sobre o pôr do sol do fundo era ilegível
-            font.text(c, 'SEM MEDALHA', 44, 128, {
-                color: 'p', align: 'center', mono: true, outline: '0'
+            px.blitScreen(sprites.get('star'), W / 2 - 16, 110);
+            px.blitScreen(sprites.get('star'), W / 2 + 16, 110);
+        }
+
+        const pose = this.entry.medal ? 'ballHead' : 'ballIdle';
+        const bob = Math.round(Math.abs(Math.sin(this.t * 6)) * 8);
+        px.blitScreen(sprites.get(pose), W / 2, 188 - bob);
+        if (sprites.has('heart')) {
+            px.blitScreen(sprites.get('heart'), W / 2 - 28, 150 - bob);
+            px.blitScreen(sprites.get('heart'), W / 2 + 28, 154 - bob);
+        }
+
+        if (Math.floor(this.t * 2.2) % 2 === 0) {
+            font.text(c, this.champ.mode === 'champ' ? 'TOQUE: PROXIMO' : 'TOQUE: DE NOVO', W / 2, 210, {
+                color: 'A', align: 'center', mono: true, scale: 2, outline: '0'
             });
         }
-
-        if (this.isRecord && Math.floor(this.t * 3) % 2 === 0) {
-            font.text(c, 'RECORDE PESSOAL!', W / 2, 106, { color: 'x', align: 'center', mono: true });
-        }
-
-        // notas dos jurados nas provas julgadas
-        if (this.judges) {
-            judgePanel(px, font, this.judges, this.t * 1.4);
-        } else if (this.entry.table && this.entry.table.length) {
-            // tabela da prova nas provas não julgadas
-            const x = 96;
-            panel(px, x, 112, W - x - 12, 84, { fill: '1', border: '0', light: 'n' });
-            this.entry.table.slice(0, 5).forEach((row, i) => {
-                const isPlayer = row.id === 'player';
-                const y = 118 + i * 15;
-                font.text(c, `${i + 1}º`, x + 6, y, { color: isPlayer ? 'A' : 'o', mono: true });
-                font.text(c, row.name, x + 26, y, { color: isPlayer ? 'A' : 'q', mono: true });
-                font.text(c, String(row.score), W - 20, y, {
-                    color: isPlayer ? 'A' : 'p', align: 'right', mono: true
-                });
-            });
-        }
-
-        screenFooter(px, font, this.champ.mode === 'champ' ? 'Z SEGUE PARA A PRÓXIMA PROVA' : 'Z VOLTA · X MENU');
     }
 };
 
@@ -600,10 +591,11 @@ export const podiumScene = {
     update(dtMs) {
         const ctx = this.ctx;
         this.t += dtMs / 1000;
-        if (this.t < 1) return;
-        if (ctx.input.state.a.pressed || ctx.input.state.start.pressed) {
+        if (this.t < 0.8) return;
+        if (tapped(ctx.input)) {
+            consumeTap(ctx.input);
             ctx.audio.play('ui_confirm');
-            ctx.goto(menuScene);
+            ctx.goto(eventSelectScene, { mode: 'single' });
         }
     },
     draw() {

--- a/labs/santos-games/src/main.js
+++ b/labs/santos-games/src/main.js
@@ -150,9 +150,10 @@ function applyOptions() {
 function setTouchLayout(layout) {
     const overlay = document.getElementById('svcTouch');
     if (!overlay) return;
-    // coarse pointer OU dispositivos sem hover (celulares/tablets) — o overlay some no desktop
     const touchy = matchMedia('(pointer: coarse), (hover: none)').matches;
-    state.input.attachTouch(overlay, touchy ? (layout || 'FULL') : null);
+    overlay.classList.toggle('tp--kids', layout === 'PLAY' || layout === 'FULL');
+    overlay.classList.toggle('tp--coarse', touchy);
+    state.input.attachTouch(overlay, layout ? 'FULL' : null);
 }
 
 function updateSoundButton() {
@@ -161,9 +162,9 @@ function updateSoundButton() {
     const muted = !!state.store.getOpts().mute;
     btn.setAttribute('aria-pressed', String(!muted));
     const label = btn.querySelector('[data-label]');
-    if (label) label.textContent = muted ? 'Som desativado' : 'Som ativado';
+    if (label) label.textContent = muted ? 'Som desligado' : 'Som ligado';
     const icon = btn.querySelector('[data-icon]');
-    if (icon) icon.textContent = muted ? '◌' : '◉';
+    if (icon) icon.textContent = muted ? '🔇' : '🔊';
 }
 
 // ---------------------------------------------------------------------------
@@ -253,12 +254,14 @@ function boot() {
 
     state.px = new PixelSurface(wrap, stage, screen);
     state.input = new InputManager();
+    state.input.attachPointer(screen);
     state.font = createFont();
     state.store = new Store();
     state.audio = createAudio();
     state.rng = makeRng(Date.now() & 0xffffffff);
     state.scenery = buildScenery();
     state.sprites = buildAtlas({ shirt: 'c', trim: 'y', skin: 'u', hair: '0' });
+    setSponsor(SPONSORS[0]);
 
     applyOptions();
 
@@ -305,7 +308,7 @@ function boot() {
 
     const resetBtn = document.getElementById('svcResetBtn');
     on(resetBtn, 'click', () => {
-        if (!window.confirm('Apagar todos os recordes e medalhas do Santos Games?')) return;
+        if (!window.confirm('Apagar as estrelas e medalhas?')) return;
         state.store.reset();
         applyOptions();
     });

--- a/labs/santos-games/style.css
+++ b/labs/santos-games/style.css
@@ -311,17 +311,8 @@ html, body {
 }
 
 .tp-left, .tp-right {
-    width: 52px;
-    height: 52px;
-    border-radius: 16px;
-    font-size: 1.3rem;
-    bottom: 16px;
-    display: none;
+    display: none !important;
 }
-.tp-left { left: 12px; }
-.tp-right { left: 72px; }
-.tp--coarse .tp-left,
-.tp--coarse .tp-right { display: flex; }
 
 .tp-tap {
     width: 72px;

--- a/labs/santos-games/style.css
+++ b/labs/santos-games/style.css
@@ -1,15 +1,16 @@
-/* Santos Games — shell limpo estilo emulador Mega Drive (sem CRT/TV) */
+/* Santos Games — praia colorida, leitura grande, toque óbvio */
 
 :root {
-    --sg-ink: #0c0c12;
-    --sg-panel: #14141c;
-    --sg-line: #2a2a36;
-    --sg-teal: #38c8b8;
-    --sg-coral: #f05040;
-    --sg-sun: #f0c040;
-    --sg-text: #e8e8f0;
-    --sg-muted: #9898a8;
-    --font-display: "Bungee", "Arial Black", sans-serif;
+    --sg-ink: #0e3a4a;
+    --sg-panel: #fff8e8;
+    --sg-line: #f0c878;
+    --sg-teal: #1aa7c4;
+    --sg-coral: #ff6b4a;
+    --sg-sun: #ffd24a;
+    --sg-sea: #3ec6d8;
+    --sg-text: #123848;
+    --sg-muted: #4a7080;
+    --font-display: "Fredoka", "Nunito", sans-serif;
     --font-ui: "Nunito", "Trebuchet MS", sans-serif;
 }
 
@@ -21,7 +22,7 @@ html, body {
     overflow: hidden;
     font-family: var(--font-ui);
     color: var(--sg-text);
-    background: var(--sg-ink);
+    background: #1aa7c4;
 }
 
 .container {
@@ -38,7 +39,32 @@ html, body {
     z-index: 0;
     pointer-events: none;
     background:
-        radial-gradient(ellipse 70% 50% at 50% 40%, #1a2430 0%, var(--sg-ink) 70%);
+        linear-gradient(180deg, #4ec8e8 0%, #7ad4ea 38%, #ffe7a0 62%, #f0c070 100%);
+    animation: sgSky 12s ease-in-out infinite alternate;
+}
+
+@keyframes sgSky {
+    from { filter: saturate(1); }
+    to { filter: saturate(1.15) brightness(1.04); }
+}
+
+.sg-sun {
+    position: fixed;
+    top: 8%;
+    right: 12%;
+    width: 90px;
+    height: 90px;
+    border-radius: 50%;
+    background: radial-gradient(circle at 35% 35%, #fff6c8, #ffd24a 55%, #ff9a2a);
+    box-shadow: 0 0 40px 12px rgba(255, 210, 74, 0.55);
+    z-index: 0;
+    pointer-events: none;
+    animation: sgBob 4s ease-in-out infinite;
+}
+
+@keyframes sgBob {
+    0%, 100% { transform: translateY(0); }
+    50% { transform: translateY(8px); }
 }
 
 .sg-layout {
@@ -51,8 +77,8 @@ html, body {
 }
 
 .sg-header, .sg-footer {
-    background: var(--sg-panel);
-    border-bottom: 1px solid var(--sg-line);
+    background: rgba(255, 248, 232, 0.92);
+    border-bottom: 3px solid var(--sg-line);
     padding: 0.65rem 1.1rem;
     display: flex;
     align-items: center;
@@ -61,8 +87,14 @@ html, body {
 
 .sg-footer {
     border-bottom: none;
-    border-top: 1px solid var(--sg-line);
+    border-top: 3px solid var(--sg-line);
     margin-top: auto;
+}
+
+.sg-header .app-logo {
+    font-family: var(--font-display);
+    font-weight: 700;
+    letter-spacing: 0.02em;
 }
 
 .sg-shell {
@@ -79,7 +111,6 @@ html, body {
     overflow: hidden;
 }
 
-/* ---------- emulador: moldura fina, pixel integer ---------- */
 .sg-stage {
     flex: 1;
     display: flex;
@@ -88,6 +119,7 @@ html, body {
     align-items: center;
     min-width: 0;
     min-height: 0;
+    gap: 0.55rem;
 }
 
 .sg-emu {
@@ -96,10 +128,11 @@ html, body {
     display: flex;
     align-items: center;
     justify-content: center;
-    background: #000;
-    border: none;
-    outline: 1px solid var(--sg-line);
-    box-shadow: 0 8px 28px rgba(0, 0, 0, 0.45);
+    background: #123848;
+    border: 6px solid #fff8e8;
+    border-radius: 18px;
+    outline: 4px solid #ffd24a;
+    box-shadow: 0 14px 32px rgba(18, 56, 72, 0.28);
     width: 320px;
     height: 224px;
     max-width: none;
@@ -113,29 +146,47 @@ html, body {
     display: block;
     image-rendering: pixelated;
     image-rendering: crisp-edges;
-    background: #000;
+    background: #123848;
+    border-radius: 10px;
+    cursor: pointer;
 }
 
-/* ---------- painel ---------- */
+.sg-hint {
+    margin: 0;
+    font-family: var(--font-display);
+    font-size: 1rem;
+    font-weight: 600;
+    color: #123848;
+    text-align: center;
+    text-shadow: 0 1px 0 rgba(255, 255, 255, 0.6);
+    animation: sgPulse 1.4s ease-in-out infinite;
+}
+
+@keyframes sgPulse {
+    0%, 100% { transform: scale(1); opacity: 0.85; }
+    50% { transform: scale(1.04); opacity: 1; }
+}
+
 .sg-side {
     width: 280px;
     flex-shrink: 0;
     background: var(--sg-panel);
-    border: 1px solid var(--sg-line);
-    border-radius: 10px;
+    border: 3px solid var(--sg-line);
+    border-radius: 18px;
     padding: 1rem 1.05rem;
     display: flex;
     flex-direction: column;
-    gap: 0.95rem;
+    gap: 0.85rem;
     overflow-y: auto;
     color: var(--sg-text);
+    box-shadow: 0 10px 24px rgba(18, 56, 72, 0.12);
 }
 
 .sg-kicker {
     display: block;
-    font-size: 0.65rem;
+    font-size: 0.72rem;
     font-weight: 800;
-    letter-spacing: 0.14em;
+    letter-spacing: 0.12em;
     text-transform: uppercase;
     color: var(--sg-teal);
     margin-bottom: 0.3rem;
@@ -143,90 +194,68 @@ html, body {
 
 .sg-side-block h2 {
     font-family: var(--font-display);
-    font-size: 1.05rem;
-    line-height: 1.2;
-    font-weight: 400;
-    margin: 0 0 0.45rem;
-    color: var(--sg-sun);
+    font-size: 1.35rem;
+    line-height: 1.15;
+    font-weight: 700;
+    margin: 0 0 0.4rem;
+    color: var(--sg-coral);
 }
 
 .sg-side-block p {
     margin: 0;
-    font-size: 0.84rem;
-    line-height: 1.4;
+    font-size: 0.92rem;
+    line-height: 1.35;
+    font-weight: 700;
     color: var(--sg-muted);
 }
 
 .sg-events {
     list-style: none;
     margin: 0;
-    padding: 0.25rem;
+    padding: 0;
     display: grid;
-    gap: 2px;
-    background: #0c0c12;
-    border-radius: 8px;
-    border: 1px solid var(--sg-line);
-    counter-reset: prova;
+    grid-template-columns: 1fr 1fr;
+    gap: 8px;
 }
 
 .sg-events li {
-    counter-increment: prova;
     display: flex;
-    align-items: baseline;
-    gap: 0.4rem;
-    padding: 0.4rem 0.5rem;
-    border-radius: 6px;
-    font-size: 0.82rem;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.15rem;
+    padding: 0.7rem 0.35rem 0.55rem;
+    border-radius: 14px;
+    font-size: 0.92rem;
     cursor: pointer;
-    transition: background 0.12s ease;
+    background: #fff;
+    border: 3px solid #ffe09a;
+    transition: transform 0.12s ease, background 0.12s ease, box-shadow 0.12s ease;
+    min-height: 72px;
 }
+
+.sg-events li:nth-child(1) { background: #d6f6ff; }
+.sg-events li:nth-child(2) { background: #ffe3d2; }
+.sg-events li:nth-child(3) { background: #e3ffd4; }
+.sg-events li:nth-child(4) { background: #fff3b0; }
+.sg-events li:nth-child(5) { background: #ffd6ec; }
+.sg-events li:nth-child(6) { background: #d4e8ff; }
 
 .sg-events li:hover,
 .sg-events li:focus-visible {
-    background: rgba(56, 200, 184, 0.14);
+    transform: translateY(-3px) scale(1.04);
+    box-shadow: 0 8px 0 rgba(18, 56, 72, 0.12);
     outline: none;
+    border-color: var(--sg-coral);
 }
 
-.sg-events li::before {
-    content: counter(prova);
+.sg-events li:active { transform: translateY(1px) scale(0.98); }
+
+.sg-ico { font-size: 1.55rem; line-height: 1; }
+.sg-events b {
+    color: var(--sg-ink);
     font-family: var(--font-display);
-    font-size: 0.68rem;
-    color: var(--sg-coral);
-    min-width: 1em;
-}
-
-.sg-events b { color: #fff; font-weight: 800; }
-.sg-events span {
-    margin-left: auto;
-    color: var(--sg-muted);
-    font-size: 0.7rem;
-}
-
-.sg-key-row {
-    display: flex;
-    align-items: center;
-    gap: 0.65rem;
-    padding: 0.18rem 0;
-    font-size: 0.82rem;
-    color: var(--sg-muted);
-}
-
-.sg-key-row kbd {
-    min-width: 54px;
-    text-align: center;
-    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-    font-size: 0.7rem;
-    padding: 0.22rem 0.4rem;
-    border-radius: 4px;
-    background: #0c0c12;
-    border: 1px solid var(--sg-line);
-    color: var(--sg-text);
-}
-
-.sg-note {
-    margin: 0.45rem 0 0;
-    font-size: 0.72rem;
-    color: #686878;
+    font-weight: 700;
 }
 
 .sg-actions {
@@ -237,27 +266,28 @@ html, body {
 }
 
 .sg-btn {
-    padding: 0.65rem 0.8rem;
-    font-family: var(--font-ui);
-    font-weight: 800;
-    font-size: 0.88rem;
-    color: #101018;
+    padding: 0.75rem 0.8rem;
+    font-family: var(--font-display);
+    font-weight: 700;
+    font-size: 1rem;
+    color: #fff;
     background: var(--sg-coral);
     border: none;
-    border-radius: 8px;
+    border-radius: 14px;
     cursor: pointer;
+    box-shadow: 0 4px 0 #c44830;
 }
-
-.sg-btn:hover { filter: brightness(1.08); }
+.sg-btn:hover { filter: brightness(1.06); }
+.sg-btn:active { transform: translateY(2px); box-shadow: 0 2px 0 #c44830; }
 .sg-btn--ghost {
     color: var(--sg-text);
     background: transparent;
-    border: 1px solid var(--sg-line);
+    border: 2px solid var(--sg-line);
+    box-shadow: none;
 }
-.sg-btn--ghost:hover { background: rgba(255, 255, 255, 0.05); filter: none; }
+.sg-btn--ghost:hover { background: rgba(255, 210, 74, 0.25); filter: none; }
 .sg-btn[aria-pressed="false"] [data-icon] { opacity: 0.4; }
 
-/* ---------- touch ---------- */
 .svc-touch { position: absolute; inset: 0; pointer-events: none; z-index: 10; }
 .svc-touch.tp--hidden { display: none; }
 .svc-touch button {
@@ -266,31 +296,62 @@ html, body {
     display: flex;
     align-items: center;
     justify-content: center;
-    font: inherit;
-    font-size: 1rem;
-    font-weight: 800;
-    color: rgba(255, 255, 255, 0.92);
-    background: rgba(16, 16, 24, 0.72);
-    border: 1px solid rgba(56, 200, 184, 0.45);
-    border-radius: 50%;
+    font-family: var(--font-display);
+    font-weight: 700;
+    color: #123848;
+    background: rgba(255, 248, 232, 0.88);
+    border: 3px solid #ffd24a;
     touch-action: none;
     user-select: none;
 }
 .svc-touch button:active {
-    background: rgba(240, 80, 64, 0.8);
+    background: #ff6b4a;
+    color: #fff;
     transform: scale(0.94);
 }
-.tp-dpad button { width: 46px; height: 46px; border-radius: 8px; }
-.tp-up { left: 62px; bottom: 108px; }
-.tp-down { left: 62px; bottom: 12px; }
-.tp-left { left: 14px; bottom: 60px; }
-.tp-right { left: 110px; bottom: 60px; }
-.tp-actions button { width: 56px; height: 56px; }
-.tp-a { right: 14px; bottom: 26px; background: rgba(240, 80, 64, 0.55); }
-.tp-b { right: 76px; bottom: 62px; background: rgba(56, 200, 184, 0.4); }
+
+.tp-left, .tp-right {
+    width: 52px;
+    height: 52px;
+    border-radius: 16px;
+    font-size: 1.3rem;
+    bottom: 16px;
+    display: none;
+}
+.tp-left { left: 12px; }
+.tp-right { left: 72px; }
+.tp--coarse .tp-left,
+.tp--coarse .tp-right { display: flex; }
+
+.tp-tap {
+    width: 72px;
+    height: 72px;
+    right: 10px;
+    bottom: 10px;
+    border-radius: 50%;
+    font-size: 0.82rem;
+    letter-spacing: 0.04em;
+    background: #ff6b4a;
+    color: #fff;
+    border-color: #fff8e8;
+    box-shadow: 0 6px 0 #c44830;
+    animation: sgTap 1.1s ease-in-out infinite;
+}
+@keyframes sgTap {
+    0%, 100% { transform: scale(1); }
+    50% { transform: scale(1.07); }
+}
+.tp-tap:active { animation: none; }
+
 .tp-start {
-    width: 46px; height: 30px; border-radius: 14px !important;
-    right: 50%; transform: translateX(50%); bottom: 10px; font-size: 0.8rem;
+    width: 40px;
+    height: 28px;
+    border-radius: 12px;
+    right: 50%;
+    transform: translateX(50%);
+    top: 8px;
+    font-size: 0.75rem;
+    opacity: 0.7;
 }
 
 @media (max-width: 980px) {
@@ -313,21 +374,19 @@ html, body {
     body, html { overflow: auto; }
     .sg-layout { height: auto; min-height: 100vh; }
     .sg-header, .sg-footer { padding: 0.55rem 0.75rem; }
-    .tp-dpad button { width: 42px; height: 42px; }
-    .tp-up { left: 54px; bottom: 96px; }
-    .tp-down { left: 54px; bottom: 10px; }
-    .tp-left { left: 10px; bottom: 53px; }
-    .tp-right { left: 98px; bottom: 53px; }
-    .tp-actions button { width: 50px; height: 50px; }
+    .sg-sun { width: 56px; height: 56px; }
+    .tp-tap { width: 80px; height: 80px; font-size: 0.85rem; }
 }
 
 @media (max-height: 560px) and (orientation: landscape) {
     .sg-shell { flex-direction: row; padding: 0.35rem; gap: 0.65rem; }
-    .sg-side { width: 210px; padding: 0.65rem; }
-    .sg-side-block h2 { font-size: 0.9rem; }
-    .sg-events span { display: none; }
+    .sg-side { width: 200px; padding: 0.65rem; }
+    .sg-side-block h2 { font-size: 1rem; }
+    .sg-hint { display: none; }
+    .sg-events { grid-template-columns: 1fr 1fr; }
 }
 
 @media (prefers-reduced-motion: reduce) {
+    .sg-bg, .sg-sun, .sg-hint, .tp-tap { animation: none; }
     .sg-events li { transition: none; }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Santos Games was a California Games tribute with sponsor menus, Z/X combos, and dense 16-bit UI — too still and too hard for a 3–4 year old.

This revision keeps the six beach sports and pixel look, and turns the lab into a tap-to-play game.

## What changed
- **Flow:** title → tap a drawing → short “TOQUE!” splash → play → celebration. No sponsor, championship menus, or Z/X homework on the kid path.
- **One action:** click/tap the canvas (or the big TOQUE button). Characters walk/ride toward the play by themselves.
- **Cues:** a star and “TOQUE!” blink at the moment to tap. Success text is BOA / UAU / OPS.
- **Characters:** chibi heads, eyes, smile; bigger ball; crabs, balloons, clouds, sparkles.
- **Shell:** sand/sea colors, six big picture cards on the side, pulsing TOQUE overlay in play.
- **Sports:** shorter rounds, generous timing, auto-pump / auto-jump / auto-steer so the screen never sits still.

## How to try
Open `/labs/santos-games/`, tap the title, pick Surfe / Skate / Bola / Bike / Raquete / Barco, then mash tap when the star blinks.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7805c860-1b11-4bbb-8092-f1d8504f5cad?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7805c860-1b11-4bbb-8092-f1d8504f5cad&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

