### PR TITLE
feat(river-knight): visual revision, closer camera, and a livelier river

### DIFF
--- a/labs/river-knight/index.html
+++ b/labs/river-knight/index.html
@@ -248,7 +248,7 @@
     </main>
 
     <script src="/labs/shared.js?v=6" defer></script>
-    <script type="module" src="src/main.js?v=14"></script>
+    <script type="module" src="src/main.js?v=15"></script>
 </body>
 
 </html>

--- a/labs/river-knight/index.html
+++ b/labs/river-knight/index.html
@@ -27,7 +27,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;600;700;800&family=Outfit:wght@300;400;500;600;700&display=swap"
         rel="stylesheet">
     <link rel="stylesheet" href="/labs/shared.css?v=6">
-    <link rel="stylesheet" href="style.css?v=4">
+    <link rel="stylesheet" href="style.css?v=5">
 
     <script type="importmap">
     {
@@ -100,6 +100,7 @@
                 <span class="reticle-dot"></span>
                 <span id="reticleLabel" class="reticle-label"></span>
             </div>
+            <p id="hintBar" class="hint-bar" aria-hidden="true">Aponte o navio e clique — a mira trava sozinha nos inimigos</p>
             <div class="throw-meter" title="Canhão pronto">
                 <i id="throwFill"></i>
             </div>
@@ -141,9 +142,8 @@
                 <header class="menu-head">
                     <p class="eyebrow"><i></i> three.js · ondas de Gerstner · céu procedural</p>
                     <h1>River <span>Knight</span></h1>
-                    <p class="lede">A princesa está presa na torre de Morvain. Entre o seu drakkar e o
-                        castelo há quatro quilômetros de rio, arqueiros nas margens, barcos de guerra e
-                        uma barcaça negra bloqueando o portão. Reme.</p>
+                    <p class="lede">A princesa está presa na torre de Morvain. O barco já avança — você
+                        aponta, dispara e desvia. A mira trava sozinha no alvo mais próximo.</p>
                 </header>
 
                 <div class="menu-grid">
@@ -248,7 +248,7 @@
     </main>
 
     <script src="/labs/shared.js?v=6" defer></script>
-    <script type="module" src="src/main.js?v=13"></script>
+    <script type="module" src="src/main.js?v=14"></script>
 </body>
 
 </html>

--- a/labs/river-knight/src/castle.js
+++ b/labs/river-knight/src/castle.js
@@ -13,7 +13,7 @@ import {
     woodMaterial
 } from './models.js?v=14';
 import { centerX, halfWidth, terrainHeight } from './river.js';
-import { waterHeight, waterSlope } from './water.js?v=14';
+import { waterHeight, waterSlope } from './water.js?v=15';
 import { COLORS, CASTLE_Z, SCORE } from './config.js?v=14';
 import { clamp, damp, randRange } from './utils.js';
 

--- a/labs/river-knight/src/castle.js
+++ b/labs/river-knight/src/castle.js
@@ -11,10 +11,10 @@ import {
     metalMaterial,
     plainMaterial,
     woodMaterial
-} from './models.js';
+} from './models.js?v=14';
 import { centerX, halfWidth, terrainHeight } from './river.js';
-import { waterHeight, waterSlope } from './water.js';
-import { COLORS, CASTLE_Z, SCORE } from './config.js';
+import { waterHeight, waterSlope } from './water.js?v=14';
+import { COLORS, CASTLE_Z, SCORE } from './config.js?v=14';
 import { clamp, damp, randRange } from './utils.js';
 
 const tmpSlope = { dx: 0, dz: 0 };
@@ -94,45 +94,66 @@ function buildTorch(color = 0xff9a3c, intensity = 9) {
 /** A princesa acenando na janela da torre. */
 function buildPrincess() {
     const group = new THREE.Group();
+    const skin = plainMaterial(0xf0c9a4, 0.75, 0);
+    const hairMat = plainMaterial(0x6b3b1c, 0.8, 0);
+    const gold = metalMaterial(0xf0cf7a, 0.3);
 
-    const dress = new THREE.Mesh(new THREE.ConeGeometry(0.42, 1.1, 12), plainMaterial(COLORS.princess, 0.7, 0.03));
+    const dress = new THREE.Mesh(new THREE.ConeGeometry(0.46, 1.18, 12), plainMaterial(COLORS.princess, 0.7, 0.03));
     dress.position.y = 0.55;
     group.add(dress);
 
-    const bodice = new THREE.Mesh(new THREE.CylinderGeometry(0.17, 0.24, 0.42, 10), plainMaterial(0xb85a8a, 0.7, 0.03));
-    bodice.position.y = 1.18;
+    const hem = new THREE.Mesh(new THREE.TorusGeometry(0.42, 0.03, 6, 14), metalMaterial(0xf3c96b, 0.45));
+    hem.rotation.x = Math.PI / 2;
+    hem.position.y = 0.08;
+    group.add(hem);
+
+    const bodice = new THREE.Mesh(new THREE.CylinderGeometry(0.17, 0.25, 0.44, 10), plainMaterial(0xb85a8a, 0.7, 0.03));
+    bodice.position.y = 1.2;
     group.add(bodice);
 
-    const head = new THREE.Mesh(new THREE.SphereGeometry(0.17, 12, 10), plainMaterial(0xf0c9a4, 0.75, 0));
-    head.position.y = 1.55;
+    const head = new THREE.Mesh(new THREE.SphereGeometry(0.175, 12, 10), skin);
+    head.position.y = 1.58;
     group.add(head);
 
-    const hair = new THREE.Mesh(new THREE.SphereGeometry(0.2, 12, 10, 0, Math.PI * 2, 0, Math.PI * 0.7),
-        plainMaterial(0x6b3b1c, 0.8, 0));
-    hair.position.y = 1.58;
+    for (const sx of [-1, 1]) {
+        const eye = new THREE.Mesh(new THREE.SphereGeometry(0.022, 8, 6), plainMaterial(0x2a1c12, 0.5, 0));
+        eye.position.set(sx * 0.05, 1.6, 0.15);
+        group.add(eye);
+    }
+
+    const hair = new THREE.Mesh(new THREE.SphereGeometry(0.21, 12, 10, 0, Math.PI * 2, 0, Math.PI * 0.7), hairMat);
+    hair.position.y = 1.62;
     group.add(hair);
 
-    const braid = new THREE.Mesh(new THREE.CylinderGeometry(0.07, 0.05, 0.8, 6), plainMaterial(0x6b3b1c, 0.8, 0));
-    braid.position.set(0, 1.25, -0.18);
+    const braid = new THREE.Mesh(new THREE.CylinderGeometry(0.07, 0.045, 0.9, 6), hairMat);
+    braid.position.set(0, 1.22, -0.2);
     group.add(braid);
 
-    const crown = new THREE.Mesh(new THREE.CylinderGeometry(0.14, 0.14, 0.09, 10), metalMaterial(0xf0cf7a, 0.3));
-    crown.position.y = 1.7;
+    const crown = new THREE.Mesh(new THREE.CylinderGeometry(0.15, 0.15, 0.09, 10), gold);
+    crown.position.y = 1.74;
     group.add(crown);
+    for (let i = 0; i < 5; i++) {
+        const a = (i / 5) * Math.PI * 2;
+        const spike = new THREE.Mesh(new THREE.ConeGeometry(0.025, 0.14, 5), gold);
+        spike.position.set(Math.cos(a) * 0.12, 1.84, Math.sin(a) * 0.12);
+        group.add(spike);
+    }
 
     const arm = new THREE.Group();
-    arm.position.set(0.22, 1.36, 0);
-    const armMesh = new THREE.Mesh(new THREE.CylinderGeometry(0.06, 0.055, 0.5, 8), plainMaterial(0xf0c9a4, 0.75, 0));
+    arm.position.set(0.24, 1.38, 0.06);
+    const armMesh = new THREE.Mesh(new THREE.CylinderGeometry(0.06, 0.055, 0.52, 8), skin);
     armMesh.position.y = -0.22;
     arm.add(armMesh);
     group.add(arm);
 
-    const scarf = new THREE.Mesh(new THREE.PlaneGeometry(0.5, 0.22), new THREE.MeshStandardMaterial({
+    const scarf = new THREE.Mesh(new THREE.PlaneGeometry(0.62, 0.28), new THREE.MeshStandardMaterial({
         color: 0xffe9f2,
         side: THREE.DoubleSide,
-        roughness: 0.9
+        roughness: 0.9,
+        emissive: new THREE.Color(0xffc8d8),
+        emissiveIntensity: 0.25
     }));
-    scarf.position.set(0.3, -0.42, 0);
+    scarf.position.set(0.32, -0.44, 0.04);
     arm.add(scarf);
 
     group.traverse((c) => {

--- a/labs/river-knight/src/config.js
+++ b/labs/river-knight/src/config.js
@@ -15,30 +15,30 @@ export const CASTLE_Z = -COURSE_LENGTH;
 export const BOSS_Z = CASTLE_Z + 240;
 
 export const BOAT = {
-    baseSpeed: 26,
-    boostSpeed: 41,
-    brakeSpeed: 13,
-    accel: 16,
-    strafeSpeed: 15.5,
-    strafeAccel: 46,
+    baseSpeed: 32,
+    boostSpeed: 49,
+    brakeSpeed: 15,
+    accel: 18,
+    strafeSpeed: 17.5,
+    strafeAccel: 52,
     maxHull: 5,
     /** Recarga de canhão (uma salva). */
-    throwCooldown: 0.78,
-    furyCooldown: 0.34,
-    invulnAfterHit: 1.4,
-    bankLimitPadding: 3.4
+    throwCooldown: 0.56,
+    furyCooldown: 0.26,
+    invulnAfterHit: 1.65,
+    bankLimitPadding: 3.2
 };
 
 /** Canhão de bordo — mira automática (estilo jogos de navio). */
 export const CANNON = {
-    speed: 108,
+    speed: 118,
     gravity: 11,
     life: 3.4,
     damage: 1,
     /** Alcance de trava automática. */
-    assistRange: 155,
-    /** Cone bem amplo (~87°): só precisa apontar o navio. */
-    assistCone: 0.05,
+    assistRange: 175,
+    /** Cone bem amplo: só precisa apontar o navio. */
+    assistCone: 0.02,
     loft: 6.2,
     ballRadius: 1.85
 };
@@ -51,8 +51,8 @@ export const DIFFICULTY = {
         id: 'squire',
         label: 'Escudeiro',
         blurb: 'Rio calmo, inimigos raros. Ideal para conhecer o trecho.',
-        spawnScale: 0.68,
-        enemyFireScale: 0.72,
+        spawnScale: 0.62,
+        enemyFireScale: 0.58,
         damageScale: 1,
         hull: 6,
         scoreScale: 0.8
@@ -106,22 +106,28 @@ export const QUALITY = {
         terrainSegments: 150,
         waterSegments: 110,
         scatterScale: 0.5,
-        fogDensity: 0.0024,
-        drawDistance: 620
+        fogDensity: 0.0022,
+        drawDistance: 620,
+        pointLights: false,
+        reeds: 160,
+        birds: 0
     },
     medium: {
         id: 'medium',
         label: 'Equilibrada',
-        pixelRatio: 1.35,
+        pixelRatio: 1.25,
         antialias: true,
         shadows: true,
         shadowSize: 1536,
         bloom: true,
-        terrainSegments: 216,
-        waterSegments: 168,
-        scatterScale: 0.8,
-        fogDensity: 0.0017,
-        drawDistance: 900
+        terrainSegments: 200,
+        waterSegments: 156,
+        scatterScale: 0.85,
+        fogDensity: 0.0015,
+        drawDistance: 900,
+        pointLights: false,
+        reeds: 280,
+        birds: 10
     },
     high: {
         id: 'high',
@@ -131,11 +137,14 @@ export const QUALITY = {
         shadows: true,
         shadowSize: 2048,
         bloom: true,
-        terrainSegments: 268,
-        waterSegments: 220,
+        terrainSegments: 248,
+        waterSegments: 200,
         scatterScale: 1,
-        fogDensity: 0.0014,
-        drawDistance: 1150
+        fogDensity: 0.00125,
+        drawDistance: 1150,
+        pointLights: true,
+        reeds: 380,
+        birds: 14
     }
 };
 
@@ -146,52 +155,61 @@ export const QUALITY = {
 export const SKY_STOPS = [
     {
         at: 0,
-        zenith: [0.09, 0.19, 0.38],
-        horizon: [0.52, 0.50, 0.50],
-        ground: [0.11, 0.12, 0.14],
-        sun: [1.0, 0.88, 0.68],
-        sunDir: [0.80, 0.28, -0.53],
-        fog: [0.44, 0.47, 0.54],
-        light: [1.0, 0.94, 0.84],
-        lightIntensity: 1.35,
-        ambient: [0.30, 0.38, 0.52]
+        zenith: [0.16, 0.32, 0.58],
+        horizon: [0.78, 0.72, 0.62],
+        ground: [0.16, 0.18, 0.16],
+        sun: [1.0, 0.93, 0.74],
+        sunDir: [0.62, 0.42, -0.66],
+        fog: [0.62, 0.68, 0.72],
+        light: [1.0, 0.96, 0.88],
+        lightIntensity: 1.72,
+        ambient: [0.38, 0.46, 0.58]
     },
     {
         at: 0.45,
-        zenith: [0.07, 0.16, 0.40],
-        horizon: [0.82, 0.50, 0.24],
-        ground: [0.14, 0.11, 0.10],
-        sun: [1.0, 0.74, 0.38],
-        sunDir: [0.90, 0.20, -0.39],
-        fog: [0.52, 0.38, 0.30],
-        light: [1.0, 0.80, 0.56],
-        lightIntensity: 1.5,
-        ambient: [0.30, 0.32, 0.46]
+        zenith: [0.10, 0.22, 0.48],
+        horizon: [0.92, 0.58, 0.28],
+        ground: [0.16, 0.12, 0.10],
+        sun: [1.0, 0.78, 0.42],
+        sunDir: [0.84, 0.28, -0.46],
+        fog: [0.58, 0.42, 0.32],
+        light: [1.0, 0.84, 0.58],
+        lightIntensity: 1.68,
+        ambient: [0.36, 0.34, 0.44]
     },
     {
         at: 0.82,
-        zenith: [0.035, 0.055, 0.17],
-        horizon: [0.60, 0.21, 0.14],
-        ground: [0.09, 0.06, 0.08],
-        sun: [1.0, 0.46, 0.22],
-        sunDir: [0.62, 0.11, -0.78],
-        fog: [0.27, 0.15, 0.17],
-        light: [1.0, 0.56, 0.34],
-        lightIntensity: 1.25,
-        ambient: [0.20, 0.21, 0.36]
+        zenith: [0.05, 0.08, 0.22],
+        horizon: [0.72, 0.28, 0.16],
+        ground: [0.10, 0.06, 0.07],
+        sun: [1.0, 0.52, 0.24],
+        sunDir: [0.58, 0.16, -0.80],
+        fog: [0.30, 0.16, 0.16],
+        light: [1.0, 0.60, 0.36],
+        lightIntensity: 1.38,
+        ambient: [0.24, 0.22, 0.36]
     },
     {
         at: 1,
-        zenith: [0.018, 0.026, 0.085],
-        horizon: [0.32, 0.10, 0.11],
+        zenith: [0.022, 0.032, 0.10],
+        horizon: [0.38, 0.12, 0.12],
         ground: [0.05, 0.035, 0.055],
-        sun: [1.0, 0.36, 0.18],
-        sunDir: [0.34, 0.05, -0.94],
-        fog: [0.14, 0.08, 0.11],
-        light: [1.0, 0.44, 0.28],
-        lightIntensity: 1.05,
-        ambient: [0.16, 0.17, 0.32]
+        sun: [1.0, 0.40, 0.20],
+        sunDir: [0.32, 0.08, -0.94],
+        fog: [0.16, 0.08, 0.10],
+        light: [1.0, 0.48, 0.30],
+        lightIntensity: 1.12,
+        ambient: [0.18, 0.18, 0.32]
     }
+];
+
+/** Batidas narrativas — o rio deixa de ser um corredor vazio. */
+export const LANDMARKS = [
+    { at: 0.04, text: 'O vale de Eld' },
+    { at: 0.22, text: 'As corredeiras' },
+    { at: 0.48, text: 'As torres de vigia' },
+    { at: 0.72, text: 'O desfiladeiro de Morvain' },
+    { at: 0.90, text: 'As muralhas à vista!' }
 ];
 
 export const COLORS = {

--- a/labs/river-knight/src/effects.js
+++ b/labs/river-knight/src/effects.js
@@ -9,7 +9,7 @@
 
 import * as THREE from 'three';
 import { sparkTexture, smokeTexture, foamTexture } from './textures.js?v=14';
-import { waterHeight } from './water.js?v=14';
+import { waterHeight } from './water.js?v=15';
 
 /* ------------------------------------------------------------------ */
 /* Partículas                                                          */

--- a/labs/river-knight/src/effects.js
+++ b/labs/river-knight/src/effects.js
@@ -8,8 +8,8 @@
  */
 
 import * as THREE from 'three';
-import { sparkTexture, smokeTexture, foamTexture } from './textures.js';
-import { waterHeight } from './water.js';
+import { sparkTexture, smokeTexture, foamTexture } from './textures.js?v=14';
+import { waterHeight } from './water.js?v=14';
 
 /* ------------------------------------------------------------------ */
 /* Partículas                                                          */
@@ -270,7 +270,7 @@ class Wake {
             const px = -dz;
             const pz = dx;
 
-            const w = Math.min(s.width, 4.2);
+            const w = Math.min(s.width, 5.2);
             const y = waterHeight(s.x, s.z, time) + 0.04;
             this.positions[a] = s.x - px * w;
             this.positions[a + 1] = y;
@@ -285,7 +285,7 @@ class Wake {
             this.uvs[u + 3] = idx / this.samples;
 
             const headFade = Math.min(1, s.age / 0.35);
-            const fade = Math.max(0, 1 - s.age / 3.3) ** 1.45 * s.strength * 0.7 * headFade;
+            const fade = Math.max(0, 1 - s.age / 3.3) ** 1.45 * s.strength * 0.85 * headFade;
             this.alphas[i * 2] = fade;
             this.alphas[i * 2 + 1] = fade;
         }

--- a/labs/river-knight/src/entities.js
+++ b/labs/river-knight/src/entities.js
@@ -16,10 +16,10 @@ import {
     buildArrowMesh,
     buildCannonballMesh,
     plainMaterial
-} from './models.js?v=12';
-import { waterHeight, waterSlope } from './water.js';
+} from './models.js?v=14';
+import { waterHeight, waterSlope } from './water.js?v=14';
 import { centerX, halfWidth, terrainHeight } from './river.js';
-import { CANNON, SCORE } from './config.js?v=12';
+import { CANNON, SCORE } from './config.js?v=14';
 import { clamp, damp, randRange } from './utils.js';
 
 const tmpSlope = { dx: 0, dz: 0 };
@@ -168,8 +168,8 @@ class EnemyShip extends Entity {
 /* ================================================================== */
 
 class Tower extends Entity {
-    constructor() {
-        super(buildWatchtower());
+    constructor(lit = true) {
+        super(buildWatchtower({ lit }));
         this.kind = 'tower';
         this.radius = 3.4;
         this.maxHp = 4;
@@ -204,8 +204,8 @@ class Tower extends Entity {
             const s = 0.85 + Math.sin(ctx.time * 9 + pos.x) * 0.15;
             fire.scale.set(s, s * 1.25, s);
         }
-        if (Math.random() < 0.35) {
-            ctx.effects.fire(pos.x, pos.y + 11, pos.z, 1, 0.9);
+        if (dz > -90 && dz < 12 && Math.random() < 0.035) {
+            ctx.effects.fire(pos.x, pos.y + 11, pos.z, 1, 0.85);
         }
 
         const dz = pos.z - ctx.player.z;
@@ -476,8 +476,8 @@ class Arrow extends Entity {
             const s = 0.9 + Math.sin(ctx.time * 24) * 0.2;
             flame.scale.set(s, s, s * 1.8);
         }
-        if (Math.random() < 0.7) {
-            ctx.effects.fire(this.group.position.x, this.group.position.y, this.group.position.z, 1, 0.5);
+        if (Math.random() < 0.05) {
+            ctx.effects.fire(this.group.position.x, this.group.position.y, this.group.position.z, 1, 0.45);
         }
 
         this.life -= dt;
@@ -557,7 +557,7 @@ export class Entities {
         };
 
         make('enemyShips', () => new EnemyShip(), POOL_SIZES.enemyShips);
-        make('towers', () => new Tower(), POOL_SIZES.towers);
+        make('towers', () => new Tower(quality.pointLights), POOL_SIZES.towers);
         make('barricades', () => new Barricade(), POOL_SIZES.barricades);
         make('rocks', (i) => new RockObstacle(i), POOL_SIZES.rocks);
         make('whirlpools', () => new Whirlpool(), POOL_SIZES.whirlpools);

--- a/labs/river-knight/src/entities.js
+++ b/labs/river-knight/src/entities.js
@@ -17,7 +17,7 @@ import {
     buildCannonballMesh,
     plainMaterial
 } from './models.js?v=14';
-import { waterHeight, waterSlope } from './water.js?v=14';
+import { waterHeight, waterSlope } from './water.js?v=15';
 import { centerX, halfWidth, terrainHeight } from './river.js';
 import { CANNON, SCORE } from './config.js?v=14';
 import { clamp, damp, randRange } from './utils.js';
@@ -204,11 +204,12 @@ class Tower extends Entity {
             const s = 0.85 + Math.sin(ctx.time * 9 + pos.x) * 0.15;
             fire.scale.set(s, s * 1.25, s);
         }
+
+        const dz = pos.z - ctx.player.z;
         if (dz > -90 && dz < 12 && Math.random() < 0.035) {
             ctx.effects.fire(pos.x, pos.y + 11, pos.z, 1, 0.85);
         }
 
-        const dz = pos.z - ctx.player.z;
         this.fireTimer -= dt;
         if (this.fireTimer <= 0 && dz < 6 && dz > -150) {
             this.fireTimer = this.fireRate * randRange(0.85, 1.2);

--- a/labs/river-knight/src/hud.js
+++ b/labs/river-knight/src/hud.js
@@ -4,7 +4,7 @@
  */
 
 import { formatTime } from './utils.js';
-import { DIFFICULTY } from './config.js';
+import { DIFFICULTY } from './config.js?v=14';
 
 const $ = (id) => document.getElementById(id);
 
@@ -33,6 +33,7 @@ export class Hud {
             reticle: $('reticle'),
             reticleLabel: $('reticleLabel'),
             throwFill: $('throwFill'),
+            hintBar: $('hintBar'),
 
             loading: $('loadingOverlay'),
             loadingFill: $('loadingFill'),
@@ -179,8 +180,12 @@ export class Hud {
         }, 90);
     }
 
-    /** Mira: trava visual quando há torre/inimigo no cone. */
-    setAim(lock) {
+    /** Mira: trava visual quando há torre/inimigo no cone. xPct/yPct em 0–100. */
+    setAim(lock, xPct = 50, yPct = 46) {
+        if (this.el.hud) {
+            this.el.hud.style.setProperty('--aim-x', `${xPct}%`);
+            this.el.hud.style.setProperty('--aim-y', `${yPct}%`);
+        }
         if (!this.el.reticle) return;
         const locked = Boolean(lock);
         this.el.reticle.dataset.lock = String(locked);
@@ -191,6 +196,11 @@ export class Hud {
         }
         const labels = { towers: 'Torre', enemyShips: 'Navio', barricades: 'Barricada' };
         this.el.reticleLabel.textContent = labels[lock.kind] || 'Alvo';
+    }
+
+    setHint(visible) {
+        if (!this.el.hintBar) return;
+        this.el.hintBar.classList.toggle('is-on', Boolean(visible));
     }
 
     /** 0 = recarregando, 1 = canhão pronto. */

--- a/labs/river-knight/src/main.js
+++ b/labs/river-knight/src/main.js
@@ -12,30 +12,31 @@ import {
     COURSE_LENGTH,
     CASTLE_Z,
     BOSS_Z,
+    LANDMARKS,
     STORAGE_KEY,
     BOAT
-} from './config.js?v=12';
-import { createSky, createSkyUniforms, sampleSkyPalette, applySkyPalette } from './sky.js';
-import { createWater, waterHeight } from './water.js';
-import { createTerrain } from './terrain.js';
-import { Effects } from './effects.js?v=12';
-import { Entities } from './entities.js?v=12';
-import { World } from './world.js';
-import { Player } from './player.js?v=12';
-import { createCastle, BossBarge } from './castle.js';
-import { Hud } from './hud.js';
+} from './config.js?v=14';
+import { createSky, createSkyUniforms, sampleSkyPalette, applySkyPalette } from './sky.js?v=14';
+import { createWater, waterHeight } from './water.js?v=14';
+import { createTerrain } from './terrain.js?v=14';
+import { Effects } from './effects.js?v=14';
+import { Entities } from './entities.js?v=14';
+import { World } from './world.js?v=14';
+import { Player } from './player.js?v=14';
+import { createCastle, BossBarge } from './castle.js?v=14';
+import { Hud } from './hud.js?v=14';
 import { Input } from './input.js';
-import { GameAudio } from './audio.js?v=12';
-import { updateCloth } from './models.js?v=12';
+import { GameAudio } from './audio.js?v=14';
+import { updateCloth } from './models.js?v=14';
 import { centerX, halfWidth } from './river.js';
 import { clamp, damp, detectMobile, formatTime, randRange } from './utils.js';
 
 const WHITE = new THREE.Color(1, 1, 1);
 
 const CAMERA_MODES = [
-    { name: 'perseguição', offset: new THREE.Vector3(0, 9.4, 20.5), look: new THREE.Vector3(0, 4.8, -12) },
-    { name: 'proa', offset: new THREE.Vector3(0, 7.2, 15.5), look: new THREE.Vector3(0, 3.6, -22) },
-    { name: 'aérea', offset: new THREE.Vector3(0, 17, 30), look: new THREE.Vector3(0, 1.5, -12) }
+    { name: 'perseguição', offset: new THREE.Vector3(0, 6.35, 13.0), look: new THREE.Vector3(0, 3.05, -14) },
+    { name: 'proa', offset: new THREE.Vector3(0, 5.4, 10.4), look: new THREE.Vector3(0, 2.7, -20) },
+    { name: 'aérea', offset: new THREE.Vector3(0, 15, 26), look: new THREE.Vector3(0, 1.5, -14) }
 ];
 
 class Game {
@@ -60,6 +61,10 @@ class Game {
         this.fpsFrames = 0;
         this.hudAccum = 0;
         this.pullVec = { x: 0, drag: 0 };
+        this.landmarkIndex = 0;
+        this.fpsLowTime = 0;
+        this.adapted = false;
+        this._aimNdc = new THREE.Vector3();
     }
 
     /* ------------------------------------------------------------------ */
@@ -129,13 +134,13 @@ class Game {
         this.renderer.setPixelRatio(pixelRatio);
         this.renderer.setSize(window.innerWidth, window.innerHeight, false);
         this.renderer.toneMapping = THREE.ACESFilmicToneMapping;
-        this.renderer.toneMappingExposure = 0.98;
+        this.renderer.toneMappingExposure = 1.06;
         this.renderer.shadowMap.enabled = quality.shadows;
         this.renderer.shadowMap.type = THREE.PCFShadowMap;
 
         this.scene = new THREE.Scene();
         this.camera = new THREE.PerspectiveCamera(
-            58,
+            62,
             window.innerWidth / window.innerHeight,
             0.4,
             quality.drawDistance * 3.2
@@ -171,7 +176,7 @@ class Game {
 
         // Luz de preenchimento presa à câmera: sem ela o barco fica só silhueta
         // quando o sol está de frente.
-        this.fill = new THREE.DirectionalLight(0xbcd2ff, 0.55);
+        this.fill = new THREE.DirectionalLight(0xc5d8ff, 0.7);
         this.fill.castShadow = false;
         this.scene.add(this.fill, this.fill.target);
 
@@ -245,9 +250,9 @@ class Game {
 
             const bloom = new UnrealBloomPass(
                 new THREE.Vector2(window.innerWidth, window.innerHeight),
-                0.30,
-                0.75,
-                0.92
+                0.18,
+                0.7,
+                0.88
             );
             composer.addPass(bloom);
             composer.addPass(new OutputPass());
@@ -345,6 +350,7 @@ class Game {
         this.hud.showMenu();
         this.hud.setTouchVisible(false);
         this.hud.clearMessage();
+        this.hud.setHint(false);
         this.hud.showBoss(false);
         this.hud.setBestScore(this.settings.best);
 
@@ -385,6 +391,8 @@ class Game {
         this.victoryTimer = 0;
         this.defeatTimer = 0;
         this.cameraMode = 0;
+        this.landmarkIndex = 0;
+        this.hud.setHint(true);
 
         this.entities.reset();
         this.boss.reset();
@@ -399,7 +407,7 @@ class Game {
         this.hud.setScore(0);
         this.hud.setCombo(1);
         this.hud.setTime(0);
-        this.hud.message('Rumo ao castelo!', 'gold', 1800);
+        this.hud.message('Rumo ao castelo — aponte o navio e dispare!', 'gold', 2200);
 
         this.updateCamera(1, true);
     }
@@ -510,7 +518,18 @@ class Game {
         this.fpsAccum += raw;
         this.fpsFrames++;
         if (this.fpsAccum > 0.5) {
-            this.hud.setFps(this.fpsFrames / this.fpsAccum);
+            const fps = this.fpsFrames / this.fpsAccum;
+            this.hud.setFps(fps);
+            if (this.state === 'playing' && !this.adapted) {
+                if (fps < 38) this.fpsLowTime += 0.5;
+                else this.fpsLowTime = Math.max(0, this.fpsLowTime - 0.35);
+                if (this.fpsLowTime > 2.2) {
+                    this.adapted = true;
+                    this.renderer.setPixelRatio(Math.min(this.renderer.getPixelRatio(), 1.05));
+                    this.composer = null;
+                    this.hud.message('Qualidade ajustada para o rio fluir', 'gold', 2400);
+                }
+            }
             this.fpsAccum = 0;
             this.fpsFrames = 0;
         }
@@ -548,7 +567,7 @@ class Game {
 
     updateIdle(dt) {
         // Telas finais: o rio continua vivo ao fundo.
-        this.world.update(dt, this.time, this.player.z);
+        this.world.update(dt, this.time, this.player.z, this.effects);
         this.entities.update(dt, this.makeContext(dt));
         this.castle.update(dt, this.time);
         this.updateCamera(dt);
@@ -582,7 +601,7 @@ class Game {
         this.camera.position.set(cx, wy + 9 + Math.sin(this.menuAngle * 2) * 2.2, cz);
         this.camera.lookAt(p.x, wy + 2.6, p.z);
 
-        this.world.update(dt, this.time, p.z);
+        this.world.update(dt, this.time, p.z, this.effects);
         this.castle.update(dt, this.time);
     }
 
@@ -640,10 +659,18 @@ class Game {
 
         this.player.update(dt, ctx);
 
-        // Mira automática — só aponta o navio; a retícula trava sozinha.
+        // Mira automática — a retícula segue o alvo no mundo.
         {
             const lock = this.player.getAimLock(this.entities);
-            this.hud.setAim(lock);
+            if (lock) {
+                this._aimNdc.set(lock.x, lock.y, lock.z).project(this.camera);
+                const x = (this._aimNdc.x * 0.5 + 0.5) * 100;
+                const y = (-this._aimNdc.y * 0.5 + 0.5) * 100;
+                const onScreen = this._aimNdc.z < 1 && x > 8 && x < 92 && y > 10 && y < 88;
+                this.hud.setAim(lock, onScreen ? x : 50, onScreen ? y : 46);
+            } else {
+                this.hud.setAim(null, 50, 46);
+            }
             const cd = this.player.hasFury ? BOAT.furyCooldown : BOAT.throwCooldown;
             const ready = 1 - clamp(this.player.throwTimer / cd, 0, 1);
             this.hud.setThrowReady(ready);
@@ -666,7 +693,7 @@ class Game {
         }
 
         this.world.direct(this.player.z, this.entities, this.difficulty);
-        this.world.update(dt, this.time, this.player.z);
+        this.world.update(dt, this.time, this.player.z, this.effects);
         this.entities.update(dt, ctx);
         this.entities.resolveAxeHits(ctx);
         this.castle.update(dt, this.time);
@@ -682,6 +709,13 @@ class Game {
         }
 
         this.score += this.player.speed * dt * SCORE.distancePerMeter * (this.difficulty?.scoreScale ?? 1);
+
+        const progress = clamp(this.player.distance / COURSE_LENGTH, 0, 1);
+        while (this.landmarkIndex < LANDMARKS.length && progress >= LANDMARKS[this.landmarkIndex].at) {
+            this.hud.message(LANDMARKS[this.landmarkIndex].text, 'gold', 2400);
+            this.landmarkIndex++;
+        }
+        if (this.elapsed > 8) this.hud.setHint(false);
 
         if (!this.player.alive) {
             this.gameOver();
@@ -915,7 +949,7 @@ class Game {
             this.effects.smokePuff(p.x, p.root.position.y + 2, p.z, 1, 1.8);
         }
 
-        this.world.update(dt, this.time, p.z);
+        this.world.update(dt, this.time, p.z, this.effects);
         this.entities.update(dt, this.makeContext(dt));
         this.castle.update(dt, this.time);
         this.updateCamera(dt);
@@ -927,7 +961,7 @@ class Game {
         this.victoryTimer += dt;
         const ctx = this.makeContext(dt);
         this.player.update(dt, ctx);
-        this.world.update(dt, this.time, this.player.z);
+        this.world.update(dt, this.time, this.player.z, this.effects);
         this.entities.update(dt, ctx);
         this.castle.update(dt, this.time);
 
@@ -1012,6 +1046,14 @@ class Game {
             p.position.z + lookZ
         );
         this.camera.lookAt(this.lookTarget);
+
+        if (this.state === 'playing') {
+            const span = Math.max(1, BOAT.boostSpeed - BOAT.baseSpeed);
+            const boostT = clamp((p.speed - BOAT.baseSpeed) / span, 0, 1);
+            const fov = 61 + boostT * 7 + Math.abs(p.roll) * 8;
+            this.camera.fov = damp(this.camera.fov, fov, 3.4, dt);
+            this.camera.updateProjectionMatrix();
+        }
     }
 
     updateEnvironment(dt) {

--- a/labs/river-knight/src/main.js
+++ b/labs/river-knight/src/main.js
@@ -17,10 +17,10 @@ import {
     BOAT
 } from './config.js?v=14';
 import { createSky, createSkyUniforms, sampleSkyPalette, applySkyPalette } from './sky.js?v=14';
-import { createWater, waterHeight } from './water.js?v=14';
+import { createWater, waterHeight } from './water.js?v=15';
 import { createTerrain } from './terrain.js?v=14';
-import { Effects } from './effects.js?v=14';
-import { Entities } from './entities.js?v=14';
+import { Effects } from './effects.js?v=15';
+import { Entities } from './entities.js?v=15';
 import { World } from './world.js?v=14';
 import { Player } from './player.js?v=14';
 import { createCastle, BossBarge } from './castle.js?v=14';
@@ -29,7 +29,7 @@ import { Input } from './input.js';
 import { GameAudio } from './audio.js?v=14';
 import { updateCloth } from './models.js?v=14';
 import { centerX, halfWidth } from './river.js';
-import { clamp, damp, detectMobile, formatTime, randRange } from './utils.js';
+import { clamp, damp, detectMobile, detectSoftwareGL, formatTime, randRange } from './utils.js?v=15';
 
 const WHITE = new THREE.Color(1, 1, 1);
 
@@ -98,7 +98,7 @@ class Game {
     resolveQuality() {
         const choice = this.settings.quality;
         if (choice !== 'auto' && QUALITY[choice]) return QUALITY[choice];
-        if (detectMobile()) return QUALITY.low;
+        if (detectMobile() || detectSoftwareGL()) return QUALITY.low;
         const big = Math.min(window.innerWidth, window.innerHeight) >= 900;
         return big ? QUALITY.high : QUALITY.medium;
     }
@@ -523,7 +523,7 @@ class Game {
             if (this.state === 'playing' && !this.adapted) {
                 if (fps < 38) this.fpsLowTime += 0.5;
                 else this.fpsLowTime = Math.max(0, this.fpsLowTime - 0.35);
-                if (this.fpsLowTime > 2.2) {
+                if (this.fpsLowTime > 1.2) {
                     this.adapted = true;
                     this.renderer.setPixelRatio(Math.min(this.renderer.getPixelRatio(), 1.05));
                     this.composer = null;
@@ -542,22 +542,26 @@ class Game {
         this.time += dt;
         updateCloth(this.time);
 
-        switch (this.state) {
-            case 'menu':
-                this.updateMenu(dt);
-                break;
-            case 'playing':
-                this.updatePlaying(dt);
-                break;
-            case 'defeat':
-                this.updateDefeat(dt);
-                break;
-            case 'victory-seq':
-                this.updateVictorySequence(dt);
-                break;
-            default:
-                this.updateIdle(dt);
-                break;
+        try {
+            switch (this.state) {
+                case 'menu':
+                    this.updateMenu(dt);
+                    break;
+                case 'playing':
+                    this.updatePlaying(dt);
+                    break;
+                case 'defeat':
+                    this.updateDefeat(dt);
+                    break;
+                case 'victory-seq':
+                    this.updateVictorySequence(dt);
+                    break;
+                default:
+                    this.updateIdle(dt);
+                    break;
+            }
+        } catch (err) {
+            console.error('[River Knight]', err);
         }
 
         this.effects.update(dt, this.time);

--- a/labs/river-knight/src/models.js
+++ b/labs/river-knight/src/models.js
@@ -7,8 +7,8 @@
  */
 
 import * as THREE from 'three';
-import { COLORS } from './config.js';
-import { woodTexture, sailTexture, shieldTexture, stoneTexture, bannerTexture } from './textures.js';
+import { COLORS } from './config.js?v=14';
+import { woodTexture, sailTexture, shieldTexture, stoneTexture, bannerTexture } from './textures.js?v=14';
 
 /* ------------------------------------------------------------------ */
 /* Materiais                                                           */
@@ -117,7 +117,46 @@ export function clothMaterial({ map = null, color = 0xffffff, side = THREE.Doubl
     return material;
 }
 
-/** Avança a animação de todos os tecidos criados. */
+/** Vento barato em árvores/juncos instanciados (desloca o topo no vertex shader). */
+export function applyVegetationWind(material, amount = 0.11) {
+    material.userData.uniforms = {
+        uTime: { value: 0 },
+        uWind: { value: amount }
+    };
+    material.onBeforeCompile = (shader) => {
+        shader.uniforms.uTime = material.userData.uniforms.uTime;
+        shader.uniforms.uWind = material.userData.uniforms.uWind;
+        shader.vertexShader = shader.vertexShader
+            .replace(
+                '#include <common>',
+                /* glsl */ `
+                #include <common>
+                uniform float uTime;
+                uniform float uWind;
+                `
+            )
+            .replace(
+                '#include <begin_vertex>',
+                /* glsl */ `
+                #include <begin_vertex>
+                float rkH = max(transformed.y, 0.0);
+                #ifdef USE_INSTANCING
+                vec3 rkOrig = instanceMatrix[3].xyz;
+                #else
+                vec3 rkOrig = vec3(0.0);
+                #endif
+                float rkB = sin(uTime * 1.28 + rkOrig.x * 0.16 + rkOrig.z * 0.12) * uWind * rkH;
+                transformed.x += rkB;
+                transformed.z += rkB * 0.55;
+                `
+            );
+    };
+    material.customProgramCacheKey = () => 'river-knight-veg-wind';
+    registerCloth(material);
+    return material;
+}
+
+/** Avança a animação de todos os tecidos e da vegetação. */
 const clothMaterials = new Set();
 export function registerCloth(material) {
     clothMaterials.add(material);
@@ -269,36 +308,43 @@ export function buildDeckGeometry({
 function buildDragonHead(color) {
     const group = new THREE.Group();
     const mat = woodMaterial(true, color);
+    const dark = woodMaterial(true, 0x2a1810);
 
-    const neck = new THREE.Mesh(new THREE.CylinderGeometry(0.16, 0.26, 1.5, 10), mat);
-    neck.rotation.x = -0.35;
-    neck.position.y = 0.7;
+    const neck = new THREE.Mesh(new THREE.CylinderGeometry(0.13, 0.24, 1.65, 8), mat);
+    neck.rotation.x = -0.42;
+    neck.position.set(0, 0.72, 0.15);
     group.add(neck);
 
-    const skull = new THREE.Mesh(new THREE.BoxGeometry(0.42, 0.4, 0.95), mat);
-    skull.position.set(0, 1.42, 0.42);
-    skull.rotation.x = 0.25;
+    const skull = new THREE.Mesh(new THREE.SphereGeometry(0.28, 10, 8), mat);
+    skull.scale.set(0.85, 0.78, 1.15);
+    skull.position.set(0, 1.48, 0.55);
     group.add(skull);
 
-    const snout = new THREE.Mesh(new THREE.BoxGeometry(0.3, 0.24, 0.55), mat);
-    snout.position.set(0, 1.3, 1.0);
-    snout.rotation.x = 0.25;
+    const snout = new THREE.Mesh(new THREE.ConeGeometry(0.18, 0.72, 8), mat);
+    snout.rotation.x = Math.PI / 2;
+    snout.position.set(0, 1.38, 1.12);
     group.add(snout);
 
-    // Crista de espinhos.
-    for (let i = 0; i < 4; i++) {
-        const spike = new THREE.Mesh(new THREE.ConeGeometry(0.09, 0.34, 6), mat);
-        spike.position.set(0, 1.6 - i * 0.06, 0.1 - i * 0.28);
-        spike.rotation.x = -0.5;
+    const jaw = new THREE.Mesh(new THREE.BoxGeometry(0.22, 0.08, 0.42), dark);
+    jaw.position.set(0, 1.22, 0.95);
+    jaw.rotation.x = 0.18;
+    group.add(jaw);
+
+    for (let i = 0; i < 5; i++) {
+        const spike = new THREE.Mesh(new THREE.ConeGeometry(0.07, 0.32, 5), dark);
+        spike.position.set(0, 1.72 - i * 0.07, 0.22 - i * 0.22);
+        spike.rotation.x = -0.55;
         group.add(spike);
     }
 
-    // Olhos brilhantes.
     const eyeMat = plainMaterial(0xffb347, 0.3, 0, 0xff7a1a, 2.4);
     for (const sx of [-1, 1]) {
-        const eye = new THREE.Mesh(new THREE.SphereGeometry(0.07, 8, 8), eyeMat);
-        eye.position.set(sx * 0.17, 1.46, 0.72);
+        const eye = new THREE.Mesh(new THREE.SphereGeometry(0.055, 8, 6), eyeMat);
+        eye.position.set(sx * 0.16, 1.54, 0.78);
         group.add(eye);
+        const nostril = new THREE.Mesh(new THREE.SphereGeometry(0.035, 6, 5), dark);
+        nostril.position.set(sx * 0.07, 1.34, 1.38);
+        group.add(nostril);
     }
 
     return group;
@@ -330,7 +376,6 @@ export function buildLongship({
     hull.castShadow = true;
     hull.receiveShadow = true;
     hull.material.side = THREE.DoubleSide;
-    hull.material.color.multiplyScalar(0.88);
     group.add(hull);
     parts.hull = hull;
 
@@ -393,9 +438,10 @@ export function buildLongship({
         group.add(plank);
     }
 
-    // Anteparas na proa/popa (bem nas pontas) — bloqueiam o túnel para a água.
+    // Anteparas internas — a popa usa o transom dedicado (abaixo), para a
+    // câmera de perseguição não bater num muro marrom na frente do guerreiro.
     const bulkMat = woodMaterial(true, 0x2e1c12);
-    for (const t of [-0.94, -0.55, 0.55, 0.94]) {
+    for (const t of [-0.55, 0.55, 0.94]) {
         const { hw, sheer, dep, z } = hullShapeAt(t, { length, beam });
         const deckY = sheer - deckDrop;
         const bilge = sheer - dep * 0.85;
@@ -406,9 +452,9 @@ export function buildLongship({
         group.add(bulk);
     }
 
-    // Espelho de popa/proa — a câmera de perseguição olha para dentro do U;
-    // sem painel sólido a água atravessa o casco.
-    for (const t of [-0.995, 0.995]) {
+    // Tampão da proa — bloqueia o túnel para a água. A popa fica a cargo do transom.
+    {
+        const t = 0.995;
         const { hw, sheer, dep, z } = hullShapeAt(t, { length, beam });
         const bilge = sheer - dep;
         const h = Math.max(1.15, sheer - bilge + 0.6);
@@ -421,64 +467,61 @@ export function buildLongship({
         group.add(panel);
     }
 
-    // Plataforma de popa (guerreiro) — fecha o túnel que a câmera vê.
+    // Plataforma de popa: o tampão fica SÓ abaixo do convés para a água não
+    // atravessar, e a câmera de perseguição vê o guerreiro, o mastro e a vela.
     {
         const sternMat = woodMaterial(true, 0x4a3222);
         const sternDark = woodMaterial(true, 0x2a1a12);
 
-        // Bloco único da quilha ao peitoril, da popa até midships.
-        // Centro alto o bastante para o topo ficar acima da linha d'água.
-        const sternPlug = new THREE.Mesh(
-            new THREE.BoxGeometry(beam * 0.98, 2.4, length * 0.52),
+        const sternBilge = new THREE.Mesh(
+            new THREE.BoxGeometry(beam * 0.82, 0.85, length * 0.38),
             sternDark
         );
-        sternPlug.position.set(0, 0.05, -length * 0.24);
-        sternPlug.raycast = () => {};
-        group.add(sternPlug);
+        sternBilge.position.set(0, -0.98, -length * 0.18);
+        sternBilge.raycast = () => {};
+        group.add(sternBilge);
 
         const platform = new THREE.Mesh(
-            new THREE.BoxGeometry(beam * 0.98, 0.32, length * 0.52),
+            new THREE.BoxGeometry(beam * 0.84, 0.12, length * 0.32),
             sternMat
         );
-        platform.position.set(0, -deckDrop + 0.55, -length * 0.2);
+        platform.position.set(0, -deckDrop + 0.06, -length * 0.2);
         platform.castShadow = true;
         platform.receiveShadow = true;
         group.add(platform);
         parts.sternPlatform = platform;
 
-        // Convés elevado contínuo (leitura de madeira, não de vazio).
-        const aftDeck = new THREE.Mesh(
-            new THREE.BoxGeometry(beam * 1.0, 0.18, length * 0.54),
-            woodMaterial(true, 0x5c3d28)
-        );
-        aftDeck.position.set(0, -deckDrop + 0.7, -length * 0.18);
-        aftDeck.receiveShadow = true;
-        group.add(aftDeck);
-
         const rail = new THREE.Mesh(
-            new THREE.BoxGeometry(beam * 0.96, 0.48, 0.18),
+            new THREE.BoxGeometry(beam * 0.88, 0.32, 0.12),
             woodMaterial(true, 0x3a2618)
         );
-        rail.position.set(0, -deckDrop + 0.98, -length * 0.44);
+        rail.position.set(0, -deckDrop + 0.28, -length * 0.48);
         group.add(rail);
 
         for (const side of [-1, 1]) {
             const cheek = new THREE.Mesh(
-                new THREE.BoxGeometry(0.22, 1.35, length * 0.5),
+                new THREE.BoxGeometry(0.12, 0.48, length * 0.3),
                 woodMaterial(true, 0x3a2618)
             );
-            cheek.position.set(side * beam * 0.46, -deckDrop + 0.35, -length * 0.2);
+            cheek.position.set(side * beam * 0.42, -deckDrop + 0.08, -length * 0.2);
             group.add(cheek);
         }
 
-        // Tampa de popa alta — silhueta fechada vista da câmera de perseguição.
         const transom = new THREE.Mesh(
-            new THREE.BoxGeometry(beam * 0.98, 1.75, 0.32),
+            new THREE.BoxGeometry(beam * 0.9, 1.05, 0.16),
             woodMaterial(true, 0x2e1c12)
         );
-        transom.position.set(0, 0.15, -length * 0.48);
+        transom.position.set(0, -0.28, -length * 0.495);
         transom.castShadow = true;
         group.add(transom);
+
+        const rudder = new THREE.Mesh(
+            new THREE.BoxGeometry(0.08, 1.15, 0.55),
+            woodMaterial(true, 0x3a2618)
+        );
+        rudder.position.set(0, -0.55, -length * 0.52);
+        group.add(rudder);
+        parts.rudder = rudder;
     }
 
     // Sombra de contato na superfície da água (o corpo d'água é opaco).
@@ -602,7 +645,7 @@ export function buildLongship({
     const sailMat = registerCloth(clothMaterial({
         map: sailTexture({ base: sailBase, stripe: sailStripe, emblem }),
         side: THREE.DoubleSide,
-        wind: 0.5
+        wind: 0.82
     }));
     sailMat.transparent = false;
     sailMat.alphaTest = 0;
@@ -793,121 +836,138 @@ export function buildWarrior({ tunic = 0x8c2f3a, cape = 0x7a1f2b } = {}) {
     const leather = plainMaterial(0x4a3524, 0.85, 0.02);
     const skin = plainMaterial(0xd9a77c, 0.75, 0);
     const cloth = plainMaterial(tunic, 0.85, 0);
+    const eyeWhite = plainMaterial(0xf4efe6, 0.4, 0);
+    const iris = plainMaterial(0x2a1c12, 0.5, 0);
 
-    // Pernas.
     for (const sx of [-1, 1]) {
-        const leg = new THREE.Mesh(new THREE.CylinderGeometry(0.115, 0.1, 0.78, 8), leather);
-        leg.position.set(sx * 0.15, 0.39, 0);
+        const leg = new THREE.Mesh(new THREE.CylinderGeometry(0.12, 0.105, 0.82, 8), leather);
+        leg.position.set(sx * 0.16, 0.41, 0.02);
         leg.castShadow = true;
         group.add(leg);
-        const boot = new THREE.Mesh(new THREE.BoxGeometry(0.2, 0.14, 0.34), plainMaterial(0x2e2116, 0.9, 0));
-        boot.position.set(sx * 0.15, 0.07, 0.04);
+        const boot = new THREE.Mesh(new THREE.BoxGeometry(0.22, 0.16, 0.38), plainMaterial(0x2e2116, 0.9, 0));
+        boot.position.set(sx * 0.16, 0.07, 0.06);
         group.add(boot);
     }
 
     const torso = new THREE.Group();
-    torso.position.y = 0.78;
+    torso.position.y = 0.82;
     group.add(torso);
 
-    const chest = new THREE.Mesh(new THREE.CylinderGeometry(0.29, 0.24, 0.62, 10), cloth);
-    chest.position.y = 0.3;
+    const chest = new THREE.Mesh(new THREE.CylinderGeometry(0.31, 0.25, 0.66, 10), cloth);
+    chest.position.y = 0.32;
     chest.castShadow = true;
     torso.add(chest);
 
-    // Cota de malha / peitoral.
-    const plate = new THREE.Mesh(new THREE.CylinderGeometry(0.3, 0.26, 0.36, 10), steel);
-    plate.position.y = 0.42;
+    const plate = new THREE.Mesh(new THREE.CylinderGeometry(0.32, 0.27, 0.38, 10), steel);
+    plate.position.y = 0.46;
     plate.castShadow = true;
     torso.add(plate);
 
-    const belt = new THREE.Mesh(new THREE.CylinderGeometry(0.26, 0.26, 0.1, 10), leather);
+    const crossV = new THREE.Mesh(new THREE.BoxGeometry(0.06, 0.28, 0.04), metalMaterial(0xd4b45a, 0.35));
+    crossV.position.set(0, 0.48, 0.3);
+    torso.add(crossV);
+    const crossH = new THREE.Mesh(new THREE.BoxGeometry(0.18, 0.05, 0.04), metalMaterial(0xd4b45a, 0.35));
+    crossH.position.set(0, 0.5, 0.3);
+    torso.add(crossH);
+
+    const belt = new THREE.Mesh(new THREE.CylinderGeometry(0.27, 0.27, 0.1, 10), leather);
     belt.position.y = 0.04;
     torso.add(belt);
+    const buckle = new THREE.Mesh(new THREE.BoxGeometry(0.12, 0.1, 0.04), metalMaterial(0xd4b45a, 0.4));
+    buckle.position.set(0, 0.04, 0.27);
+    torso.add(buckle);
 
-    // Ombreiras.
     for (const sx of [-1, 1]) {
-        const pauldron = new THREE.Mesh(new THREE.SphereGeometry(0.16, 10, 8, 0, Math.PI * 2, 0, Math.PI / 2), steel);
-        pauldron.position.set(sx * 0.3, 0.56, 0);
+        const pauldron = new THREE.Mesh(new THREE.SphereGeometry(0.17, 10, 8, 0, Math.PI * 2, 0, Math.PI / 2), steel);
+        pauldron.position.set(sx * 0.32, 0.6, 0);
         pauldron.rotation.z = sx * 0.35;
         pauldron.castShadow = true;
         torso.add(pauldron);
     }
 
-    // Cabeça + elmo.
     const head = new THREE.Group();
-    head.position.y = 0.74;
+    head.position.y = 0.78;
     torso.add(head);
 
-    const skull = new THREE.Mesh(new THREE.SphereGeometry(0.17, 12, 10), skin);
+    const skull = new THREE.Mesh(new THREE.SphereGeometry(0.175, 12, 10), skin);
     head.add(skull);
 
-    const helm = new THREE.Mesh(new THREE.SphereGeometry(0.2, 12, 10, 0, Math.PI * 2, 0, Math.PI * 0.62), steel);
+    for (const sx of [-1, 1]) {
+        const eye = new THREE.Mesh(new THREE.SphereGeometry(0.028, 8, 6), eyeWhite);
+        eye.position.set(sx * 0.055, 0.02, 0.155);
+        head.add(eye);
+        const pupil = new THREE.Mesh(new THREE.SphereGeometry(0.014, 6, 5), iris);
+        pupil.position.set(sx * 0.055, 0.02, 0.175);
+        head.add(pupil);
+    }
+
+    const helm = new THREE.Mesh(new THREE.SphereGeometry(0.205, 12, 10, 0, Math.PI * 2, 0, Math.PI * 0.62), steel);
     helm.position.y = 0.02;
     helm.castShadow = true;
     head.add(helm);
 
-    const nasal = new THREE.Mesh(new THREE.BoxGeometry(0.05, 0.2, 0.05), steel);
-    nasal.position.set(0, -0.03, 0.17);
+    const nasal = new THREE.Mesh(new THREE.BoxGeometry(0.045, 0.2, 0.05), steel);
+    nasal.position.set(0, -0.03, 0.175);
     head.add(nasal);
 
+    const visor = new THREE.Mesh(new THREE.BoxGeometry(0.22, 0.04, 0.04), darkSteel);
+    visor.position.set(0, 0.04, 0.175);
+    head.add(visor);
+
     for (const sx of [-1, 1]) {
-        const horn = new THREE.Mesh(new THREE.ConeGeometry(0.055, 0.34, 7), plainMaterial(0xe8dfc8, 0.6, 0));
-        horn.position.set(sx * 0.19, 0.12, -0.02);
-        horn.rotation.z = sx * -0.85;
-        horn.rotation.x = -0.15;
+        const horn = new THREE.Mesh(new THREE.ConeGeometry(0.048, 0.3, 7), plainMaterial(0xe8dfc8, 0.6, 0));
+        horn.position.set(sx * 0.18, 0.14, -0.02);
+        horn.rotation.z = sx * -0.78;
+        horn.rotation.x = -0.12;
         head.add(horn);
     }
 
-    const beard = new THREE.Mesh(new THREE.ConeGeometry(0.13, 0.22, 8), plainMaterial(0x8a5b2f, 0.9, 0));
-    beard.position.set(0, -0.14, 0.06);
+    const beard = new THREE.Mesh(new THREE.ConeGeometry(0.13, 0.24, 8), plainMaterial(0x6a4220, 0.9, 0));
+    beard.position.set(0, -0.15, 0.07);
     beard.rotation.x = Math.PI;
     head.add(beard);
 
-    // Braços (pivô no ombro).
-    const armGeo = new THREE.CylinderGeometry(0.085, 0.075, 0.56, 8);
+    const armGeo = new THREE.CylinderGeometry(0.09, 0.078, 0.58, 8);
     const armR = new THREE.Group();
-    armR.position.set(0.3, 0.52, 0);
+    armR.position.set(0.32, 0.54, 0);
     torso.add(armR);
     const armRMesh = new THREE.Mesh(armGeo, cloth);
     armRMesh.position.y = -0.28;
     armRMesh.castShadow = true;
     armR.add(armRMesh);
-    const bracerR = new THREE.Mesh(new THREE.CylinderGeometry(0.095, 0.09, 0.18, 8), darkSteel);
-    bracerR.position.y = -0.5;
+    const bracerR = new THREE.Mesh(new THREE.CylinderGeometry(0.1, 0.092, 0.18, 8), darkSteel);
+    bracerR.position.y = -0.52;
     armR.add(bracerR);
 
     const armL = new THREE.Group();
-    armL.position.set(-0.3, 0.52, 0);
+    armL.position.set(-0.32, 0.54, 0);
     torso.add(armL);
     const armLMesh = new THREE.Mesh(armGeo, cloth);
     armLMesh.position.y = -0.28;
     armLMesh.castShadow = true;
     armL.add(armLMesh);
 
-    // Escudo no braço esquerdo.
     const shield = new THREE.Mesh(
-        new THREE.CylinderGeometry(0.34, 0.34, 0.08, 16),
+        new THREE.CylinderGeometry(0.36, 0.36, 0.09, 16),
         new THREE.MeshStandardMaterial({ map: shieldTexture('#2f5d7c', '#e8dcb8'), roughness: 0.68 })
     );
     shield.rotation.z = Math.PI / 2;
     shield.rotation.y = 0.2;
-    shield.position.set(-0.16, -0.5, 0.06);
+    shield.position.set(-0.18, -0.5, 0.08);
     shield.castShadow = true;
     armL.add(shield);
 
-    // Machado na mão direita.
-    const axe = buildAxeMesh(0.85);
-    axe.position.set(0.02, -0.62, 0.06);
+    const axe = buildAxeMesh(0.9);
+    axe.position.set(0.02, -0.64, 0.06);
     axe.rotation.set(-0.4, 0, 0.3);
     armR.add(axe);
 
-    // Capa.
-    const capeMat = registerCloth(clothMaterial({ color: cape, side: THREE.DoubleSide, wind: 0.4 }));
+    const capeMat = registerCloth(clothMaterial({ color: cape, side: THREE.DoubleSide, wind: 0.55 }));
     capeMat.transparent = false;
     capeMat.alphaTest = 0;
-    const capeMesh = new THREE.Mesh(new THREE.PlaneGeometry(0.66, 0.95, 8, 8), capeMat);
-    capeMesh.position.set(0, 0.18, -0.26);
-    capeMesh.rotation.x = 0.12;
+    const capeMesh = new THREE.Mesh(new THREE.PlaneGeometry(0.72, 1.05, 8, 8), capeMat);
+    capeMesh.position.set(0, 0.16, -0.28);
+    capeMesh.rotation.x = 0.14;
     capeMesh.castShadow = true;
     torso.add(capeMesh);
 
@@ -999,16 +1059,16 @@ export function buildArrowMesh() {
 /** Pinheiro em camadas — geometria única para uso em InstancedMesh. */
 export function buildPineGeometry() {
     const parts = [];
-    const trunk = new THREE.CylinderGeometry(0.22, 0.34, 3.4, 7);
-    trunk.translate(0, 1.7, 0);
+    const trunk = new THREE.CylinderGeometry(0.2, 0.36, 3.6, 7);
+    trunk.translate(0, 1.8, 0);
     parts.push({ geo: trunk, color: new THREE.Color(0x4a3423) });
 
-    for (let i = 0; i < 4; i++) {
-        const r = 2.3 - i * 0.45;
-        const h = 2.4 - i * 0.28;
-        const cone = new THREE.ConeGeometry(r, h, 8);
-        cone.translate(0, 2.9 + i * 1.35, 0);
-        parts.push({ geo: cone, color: new THREE.Color().setHSL(0.31, 0.42, 0.16 + i * 0.035) });
+    for (let i = 0; i < 5; i++) {
+        const r = 2.45 - i * 0.38;
+        const h = 2.2 - i * 0.18;
+        const cone = new THREE.ConeGeometry(r, h, 7);
+        cone.translate((i % 2) * 0.12, 2.7 + i * 1.18, (i % 3 - 1) * 0.08);
+        parts.push({ geo: cone, color: new THREE.Color().setHSL(0.30, 0.46, 0.15 + i * 0.032) });
     }
     return mergeWithColors(parts);
 }
@@ -1032,6 +1092,21 @@ export function buildOakGeometry() {
         s.translate(x, y, z);
         parts.push({ geo: s, color: new THREE.Color().setHSL(0.26, 0.38, 0.19 + Math.random() * 0.06) });
     }
+    return mergeWithColors(parts);
+}
+
+/** Junco da beira — dois planos cruzados, barato em InstancedMesh. */
+export function buildReedGeometry() {
+    const parts = [];
+    const blade = new THREE.PlaneGeometry(0.22, 1.7, 1, 3);
+    blade.translate(0, 0.85, 0);
+    parts.push({ geo: blade, color: new THREE.Color(0x3d5a28) });
+    const blade2 = blade.clone();
+    blade2.rotateY(Math.PI / 2);
+    parts.push({ geo: blade2, color: new THREE.Color(0x4a6b30) });
+    const tip = new THREE.ConeGeometry(0.05, 0.28, 4);
+    tip.translate(0, 1.78, 0);
+    parts.push({ geo: tip, color: new THREE.Color(0x6b5428) });
     return mergeWithColors(parts);
 }
 
@@ -1105,7 +1180,7 @@ export function mergeWithColors(parts) {
 }
 
 /** Torre de vigia inimiga fincada na margem. */
-export function buildWatchtower() {
+export function buildWatchtower({ lit = true } = {}) {
     const group = new THREE.Group();
     const stone = stoneMaterial('#7d7a72');
 
@@ -1140,12 +1215,14 @@ export function buildWatchtower() {
     );
     fire.position.y = 10.9;
     group.add(fire);
-    const light = new THREE.PointLight(0xff8c3a, 14, 32, 2);
-    light.position.y = 11;
-    group.add(light);
+    if (lit) {
+        const light = new THREE.PointLight(0xff8c3a, 14, 32, 2);
+        light.position.y = 11;
+        group.add(light);
+        group.userData.light = light;
+    }
 
     group.userData.fire = fire;
-    group.userData.light = light;
     return group;
 }
 

--- a/labs/river-knight/src/player.js
+++ b/labs/river-knight/src/player.js
@@ -7,10 +7,10 @@
  */
 
 import * as THREE from 'three';
-import { buildLongship, buildWarrior } from './models.js?v=12';
-import { waterHeight, waterSlope } from './water.js';
+import { buildLongship, buildWarrior } from './models.js?v=14';
+import { waterHeight, waterSlope } from './water.js?v=14';
 import { centerX, halfWidth } from './river.js';
-import { BOAT, CANNON } from './config.js?v=12';
+import { BOAT, CANNON } from './config.js?v=14';
 import { clamp, damp, lerp } from './utils.js';
 
 const tmpSlope = { dx: 0, dz: 0 };
@@ -40,8 +40,8 @@ export class Player {
         this.parts = parts;
 
         const { group: warrior, parts: wParts } = buildWarrior({});
-        // Pés no convés midship (sheer 0 − drop 0.26).
-        warrior.position.set(0, 0.95, -1.4);
+        warrior.position.set(0, 1.08, -2.55);
+        warrior.scale.setScalar(1.42);
         ship.add(warrior);
         this.warrior = warrior;
         this.wParts = wParts;
@@ -101,23 +101,29 @@ export class Player {
     }
 
     _setOpacity(value) {
-        this.root.traverse((child) => {
-            if (!child.material || child === this.shieldBubble) return;
-            const mats = Array.isArray(child.material) ? child.material : [child.material];
-            for (const m of mats) {
-                if (m.userData.baseOpacity === undefined) {
-                    m.userData.baseOpacity = m.opacity;
-                    m.userData.baseTransparent = m.transparent;
+        if (!this._fadeMats) {
+            this._fadeMats = [];
+            this.root.traverse((child) => {
+                if (!child.material || child === this.shieldBubble) return;
+                const mats = Array.isArray(child.material) ? child.material : [child.material];
+                for (const m of mats) {
+                    if (m.userData.baseOpacity === undefined) {
+                        m.userData.baseOpacity = m.opacity;
+                        m.userData.baseTransparent = m.transparent;
+                    }
+                    this._fadeMats.push(m);
                 }
-                if (value >= 1) {
-                    m.opacity = m.userData.baseOpacity;
-                    m.transparent = m.userData.baseTransparent;
-                } else {
-                    m.transparent = true;
-                    m.opacity = m.userData.baseOpacity * value;
-                }
+            });
+        }
+        for (const m of this._fadeMats) {
+            if (value >= 1) {
+                m.opacity = m.userData.baseOpacity;
+                m.transparent = m.userData.baseTransparent;
+            } else {
+                m.transparent = true;
+                m.opacity = m.userData.baseOpacity * value;
             }
-        });
+        }
     }
 
     /* ------------------------------------------------------------------ */
@@ -186,12 +192,27 @@ export class Player {
             0.14
         );
 
+        const speedRatio = this.speed / BOAT.boostSpeed;
+
         // --- remos ---
-        const rowSpeed = 2.2 + (this.speed / BOAT.boostSpeed) * 3.4;
+        const rowSpeed = 2.4 + (this.speed / BOAT.boostSpeed) * 3.8;
         for (const oar of this.parts.oars) {
             const phase = time * rowSpeed + oar.userData.phase;
-            oar.rotation.x = Math.sin(phase) * 0.46;
-            oar.rotation.z = oar.userData.baseRoll - oar.userData.side * Math.sin(phase + 1.3) * 0.22;
+            const dip = Math.sin(phase);
+            oar.rotation.x = dip * 0.5;
+            oar.rotation.z = oar.userData.baseRoll - oar.userData.side * Math.sin(phase + 1.3) * 0.24;
+            if (dip > 0.82 && Math.random() < 0.18 && oar.position) {
+                effects.splash(
+                    this.x + oar.userData.side * 3.6,
+                    wy + 0.02,
+                    this.z + (oar.position.z || 0) * 0.2,
+                    2,
+                    0.28 + speedRatio * 0.2
+                );
+            }
+        }
+        if (this.parts.rudder) {
+            this.parts.rudder.rotation.y = -this.yaw * 1.8;
         }
 
         // --- guerreiro ---
@@ -225,19 +246,18 @@ export class Player {
         }
 
         // --- espuma da proa e esteira (fora do casco, nunca sobre o convés) ---
-        const speedRatio = this.speed / BOAT.boostSpeed;
         const sternZ = this.z + 9.2;
-        effects.wake.push(this.x - 1.1, sternZ, 1.35 + speedRatio * 1.1, 0.55 + speedRatio * 0.4);
-        effects.wake.push(this.x + 1.1, sternZ, 1.35 + speedRatio * 1.1, 0.55 + speedRatio * 0.4);
+        effects.wake.push(this.x - 1.15, sternZ, 1.55 + speedRatio * 1.35, 0.7 + speedRatio * 0.5);
+        effects.wake.push(this.x + 1.15, sternZ, 1.55 + speedRatio * 1.35, 0.7 + speedRatio * 0.5);
 
-        if (Math.random() < 0.22 + speedRatio * 0.22) {
+        if (Math.random() < 0.28 + speedRatio * 0.28) {
             const bowX = this.x + Math.sin(this.yaw) * 7.2;
             const bowZ = this.z - 7.6;
-            effects.splash(bowX, wy + 0.05, bowZ, 1, 0.22 + speedRatio * 0.22);
+            effects.splash(bowX, wy + 0.05, bowZ, 2, 0.28 + speedRatio * 0.28);
         }
-        if (Math.random() < 0.1 + speedRatio * 0.12) {
+        if (Math.random() < 0.14 + speedRatio * 0.16) {
             const side = Math.random() < 0.5 ? -1 : 1;
-            effects.splash(this.x + side * 3.4, wy + 0.02, this.z + 8.6, 1, 0.14 + speedRatio * 0.14);
+            effects.splash(this.x + side * 3.4, wy + 0.02, this.z + 8.6, 1, 0.18 + speedRatio * 0.16);
         }
 
         // --- temporizadores ---
@@ -249,8 +269,10 @@ export class Player {
         // Piscar durante a invulnerabilidade.
         if (this.invuln > 0 && !this.hasShield) {
             this._setOpacity(0.35 + Math.abs(Math.sin(time * 22)) * 0.65);
-        } else {
+            this._faded = true;
+        } else if (this._faded) {
             this._setOpacity(1);
+            this._faded = false;
         }
 
         this.shieldBubble.visible = this.hasShield;

--- a/labs/river-knight/src/player.js
+++ b/labs/river-knight/src/player.js
@@ -106,13 +106,18 @@ export class Player {
             this.root.traverse((child) => {
                 if (!child.material || child === this.shieldBubble) return;
                 const mats = Array.isArray(child.material) ? child.material : [child.material];
-                for (const m of mats) {
-                    if (m.userData.baseOpacity === undefined) {
-                        m.userData.baseOpacity = m.opacity;
-                        m.userData.baseTransparent = m.transparent;
-                    }
-                    this._fadeMats.push(m);
-                }
+                const next = mats.map((m) => {
+                    // Tecidos têm shader próprio; o resto é material em cache
+                    // compartilhado — clonar evita o pisca da invulnerabilidade
+                    // vazar para inimigos, torres e a princesa.
+                    if (m.userData.uniforms) return m;
+                    const clone = m.clone();
+                    clone.userData.baseOpacity = clone.opacity;
+                    clone.userData.baseTransparent = clone.transparent;
+                    this._fadeMats.push(clone);
+                    return clone;
+                });
+                child.material = Array.isArray(child.material) ? next : next[0];
             });
         }
         for (const m of this._fadeMats) {

--- a/labs/river-knight/src/player.js
+++ b/labs/river-knight/src/player.js
@@ -8,7 +8,7 @@
 
 import * as THREE from 'three';
 import { buildLongship, buildWarrior } from './models.js?v=14';
-import { waterHeight, waterSlope } from './water.js?v=14';
+import { waterHeight, waterSlope } from './water.js?v=15';
 import { centerX, halfWidth } from './river.js';
 import { BOAT, CANNON } from './config.js?v=14';
 import { clamp, damp, lerp } from './utils.js';

--- a/labs/river-knight/src/sky.js
+++ b/labs/river-knight/src/sky.js
@@ -8,7 +8,7 @@
  */
 
 import * as THREE from 'three';
-import { SKY_STOPS } from './config.js';
+import { SKY_STOPS } from './config.js?v=14';
 
 export const SKY_GLSL = /* glsl */ `
 uniform vec3 uZenith;
@@ -182,9 +182,12 @@ export function createSky(uniforms) {
                 float up = max(dir.y, 0.015);
                 vec2 cp = dir.xz / up;
                 vec2 drift = vec2(uTime * 0.0065, uTime * 0.0022);
-                float clouds = rkFbm(cp * 0.55 + drift);
-                clouds = smoothstep(0.46, 0.92, clouds) * uCloud;
-                clouds *= smoothstep(0.0, 0.20, dir.y);
+                float clouds = rkFbm(cp * 0.48 + drift);
+                float wisps = rkFbm(cp * 1.15 + drift * 1.4 + 8.2);
+                clouds = smoothstep(0.38, 0.88, clouds) * uCloud;
+                clouds += smoothstep(0.55, 0.95, wisps) * uCloud * 0.35;
+                clouds *= smoothstep(0.0, 0.18, dir.y);
+                clouds = clamp(clouds, 0.0, 1.0);
 
                 float sunFacing = max(dot(dir, uSunDir), 0.0);
                 vec3 cloudLit = mix(uHorizon * 0.85, uSunColor, pow(sunFacing, 2.0) * 0.7);

--- a/labs/river-knight/src/terrain.js
+++ b/labs/river-knight/src/terrain.js
@@ -9,7 +9,7 @@
 import * as THREE from 'three';
 import { buildRadialGrid } from './utils.js';
 import { RIVER_GLSL } from './river.js';
-import { NOISE_GLSL } from './sky.js';
+import { NOISE_GLSL } from './sky.js?v=14';
 
 export function createTerrain(quality) {
     const geometry = buildRadialGrid(
@@ -77,19 +77,27 @@ export function createTerrain(quality) {
                 vec3 rkTerrainColor(vec3 p, float slope) {
                     float h = p.y;
 
-                    vec3 silt = vec3(0.11, 0.10, 0.08);
-                    vec3 sand = vec3(0.46, 0.40, 0.29);
-                    vec3 grass = vec3(0.13, 0.21, 0.09);
-                    vec3 grassDry = vec3(0.25, 0.24, 0.11);
-                    vec3 rock = vec3(0.22, 0.21, 0.20);
+                    vec3 silt = vec3(0.10, 0.11, 0.08);
+                    vec3 sand = vec3(0.50, 0.42, 0.28);
+                    vec3 mud = vec3(0.22, 0.18, 0.11);
+                    vec3 grass = vec3(0.16, 0.28, 0.10);
+                    vec3 grassLush = vec3(0.10, 0.22, 0.07);
+                    vec3 grassDry = vec3(0.32, 0.30, 0.14);
+                    vec3 rock = vec3(0.24, 0.23, 0.21);
+                    vec3 pebble = vec3(0.38, 0.36, 0.32);
                     vec3 snow = vec3(0.82, 0.84, 0.88);
 
                     float n1 = rkFbm(p.xz * 0.045);
                     float n2 = rkValueNoise(p.xz * 0.35);
+                    float n3 = rkValueNoise(p.xz * 1.15);
 
-                    // Leito submerso → areia da praia → grama.
-                    vec3 col = mix(silt, sand, smoothstep(-3.4, -0.4, h));
-                    col = mix(col, mix(grass, grassDry, n1), smoothstep(0.15, 2.4, h));
+                    vec3 col = mix(silt, mud, smoothstep(-3.4, -0.6, h));
+                    col = mix(col, sand, smoothstep(-0.8, 0.55, h));
+                    vec3 turf = mix(grassLush, grass, n1);
+                    turf = mix(turf, grassDry, smoothstep(0.55, 0.9, n1) * 0.7);
+                    col = mix(col, turf, smoothstep(0.2, 2.1, h));
+                    float pebbles = smoothstep(0.55, 0.92, n3) * (1.0 - smoothstep(1.8, 4.5, h)) * smoothstep(-0.2, 0.8, h);
+                    col = mix(col, pebble, pebbles * 0.55);
 
                     // Faixas de rocha nas encostas íngremes.
                     float rocky = 1.0 - smoothstep(0.52, 0.82, slope);

--- a/labs/river-knight/src/textures.js
+++ b/labs/river-knight/src/textures.js
@@ -60,8 +60,8 @@ export function woodTexture(dark = false) {
         const size = 512;
         const el = canvas(size);
         const ctx = el.getContext('2d');
-        const base = dark ? '#3a2417' : '#6d472a';
-        const light = dark ? '#4c3120' : '#8a5c37';
+        const base = dark ? '#2c1a10' : '#7a5130';
+        const light = dark ? '#5a3a24' : '#c08a52';
 
         ctx.fillStyle = base;
         ctx.fillRect(0, 0, size, size);
@@ -109,8 +109,8 @@ export function woodTexture(dark = false) {
             }
         }
 
-        grain(ctx, size, size, 26, dark ? 5 : 1);
-        return toTexture(el, { repeat: [1, 1] });
+        grain(ctx, size, size, 34, dark ? 5 : 1);
+        return toTexture(el, { repeat: [1.4, 2.2], aniso: 8 });
     });
 }
 
@@ -199,7 +199,7 @@ export function stoneTexture(tint = '#8f8d87') {
         const size = 512;
         const el = canvas(size);
         const ctx = el.getContext('2d');
-        ctx.fillStyle = '#3a3833';
+        ctx.fillStyle = '#2a2824';
         ctx.fillRect(0, 0, size, size);
 
         const rows = 10;
@@ -234,8 +234,8 @@ export function stoneTexture(tint = '#8f8d87') {
             }
         }
 
-        grain(ctx, size, size, 30, 4);
-        return toTexture(el);
+        grain(ctx, size, size, 38, 4);
+        return toTexture(el, { repeat: [1.6, 2.4], aniso: 8 });
     });
 }
 
@@ -343,21 +343,32 @@ export function foamTexture() {
         const ctx = el.getContext('2d');
         ctx.clearRect(0, 0, size, size);
 
-        // Bolhas de espuma distribuídas de forma tileável no eixo X.
-        for (let i = 0; i < 900; i++) {
+        // Estelas alongadas no eixo do rio + bolhas — espuma de corrente, não de disco.
+        for (let i = 0; i < 220; i++) {
             const x = noise2(i, 1.3) * size;
             const y = noise2(i, 4.9) * size;
-            const r = 2.4 + noise2(i, 7.1) * 9.0;
-            const a = 0.06 + noise2(i, 9.4) * 0.42;
+            const rw = 14 + noise2(i, 7.1) * 46;
+            const rh = 2.2 + noise2(i, 8.2) * 5.5;
+            const a = 0.08 + noise2(i, 9.4) * 0.38;
             for (const dx of [-size, 0, size]) {
-                const g = ctx.createRadialGradient(x + dx, y, 0, x + dx, y, r);
+                const g = ctx.createRadialGradient(x + dx, y, 0, x + dx, y, rw);
                 g.addColorStop(0, `rgba(255,255,255,${a})`);
                 g.addColorStop(1, 'rgba(255,255,255,0)');
                 ctx.fillStyle = g;
                 ctx.beginPath();
-                ctx.arc(x + dx, y, r, 0, Math.PI * 2);
+                ctx.ellipse(x + dx, y, rw, rh, 0, 0, Math.PI * 2);
                 ctx.fill();
             }
+        }
+        for (let i = 0; i < 280; i++) {
+            const x = noise2(i, 11.3) * size;
+            const y = noise2(i, 14.9) * size;
+            const r = 1.4 + noise2(i, 17.1) * 4.2;
+            const a = 0.04 + noise2(i, 19.4) * 0.22;
+            ctx.fillStyle = `rgba(255,255,255,${a})`;
+            ctx.beginPath();
+            ctx.arc(x, y, r, 0, Math.PI * 2);
+            ctx.fill();
         }
         return toTexture(el, { srgb: true });
     });

--- a/labs/river-knight/src/utils.js
+++ b/labs/river-knight/src/utils.js
@@ -121,6 +121,20 @@ export function detectMobile() {
     return Boolean(coarse && narrow) || /Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
 }
 
+/** SwiftShader / llvmpipe / etc. — auto quality must not pick "Cinemática". */
+export function detectSoftwareGL() {
+    try {
+        const canvas = document.createElement('canvas');
+        const gl = canvas.getContext('webgl2') || canvas.getContext('webgl');
+        if (!gl) return true;
+        const info = gl.getExtension('WEBGL_debug_renderer_info');
+        const name = info ? String(gl.getParameter(info.UNMASKED_RENDERER_WEBGL) || '') : '';
+        return /swiftshader|llvmpipe|softpipe|microsoft basic render|\bcpu\b/i.test(name);
+    } catch (err) {
+        return false;
+    }
+}
+
 /** Formata segundos como m:ss. */
 export function formatTime(seconds) {
     const s = Math.max(0, Math.floor(seconds));

--- a/labs/river-knight/src/water.js
+++ b/labs/river-knight/src/water.js
@@ -8,8 +8,8 @@
 import * as THREE from 'three';
 import { buildRadialGrid } from './utils.js';
 import { RIVER_GLSL } from './river.js';
-import { SKY_GLSL, NOISE_GLSL } from './sky.js';
-import { foamTexture } from './textures.js';
+import { SKY_GLSL, NOISE_GLSL } from './sky.js?v=14';
+import { foamTexture } from './textures.js?v=14';
 
 /**
  * Conjunto de ondas: direção (normalizada), amplitude, comprimento, velocidade.
@@ -108,8 +108,8 @@ export function createWater(skyUniforms, quality) {
         uFoam: { value: foamTexture() },
         uFogColor: { value: new THREE.Color(0.7, 0.7, 0.75) },
         uFogDensity: { value: quality.fogDensity },
-        uShallow: { value: new THREE.Color(0.22, 0.44, 0.36) },
-        uDeep: { value: new THREE.Color(0.01, 0.03, 0.06) }
+        uShallow: { value: new THREE.Color(0.18, 0.42, 0.34) },
+        uDeep: { value: new THREE.Color(0.02, 0.07, 0.10) }
     };
 
     const material = new THREE.ShaderMaterial({
@@ -193,25 +193,31 @@ export function createWater(skyUniforms, quality) {
                 // Luz atravessando a crista da onda (subsurface fake).
                 body += uSunColor * uShallow * smoothstep(0.6, 1.9, vPhase) * 0.10 * (1.0 - depth * 0.65);
 
+                // Cáusticos baratos no raso — o leito do rio "pisca" com o sol.
+                float caust = rkValueNoise(rp * 1.85 + vec2(uTime * 0.18, -uTime * 0.14));
+                caust *= rkValueNoise(rp * 3.4 + vec2(-uTime * 0.11, uTime * 0.16));
+                body += uSunColor * caust * (1.0 - depth) * 0.16;
+
                 vec3 col = mix(body, refl, fres * 0.88);
 
-                // Brilho especular do sol na crista das ondas.
+                // Brilho especular do sol (rio, não oceano).
                 vec3 H = normalize(V + uSunDir);
-                float spec = pow(max(dot(N, H), 0.0), 420.0);
-                float sparkle = pow(max(dot(N, H), 0.0), 72.0) *
-                    smoothstep(0.55, 1.0, rkValueNoise(rp * 3.1 + uTime * 0.6));
-                col += uSunColor * (spec * 2.2 + sparkle * 0.28);
+                float spec = pow(max(dot(N, H), 0.0), 96.0);
+                float sparkle = pow(max(dot(N, H), 0.0), 48.0) *
+                    smoothstep(0.62, 1.0, rkValueNoise(rp * 2.4 + uTime * 0.45));
+                col += uSunColor * (spec * 0.85 + sparkle * 0.14);
 
                 // Espuma junto às margens e nas cristas mais altas.
                 float shore = rkShoreDist(vWorld.x, vWorld.z);
                 // smoothstep exige edge0 < edge1 (fora disso o resultado é indefinido em GLSL).
                 float band = smoothstep(-12.5, -2.8, shore) * (1.0 - smoothstep(-2.0, 1.4, shore));
                 float crest = smoothstep(1.15, 2.15, vPhase);
-                // Corrente sutil no eixo do rio (Z negativo ≈ descida).
-                vec2 fuv = vWorld.xz * 0.046 + vec2(uTime * 0.0035, uTime * 0.045);
+                vec2 fuv = vWorld.xz * 0.038 + vec2(uTime * 0.004, uTime * 0.07);
                 float ftex = texture2D(uFoam, fuv).a;
-                float foam = clamp(band * 1.35 + crest * 0.24, 0.0, 1.0) * smoothstep(0.05, 0.5, ftex);
-                col = mix(col, vec3(0.92, 0.96, 0.99), clamp(foam, 0.0, 1.0) * 0.92);
+                float current = smoothstep(0.35, 0.85, rkValueNoise(vec2(vWorld.x * 0.08, vWorld.z * 0.025 + uTime * 0.12)));
+                float foam = clamp(band * 1.15 + crest * 0.18 + current * 0.12 * (1.0 - depth), 0.0, 1.0)
+                    * smoothstep(0.08, 0.55, ftex);
+                col = mix(col, vec3(0.88, 0.94, 0.96), clamp(foam, 0.0, 1.0) * 0.72);
 
                 // Névoa exponencial casada com o céu.
                 float dist = length(cameraPosition - vWorld);

--- a/labs/river-knight/src/water.js
+++ b/labs/river-knight/src/water.js
@@ -205,7 +205,7 @@ export function createWater(skyUniforms, quality) {
                 float spec = pow(max(dot(N, H), 0.0), 96.0);
                 float sparkle = pow(max(dot(N, H), 0.0), 48.0) *
                     smoothstep(0.62, 1.0, rkValueNoise(rp * 2.4 + uTime * 0.45));
-                col += uSunColor * (spec * 0.85 + sparkle * 0.14);
+                col += uSunColor * (spec * 0.55 + sparkle * 0.06);
 
                 // Espuma junto às margens e nas cristas mais altas.
                 float shore = rkShoreDist(vWorld.x, vWorld.z);

--- a/labs/river-knight/src/world.js
+++ b/labs/river-knight/src/world.js
@@ -4,9 +4,9 @@
  */
 
 import * as THREE from 'three';
-import { buildPineGeometry, buildOakGeometry, buildRockGeometry, plainMaterial } from './models.js';
+import { buildPineGeometry, buildOakGeometry, buildRockGeometry, buildReedGeometry, applyVegetationWind } from './models.js?v=14';
 import { centerX, halfWidth, terrainHeight } from './river.js';
-import { COURSE_LENGTH, BOSS_Z } from './config.js';
+import { COURSE_LENGTH, BOSS_Z } from './config.js?v=14';
 import { clamp, randRange, pick } from './utils.js';
 
 const SPAWN_AHEAD = 430;
@@ -24,18 +24,23 @@ class Scatter {
         sink = 0.6,
         tint = null,
         minHeight = 0.8,
-        maxSlope = 1.35
+        maxSlope = 1.35,
+        wind = 0,
+        keepAfloat = false,
+        yScale = 1
     }) {
         const material = new THREE.MeshStandardMaterial({
             vertexColors: !tint,
             color: tint || 0xffffff,
             roughness: 0.92,
-            metalness: 0
+            metalness: 0,
+            side: keepAfloat ? THREE.DoubleSide : THREE.FrontSide
         });
+        if (wind > 0) applyVegetationWind(material, wind);
 
         this.mesh = new THREE.InstancedMesh(geometry, material, count);
         this.mesh.instanceMatrix.setUsage(THREE.DynamicDrawUsage);
-        this.mesh.castShadow = true;
+        this.mesh.castShadow = !keepAfloat;
         this.mesh.receiveShadow = true;
         this.mesh.frustumCulled = false;
         scene.add(this.mesh);
@@ -47,6 +52,8 @@ class Scatter {
         this.sink = sink;
         this.minHeight = minHeight;
         this.maxSlope = maxSlope;
+        this.keepAfloat = keepAfloat;
+        this.yScale = yScale;
         this.items = new Array(count);
         this.dummy = new THREE.Object3D();
 
@@ -71,12 +78,14 @@ class Scatter {
         const yU = terrainHeight(x, z + eps);
         const slope = Math.max(Math.abs(yL - yR), Math.abs(yD - yU)) / (2 * eps);
         item.x = x;
-        item.y = y - this.sink;
+        item.y = this.keepAfloat ? Math.max(y, -0.15) - this.sink : y - this.sink;
         item.z = z;
         item.scale = randRange(this.scaleRange[0], this.scaleRange[1]);
         item.rot = randRange(0, Math.PI * 2);
         item.tilt = randRange(-0.06, 0.06);
-        item.valid = y > this.minHeight && slope < this.maxSlope;
+        item.valid = this.keepAfloat
+            ? y < 2.4 && slope < this.maxSlope
+            : y > this.minHeight && slope < this.maxSlope;
     }
 
     /** Distribui tudo de uma vez ao (re)iniciar a partida. */
@@ -94,7 +103,7 @@ class Scatter {
         const d = this.dummy;
         d.position.set(item.x, item.y, item.z);
         d.rotation.set(item.tilt, item.rot, item.tilt * 0.6);
-        d.scale.setScalar(item.valid ? item.scale : 0.0001);
+        d.scale.set(item.valid ? item.scale : 0.0001, item.valid ? item.scale * this.yScale : 0.0001, item.valid ? item.scale : 0.0001);
         d.updateMatrix();
         this.mesh.setMatrixAt(i, d.matrix);
     }
@@ -165,48 +174,76 @@ class Birds {
 export class World {
     constructor(scene, quality) {
         const s = quality.scatterScale;
-        this.pines = new Scatter(scene, buildPineGeometry(), Math.round(150 * s), {
+        this.pines = new Scatter(scene, buildPineGeometry(), Math.round(180 * s), {
+            minDist: 0.8,
+            maxDist: 88,
+            scale: [0.8, 1.65],
+            minHeight: 1.0,
+            maxSlope: 1.2,
+            wind: 0.09
+        });
+        this.oaks = new Scatter(scene, buildOakGeometry(), Math.round(85 * s), {
             minDist: 1.2,
-            maxDist: 95,
-            scale: [0.75, 1.5],
-            minHeight: 1.2,
-            maxSlope: 1.15
+            maxDist: 72,
+            scale: [0.75, 1.45],
+            minHeight: 1.0,
+            maxSlope: 1.15,
+            wind: 0.07
         });
-        this.oaks = new Scatter(scene, buildOakGeometry(), Math.round(70 * s), {
-            minDist: 1.6,
-            maxDist: 78,
-            scale: [0.7, 1.35],
-            minHeight: 1.2,
-            maxSlope: 1.1
-        });
-        this.bankRocks = new Scatter(scene, buildRockGeometry(5), Math.round(110 * s), {
-            minDist: 0.2,
-            maxDist: 18,
+        this.bankRocks = new Scatter(scene, buildRockGeometry(5), Math.round(120 * s), {
+            minDist: 0.15,
+            maxDist: 16,
             scale: [0.7, 2.4],
             sink: 1.25,
             tint: 0x54504a,
-            minHeight: 0.45,
+            minHeight: 0.35,
             maxSlope: 1.95
         });
+        this.reeds = new Scatter(scene, buildReedGeometry(), quality.reeds ?? 280, {
+            minDist: -1.2,
+            maxDist: 7.5,
+            scale: [0.7, 1.45],
+            sink: 0.05,
+            minHeight: -2,
+            maxSlope: 2.4,
+            wind: 0.22,
+            keepAfloat: true,
+            yScale: 1.15
+        });
 
-        this.birds = quality.id === 'low' ? null : new Birds(scene, 12);
+        this.birds = quality.birds === 0 ? null : new Birds(scene, quality.birds ?? 12);
         this.nextSpawnZ = 0;
         this.lastKind = null;
+        this._fishAcc = 0;
     }
 
     reset(playerZ) {
         this.pines.reset(playerZ);
         this.oaks.reset(playerZ);
         this.bankRocks.reset(playerZ);
-        this.nextSpawnZ = playerZ - 150;
+        this.reeds.reset(playerZ);
+        this.nextSpawnZ = playerZ - 70;
         this.lastKind = null;
     }
 
-    update(dt, time, playerZ) {
+    update(dt, time, playerZ, effects) {
         this.pines.update(playerZ);
         this.oaks.update(playerZ);
         this.bankRocks.update(playerZ);
+        this.reeds.update(playerZ);
         this.birds?.update(dt, time, playerZ);
+
+        if (effects) {
+            this._fishAcc += dt;
+            if (this._fishAcc > 0.55) {
+                this._fishAcc = 0;
+                if (Math.random() < 0.45) {
+                    const z = playerZ - randRange(18, 90);
+                    const x = centerX(z) + randRange(-0.7, 0.7) * halfWidth(z);
+                    effects.splash(x, 0.12, z, 6, 0.7);
+                }
+            }
+        }
     }
 
     /**
@@ -220,7 +257,7 @@ export class World {
             const z = this.nextSpawnZ;
             if (z > BOSS_Z + 130) this._spawnEncounter(z, progress, entities, difficulty);
 
-            const gap = randRange(54, 104) / (0.8 + difficulty.spawnScale * 0.45 + progress * 0.5);
+            const gap = randRange(36, 78) / (0.85 + difficulty.spawnScale * 0.5 + progress * 0.55);
             this.nextSpawnZ -= Math.max(26, gap);
             if (this.nextSpawnZ < BOSS_Z + 130) break;
         }
@@ -233,10 +270,10 @@ export class World {
 
         // Pesos por fase da jornada.
         const weights = [
-            ['rock', 26 - progress * 10],
-            ['pickup', 20 - progress * 6],
-            ['enemyShip', 6 + progress * 26],
-            ['tower', 8 + progress * 24],
+            ['rock', 16 - progress * 6],
+            ['pickup', 22 - progress * 5],
+            ['enemyShip', 14 + progress * 22],
+            ['tower', 12 + progress * 20],
             ['barricade', 8 + progress * 12],
             ['whirlpool', 4 + progress * 8]
         ];

--- a/labs/river-knight/style.css
+++ b/labs/river-knight/style.css
@@ -479,14 +479,14 @@ body[data-state="playing"] .game-shell > header .app-logo {
 /* --- mira / arremesso --- */
 .reticle {
     position: absolute;
-    left: 50%;
-    top: 46%;
+    left: var(--aim-x, 50%);
+    top: var(--aim-y, 46%);
     width: 2.6rem;
     height: 2.6rem;
     transform: translate(-50%, -50%);
     pointer-events: none;
     opacity: 0.55;
-    transition: opacity 0.2s ease, color 0.2s ease;
+    transition: opacity 0.2s ease, color 0.2s ease, left 0.12s ease, top 0.12s ease;
     color: oklch(88% 0.04 90);
     z-index: 4;
 }
@@ -538,8 +538,8 @@ body[data-state="playing"] .game-shell > header .app-logo {
 
 .throw-meter {
     position: absolute;
-    left: 50%;
-    top: calc(46% + 1.85rem);
+    left: var(--aim-x, 50%);
+    top: calc(var(--aim-y, 46%) + 1.85rem);
     width: 3.4rem;
     height: 3px;
     transform: translateX(-50%);
@@ -549,6 +549,7 @@ body[data-state="playing"] .game-shell > header .app-logo {
     pointer-events: none;
     z-index: 4;
     box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+    transition: left 0.12s ease, top 0.12s ease;
 }
 
 .throw-meter > i {
@@ -567,6 +568,36 @@ body[data-state="playing"] .throw-meter {
 body:not([data-state="playing"]) .reticle,
 body:not([data-state="playing"]) .throw-meter {
     display: none;
+}
+
+.hint-bar {
+    position: absolute;
+    left: 50%;
+    bottom: calc(4.8rem + var(--safe-bottom));
+    translate: -50% 10px;
+    margin: 0;
+    max-width: min(28rem, 88vw);
+    padding: 0.45rem 0.9rem;
+    border-radius: 999px;
+    background: color-mix(in oklab, oklch(14% 0.03 285) 55%, transparent);
+    border: 1px solid var(--line-soft);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    font-family: 'Cinzel', Georgia, serif;
+    font-size: 0.72rem;
+    letter-spacing: 0.08em;
+    text-align: center;
+    color: var(--gold);
+    text-shadow: 0 1px 12px rgba(0, 0, 0, 0.7);
+    opacity: 0;
+    pointer-events: none;
+    z-index: 5;
+    transition: opacity 0.45s var(--ease), translate 0.45s var(--ease);
+}
+
+.hint-bar.is-on {
+    opacity: 1;
+    translate: -50% 0;
 }
 
 /* --- ações --- */
@@ -721,6 +752,19 @@ body:not([data-state="playing"]) .throw-meter {
     -webkit-backdrop-filter: blur(5px) saturate(0.9);
     animation: fadeIn 0.4s var(--ease);
     overflow-y: auto;
+}
+
+.menu-overlay {
+    background:
+        radial-gradient(140% 100% at 50% 0%, oklch(16% 0.05 280 / 0.12), oklch(6% 0.02 285 / 0.42));
+    backdrop-filter: blur(2px) saturate(1.05);
+    -webkit-backdrop-filter: blur(2px) saturate(1.05);
+}
+
+.menu-overlay .overlay-card {
+    background: linear-gradient(160deg,
+            color-mix(in oklab, oklch(17% 0.03 285) 72%, transparent),
+            color-mix(in oklab, oklch(10% 0.03 285) 78%, transparent));
 }
 
 .overlay[hidden] {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Revise River Knight so the chase camera reads as a ship game, the river feels less empty, and the loop stays easy and cheap to render.

## What changed
- **Chase camera**: closer offset, lower stern wall, warrior/mast/sail visible instead of a solid brown transom blob.
- **Feel**: faster boat, wider auto-aim, shorter cannon cooldown, earlier encounters, narrative landmarks along the course.
- **World**: reeds, vegetation wind, denser pines, fish splashes, richer sky/water/terrain textures.
- **HUD**: reticle follows the locked target in screen space; hint bar on Zarpar; menu lets more of the 3D scene show through.
- **Perf**: skip tower point lights on medium/low, throttle fire particles, cache hull fade materials, drop pixel ratio + bloom if FPS stays under 38. Auto quality uses Performance on software WebGL (SwiftShader / llvmpipe).
- **Fixes**: invulnerability blink no longer fades shared materials; `Tower.update` no longer hits a TDZ on `dz` (that crash black-screened the first watchtower).

Vanilla HTML/CSS/JS + Three.js, no build step.

## How to try
Open `/labs/river-knight/`, wait for the menu, click **Zarpar**. Steer with A/D, fire with click/space, C cycles cameras. Boss appears near the castle (~3960 m).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-caf6cdc1-2ca2-460d-88d5-80b7593ad6d0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-caf6cdc1-2ca2-460d-88d5-80b7593ad6d0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

