### PR TITLE
polish(ravi-123): janela, rodas e mercado após o playthrough

### DIFF
--- a/labs/ravi-123/index.html
+++ b/labs/ravi-123/index.html
@@ -19,7 +19,7 @@
   <meta property="og:locale" content="pt_BR">
 
   <link rel="stylesheet" href="/labs/shared.css?v=6">
-  <link rel="stylesheet" href="style.css?v=22">
+  <link rel="stylesheet" href="style.css?v=23">
 </head>
 
 <body>
@@ -48,7 +48,7 @@
     </p>
   </noscript>
 
-  <script type="module" src="main.js?v=22"></script>
+  <script type="module" src="main.js?v=23"></script>
   <script src="/labs/shared.js?v=6" defer></script>
 </body>
 

--- a/labs/ravi-123/scenes.js
+++ b/labs/ravi-123/scenes.js
@@ -372,15 +372,17 @@ export function drawVehicleRack(ctx, spots, clock = 0) {
     const nW = v.wheels;
     const pipY = y + spot.h - 8;
     if (nW === 0) {
-      raised(pen, Math.round(spot.x + (spot.w - 16) / 2), pipY - 2, 16, 9, K.YEL, K.YEL_L, K.OCHRE);
-      F.textCenter(ctx, '0', spot.x + spot.w / 2, pipY, K.RED_D);
+      raised(pen, Math.round(spot.x + (spot.w - 20) / 2), pipY - 3, 20, 11, K.YEL, K.YEL_L, K.OCHRE);
+      F.textCenter(ctx, '0', spot.x + spot.w / 2, pipY - 1, K.RED_D);
     } else {
-      const span = Math.min(spot.w - 8, nW * 6);
+      const pipR = nW >= 8 ? 2 : 3;
+      const span = Math.min(spot.w - 10, nW * (pipR * 2 + 2));
       const x0 = Math.round(spot.x + (spot.w - span) / 2);
       for (let i = 0; i < nW; i++) {
         const px = x0 + Math.round((i * span) / Math.max(1, nW - 1));
-        pen.col(K.BLACK).ellipse(px, pipY + 3, 3, 3);
-        pen.col(K.GRAY_L).ellipse(px, pipY + 3, 1, 1);
+        pen.col(K.WHITE).ellipse(px, pipY + 3, pipR + 1, pipR + 1);
+        pen.col(K.BLACK).ellipse(px, pipY + 3, pipR, pipR);
+        pen.col(K.GRAY_L).px(px, pipY + 2);
       }
     }
   }

--- a/labs/ravi-123/world.js
+++ b/labs/ravi-123/world.js
@@ -10,6 +10,7 @@
 import { W, STAGE_H, makeSurface } from './screen.js';
 import { K, Pen } from './assets.js';
 import { wave, hop, wrap } from './anim.js';
+import * as F from './font.js';
 
 const baked = new Map();
 
@@ -26,12 +27,24 @@ function windowFrame(pen, x, y, w, h, night) {
   pen.col(night ? K.NAVY : K.BLU_L).rect(x, y, w, h);
   pen.col(K.WOOD_D).vline(x + (w >> 1), y, h).hline(x, y + (h >> 1), w);
   if (night) {
-    pen.col(K.YEL_L).ellipse(x + w - 8, y + 6, 4, 4);
-    pen.col(K.YEL).ellipse(x + w - 7, y + 6, 2, 2);
+    pen.col(K.YEL_L).ellipse(x + w - 10, y + 8, 6, 6);
+    pen.col(K.YEL).ellipse(x + w - 9, y + 8, 4, 4);
+    pen.col(K.WHITE).px(x + 8, y + 10).px(x + 18, y + 22).px(x + 28, y + 12);
+    pen.col(K.YEL_L).px(x + 14, y + 30).px(x + 22, y + 8);
   } else {
     pen.col(K.YEL_L).ellipse(x + 8, y + 6, 5, 5);
     pen.col(K.YEL).ellipse(x + 8, y + 6, 3, 3);
   }
+  // Varão + cortinas + peitoril — a janela deixa de ser um retângulo azul
+  pen.col(K.OCHRE).rect(x - 4, y - 5, w + 8, 3);
+  const cloth = night ? K.PUR : K.RED;
+  const fold = night ? K.PUR_L : K.RED_L;
+  pen.col(cloth).rect(x - 1, y, 7, h);
+  pen.col(fold).vline(x + 1, y + 2, h - 4).vline(x + 4, y + 6, h - 10);
+  pen.col(cloth).rect(x + w - 6, y, 7, h);
+  pen.col(fold).vline(x + w - 4, y + 2, h - 4).vline(x + w - 1, y + 6, h - 10);
+  pen.col(K.WOOD_D).rect(x - 4, y + h, w + 8, 4);
+  pen.col(K.OCHRE).hline(x - 3, y + h, w + 6);
 }
 
 function houseRoom(pen, night) {
@@ -169,6 +182,16 @@ function paintMarket(pen) {
       pen.col((((x + y) / 10) | 0) % 2 ? K.BLU_L : K.WHITE).rect(x, y, 10, 10);
     }
   }
+  // Placa MERCADO sob o toldo
+  pen.col(K.WOOD_D).rect(118, 22, 84, 14);
+  pen.col(K.YEL).rect(120, 24, 80, 10);
+  F.textCenter(pen.ctx, 'MERCADO', 160, 25, K.RED, { shadow: K.SAND });
+  // Cebolas e pimentões pendurados
+  pen.col(K.WOOD_D).hline(22, 24, 40);
+  for (let i = 0; i < 4; i++) {
+    pen.col(i % 2 ? K.PUR : K.GRN).ellipse(28 + i * 10, 32, 4, 5);
+    pen.col(K.WOOD_D).vline(28 + i * 10, 24, 4);
+  }
   // Bancada de frutas (esquerda, atrás do Ravi)
   pen.col(K.WOOD_D).rect(8, 58, 70, 40);
   pen.col(K.OCHRE).rect(10, 60, 66, 12);
@@ -176,6 +199,10 @@ function paintMarket(pen) {
   blobFruit(pen, 38, 80, K.YEL);
   blobFruit(pen, 54, 78, K.GRN);
   blobFruit(pen, 70, 80, K.ORANGE);
+  // Caixote extra
+  pen.col(K.OCHRE).rect(78, 86, 16, 12);
+  pen.col(K.WOOD_D).frame(78, 86, 16, 12);
+  blobFruit(pen, 86, 90, K.PINK);
   // Prateleira ao fundo
   pen.col(K.WOOD_D).rect(100, 40, 90, 50);
   const cans = [K.RED, K.BLU, K.GRN, K.PUR, K.ORANGE, K.CYAN, K.PINK, K.YEL];
@@ -183,6 +210,10 @@ function paintMarket(pen) {
     pen.col(cans[i]).rect(106 + (i % 4) * 20, 46 + ((i / 4) | 0) * 20, 14, 16);
     pen.col(K.WHITE).rect(108 + (i % 4) * 20, 48 + ((i / 4) | 0) * 20, 10, 4);
   }
+  // Pôster de maçã na parede livre (direita do fundo)
+  pen.col(K.WOOD_D).rect(196, 40, 22, 28);
+  pen.col(K.CREAM).rect(198, 42, 18, 24);
+  blobFruit(pen, 207, 54, K.RED);
 }
 
 function blobFruit(pen, x, y, c) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
O playthrough completo do Ravi 1·2·3 passou sem crash. Este PR entra só com os três polimentos visuais que o teste apontou:

- Janela do quarto com cortina, lua e estrelas (em vez de um retângulo azul)
- Bolinhas das rodas nos veículos com aro claro, para contar melhor
- Mercado com placa, verduras penduradas e pôster — a parede deixa de ficar vazia

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-05b5e224-9a98-4777-8d36-1d0c4dac2228?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-05b5e224-9a98-4777-8d36-1d0c4dac2228&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

