### PR TITLE
fix(river-knight): allow victory after the castle gate opens

### DIFF
--- a/labs/river-knight/index.html
+++ b/labs/river-knight/index.html
@@ -248,7 +248,7 @@
     </main>
 
     <script src="/labs/shared.js?v=6" defer></script>
-    <script type="module" src="src/main.js?v=15"></script>
+    <script type="module" src="src/main.js?v=16"></script>
 </body>
 
 </html>

--- a/labs/river-knight/src/main.js
+++ b/labs/river-knight/src/main.js
@@ -680,8 +680,8 @@ class Game {
             this.hud.setThrowReady(ready);
         }
 
-        // O chefe fecha o rio: não dá para passar por ele.
-        if (this.boss.active && this.boss.dying <= 0) {
+        // O chefe fecha o rio até morrer (ou o portão abrir).
+        if (this.boss.active && this.boss.dying <= 0 && !this.gateOpened) {
             const wall = this.boss.group.position.z + 34;
             if (this.player.z < wall) {
                 this.player.z = wall;
@@ -727,7 +727,7 @@ class Game {
         }
 
         // Chegada: o drakkar cruza o vão do portão.
-        if (this.player.z <= CASTLE_Z - 4 && this.gateOpened) {
+        if (this.gateOpened && this.player.z <= CASTLE_Z + 2) {
             this.startVictory();
         }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to #69.

The Black Barge still blocked the river after the castle gate opened, so the drakkar could never cross the gate line and victory never started. Skip that wall once the portcullis is up, and count the run as won as soon as the boat crosses the gate.

## How to try
Play through to the Barcaça Negra, sink it, then sail through the open gate. You should get the victory overlay (princesa livre).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-caf6cdc1-2ca2-460d-88d5-80b7593ad6d0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-caf6cdc1-2ca2-460d-88d5-80b7593ad6d0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

