### PR TITLE
feat(rock-kombat): overhaul arcade estilo Street Fighter / Mortal Kombat

### DIFF
--- a/labs/rock-kombat/ai.js
+++ b/labs/rock-kombat/ai.js
@@ -12,7 +12,7 @@ export function updateCpu(match, difficulty, cpuInput) {
   const player = match.p1;
   const config = AI_CONFIG[difficulty] || AI_CONFIG.normal;
 
-  if (cpu.state === 'attack' && cpu.moveConnected && cpu.move?.cancel && Math.random() < config.attack) {
+  if (cpu.state === 'attack' && cpu.moveConnected && cpu.move?.cancel && Math.random() < config.attack * 0.4) {
     if (cpu.move.cancel.includes('kick')) cpuInput.tap('kick');
     else if (cpu.move.cancel.includes('special') && cpu.meter >= SPECIAL_COST) cpuInput.tap('special');
     return;

--- a/labs/rock-kombat/ai.js
+++ b/labs/rock-kombat/ai.js
@@ -1,107 +1,143 @@
 // ==========================================================================
-// Rock Kombat — AI Module
-// CPU decision-making with difficulty-based behavior profiles
+// Rock Kombat — CPU AI
+// Archetype spacing, wakeup, anti-air, sticky block, dash pressure
 // ==========================================================================
 
 import { AI_CONFIG, SPECIAL_COST, GROUND, BODY_WIDTH } from './constants.js';
 import { random } from './utils.js';
 import { moveFor } from './fighter.js';
 
-/**
- * CPU AI decision loop. Called every frame; uses a think-timer to throttle
- * decisions so the CPU doesn't react inhumanly fast.
- *
- * Key improvements over original:
- * - Range awareness: CPU walks into effective attack range before committing
- * - Air kick capability: CPU can jump-kick downed opponents
- * - Smarter special usage: considers distance and fighter type
- */
 export function updateCpu(match, difficulty, cpuInput) {
   const cpu = match.p2;
   const player = match.p1;
-  const config = AI_CONFIG[difficulty];
+  const config = AI_CONFIG[difficulty] || AI_CONFIG.normal;
 
-  // Think timer: prevents frame-perfect reactions
-  if (--match.cpuThink > 0) return;
-  match.cpuThink = Math.floor(random(config.think[0], config.think[1]));
+  if (cpu.state === 'attack' && cpu.moveConnected && cpu.move?.cancel && Math.random() < config.attack) {
+    if (cpu.move.cancel.includes('kick')) cpuInput.tap('kick');
+    else if (cpu.move.cancel.includes('special') && cpu.meter >= SPECIAL_COST) cpuInput.tap('special');
+    return;
+  }
 
-  cpuInput.clearDirections();
-  if (!cpu.neutral()) return;
-
-  const distance = Math.abs(player.x - cpu.x);
-  const toward = player.x < cpu.x ? 'left' : 'right';
-  const away = toward === 'left' ? 'right' : 'left';
-
-  // --- Threat detection: block incoming attacks ---
-  const threat = player.move
-    && player.moveFrame < player.move.startup + player.move.active + 2
-    && distance < player.move.reach + 95;
-
-  if (threat && Math.random() < config.guard) {
-    cpuInput.down(away);
-    if (player.move.level === 'low' || Math.random() < 0.32) {
-      cpuInput.down('down');
+  if (--match.cpuThink > 0) {
+    if (match.cpuHold && cpu.neutral()) {
+      for (const key of match.cpuHold) cpuInput.down(key);
     }
     return;
   }
 
-  // --- Opportunity: air kick on downed/getting-up opponent ---
-  if (player.state === 'getup' || player.state === 'knockdown') {
-    if (distance > 100 && distance < 200 && Math.random() < config.attack * 0.5) {
+  match.cpuThink = Math.floor(random(config.think[0], config.think[1]));
+  cpuInput.clearDirections();
+  match.cpuHold = [];
+
+  if (!cpu.neutral() && cpu.state !== 'dash' && cpu.state !== 'getup') return;
+
+  const distance = Math.abs(player.x - cpu.x);
+  const toward = player.x < cpu.x ? 'left' : 'right';
+  const away = toward === 'left' ? 'right' : 'left';
+  const id = cpu.data.id;
+
+  const incoming = player.move
+    && player.moveFrame <= player.move.startup + player.move.active + 3
+    && distance < (player.move.reach || 0) + 110;
+
+  const projectileThreat = match.projectiles.some(p =>
+    p.owner === player && Math.abs(p.x - cpu.x) < 280 && Math.sign(p.vx) === Math.sign(cpu.x - p.x)
+  );
+
+  if ((incoming || projectileThreat) && Math.random() < config.guard) {
+    cpuInput.down(away);
+    match.cpuHold = [away];
+    if ((player.move && player.move.level === 'low') || Math.random() < 0.28) {
+      cpuInput.down('down');
+      match.cpuHold.push('down');
+    }
+    if (projectileThreat && id !== 'axl' && cpu.meter >= SPECIAL_COST && Math.random() < 0.35) {
+      cpuInput.tap('special');
+    }
+    return;
+  }
+
+  if (cpu.state === 'getup' || (cpu.invuln > 0 && cpu.state === 'idle' && distance < 140)) {
+    if (Math.random() < config.punish * 0.45) {
+      cpuInput.down('down');
+      cpuInput.tap('punch');
+      return;
+    }
+    if (Math.random() < config.guard) {
+      cpuInput.down(away);
+      match.cpuHold = [away];
+      return;
+    }
+  }
+
+  if ((player.state === 'knockdown' || player.state === 'getup') && Math.random() < config.attack) {
+    if (distance > 160 && Math.random() < 0.4) {
       cpuInput.down(toward);
       cpuInput.tap('jump');
+      match.cpuHold = [toward];
+      return;
+    }
+    if (distance < 90) {
+      cpuInput.tap('punch');
       cpuInput.tap('kick');
       return;
     }
   }
 
-  // --- Choose intended attack ---
+  if (!player.grounded() && player.y < GROUND - 70 && distance < 150 && Math.random() < config.punish) {
+    cpuInput.down('down');
+    cpuInput.tap('punch');
+    return;
+  }
+
   const roll = Math.random();
   let intentName = 'kick';
   let downIntent = false;
 
-  if (cpu.meter >= SPECIAL_COST && roll < 0.18) {
+  if (cpu.meter >= SPECIAL_COST && roll < (id === 'lennon' ? 0.28 : id === 'axl' ? 0.16 : 0.2)) {
     intentName = 'special';
-  } else if (player.y < GROUND - 60 && roll < config.punish) {
-    // Anti-air: uppercut against airborne player
+  } else if (id === 'axl' && distance > 180 && distance < 360 && cpu.grounded() && Math.random() < config.dash) {
+    cpu.state = 'dash';
+    cpu.dashType = 'forward';
+    cpu.dashTimer = 12;
+    cpu.facing = player.x >= cpu.x ? 1 : -1;
+    return;
+  } else if (roll < 0.38) {
     intentName = 'punch';
-    downIntent = true;
-  } else if (roll < 0.42) {
-    intentName = 'punch';
-  } else if (roll < 0.82) {
+  } else if (roll < 0.78) {
     intentName = 'kick';
   } else {
-    // Sweep
     intentName = 'kick';
     downIntent = true;
   }
 
-  // Determine the actual move name for range calculation
-  const moveName = downIntent
-    ? (intentName === 'punch' ? 'uppercut' : 'sweep')
-    : intentName;
-  const intendedMoveData = moveFor(cpu, moveName);
+  const moveName = downIntent ? (intentName === 'punch' ? 'uppercut' : 'sweep') : intentName;
+  const intended = moveFor(cpu, moveName);
+  const requiredRange = (intended.reach || 220) + BODY_WIDTH;
 
-  // Required range = move's reach + body width
-  const requiredRange = intendedMoveData.reach + BODY_WIDTH;
-
-  // --- Not in range: walk toward opponent ---
-  if (distance > requiredRange) {
-    // For projectile specials, fire at range
-    if (intentName === 'special' && intendedMoveData.projectile && distance < 500) {
-      cpuInput.tap('special');
-      return;
+  if (intentName === 'special' && intended.projectile && distance < 560 && distance > 140) {
+    cpuInput.tap('special');
+    if (Math.random() < config.sticky) {
+      cpuInput.down(away);
+      match.cpuHold = [away];
     }
-    cpuInput.down(toward);
     return;
   }
 
-  // --- In range: execute attack based on attack probability ---
+  if (distance > requiredRange + 12) {
+    cpuInput.down(toward);
+    match.cpuHold = [toward];
+    return;
+  }
+
   if (Math.random() < config.attack) {
     if (downIntent) cpuInput.down('down');
     cpuInput.tap(intentName);
-  } else if (distance < 125) {
-    // Too close and not attacking: back off
+  } else if (distance < 120) {
     cpuInput.down(away);
+    match.cpuHold = [away];
+  } else {
+    cpuInput.down(toward);
+    match.cpuHold = [toward];
   }
 }

--- a/labs/rock-kombat/audio.js
+++ b/labs/rock-kombat/audio.js
@@ -64,7 +64,9 @@ function sfx(name, strength = 1) {
   if (name === 'parry') { tone(940, .18, .12, 'sine', 0, 1.6); tone(1320, .22, .08, 'triangle', .03, .75); }
   if (name === 'special') { tone(75, .42, .22, 'sawtooth', 0, 4.2); noise(.3, .14, .06, 380); tone(440, .36, .08, 'square', .12, .5); }
   if (name === 'super') { tone(48, .7, .3, 'sawtooth', 0, 7); noise(.55, .2, .08, 130); tone(880, .5, .11, 'triangle', .18, .35); }
-  if (name === 'ko') { tone(130, .38, .2, 'sawtooth', 0, .38); tone(82, .55, .22, 'triangle', .18, .38); }
+  if (name === 'dash') { noise(.12, .07, 0, 400); tone(220, .1, .05, 'sawtooth', 0, 1.8); }
+  if (name === 'throw') { noise(.16, .16, 0, 80); tone(110, .2, .18, 'triangle', 0, .4); tone(70, .24, .12, 'sawtooth', .04, .55); }
+  if (name === 'ko') { tone(130, .38, .2, 'sawtooth', 0, .38); tone(82, .55, .22, 'triangle', .18, .38); noise(.4, .16, .08, 60); }
   if (name === 'round') { tone(330, .12, .1, 'square'); tone(440, .12, .1, 'square', .14); tone(660, .22, .12, 'square', .28); }
   if (name === 'win') { [261.6, 329.6, 392, 523.2].forEach((f, i) => tone(f, .32, .08, 'triangle', i * .12, 1.01)); }
 }

--- a/labs/rock-kombat/combat.js
+++ b/labs/rock-kombat/combat.js
@@ -1,184 +1,241 @@
 // ==========================================================================
-// Rock Kombat — Combat Module
-// Hit resolution, projectiles, particle effects, damage numbers
+// Rock Kombat — Combat
+// Hits, blocks, parries, throws, projectile clash, KO freeze
 // ==========================================================================
 
 import {
   PARRY_COOLDOWN, METER_GAIN, W,
   LEFT_WALL, RIGHT_WALL, GROUND,
-  BODY_WIDTH, PUSH_DISTANCE
+  PUSH_DISTANCE, COMBO_DECAY, MIN_SCALE
 } from './constants.js';
-import { clamp, lerp, random } from './utils.js';
+import { clamp, lerp, random, overlap } from './utils.js';
 import audio from './audio.js';
 
-/** AABB overlap test — returns true if rectangles a and b intersect */
-export function overlap(a, b) {
-  return a && b
-    && a.left < b.right && a.right > b.left
-    && a.top < b.bottom && a.bottom > b.top;
-}
+export { overlap };
 
-/**
- * Spawn impact particles and an expanding ring at (x, y).
- * @param {boolean} heavy - More particles and larger ring for heavy hits
- */
 export function addImpact(match, x, y, color, heavy = false) {
-  const count = heavy ? 22 : 12;
+  const count = heavy ? 26 : 14;
   for (let i = 0; i < count; i++) {
     const angle = random(0, Math.PI * 2);
-    const speed = random(2, heavy ? 11 : 7);
+    const speed = random(2.2, heavy ? 13 : 8);
     match.effects.push({
       x, y,
       vx: Math.cos(angle) * speed,
-      vy: Math.sin(angle) * speed,
-      life: random(12, heavy ? 28 : 20),
-      size: random(2, heavy ? 7 : 5),
-      color
+      vy: Math.sin(angle) * speed - random(0, 2),
+      life: random(12, heavy ? 30 : 20),
+      size: random(2, heavy ? 8 : 5),
+      color,
+      spark: i % 3 === 0
     });
   }
   match.rings.push({
     x, y,
-    life: heavy ? 16 : 11,
-    max: heavy ? 16 : 11,
+    life: heavy ? 18 : 12,
+    max: heavy ? 18 : 12,
     color
   });
 }
 
-/**
- * Add a floating damage number at impact point.
- * @param {string} type - 'hit' | 'block' | 'parry'
- */
-export function addDamageNumber(match, x, y, text, type, color) {
+export function addDust(match, x, y) {
+  for (let i = 0; i < 8; i++) {
+    match.effects.push({
+      x: x + random(-18, 18),
+      y: y - random(0, 8),
+      vx: random(-2.4, 2.4),
+      vy: random(-2.2, -0.4),
+      life: random(10, 18),
+      size: random(3, 7),
+      color: '#c4b8a4',
+      spark: false
+    });
+  }
+}
+
+export function addDamageNumber(match, x, y, text, color) {
   match.damageNumbers.push({
     x, y,
-    vy: -2,
+    vy: -2.4,
     text: String(text),
     color,
-    life: 45,
-    maxLife: 45
+    life: 48,
+    maxLife: 48
   });
 }
 
-/**
- * Core hit resolution. Determines block/parry/hit outcome and applies
- * damage, hitstun, meter gain, screen effects, and emits combo events.
- */
+function scaledDamage(attacker, move) {
+  const power = 0.82 + attacker.data.power / 430;
+  const comboIndex = Math.max(0, attacker.combo);
+  const scale = comboIndex <= 1 ? 1 : Math.max(MIN_SCALE, 1 - (comboIndex - 1) * COMBO_DECAY);
+  return Math.max(1, Math.round(move.damage * power * scale));
+}
+
+function incomingFactor(defender) {
+  return clamp(1 - (defender.data.defense - 72) * 0.0045, 0.82, 1.12);
+}
+
+function cornerPush(match, attacker, defender, amount) {
+  const next = defender.x + amount;
+  if (next <= LEFT_WALL || next >= RIGHT_WALL) {
+    attacker.x -= amount * 0.85;
+    defender.x = clamp(next, LEFT_WALL, RIGHT_WALL);
+    attacker.x = clamp(attacker.x, LEFT_WALL, RIGHT_WALL);
+  } else {
+    defender.x = next;
+  }
+}
+
 export function applyHit(match, attacker, defender, move, projectile = null) {
-  const blocked = defender.blocking(attacker, move);
+  const blocked = !move.unblockable && defender.blocking(attacker, move);
   const parry = blocked && defender.parrying(attacker);
-  const impactX = lerp(attacker.x, defender.x, 0.7);
-  const impactY = defender.y - (move.level === 'low' ? 65 : 190);
+  const impactX = lerp(attacker.x, defender.x, 0.68);
+  const impactY = defender.y - (move.level === 'low' ? 62 : 188);
+  const counter = !blocked && defender.state === 'attack';
 
   if (parry) {
-    // --- PARRY: defender punishes attacker ---
     defender.gainMeter(24);
     attacker.state = 'hitstun';
-    attacker.hitstun = 13;
-    attacker.vx = -attacker.facing * 3;
+    attacker.hitstun = 14;
+    attacker.vx = -attacker.facing * 3.4;
+    attacker.move = null;
     defender.parryCooldown = PARRY_COOLDOWN;
-
-    match.hitStop = 9;
-    match.shake = 3;
+    match.hitStop = 10;
+    match.shake = 4;
     addImpact(match, impactX, impactY, '#b9f2ff', true);
-    addDamageNumber(match, impactX, impactY - 40, 'PARRY', 'parry', '#b9f2ff');
+    addDamageNumber(match, impactX, impactY - 40, 'PARRY', '#b9f2ff');
     audio.sfx('parry');
-
   } else if (blocked) {
-    // --- BLOCK: reduced chip damage, pushback ---
-    const chip = Math.max(1, Math.floor(move.damage * 0.12));
+    const chip = Math.max(1, Math.floor(move.damage * (move.name === 'special' || move.superMove ? 0.18 : 0.1) * incomingFactor(defender)));
     defender.health = clamp(defender.health - chip, 0, 100);
     defender.state = 'blockstun';
-    defender.blockstun = move.blockstun;
-    defender.x += attacker.facing * move.push * 0.45;
-
+    defender.blockstun = move.blockstun + (move.superMove ? 4 : 0);
+    defender.vx = attacker.facing * move.push * 0.12;
+    cornerPush(match, attacker, defender, attacker.facing * move.push * 0.42);
     attacker.gainMeter(move.meter * METER_GAIN.block);
     defender.gainMeter(Math.max(2, move.damage * METER_GAIN.guard));
-
     match.hitStop = Math.max(3, move.hitstop - 2);
     match.shake = 2;
     addImpact(match, impactX, impactY, '#a8c9ce');
-    addDamageNumber(match, impactX, impactY - 40, chip, 'block', '#a8c9ce');
+    addDamageNumber(match, impactX, impactY - 40, chip, '#a8c9ce');
     audio.sfx('block');
-
   } else {
-    // --- HIT: full damage, hitstun, potential combo ---
-    defender.health = clamp(defender.health - move.damage, 0, 100);
-    defender.state = move.knockdown ? 'knockdown' : 'hitstun';
-    defender.hitstun = move.hitstun;
+    let damage = Math.max(1, Math.round(scaledDamage(attacker, move) * incomingFactor(defender)));
+    if (counter) damage = Math.round(damage * 1.15);
+    if (move.superMove) damage = Math.round(damage * 1.08);
+
+    defender.health = clamp(defender.health - damage, 0, 100);
+    defender.launched = Boolean(move.launch);
+    defender.state = move.knockdown && !move.launch ? 'knockdown' : 'hitstun';
+    defender.hitstun = move.hitstun + (counter ? 6 : 0);
     defender.knockdown = move.knockdown || 0;
-    defender.vx = attacker.facing * move.push * 0.2;
+    defender.move = null;
+    defender.moveFrame = 0;
+    defender.dashTimer = 0;
+    defender.vx = attacker.facing * move.push * 0.22;
     if (move.launch) defender.vy = -move.launch;
 
+    if (move.level === 'throw') {
+      defender.x = clamp(attacker.x + attacker.facing * 88, LEFT_WALL, RIGHT_WALL);
+      defender.vx = attacker.facing * 6;
+      defender.state = 'knockdown';
+      defender.knockdown = move.knockdown;
+      defender.y = GROUND;
+      defender.vy = 0;
+      audio.sfx('throw');
+    }
+
     attacker.gainMeter(move.meter * METER_GAIN.hit);
-    defender.gainMeter(Math.max(4, move.damage * METER_GAIN.damage));
+    defender.gainMeter(Math.max(4, damage * METER_GAIN.damage));
     attacker.moveConnected = true;
-
-    // Combo tracking
     attacker.combo = attacker.comboClock > 0 ? attacker.combo + 1 : 1;
-    attacker.comboClock = 55;
+    attacker.comboClock = 58;
+    attacker.comboDamage += damage;
 
-    match.hitStop = move.hitstop;
-    match.shake = move.damage >= 10 ? 7 : 4;
-    addImpact(match, impactX, impactY, attacker.data.color, move.damage >= 10);
-    addDamageNumber(match, impactX, impactY - 40, move.damage, 'hit', attacker.data.color);
-    audio.sfx(move.damage >= 10 ? 'heavy' : 'light', move.damage / 10);
+    match.hitStop = move.hitstop + (counter ? 2 : 0);
+    match.shake = damage >= 12 || move.superMove ? 9 : damage >= 8 ? 5 : 3;
+    addImpact(match, impactX, impactY, attacker.data.color, damage >= 10 || counter);
+    addDamageNumber(match, impactX, impactY - 42, counter ? `${damage}!` : damage, attacker.data.color);
+    audio.sfx(damage >= 10 || move.superMove ? 'heavy' : 'light', damage / 10);
 
-    // Emit combo event for UI
     if (attacker.combo >= 2) {
       match.events.push({ type: 'combo', fighter: attacker });
     }
+
+    if (defender.health <= 0) {
+      defender.state = 'knockdown';
+      defender.knockdown = 90;
+      defender.vy = move.launch ? defender.vy : -7;
+      defender.launched = true;
+      match.koZoom = 28;
+      match.shake = 14;
+    }
   }
 
-  // Mark projectile as dead, or flag melee move as having hit
   if (projectile) projectile.dead = true;
   else attacker.moveHit = true;
 }
 
-/** Spawn a projectile from a fighter's special move */
 export function spawnProjectile(match, owner, move) {
-  const superScale = move.superMove ? 1.8 : 1;
+  const superScale = move.superMove ? 1.85 : 1;
+  const speed = (move.projectileSpeed || 10.5) * (move.superMove ? 1.22 : 1);
   match.projectiles.push({
     owner, move,
-    x: owner.x + owner.facing * 75,
+    x: owner.x + owner.facing * 78,
     y: owner.y - 155,
-    vx: owner.facing * (move.superMove ? 13 : owner.data.id === 'lennon' ? 9.5 : 10.5),
-    radius: 30 * superScale,
-    life: move.superMove ? 95 : 75,
+    vx: owner.facing * speed,
+    radius: (move.projectileRadius || 30) * superScale,
+    life: move.superMove ? 100 : 78,
     color: owner.data.color,
-    dead: false
+    dead: false,
+    superMove: move.superMove
   });
   match.rings.push({
-    x: owner.x + owner.facing * 50,
+    x: owner.x + owner.facing * 54,
     y: owner.y - 160,
     life: 22, max: 22,
     color: owner.data.color
   });
 }
 
-/** Update all active projectiles — movement, collision, cleanup */
 export function updateProjectiles(match) {
   for (let i = match.projectiles.length - 1; i >= 0; i--) {
     const p = match.projectiles[i];
     p.x += p.vx;
     p.life--;
 
-    const defender = p.owner === match.p1 ? match.p2 : match.p1;
-
     const box = {
       left: p.x - p.radius, right: p.x + p.radius,
       top: p.y - p.radius, bottom: p.y + p.radius
     };
 
+    for (let j = match.projectiles.length - 1; j > i; j--) {
+      const other = match.projectiles[j];
+      if (other.owner === p.owner) continue;
+      const dx = p.x - other.x;
+      const dy = p.y - other.y;
+      if (dx * dx + dy * dy < (p.radius + other.radius) ** 2) {
+        if (p.superMove && !other.superMove) {
+          other.dead = true;
+        } else if (other.superMove && !p.superMove) {
+          p.dead = true;
+        } else {
+          p.dead = true;
+          other.dead = true;
+        }
+        addImpact(match, (p.x + other.x) / 2, (p.y + other.y) / 2, '#fff4d0', true);
+        audio.sfx('block');
+      }
+    }
+
+    const defender = p.owner === match.p1 ? match.p2 : match.p1;
     if (!p.dead && defender.invuln <= 0 && overlap(box, defender.hurtBox())) {
       applyHit(match, p.owner, defender, p.move, p);
     }
 
-    if (p.life <= 0 || p.x < 0 || p.x > W) p.dead = true;
+    if (p.life <= 0 || p.x < -40 || p.x > W + 40) p.dead = true;
     if (p.dead) match.projectiles.splice(i, 1);
   }
 }
 
-/** Check if attacker's active hitbox overlaps defender's hurtbox */
 export function resolveCombat(match, attacker, defender) {
   if (defender.invuln > 0) return;
   if (overlap(attacker.activeBox(), defender.hurtBox())) {
@@ -186,48 +243,46 @@ export function resolveCombat(match, attacker, defender) {
   }
 }
 
-/** Push fighters apart when overlapping on the ground */
 export function bodyPush(match) {
   const a = match.p1, b = match.p2;
-  if (!a.grounded() || !b.grounded()) return;
   const gap = b.x - a.x;
-  if (Math.abs(gap) < PUSH_DISTANCE) {
-    const push = (PUSH_DISTANCE - Math.abs(gap)) / 2;
-    const sign = gap >= 0 ? 1 : -1;
-    a.x -= push * sign;
-    b.x += push * sign;
-    a.x = clamp(a.x, LEFT_WALL, RIGHT_WALL);
-    b.x = clamp(b.x, LEFT_WALL, RIGHT_WALL);
-  }
+  if (Math.abs(gap) >= PUSH_DISTANCE) return;
+  const push = (PUSH_DISTANCE - Math.abs(gap)) / 2;
+  const sign = gap >= 0 ? 1 : -1;
+  const airScale = (a.grounded() && b.grounded()) ? 1 : 0.45;
+  a.x -= push * sign * airScale;
+  b.x += push * sign * airScale;
+  a.x = clamp(a.x, LEFT_WALL, RIGHT_WALL);
+  b.x = clamp(b.x, LEFT_WALL, RIGHT_WALL);
 }
 
-/** Update all visual effects: particles, rings, damage numbers, screen shake */
 export function updateEffects(match) {
-  // Impact particles
   for (let i = match.effects.length - 1; i >= 0; i--) {
     const fx = match.effects[i];
     fx.x += fx.vx;
     fx.y += fx.vy;
-    fx.vx *= 0.94;
-    fx.vy *= 0.94;
+    fx.vx *= 0.93;
+    fx.vy *= 0.93;
+    fx.vy += 0.08;
     if (--fx.life <= 0) match.effects.splice(i, 1);
   }
 
-  // Expanding rings
   for (let i = match.rings.length - 1; i >= 0; i--) {
     if (--match.rings[i].life <= 0) match.rings.splice(i, 1);
   }
 
-  // Floating damage numbers
   if (match.damageNumbers) {
     for (let i = match.damageNumbers.length - 1; i >= 0; i--) {
       const dn = match.damageNumbers[i];
       dn.y += dn.vy;
+      dn.vy *= 0.96;
       if (--dn.life <= 0) match.damageNumbers.splice(i, 1);
     }
   }
 
-  // Screen shake decay
+  if (match.superFlash > 0) match.superFlash--;
+  if (match.koZoom > 0) match.koZoom--;
+
   match.shake *= 0.78;
   if (match.shake < 0.15) match.shake = 0;
 }

--- a/labs/rock-kombat/constants.js
+++ b/labs/rock-kombat/constants.js
@@ -77,7 +77,7 @@ export const MOVES = {
 };
 
 export const AI_CONFIG = {
-  easy:   { think: [18, 32], guard: 0.32, attack: 0.42, punish: 0.22, sticky: 0.35, dash: 0.08 },
+  easy:   { think: [22, 40], guard: 0.22, attack: 0.3,  punish: 0.12, sticky: 0.22, dash: 0.04 },
   normal: { think: [8, 16],  guard: 0.58, attack: 0.7,  punish: 0.55, sticky: 0.55, dash: 0.18 },
   hard:   { think: [4, 9],   guard: 0.8,  attack: 0.88, punish: 0.84, sticky: 0.72, dash: 0.3 }
 };

--- a/labs/rock-kombat/constants.js
+++ b/labs/rock-kombat/constants.js
@@ -11,11 +11,11 @@ export const RIGHT_WALL = 1120;
 
 export const STEP = 1000 / 60;
 export const INPUT_BUFFER = 10;
-export const DASH_WINDOW = 14;
+export const DASH_WINDOW = 20;
 export const PARRY_WINDOW = 3;
 export const PARRY_COOLDOWN = 30;
 export const SPECIAL_COST = 40;
-export const THROW_RANGE = 78;
+export const THROW_RANGE = 96;
 export const GRAVITY = 0.78;
 export const BACK_WALK = 0.68;
 export const LAND_LAG = 5;

--- a/labs/rock-kombat/constants.js
+++ b/labs/rock-kombat/constants.js
@@ -1,90 +1,87 @@
 // ==========================================================================
 // Rock Kombat — Game Constants
-// All configurable values, data definitions, and frame mappings
+// Arcade timing, roster, stages and Street Fighter / MK frame data
 // ==========================================================================
 
-// --- Arena dimensions ---
 export const W = 1280;
 export const H = 720;
 export const GROUND = 620;
-export const LEFT_WALL = 190;
-export const RIGHT_WALL = 1090;
+export const LEFT_WALL = 160;
+export const RIGHT_WALL = 1120;
 
-// --- Timing ---
 export const STEP = 1000 / 60;
-export const INPUT_BUFFER = 9;
-
-// --- Combat tuning ---
-export const PARRY_WINDOW = 3;       // frames (reduced from 4 for balance)
-export const PARRY_COOLDOWN = 30;    // frames between parries
-export const SPECIAL_COST = 40;      // meter required for special
+export const INPUT_BUFFER = 10;
+export const DASH_WINDOW = 14;
+export const PARRY_WINDOW = 3;
+export const PARRY_COOLDOWN = 30;
+export const SPECIAL_COST = 40;
+export const THROW_RANGE = 78;
+export const GRAVITY = 0.78;
+export const BACK_WALK = 0.68;
+export const LAND_LAG = 5;
+export const COMBO_DECAY = 0.12;
+export const MIN_SCALE = 0.42;
 
 export const METER_GAIN = Object.freeze({
-  commit: 0.2,   // on move startup
-  hit: 0.8,      // on successful hit
-  block: 0.55,   // attacker gains on blocked hit
-  damage: 0.65,  // defender gains on taking damage
-  guard: 0.3     // defender gains on blocking
+  commit: 0.18,
+  hit: 0.85,
+  block: 0.5,
+  damage: 0.7,
+  guard: 0.32
 });
 
-// --- Sizing ---
 export const SPRITE_SIZE = 405;
 export const BODY_WIDTH = 42;
-export const PUSH_DISTANCE = 92;
+export const PUSH_DISTANCE = 96;
 
-// --- Fighter roster ---
 export const FIGHTERS = [
   {
-    id: 'kurt', name: 'Kurt Cobain', short: 'KURT', era: 'GRUNGE / BALANCED',
-    style: 'Controle de espaço e impacto', special: 'Feedback Wave',
+    id: 'kurt', name: 'Kurt Cobain', short: 'KURT', era: 'GRUNGE / SHOTO',
+    style: 'Espaço, confirms e feedback à distância', special: 'Feedback Wave',
     sheet: 'assets/fighter-kurt-sheet-v2.webp',
-    color: '#c6b06a', speed: 6.1, jump: 13.1, power: 82, mobility: 72, defense: 75,
+    color: '#c6b06a', speed: 6.05, jump: 13.2, power: 84, mobility: 72, defense: 76,
     quote: 'Sem bis. Só feedback.'
   },
   {
     id: 'axl', name: 'Axl Rose', short: 'AXL', era: 'HARD ROCK / RUSHDOWN',
-    style: 'Pressão, avanço e velocidade', special: 'Paradise Rush',
+    style: 'Dash, pressão e mix-up no canto', special: 'Paradise Rush',
     sheet: 'assets/fighter-axl-sheet-v2.webp',
-    color: '#c84d3c', speed: 6.7, jump: 13.4, power: 76, mobility: 90, defense: 66,
+    color: '#c84d3c', speed: 6.85, jump: 13.55, power: 78, mobility: 92, defense: 64,
     quote: 'O palco nunca espera.'
   },
   {
-    id: 'lennon', name: 'John Lennon', short: 'LENNON', era: 'ROCK / CONTROL',
-    style: 'Defesa, contra-ataque e alcance', special: 'Peace Pulse',
+    id: 'lennon', name: 'John Lennon', short: 'LENNON', era: 'ROCK / ZONER',
+    style: 'Defesa, anti-ar e controle de tela', special: 'Peace Pulse',
     sheet: 'assets/fighter-lennon-sheet-v2.webp',
-    color: '#729788', speed: 5.7, jump: 12.7, power: 74, mobility: 68, defense: 88,
+    color: '#729788', speed: 5.55, jump: 12.55, power: 74, mobility: 66, defense: 90,
     quote: 'Dê uma chance ao contra-ataque.'
   }
 ];
 
-// --- Stage definitions ---
 export const STAGES = {
   seattle:  { name: 'SEATTLE RAIN',   image: 'assets/stage-seattle.webp',   tint: '#6f8da1', accent: '#d6a45b' },
   coliseum: { name: 'RED COLOSSEUM',  image: 'assets/stage-coliseum.webp',  tint: '#b83d31', accent: '#e5a14b' },
   cellar:   { name: 'ABBEY CELLAR',   image: 'assets/stage-cellar.webp',    tint: '#7c8c77', accent: '#c38b52' }
 };
 
-// --- Move frame data ---
-// Each move: startup (before hit), active (hitbox live), recovery (after hit)
-// damage, hitstun/blockstun (defender's frozen frames), reach (px), hitbox top/bottom (relative to feet)
-// push (knockback), hitstop (freeze on contact), meter (gain), sprite (sheet frame index)
-// level: 'mid' | 'low' | 'overhead', cancel: moves this can chain into
+// Frame data: startup / active / recovery at 60fps.
+// level: mid (stand block) | low (crouch block) | overhead (stand block) | throw (unblockable)
 export const MOVES = {
-  punch:    { startup: 5,  active: 3, recovery: 10, damage: 6,  hitstun: 15, blockstun: 9,  reach: 96,  top: 245, bottom: 105, push: 18, hitstop: 5,  meter: 10, sprite: 5, level: 'mid',      cancel: ['kick', 'special'] },
-  kick:     { startup: 10, active: 4, recovery: 17, damage: 10, hitstun: 20, blockstun: 12, reach: 145, top: 270, bottom: 70,  push: 30, hitstop: 8,  meter: 15, sprite: 6, level: 'mid',      cancel: ['special'] },
-  sweep:    { startup: 12, active: 4, recovery: 24, damage: 9,  hitstun: 14, blockstun: 14, reach: 154, top: 76,  bottom: 5,   push: 36, hitstop: 8,  meter: 14, sprite: 7, level: 'low',      knockdown: 42 },
-  uppercut: { startup: 6,  active: 5, recovery: 25, damage: 11, hitstun: 22, blockstun: 15, reach: 104, top: 320, bottom: 34,  push: 26, hitstop: 9,  meter: 16, sprite: 8, level: 'mid',      launch: 12.5 },
-  airkick:  { startup: 5,  active: 9, recovery: 10, damage: 9,  hitstun: 18, blockstun: 12, reach: 125, top: 210, bottom: 30,  push: 30, hitstop: 7,  meter: 14, sprite: 6, level: 'overhead' }
+  punch:    { startup: 4,  active: 3, recovery: 9,  damage: 6,  hitstun: 14, blockstun: 9,  reach: 98,  top: 245, bottom: 105, push: 16, hitstop: 6,  meter: 9,  sprite: 5, level: 'mid',      advance: 1.4, cancel: ['kick', 'special'] },
+  kick:     { startup: 9,  active: 4, recovery: 16, damage: 10, hitstun: 19, blockstun: 12, reach: 148, top: 270, bottom: 70,  push: 28, hitstop: 8,  meter: 14, sprite: 6, level: 'mid',      advance: 2.4, cancel: ['special'] },
+  sweep:    { startup: 11, active: 4, recovery: 26, damage: 9,  hitstun: 12, blockstun: 14, reach: 156, top: 76,  bottom: 5,   push: 34, hitstop: 8,  meter: 13, sprite: 7, level: 'low',      knockdown: 44 },
+  uppercut: { startup: 5,  active: 6, recovery: 26, damage: 12, hitstun: 24, blockstun: 15, reach: 108, top: 340, bottom: 28,  push: 22, hitstop: 10, meter: 16, sprite: 8, level: 'mid',      launch: 13.2, advance: 3.2, invuln: 5 },
+  airpunch: { startup: 4,  active: 8, recovery: 8,  damage: 7,  hitstun: 14, blockstun: 10, reach: 102, top: 200, bottom: 40,  push: 18, hitstop: 6,  meter: 10, sprite: 5, level: 'overhead' },
+  airkick:  { startup: 5,  active: 10, recovery: 8, damage: 9,  hitstun: 16, blockstun: 12, reach: 128, top: 210, bottom: 24,  push: 26, hitstop: 7,  meter: 13, sprite: 6, level: 'overhead' },
+  throw:    { startup: 3,  active: 4, recovery: 24, damage: 14, hitstun: 0,  blockstun: 0,  reach: 72,  top: 250, bottom: 40,  push: 0,  hitstop: 14, meter: 16, sprite: 5, level: 'throw',    knockdown: 50, unblockable: true }
 };
 
-// --- AI difficulty profiles ---
 export const AI_CONFIG = {
-  easy:   { think: [16, 28], guard: 0.38, attack: 0.46, punish: 0.28 },
-  normal: { think: [9, 18],  guard: 0.62, attack: 0.68, punish: 0.58 },
-  hard:   { think: [4, 10],  guard: 0.82, attack: 0.86, punish: 0.82 }
+  easy:   { think: [18, 32], guard: 0.32, attack: 0.42, punish: 0.22, sticky: 0.35, dash: 0.08 },
+  normal: { think: [8, 16],  guard: 0.58, attack: 0.7,  punish: 0.55, sticky: 0.55, dash: 0.18 },
+  hard:   { think: [4, 9],   guard: 0.8,  attack: 0.88, punish: 0.84, sticky: 0.72, dash: 0.3 }
 };
 
-// --- Sprite sheet frame indices (4 cols × 3 rows = 12 frames) ---
 export const FRAME = {
   idleA: 0, idleB: 1, forward: 2, back: 3,
   crouch: 4, punch: 5, kick: 6, sweep: 7,

--- a/labs/rock-kombat/fighter.js
+++ b/labs/rock-kombat/fighter.js
@@ -214,6 +214,9 @@ export class Fighter {
 
   chooseAction() {
     if (this.input.consume('special')) return this.beginMove('special');
+    if (this.input.consume('throw')) {
+      return this.canThrow() ? this.beginMove('throw') : this.beginMove('punch');
+    }
 
     const throwChord = this.input.has('punch') && this.input.has('kick')
       && (this.input.fresh('punch', 4) || this.input.fresh('kick', 4));

--- a/labs/rock-kombat/fighter.js
+++ b/labs/rock-kombat/fighter.js
@@ -57,7 +57,7 @@ export function moveFor(fighter, name) {
 }
 
 const LOCKED_FACE = new Set(['attack', 'hitstun', 'blockstun', 'knockdown', 'getup', 'dash', 'backdash']);
-const UNTHROWABLE = new Set(['hitstun', 'blockstun', 'knockdown', 'getup', 'victory']);
+const UNTHROWABLE = new Set(['hitstun', 'knockdown', 'getup', 'victory']);
 
 export class Fighter {
   constructor(data, input, isCpu = false) {
@@ -215,7 +215,10 @@ export class Fighter {
   chooseAction() {
     if (this.input.consume('special')) return this.beginMove('special');
 
-    if (this.input.fresh('punch', INPUT_BUFFER) && this.input.fresh('kick', INPUT_BUFFER) && this.canThrow()) {
+    const throwChord = this.input.has('punch') && this.input.has('kick')
+      && (this.input.fresh('punch', 4) || this.input.fresh('kick', 4));
+    const throwTaps = this.input.fresh('punch', INPUT_BUFFER) && this.input.fresh('kick', INPUT_BUFFER);
+    if (this.canThrow() && (throwChord || throwTaps)) {
       this.input.consume('punch');
       this.input.consume('kick');
       return this.beginMove('throw');

--- a/labs/rock-kombat/fighter.js
+++ b/labs/rock-kombat/fighter.js
@@ -1,52 +1,48 @@
 // ==========================================================================
-// Rock Kombat — Fighter Module
-// Fighter class with state machine, hitbox/hurtbox, and move execution
+// Rock Kombat — Fighter
+// Street Fighter / Mortal Kombat state machine: dash, jump arc, throws, DP
 // ==========================================================================
 
 import {
   GROUND, LEFT_WALL, RIGHT_WALL,
   SPECIAL_COST, PARRY_WINDOW, PARRY_COOLDOWN,
-  MOVES, METER_GAIN, FRAME, BODY_WIDTH
+  MOVES, METER_GAIN, FRAME, BODY_WIDTH, THROW_RANGE,
+  GRAVITY, BACK_WALK, LAND_LAG, INPUT_BUFFER
 } from './constants.js';
 import { clamp } from './utils.js';
 import audio from './audio.js';
 import { spawnProjectile } from './combat.js';
 
-/**
- * Build move data for a given fighter + move name.
- * Special/Super moves are character-specific.
- */
 export function moveFor(fighter, name) {
   if (name !== 'special') return { name, ...MOVES[name] };
 
   const superMove = fighter.meter >= 100;
 
-  // Axl Rose — rush-type special (dash forward with active hitbox)
   if (fighter.data.id === 'axl') {
     return {
       name: superMove ? 'super' : 'special',
-      startup: superMove ? 13 : 9,
-      active: superMove ? 10 : 7,
-      recovery: 24,
-      damage: superMove ? 24 : 14,
+      startup: superMove ? 11 : 8,
+      active: superMove ? 11 : 8,
+      recovery: 22,
+      damage: superMove ? 26 : 15,
       hitstun: 28, blockstun: 16,
-      reach: superMove ? 270 : 215,
+      reach: superMove ? 280 : 220,
       top: 270, bottom: 35,
-      push: 58,
-      hitstop: superMove ? 14 : 10,
+      push: 62,
+      hitstop: superMove ? 15 : 10,
       meter: 0, sprite: 6, level: 'mid',
-      rush: superMove ? 18 : 13,
+      rush: superMove ? 19 : 14,
       superMove
     };
   }
 
-  // Kurt & Lennon — projectile-type special
+  const zoner = fighter.data.id === 'lennon';
   return {
     name: superMove ? 'super' : 'special',
-    startup: superMove ? 17 : 12,
+    startup: superMove ? (zoner ? 16 : 14) : (zoner ? 13 : 11),
     active: 1,
-    recovery: superMove ? 34 : 27,
-    damage: superMove ? 22 : 13,
+    recovery: superMove ? 32 : 24,
+    damage: superMove ? (zoner ? 20 : 23) : (zoner ? 12 : 14),
     hitstun: 26, blockstun: 15,
     reach: 0,
     top: 260, bottom: 55,
@@ -54,21 +50,15 @@ export function moveFor(fighter, name) {
     hitstop: superMove ? 13 : 9,
     meter: 0, sprite: 8, level: 'mid',
     projectile: true,
+    projectileSpeed: zoner ? 8.4 : 11.2,
+    projectileRadius: zoner ? 36 : 28,
     superMove
   };
 }
 
-/**
- * Fighter — represents a player or CPU combatant.
- *
- * State machine:
- *   idle → walk / crouch / jump / attack
- *   attack → idle (on move end) / attack (on cancel)
- *   hitstun → idle / jump (on stun end)
- *   blockstun → idle (on stun end)
- *   knockdown → getup → idle
- *   victory (terminal)
- */
+const LOCKED_FACE = new Set(['attack', 'hitstun', 'blockstun', 'knockdown', 'getup', 'dash', 'backdash']);
+const UNTHROWABLE = new Set(['hitstun', 'blockstun', 'knockdown', 'getup', 'victory']);
+
 export class Fighter {
   constructor(data, input, isCpu = false) {
     this.data = data;
@@ -76,13 +66,17 @@ export class Fighter {
     this.isCpu = isCpu;
     this.wins = 0;
     this.match = null;
-    this.image = null; // set after assets load
+    this.image = null;
     this.reset(isCpu ? 910 : 370);
   }
 
-  /** Store reference to the match object (for events, freeze, projectiles) */
   setMatch(match) {
     this.match = match;
+  }
+
+  opponent() {
+    if (!this.match) return null;
+    return this.isCpu ? this.match.p1 : this.match.p2;
   }
 
   reset(x, preserveMeter = false) {
@@ -91,6 +85,7 @@ export class Fighter {
     this.y = GROUND;
     this.vx = 0;
     this.vy = 0;
+    this.jumpVx = 0;
     this.facing = this.isCpu ? -1 : 1;
     this.health = 100;
     this.whiteHealth = 100;
@@ -107,7 +102,14 @@ export class Fighter {
     this.invuln = 0;
     this.combo = 0;
     this.comboClock = 0;
+    this.comboDamage = 0;
     this.parryCooldown = 0;
+    this.dashTimer = 0;
+    this.dashType = null;
+    this.landLag = 0;
+    this.launched = false;
+    this.trail = [];
+    this.wasGrounded = true;
   }
 
   grounded() { return this.y >= GROUND - 0.1; }
@@ -116,7 +118,7 @@ export class Fighter {
 
   gainMeter(amount) { this.meter = clamp(this.meter + amount, 0, 100); }
 
-  directionTo(opponent) { return opponent.x > this.x ? 1 : -1; }
+  directionTo(opponent) { return opponent.x >= this.x ? 1 : -1; }
 
   awayHeld(opponent) {
     return this.directionTo(opponent) === 1
@@ -124,48 +126,55 @@ export class Fighter {
       : this.input.has('right');
   }
 
-  /**
-   * Is this fighter currently blocking the given move?
-   * Standing block stops mid/overhead, crouching block stops low.
-   */
+  towardHeld(opponent) {
+    return this.directionTo(opponent) === 1
+      ? this.input.has('right')
+      : this.input.has('left');
+  }
+
   blocking(opponent, move) {
-    if (!this.neutral() || !this.grounded() || !this.awayHeld(opponent)) return false;
+    if (move.unblockable) return false;
+    if (!this.grounded() || !this.awayHeld(opponent)) return false;
+    if (!this.neutral() && this.state !== 'blockstun') return false;
     if (move.level === 'low') return this.input.has('down');
     if (move.level === 'overhead') return !this.input.has('down');
     return true;
   }
 
-  /**
-   * Is the fighter performing a just-frame parry?
-   * Requires a fresh directional input within PARRY_WINDOW frames
-   * and no active parry cooldown.
-   */
   parrying(opponent) {
     if (this.parryCooldown > 0) return false;
     const away = this.directionTo(opponent) === 1 ? 'left' : 'right';
     return this.input.fresh(away, PARRY_WINDOW);
   }
 
-  /**
-   * Attempt to start a move. Returns true if successful.
-   * Handles cancel chains: a connected hit can cancel into allowed moves,
-   * but only after startup frames have elapsed (no startup cancels).
-   */
+  canThrow() {
+    const opponent = this.opponent();
+    if (!opponent || !this.grounded() || !opponent.grounded()) return false;
+    if (opponent.invuln > 0) return false;
+    if (UNTHROWABLE.has(opponent.state)) return false;
+    if (opponent.activeBox()) return false;
+    return Math.abs(opponent.x - this.x) <= THROW_RANGE;
+  }
+
   beginMove(name) {
     const next = moveFor(this, name);
 
     if (this.move) {
-      // Cancel check: must have connected AND be past startup
       const cancelable = this.moveConnected
         && this.moveFrame >= this.move.startup
         && this.move.cancel
-        && this.move.cancel.includes(name);
+        && this.move.cancel.includes(name === 'special' ? 'special' : name);
       if (!cancelable) return false;
-    } else if (!this.neutral()) {
+    } else if (this.landLag > 0) {
+      return false;
+    } else if (this.state === 'dash') {
+      if (this.dashType === 'back') return false;
+    } else if (this.state === 'getup') {
+      if (!['special', 'uppercut'].includes(next.name) && name !== 'special') return false;
+    } else if (!this.neutral() && this.state !== 'dash') {
       return false;
     }
 
-    // Meter cost for specials
     if (name === 'special') {
       if (this.meter < SPECIAL_COST) return false;
       this.meter = next.superMove ? 0 : this.meter - SPECIAL_COST;
@@ -178,17 +187,21 @@ export class Fighter {
     this.moveConnected = false;
     this.moveHit = false;
     this.state = 'attack';
+    this.dashTimer = 0;
+    this.dashType = null;
 
-    // Sound effect
+    if (next.invuln) this.invuln = Math.max(this.invuln, next.invuln);
+    if (next.superMove && this.data.id === 'axl') this.invuln = Math.max(this.invuln, 6);
+
     audio.sfx(
-      next.superMove ? 'super' : name === 'special' ? 'special' : 'whiff',
+      next.superMove ? 'super' : name === 'throw' ? 'throw' : name === 'special' ? 'special' : 'whiff',
       next.damage / 10
     );
 
-    // Super move: freeze frame + announcement via events
     if (next.superMove && this.match) {
-      this.match.freeze = 18;
-      this.match.shake = 8;
+      this.match.freeze = 20;
+      this.match.shake = 10;
+      this.match.superFlash = 18;
       this.match.events.push({
         type: 'announce',
         text: `${this.data.short} SUPER`,
@@ -199,12 +212,15 @@ export class Fighter {
     return true;
   }
 
-  /**
-   * Check buffered inputs and attempt to execute a move.
-   * Priority: special > kick > punch
-   */
   chooseAction() {
     if (this.input.consume('special')) return this.beginMove('special');
+
+    if (this.input.fresh('punch', INPUT_BUFFER) && this.input.fresh('kick', INPUT_BUFFER) && this.canThrow()) {
+      this.input.consume('punch');
+      this.input.consume('kick');
+      return this.beginMove('throw');
+    }
+
     if (this.input.consume('kick')) {
       return this.beginMove(
         !this.grounded() ? 'airkick'
@@ -214,132 +230,208 @@ export class Fighter {
     }
     if (this.input.consume('punch')) {
       return this.beginMove(
-        this.input.has('down') && this.grounded() ? 'uppercut' : 'punch'
+        !this.grounded() ? 'airpunch'
+          : this.input.has('down') ? 'uppercut'
+          : 'punch'
       );
     }
     return false;
   }
 
-  /** Main per-frame update. Handles state transitions and physics. */
+  tryDash(opponent) {
+    if (!this.grounded() || this.move || this.landLag > 0) return false;
+    if (this.input.has('down')) return false;
+    const toward = this.directionTo(opponent) === 1 ? 'right' : 'left';
+    const away = toward === 'right' ? 'left' : 'right';
+    if (this.input.consumeDash(toward)) {
+      this.state = 'dash';
+      this.dashType = 'forward';
+      this.dashTimer = 12;
+      this.stateFrame = 0;
+      audio.sfx('dash');
+      return true;
+    }
+    if (this.input.consumeDash(away)) {
+      this.state = 'backdash';
+      this.dashType = 'back';
+      this.dashTimer = 14;
+      this.invuln = Math.max(this.invuln, 8);
+      this.stateFrame = 0;
+      audio.sfx('dash');
+      return true;
+    }
+    return false;
+  }
+
+  pushTrail() {
+    if ((this.state === 'dash' || this.state === 'backdash' || (this.move && this.move.rush)) && (this.stateFrame & 1) === 0) {
+      this.trail.push({
+        x: this.x,
+        y: this.y,
+        frame: this.spriteFrame(),
+        facing: this.facing,
+        life: 8
+      });
+      if (this.trail.length > 6) this.trail.shift();
+    }
+    for (let i = this.trail.length - 1; i >= 0; i--) {
+      if (--this.trail[i].life <= 0) this.trail.splice(i, 1);
+    }
+  }
+
   update(opponent) {
     this.stateFrame++;
     if (this.invuln > 0) this.invuln--;
-    if (this.comboClock > 0) this.comboClock--; else this.combo = 0;
+    if (this.landLag > 0) this.landLag--;
+    if (this.comboClock > 0) this.comboClock--;
+    else {
+      this.combo = 0;
+      this.comboDamage = 0;
+    }
     if (this.parryCooldown > 0) this.parryCooldown--;
 
-    // White health lerps toward actual health (visual "chip" drain)
-    this.whiteHealth += (this.health - this.whiteHealth) * 0.045;
-    this.facing = this.directionTo(opponent);
+    this.whiteHealth += (this.health - this.whiteHealth) * 0.05;
+    if (!LOCKED_FACE.has(this.state)) this.facing = this.directionTo(opponent);
 
-    // --- Hitstun state ---
+    this.pushTrail();
+
     if (this.state === 'hitstun') {
       this.hitstun--;
       this.x += this.vx;
-      this.vx *= 0.88;
+      this.vx *= 0.86;
       if (!this.grounded() || this.vy) {
         this.y += this.vy;
-        this.vy += 0.72;
-        if (this.y >= GROUND) { this.y = GROUND; this.vy = 0; }
+        this.vy += GRAVITY;
+        if (this.y >= GROUND) {
+          this.y = GROUND;
+          this.vy = 0;
+          this.vx *= 0.4;
+          if (this.launched || this.hitstun > 2) {
+            this.state = 'knockdown';
+            this.knockdown = Math.max(this.knockdown, 28);
+            this.launched = false;
+            this.hitstun = 0;
+            return;
+          }
+        }
       }
-      if (this.hitstun <= 0) this.state = this.grounded() ? 'idle' : 'jump';
+      if (this.hitstun <= 0) {
+        this.launched = false;
+        this.state = this.grounded() ? 'idle' : 'jump';
+        if (!this.grounded()) this.jumpVx = this.vx;
+      }
+      this.x = clamp(this.x, LEFT_WALL, RIGHT_WALL);
       return;
     }
 
-    // --- Blockstun state ---
     if (this.state === 'blockstun') {
-      if (--this.blockstun <= 0) this.state = 'idle';
+      this.x += this.vx;
+      this.vx *= 0.8;
+      if (--this.blockstun <= 0) {
+        this.vx = 0;
+        this.state = this.input.has('down') ? 'crouch' : 'idle';
+      }
+      this.x = clamp(this.x, LEFT_WALL, RIGHT_WALL);
       return;
     }
 
-    // --- Knockdown → Getup transition ---
     if (this.state === 'knockdown') {
       if (--this.knockdown <= 0) {
         this.state = 'getup';
         this.stateFrame = 0;
-        this.invuln = 12;
+        this.invuln = 10;
+        this.vx = 0;
       }
       return;
     }
 
-    // --- Getup state (12 frames of invulnerability blink) ---
     if (this.state === 'getup') {
-      if (this.stateFrame >= 12) {
-        this.state = 'idle';
-      }
+      if (this.stateFrame >= 8) this.chooseAction();
+      if (!this.move && this.stateFrame >= 14) this.state = 'idle';
       return;
     }
 
-    // --- Victory state (terminal) ---
     if (this.state === 'victory') return;
 
-    // --- Active move ---
-    if (this.move) {
+    if (this.dashTimer > 0) {
+      this.dashTimer--;
+      const speed = this.dashType === 'back' ? -11.5 : 15.5;
+      this.x += this.facing * speed * (this.data.mobility / 80);
+      this.state = this.dashType === 'back' ? 'backdash' : 'dash';
+      if (this.dashType === 'forward') this.chooseAction();
+      if (this.dashTimer <= 0 && !this.move) this.state = 'idle';
+    } else if (this.move) {
       this.moveFrame++;
 
-      // Rush moves (Axl's special) advance position during startup+active
+      if (this.move.advance && this.moveFrame <= this.move.startup) {
+        this.x += this.facing * this.move.advance;
+      }
       if (this.move.rush && this.moveFrame <= this.move.startup + this.move.active) {
         this.x += this.facing * this.move.rush;
       }
-
-      // Projectile spawn on startup frame
       if (this.move.projectile && !this.move.spawned && this.moveFrame === this.move.startup) {
         this.move.spawned = true;
         if (this.match) spawnProjectile(this.match, this, this.move);
       }
 
-      // Try to cancel into another move (only if current move connected)
       this.chooseAction();
 
-      // Move completion
       if (this.move && this.moveFrame >= this.move.startup + this.move.active + this.move.recovery) {
         this.move = null;
         this.state = this.grounded() ? 'idle' : 'jump';
       }
     } else {
-      // --- Neutral state: movement & action ---
-      if (this.chooseAction()) return;
-
-      if (this.input.consume('jump') && this.grounded()) {
+      if (this.tryDash(opponent)) {
+        // dash started
+      } else if (this.chooseAction()) {
+        this.x = clamp(this.x, LEFT_WALL, RIGHT_WALL);
+        return;
+      } else if (this.input.consume('jump') && this.grounded() && this.landLag <= 0) {
+        const held = (this.input.has('right') ? 1 : 0) - (this.input.has('left') ? 1 : 0);
         this.vy = -this.data.jump;
+        this.jumpVx = held * this.data.speed * 1.22;
         this.state = 'jump';
-      }
-
-      const direction = (this.input.has('right') ? 1 : 0) - (this.input.has('left') ? 1 : 0);
-
-      if (this.grounded() && this.input.has('down')) {
-        this.state = 'crouch';
-      } else if (direction) {
-        this.x += direction * this.data.speed;
-        this.state = 'walk';
+        this.wasGrounded = false;
       } else if (this.grounded()) {
-        this.state = 'idle';
+        const direction = (this.input.has('right') ? 1 : 0) - (this.input.has('left') ? 1 : 0);
+        if (this.input.has('down')) {
+          this.state = 'crouch';
+        } else if (direction) {
+          const backward = direction !== this.facing;
+          this.x += direction * this.data.speed * (backward ? BACK_WALK : 1);
+          this.state = 'walk';
+        } else {
+          this.state = 'idle';
+        }
       }
     }
 
-    // --- Gravity & landing ---
     if (!this.grounded() || this.vy) {
+      if (!this.move) {
+        const airSteer = (this.input.has('right') ? 1 : 0) - (this.input.has('left') ? 1 : 0);
+        this.jumpVx += airSteer * 0.12;
+        this.jumpVx = clamp(this.jumpVx, -this.data.speed * 1.35, this.data.speed * 1.35);
+        this.x += this.jumpVx;
+      }
       this.y += this.vy;
-      this.vy += 0.72;
-      this.state = this.move ? 'attack' : 'jump';
+      this.vy += GRAVITY;
+      if (!this.move) this.state = 'jump';
       if (this.y >= GROUND) {
         this.y = GROUND;
         this.vy = 0;
+        this.jumpVx = 0;
+        this.landLag = LAND_LAG;
+        if (this.match) this.match.events.push({ type: 'dust', x: this.x, y: GROUND });
         if (!this.move) this.state = 'idle';
       }
     }
 
-    // Clamp to arena bounds
     this.x = clamp(this.x, LEFT_WALL, RIGHT_WALL);
   }
 
-  /**
-   * Returns the active hitbox rectangle during the active frames of a move.
-   * Null if no active hitbox.
-   */
   activeBox() {
     if (!this.move || this.move.projectile || this.moveHit) return null;
     if (this.moveFrame < this.move.startup || this.moveFrame >= this.move.startup + this.move.active) return null;
-
     const near = this.x + this.facing * 28;
     const far = this.x + this.facing * this.move.reach;
     return {
@@ -350,43 +442,37 @@ export class Fighter {
     };
   }
 
-  /**
-   * Returns the fighter's hurtbox (vulnerable area).
-   * Shorter when crouching.
-   */
   hurtBox() {
-    const crouching = this.state === 'crouch' || (this.move && this.move.name === 'sweep');
+    const crouching = this.state === 'crouch' || this.state === 'getup'
+      || (this.move && (this.move.name === 'sweep' || this.move.level === 'low'));
+    const dashing = this.state === 'backdash';
+    const width = dashing ? BODY_WIDTH * 0.72 : BODY_WIDTH;
     return {
-      left: this.x - BODY_WIDTH,
-      right: this.x + BODY_WIDTH,
-      top: this.y - (crouching ? 175 : 305),
-      bottom: this.y - 10
+      left: this.x - width,
+      right: this.x + width,
+      top: this.y - (crouching ? 168 : 305),
+      bottom: this.y - 8
     };
   }
 
-  /** Returns the sprite sheet frame index for the current state. */
   spriteFrame() {
     if (this.state === 'victory') return FRAME.victory;
     if (this.state === 'hitstun' || this.state === 'knockdown' || this.state === 'getup') return FRAME.hit;
-
-    // Block pose: in blockstun, or holding away while neutral
     if (this.state === 'blockstun') return FRAME.block;
     if (this.neutral() && this.match) {
-      const opponent = this.isCpu ? this.match.p1 : this.match.p2;
-      if (opponent && this.awayHeld(opponent)) return FRAME.block;
+      const opponent = this.opponent();
+      if (opponent && this.awayHeld(opponent) && this.grounded()) return FRAME.block;
     }
-
     if (this.move) return this.move.sprite;
     if (this.state === 'crouch') return FRAME.crouch;
-
+    if (this.state === 'dash') return FRAME.forward;
+    if (this.state === 'backdash') return FRAME.back;
     if (this.state === 'walk') {
       const dir = (this.input.has('right') ? 1 : 0) - (this.input.has('left') ? 1 : 0);
+      if (!dir) return FRAME.forward;
       return this.facing * dir > 0 ? FRAME.forward : FRAME.back;
     }
-
     if (this.state === 'jump') return FRAME.forward;
-
-    // Idle breathing animation
-    return Math.floor(this.stateFrame / 18) % 2 ? FRAME.idleB : FRAME.idleA;
+    return Math.floor(this.stateFrame / 16) % 2 ? FRAME.idleB : FRAME.idleA;
   }
 }

--- a/labs/rock-kombat/index.html
+++ b/labs/rock-kombat/index.html
@@ -146,7 +146,7 @@
           <span><b>PULAR</b> W · ↑</span>
           <span><b>SOCO</b> J/Q</span>
           <span><b>CHUTE</b> K/E</span>
-          <span><b>THROW</b> P+K perto</span>
+          <span><b>THROW</b> U/O ou P+K</span>
           <span><b>ESPECIAL</b> L/R</span>
           <span><b>DEFESA</b> para trás</span>
         </div>
@@ -161,6 +161,7 @@
           <div class="touch-action">
             <button data-input="punch" class="punch" type="button">P</button>
             <button data-input="kick" class="kick" type="button">K</button>
+            <button data-input="throw" class="throw" type="button">T</button>
             <button data-input="special" class="special" type="button">SP</button>
           </div>
         </div>
@@ -188,7 +189,7 @@
     <div class="guide-grid">
       <article><b>POSICIONAMENTO</b><p>Ande com A/D ou setas. Toque duas vezes para frente para dash, duas vezes para trás para backdash. Segure a direção oposta ao rival para defender. Agachado defende rasteira.</p></article>
       <article><b>GOLPES</b><p>J/Q soco. K/E chute. Agachado + soco é o anti-aéreo. Agachado + chute é rasteira. No ar, soco é overhead e chute é jump-in.</p></article>
-      <article><b>THROW E COMBOS</b><p>Perto do rival, P+K executa throw (quebra guarda). Soco confirmado cancela em chute ou especial. Buffer curto aceita o próximo comando.</p></article>
+      <article><b>THROW E COMBOS</b><p>Perto do rival, U/O ou P+K executa throw (quebra guarda). Fora de alcance, o botão de throw vira soco. Soco confirmado cancela em chute ou especial.</p></article>
       <article><b>AMPLIFIER</b><p>Atacar, acertar, defender e tomar dano carregam a barra entre rounds. Com 40%, L/R/Espaço dispara o especial. Com 100%, o mesmo comando vira Super.</p></article>
     </div>
     <p class="frame-note">Cada golpe tem startup, frames ativos e recovery. Whiff é punível. Uppercut tem invulnerabilidade no arranque. Perfect e Double K.O. encerram o round com estilo.</p>
@@ -206,6 +207,6 @@
   <footer data-lab-footer data-home-href="/"></footer>
 
   <script src="/labs/shared.js?v=6" defer></script>
-  <script type="module" src="main.js?v=2"></script>
+  <script type="module" src="main.js?v=4"></script>
 </body>
 </html>

--- a/labs/rock-kombat/index.html
+++ b/labs/rock-kombat/index.html
@@ -4,16 +4,16 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
   <title>Rock Kombat — 2D Arcade Fight</title>
-  <meta name="description" content="Jogo de luta 2D com lendas do rock, combate baseado em frame data e arte digitalizada.">
+  <meta name="description" content="Jogo de luta 2D estilo arcade com lendas do rock, combos, throws, dash e especiais.">
   <meta name="theme-color" content="#090a0c">
   <link rel="canonical" href="https://diogopaulino.com.br/labs/rock-kombat/">
   <meta property="og:title" content="Rock Kombat — 2D Arcade Fight">
   <meta property="og:description" content="Escolha sua lenda. Leia a distância. Domine o palco.">
   <meta property="og:url" content="https://diogopaulino.com.br/labs/rock-kombat/">
   <link rel="stylesheet" href="/labs/shared.css?v=6">
-  <link rel="stylesheet" href="style.css?v=5">
+  <link rel="stylesheet" href="style.css?v=6">
 </head>
-<body>
+<body data-screen="hero-screen">
   <div class="grain" aria-hidden="true"></div>
 
   <header data-lab-header data-title="Rock Kombat">
@@ -36,11 +36,11 @@
       </div>
       <div class="hero-shade" aria-hidden="true"></div>
       <div class="hero-copy">
-        <p class="overline">A NEW 2D ARCADE FIGHT</p>
+        <p class="overline">ARCADE FIGHTING GAME</p>
         <h1 id="hero-title"><span>ROCK</span> KOMBAT</h1>
-        <p>Três eras. Um palco. Combate preciso, impacto pesado e nenhuma pose desmontada.</p>
-        <button class="cta" id="enter-button" type="button"><b>PRESS START</b><span>ENTRAR NO TORNEIO</span></button>
-        <small>TECLADO · TOUCH · 60 FPS</small>
+        <p>Três lendas. Um palco. Combate preciso no estilo Street Fighter e Mortal Kombat.</p>
+        <button class="cta press-start" id="enter-button" type="button"><b>PRESS START</b><span>ENTRAR NO TORNEIO</span></button>
+        <small>TECLADO · TOUCH · BEST OF 3</small>
       </div>
     </section>
 
@@ -48,17 +48,23 @@
       <div class="select-head">
         <p class="overline">SELECT YOUR FIGHTER</p>
         <h2 id="select-title">ESCOLHA SUA <em>LENDA</em></h2>
-        <p>Personagens completos, estilos distintos e especiais próprios.</p>
+        <p>Primeiro o lutador 1. Depois o CPU. Espelho liberado. Teclas 1–3 selecionam.</p>
       </div>
 
       <div class="selection-layout">
         <div class="roster" id="roster" role="list" aria-label="Lutadores"></div>
 
         <aside class="match-setup" aria-label="Configuração da partida">
+          <div class="pick-row" role="group" aria-label="Quem está escolhendo">
+            <button data-pick="p1" class="is-active" type="button">P1</button>
+            <button data-pick="cpu" type="button">CPU</button>
+            <button id="cpu-random" type="button">CPU ALEATÓRIO</button>
+          </div>
+
           <div class="versus-preview">
             <div><small>P1</small><strong id="p1-preview">ESCOLHA</strong></div>
             <b>VS</b>
-            <div><small>CPU</small><strong id="cpu-preview">ALEATÓRIO</strong></div>
+            <div><small>CPU</small><strong id="cpu-preview">ESCOLHA</strong></div>
           </div>
 
           <fieldset>
@@ -85,27 +91,47 @@
       </div>
     </section>
 
+    <section class="screen versus" id="versus-screen" aria-label="Versus">
+      <div class="versus-duel">
+        <div class="versus-fighter p1">
+          <i class="versus-sprite" id="vs-p1-sprite"></i>
+          <small>PLAYER 1</small>
+          <strong id="vs-p1-name">KURT</strong>
+        </div>
+        <div class="versus-center">
+          <b>VS</b>
+          <span id="vs-stage-name">SEATTLE RAIN</span>
+          <em>TOQUE PARA PULAR</em>
+        </div>
+        <div class="versus-fighter p2">
+          <i class="versus-sprite" id="vs-p2-sprite"></i>
+          <small>CPU</small>
+          <strong id="vs-p2-name">AXL</strong>
+        </div>
+      </div>
+    </section>
+
     <section class="screen arena" id="arena-screen" aria-label="Arena de luta">
       <div class="arena-shell">
-        <div class="hud" aria-live="polite">
-          <div class="hud-side p1">
-            <div class="hud-name"><strong id="p1-name">KURT</strong><span>P1</span></div>
-            <div class="life"><i id="p1-life"></i><b id="p1-chip"></b></div>
-            <div class="meter"><span>AMPLIFIER</span><div><i id="p1-meter"></i></div><b id="p1-meter-label">0%</b></div>
-          </div>
-          <div class="round-hud">
-            <span id="round-label">ROUND 1</span>
-            <strong id="timer">99</strong>
-            <div class="round-wins"><i id="p1-win-1"></i><i id="p1-win-2"></i><b></b><i id="p2-win-1"></i><i id="p2-win-2"></i></div>
-          </div>
-          <div class="hud-side p2">
-            <div class="hud-name"><span>CPU</span><strong id="p2-name">AXL</strong></div>
-            <div class="life"><i id="p2-life"></i><b id="p2-chip"></b></div>
-            <div class="meter right"><b id="p2-meter-label">0%</b><div><i id="p2-meter"></i></div><span>AMPLIFIER</span></div>
-          </div>
-        </div>
-
         <div class="canvas-frame">
+          <div class="hud" aria-live="polite">
+            <div class="hud-side p1">
+              <div class="hud-name"><strong id="p1-name">KURT</strong><span>P1</span></div>
+              <div class="life"><i id="p1-life"></i><b id="p1-chip"></b></div>
+              <div class="meter"><span>AMPLIFIER</span><div><i id="p1-meter"></i></div><b id="p1-meter-label">0%</b></div>
+            </div>
+            <div class="round-hud">
+              <span id="round-label">ROUND 1</span>
+              <strong id="timer">99</strong>
+              <div class="round-wins"><i id="p1-win-1"></i><i id="p1-win-2"></i><b></b><i id="p2-win-1"></i><i id="p2-win-2"></i></div>
+            </div>
+            <div class="hud-side p2">
+              <div class="hud-name"><span>CPU</span><strong id="p2-name">AXL</strong></div>
+              <div class="life"><i id="p2-life"></i><b id="p2-chip"></b></div>
+              <div class="meter right"><b id="p2-meter-label">0%</b><div><i id="p2-meter"></i></div><span>AMPLIFIER</span></div>
+            </div>
+          </div>
+
           <canvas id="game" width="1280" height="720" aria-label="Rock Kombat, jogo de luta 2D"></canvas>
           <div class="announce" id="announce" aria-live="assertive"></div>
           <div class="combo p1" id="p1-combo"></div>
@@ -115,25 +141,27 @@
         </div>
 
         <div class="fight-help">
-          <span><b>MOVER</b> A/D ou ←/→</span>
-          <span><b>PULAR</b> W ou ↑</span>
+          <span><b>MOVER</b> A/D · ←/→</span>
+          <span><b>DASH</b> toque 2× frente</span>
+          <span><b>PULAR</b> W · ↑</span>
           <span><b>SOCO</b> J/Q</span>
           <span><b>CHUTE</b> K/E</span>
+          <span><b>THROW</b> P+K perto</span>
           <span><b>ESPECIAL</b> L/R</span>
-          <span><b>DEFESA</b> segure para trás</span>
+          <span><b>DEFESA</b> para trás</span>
         </div>
 
         <div class="touch-controls" aria-label="Controles touch">
-          <div class="touch-move">
-            <button data-input="left" type="button" aria-label="Esquerda">←</button>
-            <button data-input="jump" type="button" aria-label="Pular">↑</button>
-            <button data-input="right" type="button" aria-label="Direita">→</button>
-            <button data-input="down" type="button" aria-label="Agachar">↓</button>
+          <div class="touch-dpad">
+            <button data-input="jump" class="dir up" type="button" aria-label="Pular">↑</button>
+            <button data-input="left" class="dir left" type="button" aria-label="Esquerda">←</button>
+            <button data-input="down" class="dir down" type="button" aria-label="Agachar">↓</button>
+            <button data-input="right" class="dir right" type="button" aria-label="Direita">→</button>
           </div>
           <div class="touch-action">
             <button data-input="punch" class="punch" type="button">P</button>
             <button data-input="kick" class="kick" type="button">K</button>
-            <button data-input="special" class="special" type="button">★</button>
+            <button data-input="special" class="special" type="button">SP</button>
           </div>
         </div>
       </div>
@@ -158,21 +186,26 @@
     <p class="overline">PLAYER GUIDE</p>
     <h2>COMO JOGAR</h2>
     <div class="guide-grid">
-      <article><b>POSICIONAMENTO</b><p>Ande com A/D ou setas. Segure a direção oposta ao rival para defender. Para ataques baixos, defenda agachado.</p></article>
-      <article><b>GOLPES</b><p>J/Q dá soco. K/E dá chute. Agachado + soco executa antiaéreo; agachado + chute aplica rasteira.</p></article>
-      <article><b>COMBOS</b><p>Soco confirmado pode cancelar em chute ou especial. O buffer curto aceita o próximo comando sem exigir precisão de um frame.</p></article>
-      <article><b>AMPLIFIER</b><p>Atacar, acertar, defender e receber dano carregam a barra, que continua entre rounds. Com 40%, L/R ativa o especial. Com 100%, o mesmo comando executa a versão Super.</p></article>
+      <article><b>POSICIONAMENTO</b><p>Ande com A/D ou setas. Toque duas vezes para frente para dash, duas vezes para trás para backdash. Segure a direção oposta ao rival para defender. Agachado defende rasteira.</p></article>
+      <article><b>GOLPES</b><p>J/Q soco. K/E chute. Agachado + soco é o anti-aéreo. Agachado + chute é rasteira. No ar, soco é overhead e chute é jump-in.</p></article>
+      <article><b>THROW E COMBOS</b><p>Perto do rival, P+K executa throw (quebra guarda). Soco confirmado cancela em chute ou especial. Buffer curto aceita o próximo comando.</p></article>
+      <article><b>AMPLIFIER</b><p>Atacar, acertar, defender e tomar dano carregam a barra entre rounds. Com 40%, L/R/Espaço dispara o especial. Com 100%, o mesmo comando vira Super.</p></article>
     </div>
-    <p class="frame-note">Cada golpe possui startup, frames ativos e recovery. Ataque no vazio é punível; acerto confirmado cria vantagem.</p>
+    <p class="frame-note">Cada golpe tem startup, frames ativos e recovery. Whiff é punível. Uppercut tem invulnerabilidade no arranque. Perfect e Double K.O. encerram o round com estilo.</p>
   </dialog>
 
   <div class="pause-layer" id="pause-layer" hidden>
-    <div><p class="overline">INTERMISSION</p><h2>PAUSADO</h2><button class="cta" id="resume-button" type="button"><b>CONTINUAR</b></button><button class="quiet-button" id="quit-button" type="button">SAIR DA LUTA</button></div>
+    <div>
+      <p class="overline">INTERMISSION</p>
+      <h2>PAUSADO</h2>
+      <button class="cta" id="resume-button" type="button"><b>CONTINUAR</b></button>
+      <button class="quiet-button" id="quit-button" type="button">SAIR DA LUTA</button>
+    </div>
   </div>
 
   <footer data-lab-footer data-home-href="/"></footer>
 
   <script src="/labs/shared.js?v=6" defer></script>
-  <script type="module" src="main.js?v=1"></script>
+  <script type="module" src="main.js?v=2"></script>
 </body>
 </html>

--- a/labs/rock-kombat/input.js
+++ b/labs/rock-kombat/input.js
@@ -87,6 +87,7 @@ export function bindKeyboard(playerInput, hooks = {}) {
     KeyW: 'jump', ArrowUp: 'jump',
     KeyJ: 'punch', KeyQ: 'punch',
     KeyK: 'kick', KeyE: 'kick',
+    KeyU: 'throw', KeyO: 'throw',
     KeyL: 'special', KeyR: 'special', Space: 'special'
   };
 

--- a/labs/rock-kombat/input.js
+++ b/labs/rock-kombat/input.js
@@ -1,23 +1,28 @@
-import { INPUT_BUFFER } from './constants.js';
+import { INPUT_BUFFER, DASH_WINDOW } from './constants.js';
 
 /**
- * Input buffer with frame-aware press tracking.
- * Held = currently pressed keys, Pressed = timestamped key presses for buffered input.
+ * Frame-aware input buffer with dash double-tap tracking.
+ * Presses are stamped with the simulation frame so buffering stays stable at 60Hz.
  */
 export class InputBuffer {
   constructor() {
     this.held = new Set();
     this.pressed = new Map();
+    this.tapHistory = [];
     this.frameNumber = 0;
+    this.lastDashFrame = -99;
   }
 
-  /** Sync the internal frame counter (called each fixedUpdate) */
   updateFrame(frame) {
     this.frameNumber = frame;
   }
 
   down(action) {
-    if (!this.held.has(action)) this.pressed.set(action, this.frameNumber);
+    if (!this.held.has(action)) {
+      this.pressed.set(action, this.frameNumber);
+      this.tapHistory.push({ action, frame: this.frameNumber });
+      if (this.tapHistory.length > 10) this.tapHistory.shift();
+    }
     this.held.add(action);
   }
 
@@ -27,21 +32,39 @@ export class InputBuffer {
 
   tap(action) {
     this.pressed.set(action, this.frameNumber);
+    this.tapHistory.push({ action, frame: this.frameNumber });
+    if (this.tapHistory.length > 10) this.tapHistory.shift();
   }
 
   has(action) {
     return this.held.has(action);
   }
 
-  /** Was action pressed within the last `window` frames? (non-consuming) */
   fresh(action, window = 1) {
     return this.pressed.has(action) && this.frameNumber - this.pressed.get(action) <= window;
   }
 
-  /** Was action pressed within buffer window? Consumes the press. */
   consume(action, window = INPUT_BUFFER) {
     if (!this.pressed.has(action) || this.frameNumber - this.pressed.get(action) > window) return false;
     this.pressed.delete(action);
+    return true;
+  }
+
+  /**
+   * True on the frame a direction was double-tapped (Street Fighter dash).
+   * Consumes the gesture so it cannot retrigger until the next pair of taps.
+   */
+  consumeDash(action, window = DASH_WINDOW) {
+    if (this.frameNumber - this.lastDashFrame < 18) return false;
+    const taps = this.tapHistory.filter(t => t.action === action);
+    if (taps.length < 2) return false;
+    const latest = taps[taps.length - 1];
+    const previous = taps[taps.length - 2];
+    const recent = this.frameNumber - latest.frame <= 1;
+    const gap = latest.frame - previous.frame;
+    if (!recent || gap < 3 || gap > window) return false;
+    this.lastDashFrame = this.frameNumber;
+    this.tapHistory = this.tapHistory.filter(t => t.action !== action);
     return true;
   }
 
@@ -52,11 +75,11 @@ export class InputBuffer {
   clear() {
     this.held.clear();
     this.pressed.clear();
+    this.tapHistory.length = 0;
   }
 }
 
-/** Bind keyboard input to a player's InputBuffer */
-export function bindKeyboard(playerInput, onPause) {
+export function bindKeyboard(playerInput, hooks = {}) {
   const keyMap = {
     KeyA: 'left', ArrowLeft: 'left',
     KeyD: 'right', ArrowRight: 'right',
@@ -68,12 +91,26 @@ export function bindKeyboard(playerInput, onPause) {
   };
 
   addEventListener('keydown', event => {
+    if (event.repeat) return;
+
+    if (event.code === 'Escape') {
+      event.preventDefault();
+      if (hooks.onEscape) hooks.onEscape();
+      return;
+    }
+
+    if (hooks.shouldIgnore && hooks.shouldIgnore()) return;
+
+    if (hooks.onMenuKey && hooks.onMenuKey(event)) {
+      event.preventDefault();
+      return;
+    }
+
     const action = keyMap[event.code];
     if (action) {
       event.preventDefault();
-      playerInput.down(action);
+      if (hooks.isArena && hooks.isArena()) playerInput.down(action);
     }
-    if (event.code === 'Escape' && onPause) onPause();
   });
 
   addEventListener('keyup', event => {
@@ -82,13 +119,14 @@ export function bindKeyboard(playerInput, onPause) {
   });
 }
 
-/** Bind touch/pointer controls to on-screen buttons */
 export function bindTouch(playerInput) {
   const buttons = [...document.querySelectorAll('[data-input]')];
   buttons.forEach(button => {
     const action = button.dataset.input;
     const down = event => {
       event.preventDefault();
+      if (event.button != null && event.button !== 0) return;
+      button.setPointerCapture?.(event.pointerId);
       playerInput.down(action);
       button.classList.add('is-down');
     };
@@ -100,6 +138,7 @@ export function bindTouch(playerInput) {
     button.addEventListener('pointerdown', down);
     button.addEventListener('pointerup', up);
     button.addEventListener('pointercancel', up);
-    button.addEventListener('pointerleave', up);
+    button.addEventListener('lostpointercapture', up);
+    button.addEventListener('contextmenu', event => event.preventDefault());
   });
 }

--- a/labs/rock-kombat/main.js
+++ b/labs/rock-kombat/main.js
@@ -1,12 +1,12 @@
-import { STEP, FIGHTERS, STAGES, SPECIAL_COST } from './constants.js';
-import { $, $$ } from './utils.js';
+import { STEP, FIGHTERS, STAGES, GROUND, GRAVITY } from './constants.js';
+import { $, $$, approach } from './utils.js';
 import { InputBuffer, bindKeyboard, bindTouch } from './input.js';
 import audio from './audio.js';
 import { Fighter } from './fighter.js';
-import { resolveCombat, bodyPush, updateProjectiles, updateEffects } from './combat.js';
+import { resolveCombat, bodyPush, updateProjectiles, updateEffects, addDust } from './combat.js';
 import { updateCpu } from './ai.js';
 import { initRenderer, render } from './renderer.js';
-import { updateHud, announce, showCombo, showScreen, renderRoster } from './ui.js';
+import { updateHud, announce, showCombo, showScreen, renderRoster, fillVersus } from './ui.js';
 
 let match = null;
 let paused = false;
@@ -18,13 +18,26 @@ const images = new Map();
 let assetsReady = false;
 let frameNumber = 0;
 let hudSignature = '';
-let animationId = 0;
 let lastTime = performance.now();
 let accumulator = 0;
+let vsTimer = 0;
+let rosterApi = null;
 
 const playerInput = new InputBuffer();
 const cpuInput = new InputBuffer();
 const { ctx, renderState } = initRenderer($('#game'));
+
+function arenaActive() {
+  return Boolean(match) && $('#arena-screen').classList.contains('is-active');
+}
+
+function helpOpen() {
+  return $('#help-dialog').open;
+}
+
+function refreshFightButton() {
+  $('#fight-button').disabled = !(selected && selectedCpu && assetsReady);
+}
 
 async function loadAssets() {
   const paths = [...FIGHTERS.map(f => f.sheet), ...Object.values(STAGES).map(s => s.image)];
@@ -37,46 +50,80 @@ async function loadAssets() {
   })));
   assetsReady = true;
   $('#loading').classList.add('is-ready');
+  refreshFightButton();
 }
 
 function startRound() {
   match.timerFrames = 99 * 60;
   match.phase = 'intro';
-  match.phaseFrame = 140;
+  match.phaseFrame = 150;
   match.projectiles.length = 0;
   match.effects.length = 0;
   match.rings.length = 0;
-  if (!match.damageNumbers) match.damageNumbers = [];
   match.damageNumbers.length = 0;
-  if (!match.events) match.events = [];
   match.events.length = 0;
-  match.cpuThink = 30;
-  
+  match.cpuThink = 28;
+  match.cpuHold = [];
+  match.koSlow = 0;
+  match.koZoom = 0;
+  match.superFlash = 0;
+  match.p1.x = 120;
+  match.p2.x = 1160;
+  match.p1.y = GROUND;
+  match.p2.y = GROUND;
+  match.p1.facing = 1;
+  match.p2.facing = -1;
+  match.p1.state = 'walk';
+  match.p2.state = 'walk';
+
   $('#round-label').textContent = `ROUND ${match.round}`;
   $('#timer').textContent = '99';
-  hudSignature = updateHud(match, hudSignature);
+  hudSignature = updateHud(match, '');
   announce(`ROUND ${match.round}`, 900);
 }
 
-function endRound() {
+function koLabel() {
+  const p1Dead = match.p1.health <= 0;
+  const p2Dead = match.p2.health <= 0;
+  if (p1Dead && p2Dead) return 'DOUBLE K.O.!';
+  if (p1Dead && match.p2.health >= 99.5) return 'PERFECT';
+  if (p2Dead && match.p1.health >= 99.5) return 'PERFECT';
+  if (match.timerFrames <= 0) return 'TIME OVER';
+  return 'K.O.!';
+}
+
+function beginKo() {
   if (match.phase !== 'fight') return;
-  match.phase = 'roundEnd';
+  match.phase = 'ko';
+  match.koSlow = 52;
+  match.shake = Math.max(match.shake, 10);
   audio.sfx('ko');
-  
+  announce(koLabel(), 1200);
+}
+
+function endRound() {
+  if (match.phase !== 'fight' && match.phase !== 'ko') return;
+  match.phase = 'roundEnd';
+  match.phaseFrame = 150;
+
   if (match.p1.health === match.p2.health) {
     match.roundWinner = null;
-    match.phaseFrame = 90;
-    announce('DRAW!', 1000);
+    match.phaseFrame = 96;
+    if (match.timerFrames <= 0) announce('TIME OVER', 1000);
+    else if (match.p1.health > 0) announce('DRAW!', 1000);
   } else {
-    match.phaseFrame = 145;
     const winner = match.p1.health > match.p2.health ? match.p1 : match.p2;
+    const loser = winner === match.p1 ? match.p2 : match.p1;
     match.roundWinner = winner;
     winner.wins++;
     winner.state = 'victory';
-    announce(match.timerFrames <= 0 ? 'TIME!' : 'K.O.!', 1000);
+    winner.move = null;
+    loser.state = 'knockdown';
+    loser.knockdown = 80;
+    if (match.timerFrames <= 0 && winner.health > 0) announce('TIME OVER', 1000);
   }
-  
-  hudSignature = updateHud(match, hudSignature);
+
+  hudSignature = updateHud(match, '');
 }
 
 function finishRound() {
@@ -84,9 +131,7 @@ function finishRound() {
     finishMatch(match.roundWinner);
     return;
   }
-  if (match.roundWinner) {
-    match.round++;
-  }
+  match.round++;
   match.p1.reset(370, true);
   match.p2.reset(910, true);
   startRound();
@@ -103,66 +148,118 @@ function finishMatch(winner) {
     $('#result-copy').textContent = winner.data.quote;
     $('#result-overline').textContent = winner === match.p1 ? 'PLAYER 1 WINS' : 'CPU WINS';
     showScreen('results-screen');
-  }, 650);
+  }, 700);
 }
 
 function startMatch() {
-  if (!selected || !assetsReady) return;
-  selectedCpu = selectedCpu || FIGHTERS.filter(f => f !== selected)[Math.floor(Math.random() * 2)];
-  
+  if (!selected || !selectedCpu || !assetsReady) return;
+  clearTimeout(vsTimer);
   playerInput.clear();
   cpuInput.clear();
-  
+
   const p1 = new Fighter(selected, playerInput, false);
   const p2 = new Fighter(selectedCpu, cpuInput, true);
-  
-  // Assign loaded sprite images to fighters
   p1.image = images.get(selected.sheet);
   p2.image = images.get(selectedCpu.sheet);
-  
+
   match = {
-    p1,
-    p2,
+    p1, p2,
     round: 1,
     timerFrames: 99 * 60,
     phase: 'intro',
-    phaseFrame: 140,
+    phaseFrame: 150,
     hitStop: 0,
     freeze: 0,
     shake: 0,
+    superFlash: 0,
+    koSlow: 0,
+    koZoom: 0,
     effects: [],
     rings: [],
     projectiles: [],
     damageNumbers: [],
     events: [],
-    cpuThink: 30,
+    cpuThink: 28,
+    cpuHold: [],
     stage: STAGES[stageId],
     stageId,
     roundWinner: null
   };
-  
+
   match.p1.setMatch(match);
   match.p2.setMatch(match);
-  
+  paused = false;
+  $('#pause-layer').hidden = true;
   showScreen('arena-screen');
   audio.startMusic(stageId);
   startRound();
 }
 
+function beginVersus() {
+  if (!selected || !selectedCpu || !assetsReady) return;
+  audio.ensure();
+  audio.sfx('round');
+  fillVersus(selected, selectedCpu, STAGES[stageId]);
+  showScreen('versus-screen');
+  clearTimeout(vsTimer);
+  vsTimer = setTimeout(startMatch, 2200);
+}
+
+function skipVersus() {
+  if (!$('#versus-screen').classList.contains('is-active')) return;
+  clearTimeout(vsTimer);
+  startMatch();
+}
+
+function flushEvents() {
+  for (const event of match.events) {
+    if (event.type === 'announce') announce(event.text, event.duration);
+    else if (event.type === 'combo') showCombo(event.fighter, match);
+    else if (event.type === 'dust') addDust(match, event.x, event.y);
+  }
+  match.events.length = 0;
+}
+
+function updateIntro() {
+  match.p1.x = approach(match.p1.x, 370, 5.2);
+  match.p2.x = approach(match.p2.x, 910, 5.2);
+  match.p1.facing = 1;
+  match.p2.facing = -1;
+  match.p1.state = Math.abs(match.p1.x - 370) < 2 ? 'idle' : 'walk';
+  match.p2.state = Math.abs(match.p2.x - 910) < 2 ? 'idle' : 'walk';
+  match.p1.stateFrame++;
+  match.p2.stateFrame++;
+}
+
+function updateKoPhysics() {
+  for (const fighter of [match.p1, match.p2]) {
+    fighter.x += fighter.vx;
+    fighter.vx *= 0.9;
+    if (!fighter.grounded() || fighter.vy) {
+      fighter.y += fighter.vy;
+      fighter.vy += GRAVITY;
+      if (fighter.y >= GROUND) {
+        fighter.y = GROUND;
+        fighter.vy = 0;
+        fighter.state = 'knockdown';
+      }
+    }
+  }
+}
+
 function fixedUpdate() {
   if (!match || paused) return;
   frameNumber++;
-  
-  // Sync frame counter to input buffers
   playerInput.updateFrame(frameNumber);
   cpuInput.updateFrame(frameNumber);
-  
+
   if (match.freeze > 0) {
     match.freeze--;
     updateEffects(match);
+    flushEvents();
     return;
   }
-  
+
   if (match.hitStop > 0) {
     match.hitStop--;
     updateEffects(match);
@@ -170,66 +267,63 @@ function fixedUpdate() {
   }
 
   if (match.phase === 'intro') {
-    if (--match.phaseFrame === 70) {
+    updateIntro();
+    if (--match.phaseFrame === 72) {
       announce('FIGHT!', 850);
       audio.sfx('round');
     }
-    if (match.phaseFrame <= 0) match.phase = 'fight';
+    if (match.phaseFrame <= 0) {
+      match.phase = 'fight';
+      match.p1.state = 'idle';
+      match.p2.state = 'idle';
+    }
     updateEffects(match);
     return;
   }
-  
+
+  if (match.phase === 'ko') {
+    if (match.koSlow % 3 === 0) updateKoPhysics();
+    if (--match.koSlow <= 0) endRound();
+    updateEffects(match);
+    return;
+  }
+
   if (match.phase === 'roundEnd') {
     if (--match.phaseFrame <= 0) finishRound();
     updateEffects(match);
     return;
   }
-  
+
   if (match.phase !== 'fight') return;
 
   updateCpu(match, difficulty, cpuInput);
   match.p1.update(match.p2);
   match.p2.update(match.p1);
   bodyPush(match);
-  
+
   resolveCombat(match, match.p1, match.p2);
   resolveCombat(match, match.p2, match.p1);
-  
+
   updateProjectiles(match);
   updateEffects(match);
-  
+  flushEvents();
+
   if (--match.timerFrames % 60 === 0) {
-    $('#timer').textContent = Math.max(0, Math.ceil(match.timerFrames / 60));
+    $('#timer').textContent = String(Math.max(0, Math.ceil(match.timerFrames / 60)));
   }
-  
-  if (match.p1.health <= 0 || match.p2.health <= 0 || match.timerFrames <= 0) {
-    endRound();
-  }
-  
-  if (match.events && match.events.length > 0) {
-    for (const event of match.events) {
-      if (event.type === 'announce') {
-        announce(event.text, event.duration);
-      } else if (event.type === 'combo') {
-        showCombo(event.fighter, match);
-      }
-    }
-    match.events.length = 0;
-  }
-  
-  if ((frameNumber & 1) === 0) {
-    hudSignature = updateHud(match, hudSignature);
-  }
+
+  if (match.p1.health <= 0 || match.p2.health <= 0) beginKo();
+  else if (match.timerFrames <= 0) endRound();
+
+  if ((frameNumber & 1) === 0) hudSignature = updateHud(match, hudSignature);
 }
 
 function togglePause(force) {
   if (!match || match.phase === 'complete') return;
   paused = typeof force === 'boolean' ? force : !paused;
   $('#pause-layer').hidden = !paused;
-  
-  if (paused) {
-    audio.stopMusic();
-  } else {
+  if (paused) audio.stopMusic();
+  else {
     lastTime = performance.now();
     accumulator = 0;
     audio.startMusic(stageId);
@@ -240,40 +334,39 @@ function loop(now) {
   const delta = Math.min(50, now - lastTime);
   lastTime = now;
   accumulator += delta;
-  
   while (accumulator >= STEP) {
     fixedUpdate();
     accumulator -= STEP;
   }
-  
   render(ctx, match, frameNumber, images, renderState);
-  animationId = requestAnimationFrame(loop);
+  requestAnimationFrame(loop);
 }
 
-// Event Listeners
+function goSelect() {
+  showScreen('select-screen');
+}
+
 $('#enter-button').addEventListener('click', () => {
   audio.ensure();
   audio.sfx('ui');
-  showScreen('select-screen');
+  goSelect();
 });
 
 $('#select-back').addEventListener('click', () => showScreen('hero-screen'));
-
-$('#fight-button').addEventListener('click', startMatch);
-
+$('#fight-button').addEventListener('click', beginVersus);
+$('#versus-screen').addEventListener('click', skipVersus);
 $('#rematch-button').addEventListener('click', startMatch);
 
 $('#change-button').addEventListener('click', () => {
   match = null;
   selected = null;
   selectedCpu = null;
-  $('#fight-button').disabled = true;
-  $$('.fighter-card').forEach(card => card.classList.remove('is-selected'));
+  rosterApi?.reset();
+  refreshFightButton();
   showScreen('select-screen');
 });
 
 $('#pause-button').addEventListener('click', () => togglePause());
-
 $('#resume-button').addEventListener('click', () => togglePause(false));
 
 $('#quit-button').addEventListener('click', () => {
@@ -284,9 +377,17 @@ $('#quit-button').addEventListener('click', () => {
   showScreen('select-screen');
 });
 
-$('#help-button').addEventListener('click', () => $('#help-dialog').showModal());
+$('#help-button').addEventListener('click', () => {
+  if (arenaActive() && !paused) togglePause(true);
+  $('#help-dialog').showModal();
+});
 
 $('#help-close').addEventListener('click', () => $('#help-dialog').close());
+$('#help-dialog').addEventListener('close', () => {
+  if (arenaActive() && paused) {
+    // keep paused after closing help during a match
+  }
+});
 
 $('#sound-button').addEventListener('click', event => {
   const muted = !audio.muted;
@@ -316,19 +417,59 @@ document.addEventListener('visibilitychange', () => {
   if (document.hidden && match && !paused) togglePause(true);
 });
 
-// Initialization
-renderRoster(FIGHTERS, (selFighter, cpuFighter) => {
-  selected = selFighter;
-  selectedCpu = cpuFighter;
-  $('#p1-preview').textContent = selected.short;
-  $('#cpu-preview').textContent = selectedCpu.short;
-  $('#fight-button').disabled = false;
-  audio.sfx('ui');
+rosterApi = renderRoster(FIGHTERS, (p1, cpu) => {
+  selected = p1;
+  selectedCpu = cpu;
+  refreshFightButton();
+  if (p1) audio.sfx('ui');
 });
 
-bindKeyboard(playerInput, () => togglePause());
+bindKeyboard(playerInput, {
+  shouldIgnore: () => helpOpen(),
+  isArena: arenaActive,
+  onEscape() {
+    if (helpOpen()) {
+      $('#help-dialog').close();
+      return;
+    }
+    if ($('#versus-screen').classList.contains('is-active')) {
+      skipVersus();
+      return;
+    }
+    if (arenaActive()) togglePause();
+  },
+  onMenuKey(event) {
+    const hero = $('#hero-screen').classList.contains('is-active');
+    const select = $('#select-screen').classList.contains('is-active');
+    const versus = $('#versus-screen').classList.contains('is-active');
+    const results = $('#results-screen').classList.contains('is-active');
 
-// Ensure audio context on first keyboard interaction
+    if (hero && (event.code === 'Enter' || event.code === 'Space')) {
+      $('#enter-button').click();
+      return true;
+    }
+    if (versus && (event.code === 'Enter' || event.code === 'Space')) {
+      skipVersus();
+      return true;
+    }
+    if (results && event.code === 'Enter') {
+      $('#rematch-button').click();
+      return true;
+    }
+    if (select) {
+      if (event.code === 'Digit1' || event.code === 'Numpad1') rosterApi.selectIndex(0);
+      if (event.code === 'Digit2' || event.code === 'Numpad2') rosterApi.selectIndex(1);
+      if (event.code === 'Digit3' || event.code === 'Numpad3') rosterApi.selectIndex(2);
+      if (event.code === 'Enter' && !$('#fight-button').disabled) {
+        beginVersus();
+        return true;
+      }
+      return ['Digit1', 'Digit2', 'Digit3', 'Numpad1', 'Numpad2', 'Numpad3'].includes(event.code);
+    }
+    return false;
+  }
+});
+
 addEventListener('keydown', () => audio.ensure(), { once: true });
 bindTouch(playerInput);
 
@@ -337,4 +478,4 @@ loadAssets().catch(error => {
   console.error(error);
 });
 
-animationId = requestAnimationFrame(loop);
+requestAnimationFrame(loop);

--- a/labs/rock-kombat/renderer.js
+++ b/labs/rock-kombat/renderer.js
@@ -20,18 +20,31 @@ export function initRenderer(canvas) {
   const floorShade = ctx.createLinearGradient(0, 500, 0, H);
   floorShade.addColorStop(0, '#00000000');
   floorShade.addColorStop(1, '#00000082');
-  
-  const coliseumGlow = makeGlow('#e9a45b28', '#e9a45b12');
-  const projectileGlows = new Map();
 
-  const renderState = {
-    floorShade,
-    coliseumGlow,
-    projectileGlows,
-    makeGlow
+  return {
+    ctx,
+    renderState: {
+      floorShade,
+      coliseumGlow: makeGlow('#e9a45b28', '#e9a45b12'),
+      projectileGlows: new Map(),
+      makeGlow
+    }
   };
+}
 
-  return { ctx, renderState };
+function drawSheet(ctx, image, index, x, y, facing, size = SPRITE_SIZE, alpha = 1, extra = null) {
+  if (!image) return;
+  const cellW = image.naturalWidth / 4;
+  const cellH = image.naturalHeight / 3;
+  const col = index % 4;
+  const row = Math.floor(index / 4);
+  ctx.save();
+  ctx.globalAlpha = alpha;
+  ctx.translate(x, y);
+  if (facing < 0) ctx.scale(-1, 1);
+  if (extra) extra(ctx);
+  ctx.drawImage(image, col * cellW, row * cellH, cellW, cellH, -size / 2, -size, size, size);
+  ctx.restore();
 }
 
 export function render(ctx, match, frameNumber, images, renderState) {
@@ -40,51 +53,58 @@ export function render(ctx, match, frameNumber, images, renderState) {
   if (!match) return;
 
   ctx.save();
+
+  const mid = (match.p1.x + match.p2.x) / 2;
+  const camX = clamp(mid - W / 2, -48, 48);
+  ctx.translate(-camX * 0.35, 0);
+
   if (match.shake) {
-    ctx.translate(random(-match.shake, match.shake), random(-match.shake * 0.5, match.shake * 0.5));
+    ctx.translate(random(-match.shake, match.shake), random(-match.shake * 0.45, match.shake * 0.45));
   }
 
-  function drawStage() {
-    const image = images.get(match.stage.image);
-    if (image) ctx.drawImage(image, 0, 0, W, H);
-    
-    if (match.stageId === 'seattle') {
-      ctx.save();
-      ctx.strokeStyle = '#b8d2e05c';
-      ctx.lineWidth = 1.2;
-      for (let i = 0; i < 75; i++) {
-        const x = (i * 97 + frameNumber * 7) % W;
-        const y = (i * 53 + frameNumber * 13) % H;
-        ctx.beginPath();
-        ctx.moveTo(x, y);
-        ctx.lineTo(x - 5, y + 22);
-        ctx.stroke();
-      }
-      ctx.restore();
-    } else if (match.stageId === 'coliseum') {
-      ctx.save();
-      ctx.globalCompositeOperation = 'screen';
-      for (let i = 0; i < 5; i++) {
-        const x = 180 + i * 230 + Math.sin(frameNumber * 0.012 + i) * 65;
-        ctx.drawImage(renderState.coliseumGlow, x - 100, 70, 200, 200);
-      }
-      ctx.restore();
-    } else {
-      ctx.save();
-      ctx.fillStyle = '#d9b77b22';
-      for (let i = 0; i < 30; i++) {
-        const x = (i * 137 + frameNumber * 0.22) % W;
-        const y = 120 + ((i * 89 - frameNumber * 0.12 + H) % 430);
-        ctx.beginPath();
-        ctx.arc(x, y, 1.4 + (i % 2), 0, Math.PI * 2);
-        ctx.fill();
-      }
-      ctx.restore();
-    }
-    
-    ctx.fillStyle = renderState.floorShade;
-    ctx.fillRect(0, 500, W, 220);
+  if (match.koZoom > 0) {
+    ctx.translate(random(-match.koZoom * 0.15, match.koZoom * 0.15), random(-match.koZoom * 0.08, match.koZoom * 0.08));
   }
+
+  const image = images.get(match.stage.image);
+  if (image) ctx.drawImage(image, 0, 0, W, H);
+
+  if (match.stageId === 'seattle') {
+    ctx.save();
+    ctx.strokeStyle = '#b8d2e05c';
+    ctx.lineWidth = 1.2;
+    for (let i = 0; i < 75; i++) {
+      const x = (i * 97 + frameNumber * 7) % W;
+      const y = (i * 53 + frameNumber * 13) % H;
+      ctx.beginPath();
+      ctx.moveTo(x, y);
+      ctx.lineTo(x - 5, y + 22);
+      ctx.stroke();
+    }
+    ctx.restore();
+  } else if (match.stageId === 'coliseum') {
+    ctx.save();
+    ctx.globalCompositeOperation = 'screen';
+    for (let i = 0; i < 5; i++) {
+      const x = 180 + i * 230 + Math.sin(frameNumber * 0.012 + i) * 65;
+      ctx.drawImage(renderState.coliseumGlow, x - 100, 70, 200, 200);
+    }
+    ctx.restore();
+  } else {
+    ctx.save();
+    ctx.fillStyle = '#d9b77b22';
+    for (let i = 0; i < 30; i++) {
+      const x = (i * 137 + frameNumber * 0.22) % W;
+      const y = 120 + ((i * 89 - frameNumber * 0.12 + H) % 430);
+      ctx.beginPath();
+      ctx.arc(x, y, 1.4 + (i % 2), 0, Math.PI * 2);
+      ctx.fill();
+    }
+    ctx.restore();
+  }
+
+  ctx.fillStyle = renderState.floorShade;
+  ctx.fillRect(0, 500, W, 220);
 
   function drawShadow(fighter) {
     const air = GROUND - fighter.y;
@@ -98,94 +118,104 @@ export function render(ctx, match, frameNumber, images, renderState) {
   }
 
   function drawFighter(fighter) {
-    const image = images.get(fighter.data.sheet);
-    if (!image) return;
-    const index = fighter.spriteFrame();
-    const cellW = image.naturalWidth / 4;
-    const cellH = image.naturalHeight / 3;
-    const col = index % 4;
-    const row = Math.floor(index / 4);
-    
-    ctx.save();
-    ctx.translate(fighter.x, fighter.y);
-    if (fighter.facing < 0) ctx.scale(-1, 1);
-    if (fighter.state === 'knockdown') ctx.translate(0, 8);
-    if (fighter.invuln > 0 && Math.floor(fighter.invuln / 3) % 2 === 0) ctx.globalAlpha = 0.45;
-    ctx.filter = fighter.hitstun > 0 && fighter.hitstun > (fighter.move ? 0 : 12) ? 'brightness(1.7) saturate(.55)' : 'none';
-    
-    ctx.drawImage(image, col * cellW, row * cellH, cellW, cellH, -SPRITE_SIZE / 2, -SPRITE_SIZE, SPRITE_SIZE, SPRITE_SIZE);
-    ctx.restore();
-  }
-
-  function drawProjectiles() {
-    ctx.save();
-    ctx.globalCompositeOperation = 'screen';
-    for (const p of match.projectiles) {
-      if (!renderState.projectileGlows.has(p.color)) {
-        renderState.projectileGlows.set(p.color, renderState.makeGlow('#fff', p.color));
-      }
-      const glowSize = p.radius * 4.4;
-      ctx.drawImage(renderState.projectileGlows.get(p.color), p.x - glowSize / 2, p.y - glowSize / 2, glowSize, glowSize);
-      ctx.strokeStyle = p.color;
-      ctx.lineWidth = 4;
-      ctx.beginPath();
-      ctx.arc(p.x, p.y, p.radius, frameNumber * 0.08, frameNumber * 0.08 + Math.PI * 1.45);
-      ctx.stroke();
+    const sheet = images.get(fighter.data.sheet);
+    for (const ghost of fighter.trail || []) {
+      drawSheet(ctx, sheet, ghost.frame, ghost.x, ghost.y, ghost.facing, SPRITE_SIZE, ghost.life / 14);
     }
+    ctx.save();
+    if (fighter.invuln > 0 && Math.floor(fighter.invuln / 3) % 2 === 0) ctx.globalAlpha = 0.42;
+    const flash = fighter.hitstun > 8;
+    if (flash) ctx.filter = 'brightness(1.75) saturate(.5)';
+    drawSheet(ctx, sheet, fighter.spriteFrame(), fighter.x, fighter.y, fighter.facing, SPRITE_SIZE, ctx.globalAlpha, inner => {
+      if (fighter.state === 'knockdown') {
+        inner.translate(0, 22);
+        inner.rotate(-0.55);
+      }
+    });
     ctx.restore();
   }
 
-  function drawEffects() {
+  drawShadow(match.p1);
+  drawShadow(match.p2);
+  drawFighter(match.p1);
+  drawFighter(match.p2);
+
+  ctx.save();
+  ctx.globalCompositeOperation = 'screen';
+  for (const p of match.projectiles) {
+    if (!renderState.projectileGlows.has(p.color)) {
+      renderState.projectileGlows.set(p.color, renderState.makeGlow('#fff', p.color));
+    }
+    const glowSize = p.radius * 4.6;
+    ctx.drawImage(renderState.projectileGlows.get(p.color), p.x - glowSize / 2, p.y - glowSize / 2, glowSize, glowSize);
+    ctx.strokeStyle = '#fff';
+    ctx.lineWidth = 2;
+    ctx.beginPath();
+    ctx.arc(p.x, p.y, p.radius * 0.55, 0, Math.PI * 2);
+    ctx.stroke();
+    ctx.strokeStyle = p.color;
+    ctx.lineWidth = 5;
+    ctx.beginPath();
+    ctx.arc(p.x, p.y, p.radius, frameNumber * 0.1, frameNumber * 0.1 + Math.PI * 1.5);
+    ctx.stroke();
+  }
+
+  for (const fx of match.effects) {
+    ctx.globalAlpha = clamp(fx.life / 18, 0, 1);
+    ctx.fillStyle = fx.color;
     ctx.save();
-    ctx.globalCompositeOperation = 'screen';
-    for (const fx of match.effects) {
-      ctx.globalAlpha = clamp(fx.life / 18, 0, 1);
-      ctx.fillStyle = fx.color;
+    ctx.translate(fx.x, fx.y);
+    if (fx.spark) {
+      ctx.rotate(fx.life * 0.2);
+      ctx.fillRect(-fx.size, -1.2, fx.size * 2, 2.4);
+      ctx.fillRect(-1.2, -fx.size, 2.4, fx.size * 2);
+    } else {
       ctx.beginPath();
-      ctx.arc(fx.x, fx.y, fx.size, 0, Math.PI * 2);
+      ctx.arc(0, 0, fx.size, 0, Math.PI * 2);
       ctx.fill();
     }
-    for (const ring of match.rings) {
-      const progress = 1 - ring.life / ring.max;
-      ctx.globalAlpha = 1 - progress;
-      ctx.strokeStyle = ring.color;
-      ctx.lineWidth = 5 * (1 - progress);
-      ctx.beginPath();
-      ctx.arc(ring.x, ring.y, 16 + progress * 82, 0, Math.PI * 2);
-      ctx.stroke();
-    }
     ctx.restore();
   }
 
-  function drawDamageNumbers() {
-    if (!match.damageNumbers || !match.damageNumbers.length) return;
+  for (const ring of match.rings) {
+    const progress = 1 - ring.life / ring.max;
+    ctx.globalAlpha = 1 - progress;
+    ctx.strokeStyle = ring.color;
+    ctx.lineWidth = 5 * (1 - progress);
+    ctx.beginPath();
+    ctx.arc(ring.x, ring.y, 16 + progress * 90, 0, Math.PI * 2);
+    ctx.stroke();
+  }
+  ctx.restore();
+
+  if (match.damageNumbers?.length) {
     ctx.save();
-    ctx.font = 'bold 22px Impact, sans-serif';
+    ctx.font = 'italic 900 26px Impact, sans-serif';
     ctx.textAlign = 'center';
+    ctx.lineJoin = 'round';
     for (const dn of match.damageNumbers) {
-      ctx.globalAlpha = clamp(dn.life / 20, 0, 1);
-      ctx.fillStyle = dn.color;
+      ctx.globalAlpha = clamp(dn.life / 18, 0, 1);
+      ctx.lineWidth = 4;
       ctx.strokeStyle = '#000';
-      ctx.lineWidth = 3;
+      ctx.fillStyle = dn.color;
       ctx.strokeText(dn.text, dn.x, dn.y);
       ctx.fillText(dn.text, dn.x, dn.y);
     }
     ctx.restore();
   }
 
-  drawStage();
-  drawShadow(match.p1);
-  drawShadow(match.p2);
-  drawFighter(match.p1);
-  drawFighter(match.p2);
-  drawProjectiles();
-  drawEffects();
-  drawDamageNumbers();
+  ctx.restore();
 
-  if (match.freeze > 0) {
-    ctx.fillStyle = `rgba(255,255,255,${match.freeze / 70})`;
+  if (match.superFlash > 0) {
+    ctx.fillStyle = `rgba(255,255,255,${match.superFlash / 36})`;
+    ctx.fillRect(0, 0, W, H);
+  } else if (match.freeze > 0) {
+    ctx.fillStyle = `rgba(255,236,210,${match.freeze / 90})`;
     ctx.fillRect(0, 0, W, H);
   }
 
-  ctx.restore();
+  if (match.koZoom > 12) {
+    ctx.fillStyle = `rgba(255,255,255,${(match.koZoom - 12) / 40})`;
+    ctx.fillRect(0, 0, W, H);
+  }
 }

--- a/labs/rock-kombat/style.css
+++ b/labs/rock-kombat/style.css
@@ -1157,11 +1157,10 @@ legend {
 .versus-center em {
   display: block;
   margin-top: 14px;
-  color: #8e8b86;
-  font-size: 9px;
+  color: var(--amber);
+  font-size: 10px;
   font-weight: 900;
   letter-spacing: 0.16em;
-  animation: press-blink 1.15s step-end infinite;
 }
 
 @keyframes vs-pop {
@@ -1308,9 +1307,10 @@ dialog h2 {
   font-size: 58px;
 }
 
-.pause-layer button {
-  display: block;
-  margin: 18px auto 0;
+.pause-layer .quiet-button {
+  border: 1px solid var(--line);
+  width: 100%;
+  margin-top: 10px;
 }
 
 

--- a/labs/rock-kombat/style.css
+++ b/labs/rock-kombat/style.css
@@ -1307,6 +1307,11 @@ dialog h2 {
   font-size: 58px;
 }
 
+.pause-layer .cta {
+  display: block;
+  margin: 18px auto 0;
+}
+
 .pause-layer .quiet-button {
   border: 1px solid var(--line);
   width: 100%;
@@ -1573,6 +1578,11 @@ dialog h2 {
   .touch-action .kick {
     border-color: var(--amber);
     background: #3d2f16;
+  }
+
+  .touch-action .throw {
+    border-color: #9ad0c4;
+    background: #1a3330;
   }
 
   .touch-action .special {

--- a/labs/rock-kombat/style.css
+++ b/labs/rock-kombat/style.css
@@ -128,7 +128,7 @@ header .header-actions {
 }
 
 header .theme-switch-wrapper {
-  margin-left: 8px;
+  display: none !important;
 }
 
 .mini-brand {
@@ -153,6 +153,15 @@ header .theme-switch-wrapper {
 
 .screen.is-active {
   display: flex;
+}
+
+body[data-screen="arena-screen"] footer,
+body[data-screen="versus-screen"] footer {
+  display: none;
+}
+
+body[data-screen="arena-screen"] header .back-link span {
+  display: none;
 }
 
 .overline {
@@ -341,6 +350,14 @@ em {
   cursor: not-allowed;
 }
 
+.cta.press-start b {
+  animation: press-blink 1.15s step-end infinite;
+}
+
+@keyframes press-blink {
+  50% { opacity: 0.38; }
+}
+
 
 /* --------------------------------------------------------------------------
    8. Select Screen (Fighter Selection)
@@ -405,9 +422,40 @@ em {
   box-shadow: 0 20px 50px #000b;
 }
 
-.fighter-card.is-selected {
+.fighter-card.is-p1 {
   border-color: var(--amber);
   box-shadow: 0 0 0 2px var(--amber), 0 20px 60px #000;
+}
+
+.fighter-card.is-cpu {
+  border-color: var(--red);
+}
+
+.fighter-card.is-p1.is-cpu {
+  box-shadow: 0 0 0 2px var(--amber), 0 0 0 5px var(--red), 0 20px 60px #000;
+}
+
+.card-badges {
+  position: absolute;
+  z-index: 2;
+  top: 10px;
+  left: 10px;
+  display: flex;
+  gap: 6px;
+}
+
+.badge {
+  border: 1px solid #ffffff44;
+  background: #08090be8;
+  color: var(--amber);
+  padding: 4px 7px;
+  font-size: 9px;
+  font-weight: 900;
+  letter-spacing: 0.14em;
+}
+
+.badge.cpu {
+  color: #e37a6b;
 }
 
 /* Fighter card visual area */
@@ -501,6 +549,28 @@ em {
   box-shadow: 0 22px 70px #0008;
 }
 
+.pick-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr auto;
+  gap: 6px;
+  margin-bottom: 16px;
+}
+
+.pick-row button {
+  border: 1px solid var(--line);
+  background: #15171a;
+  padding: 9px 8px;
+  font-size: 9px;
+  font-weight: 900;
+  letter-spacing: 0.12em;
+}
+
+.pick-row button.is-active {
+  border-color: var(--amber);
+  background: #211b13;
+  color: var(--amber);
+}
+
 /* VS preview header */
 .versus-preview {
   display: grid;
@@ -574,9 +644,21 @@ legend {
   letter-spacing: 0.08em;
 }
 
+.option {
+  background:
+    linear-gradient(#15171ae6, #15171af2),
+    var(--stage) center/cover no-repeat;
+}
+
+.option[data-stage="seattle"] { --stage: url("assets/stage-seattle.webp"); }
+.option[data-stage="coliseum"] { --stage: url("assets/stage-coliseum.webp"); }
+.option[data-stage="cellar"] { --stage: url("assets/stage-cellar.webp"); }
+
 .option.is-active {
   border-color: var(--amber);
-  background: #211b13;
+  background:
+    linear-gradient(#211b13d0, #211b13f0),
+    var(--stage) center/cover no-repeat;
 }
 
 /* Difficulty selector */
@@ -633,23 +715,28 @@ legend {
    -------------------------------------------------------------------------- */
 .arena {
   align-items: center;
-  padding: 66px 10px 18px;
+  padding: 58px 10px 12px;
   background: radial-gradient(circle at center top, #241410, #08090b 55%);
 }
 
 .arena-shell {
   width: 100%;
-  max-width: min(1260px, calc((100svh - 190px) * 16/9));
+  max-width: min(1260px, calc((100svh - 130px) * 16/9));
   margin: 0 auto;
 }
 
 /* HUD — top bar during fight */
 .hud {
+  position: absolute;
+  z-index: 5;
+  inset: 0 0 auto;
   display: grid;
-  grid-template-columns: 1fr 116px 1fr;
-  gap: 16px;
+  grid-template-columns: 1fr 108px 1fr;
+  gap: 12px;
   align-items: end;
-  margin-bottom: 8px;
+  padding: 10px 14px 18px;
+  pointer-events: none;
+  background: linear-gradient(#000000d4, #0000 92%);
 }
 
 .hud-name {
@@ -706,8 +793,17 @@ legend {
 }
 
 .life i {
-  background: linear-gradient(#e5d871, #7ebc3f 48%, #357222);
-  box-shadow: 0 0 12px #9bd94766;
+  background: linear-gradient(#ff6a45, #d31818 48%, #6d0b0b);
+  box-shadow: 0 0 12px #ff3a2066;
+}
+
+.life.is-danger i {
+  animation: danger-pulse 0.45s ease-in-out infinite;
+  background: linear-gradient(#ffe066, #ff3b2f 55%, #9a0d0d);
+}
+
+@keyframes danger-pulse {
+  50% { filter: brightness(1.35); }
 }
 
 .p2 .life i,
@@ -817,9 +913,12 @@ legend {
   position: relative;
   overflow: hidden;
   aspect-ratio: 16/9;
-  border: 2px solid #4a3828;
+  border: 3px solid #3d2a1c;
   background: #08090b;
-  box-shadow: 0 0 0 5px #15110e, 0 28px 90px #000;
+  box-shadow:
+    inset 0 0 40px #0006,
+    0 0 0 6px #15110e,
+    0 28px 90px #000;
 }
 
 #game {
@@ -832,6 +931,7 @@ legend {
 /* Announcement overlay */
 .announce {
   position: absolute;
+  z-index: 5;
   inset: 0;
   display: grid;
   place-items: center;
@@ -863,11 +963,20 @@ legend {
 /* Combo counter */
 .combo {
   position: absolute;
-  top: 28%;
-  font: italic 900 44px var(--display);
+  z-index: 5;
+  top: 32%;
+  display: flex;
+  flex-direction: column;
+  font: italic 900 52px/0.85 var(--display);
   color: var(--amber);
-  text-shadow: 3px 3px #000;
+  text-shadow: 3px 3px #000, 0 0 18px #d6a54e88;
   opacity: 0;
+  pointer-events: none;
+}
+
+.combo small {
+  font-size: 12px;
+  letter-spacing: 0.16em;
 }
 
 .combo.p1 {
@@ -901,8 +1010,9 @@ legend {
 /* Pause button */
 .pause-button {
   position: absolute;
+  z-index: 6;
   right: 10px;
-  top: 10px;
+  top: 86px;
   width: 38px;
   height: 38px;
   border: 1px solid #ffffff33;
@@ -967,7 +1077,101 @@ legend {
 
 
 /* --------------------------------------------------------------------------
-   12. Results Screen
+   12. Versus Screen
+   -------------------------------------------------------------------------- */
+.versus {
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 50% 40%, #4a1812, #08090b 62%),
+    #08090b;
+}
+
+.versus-duel {
+  width: min(1180px, 96vw);
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: end;
+  gap: 12px;
+  padding: 80px 16px 40px;
+}
+
+.versus-fighter {
+  text-align: center;
+}
+
+.versus-sprite {
+  --sheet: none;
+  display: block;
+  width: min(42vw, 430px);
+  aspect-ratio: 1;
+  margin: 0 auto -28px;
+  background: var(--sheet) 0 0 / 400% 300% no-repeat;
+  filter: drop-shadow(0 24px 28px #000) drop-shadow(0 0 24px color-mix(in srgb, var(--fighter, #d6a54e) 35%, transparent));
+}
+
+.versus-fighter.p2 .versus-sprite {
+  transform: scaleX(-1);
+}
+
+.versus-fighter small {
+  display: block;
+  color: var(--steel);
+  font-size: 10px;
+  font-weight: 900;
+  letter-spacing: 0.22em;
+}
+
+.versus-fighter.p2 small {
+  color: #e37a6b;
+}
+
+.versus-fighter strong {
+  font: italic 900 clamp(36px, 6vw, 72px)/0.9 var(--display);
+  text-shadow: 4px 5px #000;
+}
+
+.versus-center {
+  text-align: center;
+  padding-bottom: 48px;
+}
+
+.versus-center b {
+  display: block;
+  color: var(--amber);
+  font: italic 900 clamp(64px, 10vw, 140px)/0.8 var(--display);
+  text-shadow: 0 8px var(--red-dark), 0 0 40px #d6a54e66;
+  animation: vs-pop 0.55s cubic-bezier(0.2, 1.4, 0.3, 1) both;
+}
+
+.versus-center span {
+  display: block;
+  margin-top: 8px;
+  color: #cfc8bc;
+  font-size: 11px;
+  font-weight: 900;
+  letter-spacing: 0.18em;
+}
+
+.versus-center em {
+  display: block;
+  margin-top: 14px;
+  color: #8e8b86;
+  font-size: 9px;
+  font-weight: 900;
+  letter-spacing: 0.16em;
+  animation: press-blink 1.15s step-end infinite;
+}
+
+@keyframes vs-pop {
+  from { transform: scale(2.4) rotate(-8deg); opacity: 0; }
+  to { transform: scale(1) rotate(-2deg); opacity: 1; }
+}
+
+
+/* --------------------------------------------------------------------------
+   13. Results Screen
    -------------------------------------------------------------------------- */
 .results {
   position: relative;
@@ -1254,6 +1458,7 @@ dialog h2 {
   .hud {
     grid-template-columns: 1fr 68px 1fr;
     gap: 5px;
+    padding: 6px 8px 12px;
   }
 
   .hud-name strong {
@@ -1284,8 +1489,24 @@ dialog h2 {
   /* Arena layout mobile */
   .arena {
     align-items: flex-start;
-    padding: 56px 4px 8px;
+    padding: 52px 4px 8px;
   }
+
+  .pause-button {
+    top: 70px;
+    width: 34px;
+    height: 34px;
+  }
+
+  .versus-duel {
+    grid-template-columns: 1fr;
+    text-align: center;
+    padding-top: 72px;
+  }
+
+  .versus-fighter.p2 { order: 3; }
+  .versus-center { order: 2; padding-bottom: 8px; }
+  .versus-sprite { width: min(58vw, 280px); margin-bottom: -36px; }
 
   .canvas-frame {
     border-width: 1px;
@@ -1299,19 +1520,24 @@ dialog h2 {
   .touch-controls {
     display: flex;
     justify-content: space-between;
-    align-items: center;
-    padding: 12px 5px calc(8px + env(safe-area-inset-bottom));
+    align-items: flex-end;
+    padding: 12px 8px calc(10px + env(safe-area-inset-bottom));
     user-select: none;
     touch-action: none;
   }
 
-  .touch-move {
+  .touch-dpad {
     display: grid;
-    grid-template-columns: repeat(3, 46px);
-    gap: 5px;
+    grid-template: ". up ." 58px "left down right" 58px / 58px 58px 58px;
+    gap: 6px;
   }
 
-  .touch-move button,
+  .touch-dpad .up { grid-area: up; }
+  .touch-dpad .left { grid-area: left; }
+  .touch-dpad .down { grid-area: down; }
+  .touch-dpad .right { grid-area: right; }
+
+  .touch-dpad button,
   .touch-action button {
     border: 1px solid #ffffff2d;
     background: #16191d;
@@ -1319,26 +1545,22 @@ dialog h2 {
     touch-action: none;
   }
 
-  .touch-move button {
-    width: 46px;
-    height: 46px;
-    border-radius: 10px;
-    font-size: 18px;
-  }
-
-  .touch-move button:nth-child(2) {
-    translate: 0 -8px;
+  .touch-dpad button {
+    width: 58px;
+    height: 58px;
+    border-radius: 14px;
+    font-size: 20px;
   }
 
   .touch-action {
     display: grid;
-    grid-template-columns: repeat(2, 52px);
-    gap: 7px;
+    grid-template-columns: repeat(2, 62px);
+    gap: 10px;
   }
 
   .touch-action button {
-    width: 52px;
-    height: 52px;
+    width: 62px;
+    height: 62px;
     border-radius: 50%;
     font: 900 18px var(--display);
   }
@@ -1354,10 +1576,10 @@ dialog h2 {
   }
 
   .touch-action .special {
-    grid-column: 2;
+    grid-column: 1 / -1;
+    justify-self: center;
     border-color: var(--red);
     background: var(--red-dark);
-    translate: 0 -8px;
   }
 
   .touch-controls button.is-down {
@@ -1395,7 +1617,7 @@ dialog h2 {
 
   .arena-shell {
     width: 100%;
-    max-width: calc((100svh - 90px) * 16/9);
+    max-width: calc((100svh - 64px) * 16/9);
     margin: 0 auto;
   }
 

--- a/labs/rock-kombat/ui.js
+++ b/labs/rock-kombat/ui.js
@@ -3,39 +3,48 @@ import { SPECIAL_COST } from './constants.js';
 
 export function updateHud(match, hudSignature) {
   if (!match) return hudSignature;
-  
+
   const p1 = match.p1;
   const p2 = match.p2;
-  
+
   const nextSignature = [
     p1.data.id, p2.data.id,
     Math.round(p1.health * 10), Math.round(p2.health * 10),
     Math.round(p1.whiteHealth * 10), Math.round(p2.whiteHealth * 10),
-    Math.round(p1.meter), Math.round(p2.meter), p1.wins, p2.wins
+    Math.round(p1.meter), Math.round(p2.meter), p1.wins, p2.wins,
+    match.round
   ].join('|');
-  
+
   if (nextSignature === hudSignature) return hudSignature;
-  
+
   $('#p1-name').textContent = p1.data.short;
   $('#p2-name').textContent = p2.data.short;
-  
+
   $('#p1-life').style.transform = `scaleX(${p1.health / 100})`;
   $('#p2-life').style.transform = `scaleX(${p2.health / 100})`;
-  
   $('#p1-chip').style.transform = `scaleX(${p1.whiteHealth / 100})`;
   $('#p2-chip').style.transform = `scaleX(${p2.whiteHealth / 100})`;
-  
+
+  $('#p1-life').parentElement.classList.toggle('is-danger', p1.health > 0 && p1.health <= 22);
+  $('#p2-life').parentElement.classList.toggle('is-danger', p2.health > 0 && p2.health <= 22);
+
   $('#p1-meter').style.width = `${p1.meter}%`;
   $('#p2-meter').style.width = `${p2.meter}%`;
-  
-  $('#p1-meter-label').textContent = p1.meter >= 100 ? 'SUPER' : p1.meter >= SPECIAL_COST ? 'READY' : `${Math.floor(p1.meter)}%`;
-  $('#p2-meter-label').textContent = p2.meter >= 100 ? 'SUPER' : p2.meter >= SPECIAL_COST ? 'READY' : `${Math.floor(p2.meter)}%`;
-  
+
+  const meterLabel = meter => meter >= 100 ? 'SUPER' : meter >= SPECIAL_COST ? 'READY' : `${Math.floor(meter)}%`;
+  $('#p1-meter-label').textContent = meterLabel(p1.meter);
+  $('#p2-meter-label').textContent = meterLabel(p2.meter);
+
+  $('#p1-meter').closest('.meter').classList.toggle('is-ready', p1.meter >= SPECIAL_COST && p1.meter < 100);
+  $('#p1-meter').closest('.meter').classList.toggle('is-super', p1.meter >= 100);
+  $('#p2-meter').closest('.meter').classList.toggle('is-ready', p2.meter >= SPECIAL_COST && p2.meter < 100);
+  $('#p2-meter').closest('.meter').classList.toggle('is-super', p2.meter >= 100);
+
   [1, 2].forEach(n => {
     $(`#p1-win-${n}`).classList.toggle('won', p1.wins >= n);
     $(`#p2-win-${n}`).classList.toggle('won', p2.wins >= n);
   });
-  
+
   return nextSignature;
 }
 
@@ -43,14 +52,15 @@ export function announce(text, duration = 850) {
   const el = $('#announce');
   el.textContent = text;
   el.classList.remove('show');
-  void el.offsetWidth; // trigger reflow
+  void el.offsetWidth;
   el.classList.add('show');
-  setTimeout(() => el.classList.remove('show'), duration);
+  clearTimeout(announce.timer);
+  announce.timer = setTimeout(() => el.classList.remove('show'), duration);
 }
 
 export function showCombo(fighter, match) {
   const el = fighter === match.p1 ? $('#p1-combo') : $('#p2-combo');
-  el.innerHTML = `${fighter.combo} <small>HITS</small>`;
+  el.innerHTML = `${fighter.combo}<small>HIT COMBO</small>`;
   el.classList.remove('show');
   void el.offsetWidth;
   el.classList.add('show');
@@ -58,25 +68,99 @@ export function showCombo(fighter, match) {
 
 export function showScreen(id) {
   $$('.screen').forEach(screen => screen.classList.toggle('is-active', screen.id === id));
+  document.body.dataset.screen = id;
   window.scrollTo(0, 0);
 }
 
-export function renderRoster(fighters, onSelect) {
+export function fillVersus(p1, p2, stage) {
+  $('#vs-p1-name').textContent = p1.short;
+  $('#vs-p2-name').textContent = p2.short;
+  $('#vs-stage-name').textContent = stage.name;
+  $('#vs-p1-sprite').style.setProperty('--sheet', `url("${p1.sheet}")`);
+  $('#vs-p2-sprite').style.setProperty('--sheet', `url("${p2.sheet}")`);
+  $('#vs-p1-sprite').style.setProperty('--fighter', p1.color);
+  $('#vs-p2-sprite').style.setProperty('--fighter', p2.color);
+}
+
+export function renderRoster(fighters, onChange) {
   $('#roster').innerHTML = fighters.map(f => `
     <button class="fighter-card" role="listitem" data-fighter="${f.id}" style="--fighter:${f.color}" aria-label="Selecionar ${f.name}, ${f.era}">
+      <span class="card-badges">
+        <i class="badge p1" hidden>P1</i>
+        <i class="badge cpu" hidden>CPU</i>
+      </span>
       <div class="fighter-visual"><i class="fighter-sprite" style="--sheet:url('${f.sheet}')"></i></div>
-      <footer><small>${f.era}</small><h3>${f.name}</h3><p>${f.style}<br>Especial: ${f.special}</p>
-        <div class="stats"><span><b>POWER</b><i style="--value:${f.power}%"></i></span><span><b>MOBILITY</b><i style="--value:${f.mobility}%"></i></span><span><b>DEFENSE</b><i style="--value:${f.defense}%"></i></span></div>
+      <footer>
+        <small>${f.era}</small>
+        <h3>${f.name}</h3>
+        <p>${f.style}<br>Especial: ${f.special}</p>
+        <div class="stats">
+          <span><b>POWER</b><i style="--value:${f.power}%"></i></span>
+          <span><b>MOBILITY</b><i style="--value:${f.mobility}%"></i></span>
+          <span><b>DEFENSE</b><i style="--value:${f.defense}%"></i></span>
+        </div>
       </footer>
     </button>`).join('');
-    
-  $$('.fighter-card').forEach(card => card.addEventListener('click', () => {
-    const selectedFighter = fighters.find(f => f.id === card.dataset.fighter);
-    const others = fighters.filter(f => f.id !== selectedFighter.id);
-    const cpuFighter = others[Math.floor(Math.random() * others.length)];
-    
-    $$('.fighter-card').forEach(item => item.classList.toggle('is-selected', item === card));
-    
-    onSelect(selectedFighter, cpuFighter);
-  }));
+
+  const state = { slot: 'p1', p1: null, cpu: null };
+
+  function sync() {
+    $$('.fighter-card').forEach(card => {
+      const id = card.dataset.fighter;
+      card.classList.toggle('is-p1', state.p1?.id === id);
+      card.classList.toggle('is-cpu', state.cpu?.id === id);
+      card.querySelector('.badge.p1').hidden = state.p1?.id !== id;
+      card.querySelector('.badge.cpu').hidden = state.cpu?.id !== id;
+    });
+    $$('[data-pick]').forEach(btn => btn.classList.toggle('is-active', btn.dataset.pick === state.slot));
+    $('#p1-preview').textContent = state.p1?.short || 'ESCOLHA';
+    $('#cpu-preview').textContent = state.cpu?.short || 'ESCOLHA';
+    onChange(state.p1, state.cpu, state.slot);
+  }
+
+  $$('.fighter-card').forEach(card => {
+    card.addEventListener('click', () => {
+      const fighter = fighters.find(f => f.id === card.dataset.fighter);
+      if (state.slot === 'p1') {
+        state.p1 = fighter;
+        if (!state.cpu) state.slot = 'cpu';
+      } else {
+        state.cpu = fighter;
+      }
+      sync();
+    });
+  });
+
+  $$('[data-pick]').forEach(btn => {
+    btn.addEventListener('click', () => {
+      state.slot = btn.dataset.pick;
+      sync();
+    });
+  });
+
+  $('#cpu-random')?.addEventListener('click', () => {
+    state.cpu = fighters[Math.floor(Math.random() * fighters.length)];
+    sync();
+  });
+
+  return {
+    getState: () => state,
+    selectIndex(index) {
+      const fighter = fighters[index];
+      if (!fighter) return;
+      if (state.slot === 'p1') {
+        state.p1 = fighter;
+        if (!state.cpu) state.slot = 'cpu';
+      } else {
+        state.cpu = fighter;
+      }
+      sync();
+    },
+    reset() {
+      state.slot = 'p1';
+      state.p1 = null;
+      state.cpu = null;
+      sync();
+    }
+  };
 }

--- a/labs/rock-kombat/utils.js
+++ b/labs/rock-kombat/utils.js
@@ -3,3 +3,14 @@ export const $$ = selector => [...document.querySelectorAll(selector)];
 export const clamp = (value, min, max) => Math.max(min, Math.min(max, value));
 export const lerp = (a, b, t) => a + (b - a) * t;
 export const random = (min, max) => min + Math.random() * (max - min);
+
+export function approach(value, target, maxDelta) {
+  if (value < target) return Math.min(target, value + maxDelta);
+  return Math.max(target, value - maxDelta);
+}
+
+export function overlap(a, b) {
+  return a && b
+    && a.left < b.right && a.right > b.left
+    && a.top < b.bottom && a.bottom > b.top;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Revisão completa do Rock Kombat com foco em jogabilidade, interação e interface no estilo dos fighters de arcade.

## Jogabilidade
- Dash (toque duplo para frente) e backdash com invulnerabilidade
- Throw dedicado (U/O ou botão T no touch) além de P+K, quebra guarda
- Arco de pulo travado no takeoff, com steering leve no ar
- Walk para trás mais lento e facing travado durante golpes/stun
- Uppercut com invuln de startup (anti-ar)
- Launch leva a knockdown na aterrissagem
- Combo scaling, counter-hit, chip maior em especiais
- Clash de projéteis, pushback de canto, afterimage no dash
- KO com slow-mo, PERFECT e DOUBLE K.O.
- Intro com walk-in, ROUND / FIGHT, best of 3
- IA com block sticky, anti-ar, meaty e arquétipos (easy mais honesto)

## Interface
- HUD arcade sobre o canvas (barras vermelhas MK, meter READY/SUPER, perigo em vida baixa)
- Tela VS antes da luta
- Select em dois passos (P1 depois CPU, inclusive espelho) + palcos com thumbnail
- PRESS START, anúncios e combo HIT COMBO
- D-pad touch em cruz + P/K/T/SP
- Pause, comandos e teclado (Enter, 1–3, Esc, U throw) revisados

## Testes no browser
Percorridos hero → select → VS → arena → pause → help → som → rematch → results, mais viewport mobile 390×844. Combate, HUD no canvas, K.O., tela de vitória e throw (U) confirmados. Sem erros de console.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ffd9d-4eb7-7095-b08a-2971051cfc7d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ffd9d-4eb7-7095-b08a-2971051cfc7d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

