### PR TITLE
Aetherion: observatório estelar 3D em three.js

### DIFF
--- a/labs/aetherion/index.html
+++ b/labs/aetherion/index.html
@@ -177,7 +177,7 @@
     </main>
 
     <script src="/labs/shared.js?v=6" defer></script>
-    <script type="module" src="src/main.js?v=1"></script>
+    <script type="module" src="src/main.js?v=2"></script>
 </body>
 
 </html>

--- a/labs/aetherion/index.html
+++ b/labs/aetherion/index.html
@@ -1,0 +1,183 @@
+<!DOCTYPE html>
+<html lang="pt-br" data-theme="dark">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport"
+        content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover">
+    <meta name="theme-color" content="#05060f">
+    <title>Aetherion — Observatório Estelar | Labs</title>
+    <meta name="description"
+        content="Observatório 3D em three.js: voe por um sistema estelar gerado em tempo real, com planetas em shaders, cinturão de asteroides e um buraco negro.">
+    <link rel="canonical" href="https://diogopaulino.com.br/labs/aetherion/">
+
+    <meta property="og:type" content="website">
+    <meta property="og:site_name" content="Diogo Paulino · Labs">
+    <meta property="og:url" content="https://diogopaulino.com.br/labs/aetherion/">
+    <meta property="og:title" content="Aetherion — Observatório Estelar">
+    <meta property="og:description"
+        content="Um sistema solar forjado em shaders. Cada visita nasce de uma semente nova.">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Aetherion — Observatório Estelar">
+    <meta name="twitter:description"
+        content="Voe entre mundos, aproxime-se de um buraco negro e forje um novo sistema no navegador.">
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@500;600;700&family=Outfit:wght@300;400;500;600;700&display=swap"
+        rel="stylesheet">
+    <link rel="stylesheet" href="/labs/shared.css?v=6">
+    <link rel="stylesheet" href="style.css?v=1">
+
+    <script type="importmap">
+    {
+        "imports": {
+            "three": "https://cdn.jsdelivr.net/npm/three@0.185.1/build/three.module.js",
+            "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.185.1/examples/jsm/"
+        }
+    }
+    </script>
+</head>
+
+<body data-state="intro">
+    <main class="game-shell">
+        <header data-lab-header data-title="Aetherion" data-back-label="Labs">
+            <template data-slot="logo">
+                <div class="app-logo">
+                    <span class="brand-mark" aria-hidden="true">✦</span>
+                    <span>Aetherion</span>
+                </div>
+            </template>
+            <template data-slot="actions">
+                <button id="helpButton" class="icon-btn" type="button" aria-label="Ajuda" title="Ajuda (?)">
+                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                        stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                        <circle cx="12" cy="12" r="10" />
+                        <path d="M9.1 9a3 3 0 0 1 5.8 1c0 2-3 2-3 4" />
+                        <path d="M12 17h.01" />
+                    </svg>
+                </button>
+            </template>
+        </header>
+
+        <section class="stage" aria-label="Observatório estelar">
+            <canvas id="scene" aria-label="Sistema estelar em 3D"></canvas>
+            <div class="vignette" aria-hidden="true"></div>
+        </section>
+
+        <div id="hud" class="hud" hidden>
+            <aside class="catalog" aria-label="Catálogo de corpos">
+                <p class="panel-kicker">Catálogo</p>
+                <nav id="bodyList" class="body-list"></nav>
+            </aside>
+
+            <article class="dossier" id="dossier" aria-live="polite">
+                <p class="panel-kicker" id="dossierKind">Estrela</p>
+                <h2 id="dossierName">Helion</h2>
+                <dl class="stats">
+                    <div><dt>Distância</dt><dd id="statDistance">—</dd></div>
+                    <div><dt>Raio</dt><dd id="statRadius">—</dd></div>
+                    <div><dt>Período</dt><dd id="statPeriod">—</dd></div>
+                    <div><dt>Composição</dt><dd id="statComp">—</dd></div>
+                </dl>
+                <p class="blurb" id="dossierBlurb"></p>
+            </article>
+
+            <div class="hint" id="hint">
+                Arraste para orbitar · clique num mundo para viajar · rolagem para zoom
+            </div>
+
+            <div class="dock" role="toolbar" aria-label="Controles do observatório">
+                <button id="systemViewBtn" class="dock-btn" type="button" title="Visão do sistema (0)">
+                    Sistema
+                </button>
+                <div class="warp" aria-label="Dilatação do tempo">
+                    <span class="warp-label">Tempo</span>
+                    <div id="warpBtns" class="warp-btns">
+                        <button type="button" data-warp="0">0</button>
+                        <button type="button" data-warp="1" class="is-on">1×</button>
+                        <button type="button" data-warp="8">8×</button>
+                        <button type="button" data-warp="32">32×</button>
+                        <button type="button" data-warp="96">96×</button>
+                    </div>
+                </div>
+                <button id="newSystemBtn" class="dock-btn accent" type="button" title="Novo sistema (N)">
+                    Novo sistema
+                </button>
+                <button id="muteBtn" class="dock-btn" type="button" title="Som (M)" aria-pressed="false">
+                    Som
+                </button>
+            </div>
+        </div>
+
+        <div id="intro" class="overlay">
+            <div class="overlay-card intro-card">
+                <p class="eyebrow"><i></i> Laboratório three.js</p>
+                <h2>Aetherion</h2>
+                <p class="lede">Um observatório estelar forjado no navegador. Cada semente nasce um sistema
+                    diferente — estrelas vivas, mundos com atmosfera, um cinturão de pedra e, às vezes,
+                    um abismo que devora a luz.</p>
+                <ul class="feature-list">
+                    <li>Voe e foque qualquer corpo com um clique</li>
+                    <li>Shaders próprios para estrela, terra, gás, lava e gelo</li>
+                    <li>Buraco negro com disco de acreção e jatos relativísticos</li>
+                </ul>
+                <div class="settings-row">
+                    <label class="field">
+                        <span>Qualidade</span>
+                        <select id="qualitySelect">
+                            <option value="auto">Automática</option>
+                            <option value="low">Performance</option>
+                            <option value="medium">Equilibrada</option>
+                            <option value="high">Cinemática</option>
+                        </select>
+                    </label>
+                </div>
+                <footer class="card-actions">
+                    <button id="startButton" class="primary-button" type="button">
+                        <span>Entrar no sistema</span>
+                        <i aria-hidden="true">→</i>
+                    </button>
+                </footer>
+            </div>
+        </div>
+
+        <div id="helpOverlay" class="overlay" hidden>
+            <div class="overlay-card compact-card">
+                <p class="eyebrow"><i></i> Comandos</p>
+                <h2>Como observar</h2>
+                <div class="keys">
+                    <span><kbd>Arrastar</kbd> orbitar a câmera</span>
+                    <span><kbd>Scroll</kbd> / <kbd>pinch</kbd> zoom</span>
+                    <span><kbd>Clique</kbd> viajar até um mundo</span>
+                    <span><kbd>[</kbd> <kbd>]</kbd> corpo anterior / próximo</span>
+                    <span><kbd>0</kbd> visão do sistema</span>
+                    <span><kbd>N</kbd> novo sistema · <kbd>M</kbd> som</span>
+                    <span><kbd>Espaço</kbd> pausar o tempo · <kbd>F</kbd> tela cheia</span>
+                </div>
+                <div class="card-actions">
+                    <button id="helpClose" class="primary-button" type="button">
+                        <span>Fechar</span>
+                    </button>
+                </div>
+            </div>
+        </div>
+
+        <div id="errorOverlay" class="overlay" hidden>
+            <div class="overlay-card compact-card">
+                <p class="eyebrow eyebrow--danger"><i></i> WebGL indisponível</p>
+                <h2>O céu não abriu.</h2>
+                <p class="lede" id="errorText">Este laboratório precisa de WebGL 2. Tente um navegador
+                    atualizado ou reative a aceleração de hardware.</p>
+            </div>
+        </div>
+
+        <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
+    </main>
+
+    <script src="/labs/shared.js?v=6" defer></script>
+    <script type="module" src="src/main.js?v=1"></script>
+</body>
+
+</html>

--- a/labs/aetherion/src/asteroids.js
+++ b/labs/aetherion/src/asteroids.js
@@ -1,0 +1,123 @@
+/**
+ * Cinturão de asteroides (InstancedMesh) e um cometa com cauda oposta ao sol.
+ */
+
+import * as THREE from 'three';
+
+function rockyGeometry(rng, radius) {
+    const geo = new THREE.IcosahedronGeometry(radius, 1);
+    const pos = geo.attributes.position;
+    const v = new THREE.Vector3();
+    for (let i = 0; i < pos.count; i++) {
+        v.fromBufferAttribute(pos, i);
+        const n = 0.72 + rng() * 0.5;
+        v.normalize().multiplyScalar(radius * n);
+        pos.setXYZ(i, v.x, v.y, v.z);
+    }
+    geo.computeVertexNormals();
+    return geo;
+}
+
+export function createAsteroidBelt({ inner, outer, count, rng, ySpread = 2.4 }) {
+    const geo = rockyGeometry(rng, 1);
+    const mat = new THREE.MeshStandardMaterial({
+        color: 0x8a8178,
+        roughness: 0.92,
+        metalness: 0.08,
+        emissive: 0x2a241c,
+        emissiveIntensity: 0.45
+    });
+    const mesh = new THREE.InstancedMesh(geo, mat, count);
+    mesh.instanceMatrix.setUsage(THREE.DynamicDrawUsage);
+
+    const dummy = new THREE.Object3D();
+    const color = new THREE.Color();
+
+    for (let i = 0; i < count; i++) {
+        const radius = inner + rng() * (outer - inner);
+        const theta = rng() * Math.PI * 2;
+        const y = (rng() - 0.5) * ySpread;
+        const s = 0.18 + rng() * 0.55;
+        dummy.position.set(Math.cos(theta) * radius, y, Math.sin(theta) * radius);
+        dummy.rotation.set(rng() * 6, rng() * 6, rng() * 6);
+        dummy.scale.setScalar(s);
+        dummy.updateMatrix();
+        mesh.setMatrixAt(i, dummy.matrix);
+        color.setHSL(0.07 + rng() * 0.06, 0.18, 0.28 + rng() * 0.22);
+        mesh.setColorAt(i, color);
+    }
+    mesh.instanceColor.needsUpdate = true;
+    mesh.instanceMatrix.needsUpdate = true;
+
+    return {
+        mesh,
+        update(dt) {
+            mesh.rotation.y += dt * 0.018;
+        }
+    };
+}
+
+export function createComet(rng) {
+    const group = new THREE.Group();
+    const nucleus = new THREE.Mesh(
+        rockyGeometry(rng, 0.55),
+        new THREE.MeshStandardMaterial({
+            color: 0xc8d4e8,
+            roughness: 0.55,
+            metalness: 0.15,
+            emissive: 0x88aacc,
+            emissiveIntensity: 0.25
+        })
+    );
+    nucleus.userData.pick = true;
+    group.add(nucleus);
+
+    const tailCount = 90;
+    const tailPos = new Float32Array(tailCount * 3);
+    const tailCol = new Float32Array(tailCount * 3);
+    for (let i = 0; i < tailCount; i++) {
+        const t = i / tailCount;
+        tailCol[i * 3] = 0.55 + (1 - t) * 0.4;
+        tailCol[i * 3 + 1] = 0.75 + (1 - t) * 0.2;
+        tailCol[i * 3 + 2] = 1.0;
+    }
+    const tailGeo = new THREE.BufferGeometry();
+    tailGeo.setAttribute('position', new THREE.BufferAttribute(tailPos, 3));
+    tailGeo.setAttribute('color', new THREE.BufferAttribute(tailCol, 3));
+    const tail = new THREE.Line(
+        tailGeo,
+        new THREE.LineBasicMaterial({
+            vertexColors: true,
+            transparent: true,
+            opacity: 0.75,
+            blending: THREE.AdditiveBlending,
+            depthWrite: false
+        })
+    );
+    group.add(tail);
+
+    const tmp = new THREE.Vector3();
+    const side = new THREE.Vector3();
+
+    return {
+        group,
+        pickMesh: nucleus,
+        update(worldPos) {
+            group.position.copy(worldPos);
+            const dir = tmp.copy(worldPos).normalize();
+            side.set(-dir.z, 0.15, dir.x).normalize();
+            const pos = tailGeo.attributes.position;
+            for (let i = 0; i < tailCount; i++) {
+                const t = i / (tailCount - 1);
+                const wobble = Math.sin(t * 14.0 + worldPos.x * 0.05) * t * 0.8;
+                pos.setXYZ(
+                    i,
+                    dir.x * t * 18 + side.x * wobble,
+                    dir.y * t * 18 + 0.3 * t,
+                    dir.z * t * 18 + side.z * wobble
+                );
+            }
+            pos.needsUpdate = true;
+        }
+    };
+}

--- a/labs/aetherion/src/audio.js
+++ b/labs/aetherion/src/audio.js
@@ -1,0 +1,155 @@
+/**
+ * Trilha ambiente sintetizada: drone espacial, vento solar e cues de warp.
+ */
+
+export class SpaceAudio {
+    constructor() {
+        this.ctx = null;
+        this.enabled = true;
+        this.volume = 0.7;
+        this._started = false;
+    }
+
+    init() {
+        if (this.ctx) {
+            if (this.ctx.state === 'suspended') this.ctx.resume();
+            return;
+        }
+        const Ctx = window.AudioContext || window.webkitAudioContext;
+        if (!Ctx) return;
+        const ctx = new Ctx();
+        this.ctx = ctx;
+
+        this.master = ctx.createGain();
+        this.master.gain.value = this.enabled ? this.volume : 0;
+
+        this.comp = ctx.createDynamicsCompressor();
+        this.comp.threshold.value = -18;
+        this.comp.ratio.value = 4;
+        this.master.connect(this.comp);
+        this.comp.connect(ctx.destination);
+
+        this.music = ctx.createGain();
+        this.music.gain.value = 0.42;
+        this.sfx = ctx.createGain();
+        this.sfx.gain.value = 0.8;
+        this.music.connect(this.master);
+        this.sfx.connect(this.master);
+
+        this._pad();
+        this._wind();
+        this._started = true;
+    }
+
+    _osc(type, freq, dest, gain = 0.08) {
+        const ctx = this.ctx;
+        const o = ctx.createOscillator();
+        o.type = type;
+        o.frequency.value = freq;
+        const g = ctx.createGain();
+        g.gain.value = gain;
+        o.connect(g);
+        g.connect(dest);
+        o.start();
+        return { o, g };
+    }
+
+    _pad() {
+        const ctx = this.ctx;
+        const filter = ctx.createBiquadFilter();
+        filter.type = 'lowpass';
+        filter.frequency.value = 420;
+        filter.Q.value = 0.7;
+        filter.connect(this.music);
+
+        this._osc('sine', 55, filter, 0.11);
+        this._osc('sine', 82.4, filter, 0.08);
+        this._osc('triangle', 110, filter, 0.03);
+        this._osc('sine', 164.8, filter, 0.025);
+
+        const lfo = ctx.createOscillator();
+        lfo.type = 'sine';
+        lfo.frequency.value = 0.07;
+        const lfoGain = ctx.createGain();
+        lfoGain.gain.value = 180;
+        lfo.connect(lfoGain);
+        lfoGain.connect(filter.frequency);
+        lfo.start();
+
+        const shimmer = this._osc('sine', 880, this.music, 0.012);
+        const trem = ctx.createOscillator();
+        trem.frequency.value = 0.18;
+        const tremG = ctx.createGain();
+        tremG.gain.value = 0.01;
+        trem.connect(tremG);
+        tremG.connect(shimmer.g.gain);
+        trem.start();
+    }
+
+    _wind() {
+        const ctx = this.ctx;
+        const buffer = ctx.createBuffer(1, ctx.sampleRate * 2, ctx.sampleRate);
+        const data = buffer.getChannelData(0);
+        for (let i = 0; i < data.length; i++) data[i] = Math.random() * 2 - 1;
+        const src = ctx.createBufferSource();
+        src.buffer = buffer;
+        src.loop = true;
+        const bp = ctx.createBiquadFilter();
+        bp.type = 'bandpass';
+        bp.frequency.value = 900;
+        bp.Q.value = 0.6;
+        const g = ctx.createGain();
+        g.gain.value = 0.035;
+        src.connect(bp);
+        bp.connect(g);
+        g.connect(this.music);
+        src.start();
+    }
+
+    setMuted(muted) {
+        this.enabled = !muted;
+        if (!this.master || !this.ctx) return;
+        this.master.gain.setTargetAtTime(muted ? 0 : this.volume, this.ctx.currentTime, 0.08);
+    }
+
+    chime() {
+        if (!this.ctx || !this.enabled) return;
+        const ctx = this.ctx;
+        const now = ctx.currentTime;
+        for (const [freq, dur] of [[523.25, 0.5], [783.99, 0.7]]) {
+            const o = ctx.createOscillator();
+            const g = ctx.createGain();
+            o.type = 'sine';
+            o.frequency.value = freq;
+            g.gain.setValueAtTime(0.0001, now);
+            g.gain.exponentialRampToValueAtTime(0.07, now + 0.02);
+            g.gain.exponentialRampToValueAtTime(0.0001, now + dur);
+            o.connect(g);
+            g.connect(this.sfx);
+            o.start(now);
+            o.stop(now + dur + 0.05);
+        }
+    }
+
+    warp() {
+        if (!this.ctx || !this.enabled) return;
+        const ctx = this.ctx;
+        const now = ctx.currentTime;
+        const o = ctx.createOscillator();
+        const g = ctx.createGain();
+        o.type = 'sawtooth';
+        o.frequency.setValueAtTime(220, now);
+        o.frequency.exponentialRampToValueAtTime(60, now + 0.45);
+        g.gain.setValueAtTime(0.0001, now);
+        g.gain.exponentialRampToValueAtTime(0.06, now + 0.03);
+        g.gain.exponentialRampToValueAtTime(0.0001, now + 0.5);
+        const f = ctx.createBiquadFilter();
+        f.type = 'lowpass';
+        f.frequency.value = 1200;
+        o.connect(f);
+        f.connect(g);
+        g.connect(this.sfx);
+        o.start(now);
+        o.stop(now + 0.55);
+    }
+}

--- a/labs/aetherion/src/blackhole.js
+++ b/labs/aetherion/src/blackhole.js
@@ -1,0 +1,153 @@
+/**
+ * Buraco negro: horizonte negro, anel de fótons, disco de acreção com
+ * rotação kepleriana / Doppler e jatos relativísticos nos polos.
+ */
+
+import * as THREE from 'three';
+import { NOISE, VERT } from './glsl.js';
+
+const DISK_VERT = /* glsl */ `
+varying vec2 vUv;
+varying vec3 vWorldPos;
+void main() {
+    vUv = uv;
+    vec4 world = modelMatrix * vec4(position, 1.0);
+    vWorldPos = world.xyz;
+    gl_Position = projectionMatrix * viewMatrix * world;
+}
+`;
+
+const DISK_FRAG = /* glsl */ `
+${NOISE}
+uniform float uTime;
+uniform vec3 uHot;
+uniform vec3 uCool;
+varying vec2 vUv;
+
+void main() {
+    float r = vUv.y;
+    float angle = vUv.x * 6.28318530718;
+    float kepler = 1.0 / pow(max(r, 0.18), 1.45);
+    float a = angle + uTime * kepler * 0.55;
+    float n = fbm(vec3(cos(a) * r * 4.0, sin(a) * r * 4.0, r * 6.0 + uTime * 0.08));
+    float spiral = 0.5 + 0.5 * sin(a * 4.0 + r * 22.0 - uTime * 1.8);
+    float dens = smoothstep(0.0, 0.12, r) * (1.0 - smoothstep(0.72, 1.0, r));
+    dens *= 0.4 + 0.6 * n * mix(0.7, 1.2, spiral);
+    vec3 col = mix(uHot, uCool, smoothstep(0.08, 0.85, r));
+    col *= 0.8 + (1.0 - r) * 2.4;
+    float doppler = 0.62 + 0.5 * sin(angle);
+    col *= doppler;
+    gl_FragColor = vec4(col, clamp(dens, 0.0, 1.0));
+}
+`;
+
+const JET_FRAG = /* glsl */ `
+${NOISE}
+uniform float uTime;
+uniform vec3 uColor;
+varying vec3 vObjectPos;
+varying vec3 vWorldNormal;
+varying vec3 vWorldPos;
+
+void main() {
+    vec3 p = vObjectPos;
+    float along = clamp(p.y * 0.5 + 0.5, 0.0, 1.0);
+    float n = fbm(vec3(p.x * 6.0, p.y * 2.0 - uTime * 0.6, p.z * 6.0));
+    vec3 view = normalize(cameraPosition - vWorldPos);
+    float f = pow(1.0 - abs(dot(normalize(vWorldNormal), view)), 2.2);
+    float alpha = (0.15 + n * 0.55) * (1.0 - along) * (0.4 + f);
+    gl_FragColor = vec4(uColor, clamp(alpha, 0.0, 0.7));
+}
+`;
+
+export function createBlackHole({ radius = 3.2, segs = 48 }) {
+    const group = new THREE.Group();
+
+    const horizon = new THREE.Mesh(
+        new THREE.SphereGeometry(radius, segs, segs),
+        new THREE.MeshBasicMaterial({ color: 0x000000 })
+    );
+    horizon.userData.pick = true;
+    group.add(horizon);
+
+    const photon = new THREE.Mesh(
+        new THREE.TorusGeometry(radius * 1.52, radius * 0.045, 12, 80),
+        new THREE.MeshBasicMaterial({
+            color: 0xffe6c2,
+            transparent: true,
+            opacity: 0.85,
+            blending: THREE.AdditiveBlending,
+            depthWrite: false
+        })
+    );
+    photon.rotation.x = Math.PI / 2;
+    group.add(photon);
+
+    const glow = new THREE.Mesh(
+        new THREE.SphereGeometry(radius * 1.12, 24, 16),
+        new THREE.MeshBasicMaterial({
+            color: 0x3a1028,
+            transparent: true,
+            opacity: 0.45,
+            blending: THREE.AdditiveBlending,
+            depthWrite: false,
+            side: THREE.BackSide
+        })
+    );
+    group.add(glow);
+
+    const diskUniforms = {
+        uTime: { value: 0 },
+        uHot: { value: new THREE.Color('#fff4d2') },
+        uCool: { value: new THREE.Color('#ff4b2a') }
+    };
+
+    const disk = new THREE.Mesh(
+        new THREE.RingGeometry(radius * 1.7, radius * 9.5, 128, 24),
+        new THREE.ShaderMaterial({
+            uniforms: diskUniforms,
+            vertexShader: DISK_VERT,
+            fragmentShader: DISK_FRAG,
+            transparent: true,
+            depthWrite: false,
+            side: THREE.DoubleSide,
+            blending: THREE.AdditiveBlending
+        })
+    );
+    disk.rotation.x = Math.PI / 2;
+    disk.rotation.z = 0.18;
+    group.add(disk);
+
+    const jetMat = new THREE.ShaderMaterial({
+        uniforms: {
+            uTime: diskUniforms.uTime,
+            uColor: { value: new THREE.Color('#9ad8ff') }
+        },
+        vertexShader: VERT,
+        fragmentShader: JET_FRAG,
+        transparent: true,
+        depthWrite: false,
+        blending: THREE.AdditiveBlending,
+        side: THREE.DoubleSide
+    });
+
+    const jetGeo = new THREE.CylinderGeometry(radius * 0.12, radius * 0.55, radius * 18, 16, 1, true);
+    const jetA = new THREE.Mesh(jetGeo, jetMat);
+    jetA.position.y = radius * 9;
+    const jetB = new THREE.Mesh(jetGeo, jetMat);
+    jetB.position.y = -radius * 9;
+    jetB.rotation.z = Math.PI;
+    group.add(jetA, jetB);
+
+    group.rotation.z = 0.22;
+    group.rotation.x = 0.12;
+
+    return {
+        group,
+        pickMesh: horizon,
+        update(time) {
+            diskUniforms.uTime.value = time;
+            disk.rotation.z = 0.18 + time * 0.02;
+        }
+    };
+}

--- a/labs/aetherion/src/camera.js
+++ b/labs/aetherion/src/camera.js
@@ -1,0 +1,149 @@
+/**
+ * Câmera do observatório: órbita esférica amortecida em torno do corpo
+ * focado, com interpolação cinematográfica ao trocar de alvo.
+ */
+
+import * as THREE from 'three';
+
+export class ObservatoryCamera {
+    constructor(camera, canvas) {
+        this.camera = camera;
+        this.canvas = canvas;
+        this.spherical = new THREE.Spherical(72, 1.12, 0.55);
+        this.desired = new THREE.Spherical(72, 1.12, 0.55);
+        this.target = new THREE.Vector3();
+        this.desiredTarget = new THREE.Vector3();
+        this.minR = 8;
+        this.maxR = 620;
+        this.dragging = false;
+        this.moved = false;
+        this.pointers = new Map();
+        this.pinch0 = 0;
+        this.auto = true;
+        this.warping = 0;
+        this._offset = new THREE.Vector3();
+        this.bind();
+    }
+
+    bind() {
+        const el = this.canvas;
+        el.addEventListener('pointerdown', (e) => this.onDown(e));
+        el.addEventListener('pointermove', (e) => this.onMove(e));
+        el.addEventListener('pointerup', (e) => this.onUp(e));
+        el.addEventListener('pointercancel', (e) => this.onUp(e));
+        el.addEventListener('wheel', (e) => this.onWheel(e), { passive: false });
+        el.addEventListener('contextmenu', (e) => e.preventDefault());
+    }
+
+    focus(position, distance, immediate = false) {
+        this.desiredTarget.copy(position);
+        this.desired.radius = THREE.MathUtils.clamp(distance, this.minR, this.maxR);
+        this.warping = 1;
+        this.auto = false;
+        if (immediate) {
+            this.target.copy(position);
+            this.spherical.radius = this.desired.radius;
+            this.warping = 0;
+        }
+    }
+
+    systemView() {
+        this.desiredTarget.set(0, 0, 0);
+        this.desired.radius = 280;
+        this.desired.phi = 1.05;
+        this.warping = 1;
+        this.auto = true;
+    }
+
+    onDown(e) {
+        this.canvas.setPointerCapture(e.pointerId);
+        this.pointers.set(e.pointerId, { x: e.clientX, y: e.clientY });
+        this.moved = false;
+        if (this.pointers.size === 1) {
+            this.dragging = true;
+            this.auto = false;
+            this.canvas.classList.add('is-dragging');
+        }
+        if (this.pointers.size === 2) {
+            const pts = [...this.pointers.values()];
+            this.pinch0 = Math.hypot(pts[0].x - pts[1].x, pts[0].y - pts[1].y);
+        }
+    }
+
+    onMove(e) {
+        if (!this.pointers.has(e.pointerId)) return;
+        const prev = this.pointers.get(e.pointerId);
+        const dx = e.clientX - prev.x;
+        const dy = e.clientY - prev.y;
+        this.pointers.set(e.pointerId, { x: e.clientX, y: e.clientY });
+
+        if (this.pointers.size === 2) {
+            const pts = [...this.pointers.values()];
+            const dist = Math.hypot(pts[0].x - pts[1].x, pts[0].y - pts[1].y);
+            if (this.pinch0 > 0) {
+                const ratio = dist / this.pinch0;
+                this.desired.radius = THREE.MathUtils.clamp(
+                    this.desired.radius / ratio,
+                    this.minR,
+                    this.maxR
+                );
+                this.pinch0 = dist;
+            }
+            this.moved = true;
+            return;
+        }
+
+        if (!this.dragging) return;
+        if (Math.abs(dx) + Math.abs(dy) > 3) this.moved = true;
+        this.desired.theta -= dx * 0.005;
+        this.desired.phi = THREE.MathUtils.clamp(this.desired.phi - dy * 0.005, 0.18, Math.PI - 0.18);
+    }
+
+    onUp(e) {
+        this.pointers.delete(e.pointerId);
+        if (this.pointers.size < 2) this.pinch0 = 0;
+        if (this.pointers.size === 0) {
+            this.dragging = false;
+            this.canvas.classList.remove('is-dragging');
+            this.canvas.releasePointerCapture?.(e.pointerId);
+        }
+    }
+
+    onWheel(e) {
+        e.preventDefault();
+        const k = Math.exp(e.deltaY * 0.0016);
+        this.desired.radius = THREE.MathUtils.clamp(this.desired.radius * k, this.minR, this.maxR);
+        this.auto = false;
+    }
+
+    consumeClick() {
+        const was = this.moved;
+        this.moved = false;
+        return !was;
+    }
+
+    update(dt) {
+        if (this.auto && !this.dragging) {
+            this.desired.theta += dt * 0.045;
+        }
+        const k = 1 - Math.pow(0.001, dt);
+        this.spherical.theta += (this.desired.theta - this.spherical.theta) * k * 1.8;
+        this.spherical.phi += (this.desired.phi - this.spherical.phi) * k * 1.8;
+        this.spherical.radius += (this.desired.radius - this.spherical.radius) * k * 1.4;
+        this.target.lerp(this.desiredTarget, k * 1.5);
+
+        this.spherical.makeSafe();
+        this._offset.setFromSpherical(this.spherical);
+        this.camera.position.copy(this.target).add(this._offset);
+        this.camera.lookAt(this.target);
+
+        if (this.warping > 0) {
+            this.warping = Math.max(0, this.warping - dt * 0.85);
+            const punch = Math.sin(this.warping * Math.PI) * 9;
+            this.camera.fov = 52 + punch;
+            this.camera.updateProjectionMatrix();
+        }
+
+        return this.warping;
+    }
+}

--- a/labs/aetherion/src/glsl.js
+++ b/labs/aetherion/src/glsl.js
@@ -1,0 +1,79 @@
+/**
+ * Fragmentos GLSL compartilhados — ruído 3D e iluminação.
+ * Value noise interpolado (hash senoidal) é barato o bastante para
+ * rodar em esferas de 96 segmentos no fragment shader.
+ */
+
+export const VERT = /* glsl */ `
+varying vec3 vWorldPos;
+varying vec3 vWorldNormal;
+varying vec3 vObjectPos;
+
+void main() {
+    vObjectPos = position;
+    vec4 world = modelMatrix * vec4(position, 1.0);
+    vWorldPos = world.xyz;
+    vWorldNormal = normalize(mat3(modelMatrix) * normal);
+    gl_Position = projectionMatrix * viewMatrix * world;
+}
+`;
+
+export const NOISE = /* glsl */ `
+float hash13(vec3 p) {
+    p = fract(p * 0.1031);
+    p += dot(p, p.yzx + 33.33);
+    return fract((p.x + p.y) * p.z);
+}
+
+float noise3(vec3 x) {
+    vec3 i = floor(x);
+    vec3 f = fract(x);
+    f = f * f * (3.0 - 2.0 * f);
+    return mix(
+        mix(mix(hash13(i), hash13(i + vec3(1,0,0)), f.x),
+            mix(hash13(i + vec3(0,1,0)), hash13(i + vec3(1,1,0)), f.x), f.y),
+        mix(mix(hash13(i + vec3(0,0,1)), hash13(i + vec3(1,0,1)), f.x),
+            mix(hash13(i + vec3(0,1,1)), hash13(i + vec3(1,1,1)), f.x), f.y),
+        f.z);
+}
+
+float fbm(vec3 p) {
+    float a = 0.5;
+    float s = 0.0;
+    for (int i = 0; i < 5; i++) {
+        s += a * noise3(p);
+        p = p * 2.03 + vec3(0.17, 0.31, 0.11);
+        a *= 0.5;
+    }
+    return s;
+}
+
+float fbm4(vec3 p) {
+    float a = 0.5;
+    float s = 0.0;
+    for (int i = 0; i < 4; i++) {
+        s += a * noise3(p);
+        p *= 2.11;
+        a *= 0.5;
+    }
+    return s;
+}
+`;
+
+export const LIGHT = /* glsl */ `
+vec3 sunDirFrom(vec3 worldPos) {
+    return normalize(-worldPos);
+}
+
+float lambert(vec3 n, vec3 l) {
+    return max(dot(n, l), 0.0);
+}
+
+float wrapLight(vec3 n, vec3 l, float w) {
+    return clamp((dot(n, l) + w) / (1.0 + w), 0.0, 1.0);
+}
+
+float fresnel(vec3 n, vec3 v, float p) {
+    return pow(1.0 - max(dot(n, v), 0.0), p);
+}
+`;

--- a/labs/aetherion/src/main.js
+++ b/labs/aetherion/src/main.js
@@ -1,0 +1,351 @@
+/**
+ * Aetherion — laço principal: renderer, pós-processamento, HUD e input.
+ */
+
+import * as THREE from 'three';
+import { EffectComposer } from 'three/addons/postprocessing/EffectComposer.js';
+import { RenderPass } from 'three/addons/postprocessing/RenderPass.js';
+import { UnrealBloomPass } from 'three/addons/postprocessing/UnrealBloomPass.js';
+import { OutputPass } from 'three/addons/postprocessing/OutputPass.js';
+
+import { StarSystem } from './system.js';
+import { ObservatoryCamera } from './camera.js';
+import { SpaceAudio } from './audio.js';
+
+const AU = 42;
+const STORAGE = 'aetherion-quality';
+
+const QUALITY = {
+    low: { planetSegs: 32, asteroids: 140, stars: 2800, bloom: false, pr: 1, antialias: false },
+    medium: { planetSegs: 56, asteroids: 380, stars: 5200, bloom: true, pr: 1.35, antialias: true },
+    high: { planetSegs: 80, asteroids: 680, stars: 8200, bloom: true, pr: 2, antialias: true }
+};
+
+function detectSoftwareGL(renderer) {
+    try {
+        const gl = renderer.getContext();
+        const info = gl.getExtension('WEBGL_debug_renderer_info');
+        if (!info) return false;
+        const name = gl.getParameter(info.UNMASKED_RENDERER_WEBGL) || '';
+        return /swiftshader|llvmpipe|softpipe|microsoft basic render/i.test(name);
+    } catch {
+        return false;
+    }
+}
+
+function pickQuality(mode, renderer) {
+    if (mode === 'low' || mode === 'medium' || mode === 'high') return QUALITY[mode];
+    const mobile = matchMedia('(pointer: coarse)').matches || innerWidth < 800;
+    if (detectSoftwareGL(renderer) || mobile) return QUALITY.low;
+    if (devicePixelRatio >= 2 && innerWidth >= 1400) return QUALITY.high;
+    return QUALITY.medium;
+}
+
+class Aetherion {
+    constructor() {
+        this.canvas = document.getElementById('scene');
+        this.hud = document.getElementById('hud');
+        this.intro = document.getElementById('intro');
+        this.help = document.getElementById('helpOverlay');
+        this.error = document.getElementById('errorOverlay');
+        this.bodyList = document.getElementById('bodyList');
+        this.hint = document.getElementById('hint');
+        this.audio = new SpaceAudio();
+        this.clock = new THREE.Clock();
+        this.simTime = 0;
+        this.warp = 1;
+        this.focusedId = 'star';
+        this.raycaster = new THREE.Raycaster();
+        this.pointer = new THREE.Vector2();
+        this.worldPos = new THREE.Vector3();
+        this.hintTimer = 0;
+        this.qualityMode = localStorage.getItem(STORAGE) || 'auto';
+        const select = document.getElementById('qualitySelect');
+        if (select) select.value = this.qualityMode;
+        this.bindUi();
+    }
+
+    bindUi() {
+        document.getElementById('startButton').addEventListener('click', () => this.start());
+        document.getElementById('newSystemBtn').addEventListener('click', () => this.forge());
+        document.getElementById('systemViewBtn').addEventListener('click', () => this.viewSystem());
+        document.getElementById('muteBtn').addEventListener('click', () => this.toggleMute());
+        document.getElementById('helpButton')?.addEventListener('click', () => this.toggleHelp(true));
+        document.getElementById('helpClose')?.addEventListener('click', () => this.toggleHelp(false));
+        document.getElementById('qualitySelect').addEventListener('change', (e) => {
+            this.qualityMode = e.target.value;
+            localStorage.setItem(STORAGE, this.qualityMode);
+        });
+        document.getElementById('warpBtns').addEventListener('click', (e) => {
+            const btn = e.target.closest('[data-warp]');
+            if (!btn) return;
+            this.setWarp(Number(btn.dataset.warp));
+        });
+        window.addEventListener('keydown', (e) => this.onKey(e));
+        window.addEventListener('resize', () => this.resize());
+    }
+
+    fail(message) {
+        document.getElementById('errorText').textContent = message;
+        this.error.hidden = false;
+        this.intro.hidden = true;
+    }
+
+    start() {
+        try {
+            this.bootRenderer();
+        } catch (err) {
+            this.fail(err?.message || 'Falha ao iniciar o WebGL.');
+            return;
+        }
+
+        this.audio.init();
+        this.system = new StarSystem(this.scene, this.quality);
+        this.system.generate();
+        this.populateCatalog();
+        this.rig.systemView();
+        this.rig.spherical.radius = 520;
+        this.focusedId = 'star';
+        this.refreshDossier();
+        this.highlightCatalog();
+
+        this.intro.hidden = true;
+        this.hud.hidden = false;
+        document.body.dataset.state = 'observing';
+        this.clock.start();
+        this.loop();
+        this.hintTimer = 8;
+    }
+
+    bootRenderer() {
+        this.renderer = new THREE.WebGLRenderer({
+            canvas: this.canvas,
+            antialias: true,
+            powerPreference: 'high-performance',
+            stencil: false
+        });
+        if (!this.renderer.getContext()) {
+            throw new Error('WebGL indisponível neste navegador.');
+        }
+
+        this.quality = pickQuality(this.qualityMode, this.renderer);
+        this.renderer.setPixelRatio(Math.min(devicePixelRatio, this.quality.pr));
+        this.renderer.setSize(innerWidth, innerHeight);
+        this.renderer.outputColorSpace = THREE.SRGBColorSpace;
+        this.renderer.toneMapping = THREE.ACESFilmicToneMapping;
+        this.renderer.toneMappingExposure = 1.05;
+        this.renderer.setClearColor(0x03040c, 1);
+
+        this.scene = new THREE.Scene();
+        this.scene.add(new THREE.HemisphereLight(0x8aa7ff, 0x06040a, 0.32));
+
+        this.camera = new THREE.PerspectiveCamera(52, innerWidth / innerHeight, 0.15, 4000);
+        this.rig = new ObservatoryCamera(this.camera, this.canvas);
+
+        this.canvas.addEventListener('pointerup', (e) => this.onCanvasClick(e));
+
+        if (this.quality.bloom) {
+            try {
+                this.composer = new EffectComposer(this.renderer);
+                this.composer.setPixelRatio(this.renderer.getPixelRatio());
+                this.composer.addPass(new RenderPass(this.scene, this.camera));
+                this.bloom = new UnrealBloomPass(
+                    new THREE.Vector2(innerWidth, innerHeight),
+                    0.42,
+                    0.48,
+                    0.78
+                );
+                this.composer.addPass(this.bloom);
+                this.composer.addPass(new OutputPass());
+            } catch {
+                this.composer = null;
+            }
+        }
+    }
+
+    populateCatalog() {
+        this.bodyList.innerHTML = '';
+        for (const body of this.system.bodies) {
+            if (body.kind === 'moon') continue;
+            const btn = document.createElement('button');
+            btn.type = 'button';
+            btn.className = 'body-btn';
+            btn.dataset.id = body.id;
+            btn.innerHTML = `<span class="swatch" style="--swatch:${body.color}"></span>
+                <span>${body.name}<small>${body.subtitle}</small></span>`;
+            btn.addEventListener('click', () => this.focusBody(body.id));
+            this.bodyList.appendChild(btn);
+        }
+    }
+
+    highlightCatalog() {
+        for (const btn of this.bodyList.querySelectorAll('.body-btn')) {
+            btn.classList.toggle('is-on', btn.dataset.id === this.focusedId);
+        }
+    }
+
+    bodyById(id) {
+        return this.system.bodies.find((b) => b.id === id);
+    }
+
+    bodyPosition(body, target) {
+        if (body.kind === 'star') return target.set(0, 0, 0);
+        if (body.kind === 'belt') return target.set(body.orbitRadius, 0.4, 0);
+        body.group.getWorldPosition(target);
+        return target;
+    }
+
+    focusBody(id, { warpSfx = true } = {}) {
+        const body = this.bodyById(id);
+        if (!body) return;
+        this.focusedId = id;
+        this.bodyPosition(body, this.worldPos);
+        this.rig.focus(this.worldPos, body.focusDistance);
+        this.refreshDossier();
+        this.highlightCatalog();
+        if (warpSfx) this.audio.warp();
+        document.getElementById('systemViewBtn').classList.remove('is-on');
+    }
+
+    viewSystem() {
+        this.focusedId = 'star';
+        this.rig.systemView();
+        this.refreshDossier();
+        this.highlightCatalog();
+        document.getElementById('systemViewBtn').classList.add('is-on');
+        this.audio.chime();
+    }
+
+    forge() {
+        this.system.generate();
+        this.populateCatalog();
+        this.viewSystem();
+        this.rig.spherical.radius = 480;
+        this.audio.chime();
+    }
+
+    refreshDossier() {
+        const body = this.bodyById(this.focusedId) || this.system.bodies[0];
+        document.getElementById('dossierKind').textContent = body.subtitle;
+        document.getElementById('dossierName').textContent = body.name;
+        const au = body.orbitRadius / AU;
+        document.getElementById('statDistance').textContent = body.orbitRadius
+            ? `${au.toFixed(2)} UA`
+            : '0 UA';
+        document.getElementById('statRadius').textContent = body.kind === 'star'
+            ? `${(body.radius / 6.4).toFixed(2)} R☉`
+            : body.kind === 'hole'
+                ? `${body.radius.toFixed(1)} Rs`
+                : `${(body.radius / 1.5).toFixed(2)} ⊕`;
+        document.getElementById('statPeriod').textContent = body.orbitRadius
+            ? `${Math.pow(Math.max(au, 0.05), 1.5).toFixed(2)} anos`
+            : '—';
+        document.getElementById('statComp').textContent = body.composition;
+        document.getElementById('dossierBlurb').textContent = body.blurb;
+    }
+
+    setWarp(value) {
+        this.warp = value;
+        for (const btn of document.querySelectorAll('#warpBtns [data-warp]')) {
+            btn.classList.toggle('is-on', Number(btn.dataset.warp) === value);
+        }
+    }
+
+    toggleMute() {
+        const next = this.audio.enabled;
+        this.audio.setMuted(next);
+        const btn = document.getElementById('muteBtn');
+        btn.textContent = this.audio.enabled ? 'Som' : 'Mudo';
+        btn.setAttribute('aria-pressed', String(!this.audio.enabled));
+    }
+
+    toggleHelp(open) {
+        this.help.hidden = !open;
+    }
+
+    onKey(e) {
+        if (e.target.matches('input, select, textarea')) return;
+        const k = e.key.toLowerCase();
+        if (k === '?' || k === 'h') this.toggleHelp(this.help.hidden);
+        if (k === 'escape') this.toggleHelp(false);
+        if (document.body.dataset.state !== 'observing') return;
+        if (k === 'n') this.forge();
+        if (k === 'm') this.toggleMute();
+        if (k === '0') this.viewSystem();
+        if (k === ' ') {
+            e.preventDefault();
+            this.setWarp(this.warp === 0 ? 1 : 0);
+        }
+        if (k === 'f') this.toggleFullscreen();
+        if (k === '[' || k === ']') {
+            const ids = this.system.bodies.filter((b) => b.kind !== 'moon').map((b) => b.id);
+            const i = Math.max(0, ids.indexOf(this.focusedId));
+            const next = k === ']'
+                ? ids[(i + 1) % ids.length]
+                : ids[(i - 1 + ids.length) % ids.length];
+            this.focusBody(next);
+        }
+        if (k === '1') this.setWarp(1);
+        if (k === '2') this.setWarp(8);
+        if (k === '3') this.setWarp(32);
+        if (k === '4') this.setWarp(96);
+    }
+
+    toggleFullscreen() {
+        if (!document.fullscreenElement) document.documentElement.requestFullscreen?.();
+        else document.exitFullscreen?.();
+    }
+
+    onCanvasClick(e) {
+        if (!this.rig.consumeClick()) return;
+        const rect = this.canvas.getBoundingClientRect();
+        this.pointer.x = ((e.clientX - rect.left) / rect.width) * 2 - 1;
+        this.pointer.y = -((e.clientY - rect.top) / rect.height) * 2 + 1;
+        this.raycaster.setFromCamera(this.pointer, this.camera);
+        const meshes = this.system.bodies.map((b) => b.pickMesh).filter(Boolean);
+        const hits = this.raycaster.intersectObjects(meshes, false);
+        if (!hits.length) return;
+        let obj = hits[0].object;
+        while (obj && !obj.userData.bodyId) obj = obj.parent;
+        const id = hits[0].object.userData.bodyId || obj?.userData.bodyId;
+        if (id) this.focusBody(id);
+    }
+
+    resize() {
+        if (!this.renderer) return;
+        const w = innerWidth;
+        const h = innerHeight;
+        this.camera.aspect = w / h;
+        this.camera.updateProjectionMatrix();
+        this.renderer.setSize(w, h);
+        this.composer?.setSize(w, h);
+        this.bloom?.setSize(w, h);
+    }
+
+    loop = () => {
+        requestAnimationFrame(this.loop);
+        const dt = Math.min(this.clock.getDelta(), 0.05);
+        this.simTime += dt * this.warp;
+        this.system.update(this.simTime, dt * Math.max(this.warp, 0.15));
+
+        const focused = this.bodyById(this.focusedId);
+        if (focused && !this.rig.auto) {
+            this.bodyPosition(focused, this.worldPos);
+            this.rig.desiredTarget.copy(this.worldPos);
+        }
+
+        this.rig.update(dt);
+        if (this.composer) this.composer.render();
+        else this.renderer.render(this.scene, this.camera);
+
+        if (this.hintTimer > 0) {
+            this.hintTimer -= dt;
+            if (this.hintTimer <= 0) this.hint.classList.add('is-gone');
+        }
+    };
+}
+
+window.addEventListener('load', () => {
+    const app = new Aetherion();
+    window.__aetherion = app;
+});

--- a/labs/aetherion/src/main.js
+++ b/labs/aetherion/src/main.js
@@ -51,7 +51,7 @@ class Aetherion {
         this.bodyList = document.getElementById('bodyList');
         this.hint = document.getElementById('hint');
         this.audio = new SpaceAudio();
-        this.clock = new THREE.Clock();
+        this.lastTick = performance.now();
         this.simTime = 0;
         this.warp = 1;
         this.focusedId = 'star';
@@ -112,7 +112,7 @@ class Aetherion {
         this.intro.hidden = true;
         this.hud.hidden = false;
         document.body.dataset.state = 'observing';
-        this.clock.start();
+        this.lastTick = performance.now();
         this.loop();
         this.hintTimer = 8;
     }
@@ -324,7 +324,9 @@ class Aetherion {
 
     loop = () => {
         requestAnimationFrame(this.loop);
-        const dt = Math.min(this.clock.getDelta(), 0.05);
+        const now = performance.now();
+        const dt = Math.min((now - this.lastTick) / 1000, 0.05);
+        this.lastTick = now;
         this.simTime += dt * this.warp;
         this.system.update(this.simTime, dt * Math.max(this.warp, 0.15));
 

--- a/labs/aetherion/src/planet.js
+++ b/labs/aetherion/src/planet.js
@@ -1,0 +1,369 @@
+/**
+ * Planetas procedurais. Cada tipo (terra, oceano, deserto, rochoso, lava,
+ * gás, gelo) tem um fragment shader próprio, com iluminação a partir da
+ * estrela no origem. Nuvens e atmosfera são esferas concêntricas.
+ */
+
+import * as THREE from 'three';
+import { VERT, NOISE, LIGHT } from './glsl.js';
+
+const FRAG = {
+    terra: /* glsl */ `
+${NOISE}
+${LIGHT}
+uniform vec3 uOcean;
+uniform vec3 uLand;
+uniform vec3 uCoast;
+uniform vec3 uIce;
+uniform vec3 uCity;
+varying vec3 vObjectPos;
+varying vec3 vWorldPos;
+varying vec3 vWorldNormal;
+
+void main() {
+    vec3 n = normalize(vWorldNormal);
+    vec3 p = normalize(vObjectPos);
+    vec3 l = sunDirFrom(vWorldPos);
+    float ndl = wrapLight(n, l, 0.12);
+    float night = smoothstep(0.12, -0.08, dot(n, l));
+
+    float h = fbm(p * 4.4);
+    float continent = smoothstep(0.46, 0.56, h);
+    float mountain = smoothstep(0.62, 0.78, h);
+    vec3 col = mix(uOcean, uCoast, smoothstep(0.44, 0.5, h));
+    col = mix(col, uLand, continent);
+    col = mix(col, vec3(0.38, 0.36, 0.32), mountain * continent);
+    float poles = smoothstep(0.62, 0.82, abs(p.y));
+    col = mix(col, uIce, poles);
+
+    vec3 lit = col * (0.04 + ndl * 1.15);
+    float spec = pow(max(dot(reflect(-l, n), normalize(cameraPosition - vWorldPos)), 0.0), 48.0);
+    lit += vec3(0.45, 0.65, 0.9) * spec * (1.0 - continent) * ndl;
+
+    float cities = smoothstep(0.52, 0.7, noise3(p * 40.0)) * continent * (1.0 - poles);
+    lit += uCity * cities * night * 1.8;
+
+    gl_FragColor = vec4(lit, 1.0);
+}
+`,
+    ocean: /* glsl */ `
+${NOISE}
+${LIGHT}
+uniform vec3 uDeep;
+uniform vec3 uShallow;
+uniform vec3 uFoam;
+varying vec3 vObjectPos;
+varying vec3 vWorldPos;
+varying vec3 vWorldNormal;
+
+void main() {
+    vec3 n = normalize(vWorldNormal);
+    vec3 p = normalize(vObjectPos);
+    vec3 l = sunDirFrom(vWorldPos);
+    float ndl = wrapLight(n, l, 0.18);
+    float h = fbm(p * 5.0);
+    vec3 col = mix(uDeep, uShallow, smoothstep(0.35, 0.7, h));
+    col = mix(col, uFoam, smoothstep(0.72, 0.88, h) * 0.4);
+    float poles = smoothstep(0.78, 0.92, abs(p.y));
+    col = mix(col, vec3(0.82, 0.9, 0.95), poles);
+    vec3 view = normalize(cameraPosition - vWorldPos);
+    float spec = pow(max(dot(reflect(-l, n), view), 0.0), 60.0);
+    vec3 lit = col * (0.05 + ndl) + vec3(0.7, 0.85, 1.0) * spec * ndl;
+    gl_FragColor = vec4(lit, 1.0);
+}
+`,
+    desert: /* glsl */ `
+${NOISE}
+${LIGHT}
+uniform vec3 uDune;
+uniform vec3 uRock;
+uniform vec3 uDark;
+varying vec3 vObjectPos;
+varying vec3 vWorldPos;
+varying vec3 vWorldNormal;
+
+void main() {
+    vec3 n = normalize(vWorldNormal);
+    vec3 p = normalize(vObjectPos);
+    vec3 l = sunDirFrom(vWorldPos);
+    float ndl = wrapLight(n, l, 0.1);
+    float h = fbm(p * 6.2 + vec3(0.0, p.x * 2.0, 0.0));
+    vec3 col = mix(uDark, uDune, smoothstep(0.3, 0.7, h));
+    col = mix(col, uRock, smoothstep(0.68, 0.85, h));
+    float poles = smoothstep(0.86, 0.96, abs(p.y));
+    col = mix(col, vec3(0.78, 0.74, 0.68), poles);
+    vec3 lit = col * (0.05 + ndl * 1.2);
+    gl_FragColor = vec4(lit, 1.0);
+}
+`,
+    rocky: /* glsl */ `
+${NOISE}
+${LIGHT}
+uniform vec3 uA;
+uniform vec3 uB;
+uniform vec3 uCrater;
+varying vec3 vObjectPos;
+varying vec3 vWorldPos;
+varying vec3 vWorldNormal;
+
+void main() {
+    vec3 n = normalize(vWorldNormal);
+    vec3 p = normalize(vObjectPos);
+    vec3 l = sunDirFrom(vWorldPos);
+    float ndl = wrapLight(n, l, 0.08);
+    float h = fbm(p * 7.0);
+    float crater = 1.0 - smoothstep(0.35, 0.55, noise3(p * 18.0));
+    vec3 col = mix(uA, uB, h);
+    col = mix(col, uCrater, crater * 0.35);
+    vec3 lit = col * (0.04 + ndl * 1.1);
+    gl_FragColor = vec4(lit, 1.0);
+}
+`,
+    lava: /* glsl */ `
+${NOISE}
+${LIGHT}
+uniform vec3 uCrust;
+uniform vec3 uGlow;
+uniform float uTime;
+varying vec3 vObjectPos;
+varying vec3 vWorldPos;
+varying vec3 vWorldNormal;
+
+void main() {
+    vec3 n = normalize(vWorldNormal);
+    vec3 p = normalize(vObjectPos);
+    vec3 l = sunDirFrom(vWorldPos);
+    float ndl = wrapLight(n, l, 0.1);
+    float crust = fbm(p * 5.5);
+    float veins = 1.0 - smoothstep(0.38, 0.52, fbm(p * 8.0 + uTime * 0.05));
+    float pulse = 0.75 + 0.25 * sin(uTime * 1.6 + crust * 10.0);
+    vec3 col = mix(uCrust, uGlow, veins * 0.85);
+    vec3 lit = col * (0.06 + ndl * 0.7) + uGlow * veins * pulse * 1.8;
+    gl_FragColor = vec4(lit, 1.0);
+}
+`,
+    gas: /* glsl */ `
+${NOISE}
+${LIGHT}
+uniform vec3 uA;
+uniform vec3 uB;
+uniform vec3 uStorm;
+uniform float uTime;
+varying vec3 vObjectPos;
+varying vec3 vWorldPos;
+varying vec3 vWorldNormal;
+
+void main() {
+    vec3 n = normalize(vWorldNormal);
+    vec3 p = normalize(vObjectPos);
+    vec3 l = sunDirFrom(vWorldPos);
+    float ndl = wrapLight(n, l, 0.22);
+    float bands = sin(p.y * 14.0 + fbm(p * 3.0 + vec3(uTime * 0.04, 0.0, 0.0)) * 3.0);
+    float nse = fbm(vec3(p.x * 3.0, p.y * 8.0, p.z * 3.0 + uTime * 0.03));
+    vec3 col = mix(uA, uB, bands * 0.5 + 0.5);
+    col = mix(col, uStorm, smoothstep(0.62, 0.82, nse) * (1.0 - abs(p.y)));
+    vec3 lit = col * (0.08 + ndl * 0.95);
+    gl_FragColor = vec4(lit, 1.0);
+}
+`,
+    ice: /* glsl */ `
+${NOISE}
+${LIGHT}
+uniform vec3 uIce;
+uniform vec3 uDeep;
+uniform vec3 uCrack;
+varying vec3 vObjectPos;
+varying vec3 vWorldPos;
+varying vec3 vWorldNormal;
+
+void main() {
+    vec3 n = normalize(vWorldNormal);
+    vec3 p = normalize(vObjectPos);
+    vec3 l = sunDirFrom(vWorldPos);
+    float ndl = wrapLight(n, l, 0.14);
+    float h = fbm(p * 6.0);
+    float cracks = 1.0 - smoothstep(0.42, 0.5, fbm(p * 14.0));
+    vec3 col = mix(uDeep, uIce, smoothstep(0.3, 0.7, h));
+    col = mix(col, uCrack, cracks * 0.35);
+    vec3 view = normalize(cameraPosition - vWorldPos);
+    float spec = pow(max(dot(reflect(-l, n), view), 0.0), 32.0);
+    vec3 lit = col * (0.07 + ndl) + vec3(0.75, 0.88, 1.0) * spec * 0.45 * ndl;
+    gl_FragColor = vec4(lit, 1.0);
+}
+`
+};
+
+const CLOUD_FRAG = /* glsl */ `
+${NOISE}
+${LIGHT}
+uniform float uTime;
+uniform float uCover;
+uniform vec3 uColor;
+varying vec3 vObjectPos;
+varying vec3 vWorldPos;
+varying vec3 vWorldNormal;
+
+void main() {
+    vec3 n = normalize(vWorldNormal);
+    vec3 p = normalize(vObjectPos);
+    vec3 l = sunDirFrom(vWorldPos);
+    float ndl = wrapLight(n, l, 0.2);
+    vec3 wp = p * 3.4 + vec3(uTime * 0.018, 0.0, 0.0);
+    float c = fbm(wp);
+    float a = smoothstep(uCover, uCover + 0.22, c) * 0.82;
+    a *= 0.35 + ndl * 0.75;
+    gl_FragColor = vec4(uColor * (0.4 + ndl), a);
+}
+`;
+
+const ATMO_FRAG = /* glsl */ `
+${LIGHT}
+uniform vec3 uColor;
+varying vec3 vWorldPos;
+varying vec3 vWorldNormal;
+
+void main() {
+    vec3 n = normalize(vWorldNormal);
+    vec3 view = normalize(cameraPosition - vWorldPos);
+    vec3 l = sunDirFrom(vWorldPos);
+    float f = pow(1.0 - abs(dot(n, view)), 3.4);
+    float day = wrapLight(n, l, 0.4);
+    float alpha = f * (0.25 + 0.85 * day);
+    gl_FragColor = vec4(uColor, clamp(alpha, 0.0, 1.0));
+}
+`;
+
+const RING_FRAG = /* glsl */ `
+${NOISE}
+uniform vec3 uA;
+uniform vec3 uB;
+varying vec3 vObjectPos;
+varying vec2 vUv;
+
+void main() {
+    float r = vUv.y;
+    float gaps = smoothstep(0.02, 0.0, abs(r - 0.42)) + smoothstep(0.015, 0.0, abs(r - 0.7));
+    float n = fbm4(vec3(vUv.x * 40.0, r * 18.0, 2.4));
+    float dens = (0.45 + 0.55 * n) * (1.0 - gaps * 8.0);
+    dens *= smoothstep(0.0, 0.08, r) * (1.0 - smoothstep(0.9, 1.0, r));
+    vec3 col = mix(uA, uB, r);
+    gl_FragColor = vec4(col, clamp(dens, 0.0, 0.85));
+}
+`;
+
+const RING_VERT = /* glsl */ `
+varying vec3 vObjectPos;
+varying vec2 vUv;
+void main() {
+    vObjectPos = position;
+    vUv = uv;
+    gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+}
+`;
+
+function colorUniforms(map) {
+    const u = {};
+    for (const [k, v] of Object.entries(map)) {
+        u[k] = { value: v.isColor ? v : new THREE.Color(v) };
+    }
+    return u;
+}
+
+function surfaceMaterial(type, uniforms) {
+    return new THREE.ShaderMaterial({
+        uniforms: { uTime: { value: 0 }, ...uniforms },
+        vertexShader: VERT,
+        fragmentShader: FRAG[type]
+    });
+}
+
+export function createPlanet({
+    type,
+    radius,
+    segs = 64,
+    colors,
+    clouds = false,
+    atmosphere = null,
+    rings = null,
+    tilt = 0
+}) {
+    const group = new THREE.Group();
+    const uniforms = colorUniforms(colors);
+    const mat = surfaceMaterial(type, uniforms);
+    const mesh = new THREE.Mesh(
+        new THREE.SphereGeometry(radius, segs, Math.max(24, segs * 0.7)),
+        mat
+    );
+    mesh.userData.pick = true;
+    group.add(mesh);
+
+    let cloudMesh = null;
+    let cloudUniforms = null;
+    if (clouds) {
+        cloudUniforms = {
+            uTime: mat.uniforms.uTime,
+            uCover: { value: colors.cloudCover ?? 0.52 },
+            uColor: { value: new THREE.Color(colors.cloud ?? '#f2f5ff') }
+        };
+        cloudMesh = new THREE.Mesh(
+            new THREE.SphereGeometry(radius * 1.018, Math.max(32, segs * 0.6), Math.max(20, segs * 0.45)),
+            new THREE.ShaderMaterial({
+                uniforms: cloudUniforms,
+                vertexShader: VERT,
+                fragmentShader: CLOUD_FRAG,
+                transparent: true,
+                depthWrite: false
+            })
+        );
+        group.add(cloudMesh);
+    }
+
+    if (atmosphere) {
+        const atmo = new THREE.Mesh(
+            new THREE.SphereGeometry(radius * 1.08, 32, 24),
+            new THREE.ShaderMaterial({
+                uniforms: { uColor: { value: new THREE.Color(atmosphere) } },
+                vertexShader: VERT,
+                fragmentShader: ATMO_FRAG,
+                transparent: true,
+                depthWrite: false,
+                blending: THREE.AdditiveBlending,
+                side: THREE.BackSide
+            })
+        );
+        group.add(atmo);
+    }
+
+    if (rings) {
+        const ring = new THREE.Mesh(
+            new THREE.RingGeometry(radius * rings.inner, radius * rings.outer, 96, 12),
+            new THREE.ShaderMaterial({
+                uniforms: {
+                    uA: { value: new THREE.Color(rings.a) },
+                    uB: { value: new THREE.Color(rings.b) }
+                },
+                vertexShader: RING_VERT,
+                fragmentShader: RING_FRAG,
+                transparent: true,
+                depthWrite: false,
+                side: THREE.DoubleSide
+            })
+        );
+        ring.rotation.x = Math.PI / 2;
+        ring.rotation.z = rings.tilt ?? 0.18;
+        group.add(ring);
+    }
+
+    group.rotation.z = tilt;
+
+    return {
+        group,
+        mesh,
+        pickMesh: mesh,
+        update(time, dt) {
+            mat.uniforms.uTime.value = time;
+            mesh.rotation.y += dt * (colors.spin ?? 0.12);
+            if (cloudMesh) cloudMesh.rotation.y += dt * 0.07;
+        }
+    };
+}

--- a/labs/aetherion/src/sky.js
+++ b/labs/aetherion/src/sky.js
@@ -1,0 +1,109 @@
+/**
+ * Céu: campo de estrelas (via láctea concentrada no equador celeste)
+ * e uma esfera de nebulosa em fbm aditivo.
+ */
+
+import * as THREE from 'three';
+import { NOISE } from './glsl.js';
+
+const NEBULA_VERT = /* glsl */ `
+varying vec3 vDir;
+void main() {
+    vDir = position;
+    gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+}
+`;
+
+const NEBULA_FRAG = /* glsl */ `
+${NOISE}
+uniform vec3 uA;
+uniform vec3 uB;
+uniform vec3 uC;
+varying vec3 vDir;
+
+void main() {
+    vec3 p = normalize(vDir);
+    float n = fbm(p * 2.2);
+    float n2 = fbm(p * 4.0 + 9.0);
+    float band = exp(-pow(p.y * 2.8, 2.0));
+    float dens = smoothstep(0.42, 0.78, n) * (0.25 + band * 0.85);
+    dens *= 0.55 + 0.45 * n2;
+    vec3 col = mix(uA, uB, n);
+    col = mix(col, uC, n2 * band);
+    gl_FragColor = vec4(col, dens * 0.55);
+}
+`;
+
+export function createSky(rng, quality) {
+    const group = new THREE.Group();
+
+    const starCount = quality.stars;
+    const positions = new Float32Array(starCount * 3);
+    const colors = new Float32Array(starCount * 3);
+    const color = new THREE.Color();
+
+    for (let i = 0; i < starCount; i++) {
+        const milky = rng() < 0.55;
+        const u = rng();
+        const v = milky ? (rng() - 0.5) * 0.42 + (rng() - 0.5) * 0.08 : rng();
+        const theta = 2 * Math.PI * u;
+        const phi = milky ? (0.5 * Math.PI + v) : Math.acos(2 * v - 1);
+        const r = 1400 + rng() * 500;
+        positions[i * 3] = r * Math.sin(phi) * Math.cos(theta);
+        positions[i * 3 + 1] = r * Math.cos(phi);
+        positions[i * 3 + 2] = r * Math.sin(phi) * Math.sin(theta);
+
+        const temp = rng();
+        if (temp < 0.15) color.setRGB(0.65, 0.78, 1.0);
+        else if (temp < 0.3) color.setRGB(1.0, 0.72, 0.45);
+        else if (temp < 0.4) color.setRGB(1.0, 0.45, 0.4);
+        else color.setRGB(0.92, 0.95, 1.0);
+        const mag = 0.45 + rng() * 0.7;
+        colors[i * 3] = color.r * mag;
+        colors[i * 3 + 1] = color.g * mag;
+        colors[i * 3 + 2] = color.b * mag;
+    }
+
+    const geo = new THREE.BufferGeometry();
+    geo.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+    geo.setAttribute('color', new THREE.BufferAttribute(colors, 3));
+
+    const stars = new THREE.Points(
+        geo,
+        new THREE.PointsMaterial({
+            size: 1.7,
+            sizeAttenuation: false,
+            vertexColors: true,
+            transparent: true,
+            opacity: 0.92,
+            depthWrite: false,
+            blending: THREE.AdditiveBlending
+        })
+    );
+    group.add(stars);
+
+    const nebula = new THREE.Mesh(
+        new THREE.SphereGeometry(1800, 32, 24),
+        new THREE.ShaderMaterial({
+            uniforms: {
+                uA: { value: new THREE.Color().setHSL(rng() * 0.2 + 0.7, 0.55, 0.28) },
+                uB: { value: new THREE.Color().setHSL(rng() * 0.15 + 0.55, 0.5, 0.22) },
+                uC: { value: new THREE.Color().setHSL(rng() * 0.1 + 0.05, 0.45, 0.3) }
+            },
+            vertexShader: NEBULA_VERT,
+            fragmentShader: NEBULA_FRAG,
+            side: THREE.BackSide,
+            transparent: true,
+            depthWrite: false,
+            blending: THREE.AdditiveBlending
+        })
+    );
+    group.add(nebula);
+
+    return {
+        group,
+        update(dt) {
+            stars.rotation.y += dt * 0.0025;
+        }
+    };
+}

--- a/labs/aetherion/src/star.js
+++ b/labs/aetherion/src/star.js
@@ -1,0 +1,128 @@
+/**
+ * Estrela central: superfície em fbm com domain-warping, coroa em fresnel
+ * e uma luz pontual que ilumina o sistema.
+ */
+
+import * as THREE from 'three';
+import { VERT, NOISE } from './glsl.js';
+
+const SURFACE = /* glsl */ `
+${NOISE}
+uniform float uTime;
+uniform vec3 uHot;
+uniform vec3 uMid;
+uniform vec3 uCool;
+uniform float uIntensity;
+varying vec3 vObjectPos;
+varying vec3 vWorldNormal;
+
+void main() {
+    vec3 p = normalize(vObjectPos);
+    float t = uTime * 0.12;
+    vec3 q = vec3(
+        fbm(p * 3.0 + vec3(t, 0.0, 0.0)),
+        fbm(p * 3.0 + vec3(4.1, t, 1.3)),
+        fbm(p * 3.0 + vec3(1.7, 2.8, t))
+    );
+    float n = fbm(p * 4.2 + q * 1.8 + vec3(0.0, t * 0.6, 0.0));
+    float spots = smoothstep(0.62, 0.78, fbm(p * 6.5 + 8.0));
+    vec3 col = mix(uCool, uMid, smoothstep(0.28, 0.55, n));
+    col = mix(col, uHot, smoothstep(0.55, 0.82, n));
+    col *= 1.0 - spots * 0.55;
+    float rim = pow(1.0 - abs(dot(normalize(vWorldNormal), vec3(0.0, 0.0, 1.0))), 2.0);
+    col += uHot * rim * 0.25;
+    gl_FragColor = vec4(col * uIntensity, 1.0);
+}
+`;
+
+const CORONA = /* glsl */ `
+${NOISE}
+uniform float uTime;
+uniform vec3 uColor;
+uniform float uAlpha;
+varying vec3 vObjectPos;
+varying vec3 vWorldNormal;
+varying vec3 vWorldPos;
+
+void main() {
+    vec3 n = normalize(vWorldNormal);
+    vec3 view = normalize(cameraPosition - vWorldPos);
+    float f = pow(1.0 - abs(dot(n, view)), 3.2);
+    vec3 p = normalize(vObjectPos);
+    float filaments = fbm(p * 5.0 + vec3(0.0, 0.0, uTime * 0.08));
+    float burst = smoothstep(0.55, 0.9, filaments);
+    float alpha = (f * 0.85 + burst * 0.35 * f) * uAlpha;
+    vec3 col = mix(uColor, vec3(1.0, 0.95, 0.8), burst * 0.45);
+    gl_FragColor = vec4(col, alpha);
+}
+`;
+
+export function createStar({ radius, palette, segs = 80 }) {
+    const group = new THREE.Group();
+    group.name = 'star';
+
+    const uniforms = {
+        uTime: { value: 0 },
+        uHot: { value: new THREE.Color(palette.hot) },
+        uMid: { value: new THREE.Color(palette.mid) },
+        uCool: { value: new THREE.Color(palette.cool) },
+        uIntensity: { value: palette.intensity }
+    };
+
+    const surface = new THREE.Mesh(
+        new THREE.SphereGeometry(radius, segs, segs),
+        new THREE.ShaderMaterial({
+            uniforms,
+            vertexShader: VERT,
+            fragmentShader: SURFACE
+        })
+    );
+    surface.userData.pick = true;
+    group.add(surface);
+
+    const coronaMat = new THREE.ShaderMaterial({
+        uniforms: {
+            uTime: uniforms.uTime,
+            uColor: { value: new THREE.Color(palette.corona) },
+            uAlpha: { value: 0.7 }
+        },
+        vertexShader: VERT,
+        fragmentShader: CORONA,
+        transparent: true,
+        depthWrite: false,
+        blending: THREE.AdditiveBlending,
+        side: THREE.BackSide
+    });
+
+    const corona = new THREE.Mesh(
+        new THREE.SphereGeometry(radius * 1.18, Math.max(24, segs / 2), Math.max(16, segs / 2)),
+        coronaMat
+    );
+    group.add(corona);
+
+    const halo = new THREE.Mesh(
+        new THREE.SphereGeometry(radius * 1.55, 24, 16),
+        coronaMat.clone()
+    );
+    halo.material.uniforms.uAlpha.value = 0.28;
+    halo.material.uniforms.uTime = uniforms.uTime;
+    group.add(halo);
+
+    const light = new THREE.PointLight(palette.light, palette.lightIntensity, 0, 0.4);
+    light.position.set(0, 0, 0);
+    group.add(light);
+
+    const ambient = new THREE.AmbientLight(palette.ambient, 0.12);
+    group.add(ambient);
+
+    return {
+        group,
+        pickMesh: surface,
+        uniforms,
+        light,
+        update(time) {
+            uniforms.uTime.value = time;
+            surface.rotation.y = time * 0.03;
+        }
+    };
+}

--- a/labs/aetherion/src/system.js
+++ b/labs/aetherion/src/system.js
@@ -1,0 +1,608 @@
+/**
+ * Gerador de sistemas estelares. Kepler simplificado: período ∝ a^1.5,
+ * órbitas quase circulares com pequena inclinação.
+ */
+
+import * as THREE from 'three';
+import { createStar } from './star.js';
+import { createPlanet } from './planet.js';
+import { createBlackHole } from './blackhole.js';
+import { createSky } from './sky.js';
+import { createAsteroidBelt, createComet } from './asteroids.js';
+
+const AU = 42;
+
+const STAR_TYPES = {
+    g: {
+        label: 'Anã amarela',
+        radius: 6.4,
+        palette: {
+            hot: '#fff6d8',
+            mid: '#ffb347',
+            cool: '#ff6a22',
+            corona: '#ffd18a',
+            light: '#ffe6b0',
+            ambient: '#1a2238',
+            intensity: 1.35,
+            lightIntensity: 1800
+        }
+    },
+    k: {
+        label: 'Anã laranja',
+        radius: 5.4,
+        palette: {
+            hot: '#ffe0c0',
+            mid: '#ff8a3d',
+            cool: '#c44512',
+            corona: '#ffb070',
+            light: '#ffc090',
+            ambient: '#241818',
+            intensity: 1.2,
+            lightIntensity: 1400
+        }
+    },
+    a: {
+        label: 'Estrela branca-azul',
+        radius: 8.2,
+        palette: {
+            hot: '#f7fbff',
+            mid: '#b8d4ff',
+            cool: '#6a9fff',
+            corona: '#cfe4ff',
+            light: '#dce8ff',
+            ambient: '#101828',
+            intensity: 1.55,
+            lightIntensity: 2400
+        }
+    },
+    m: {
+        label: 'Anã vermelha',
+        radius: 4.6,
+        palette: {
+            hot: '#ffd0a8',
+            mid: '#ff5a2a',
+            cool: '#8a1208',
+            corona: '#ff7a4a',
+            light: '#ff7040',
+            ambient: '#1c1014',
+            intensity: 1.1,
+            lightIntensity: 900
+        }
+    },
+    f: {
+        label: 'Estrela branco-amarela',
+        radius: 7.1,
+        palette: {
+            hot: '#fffaf0',
+            mid: '#ffe9a8',
+            cool: '#ffaa55',
+            corona: '#ffe7b8',
+            light: '#fff4d8',
+            ambient: '#141820',
+            intensity: 1.4,
+            lightIntensity: 2000
+        }
+    }
+};
+
+const NAMES = {
+    star: ['Helion', 'Aether', 'Lumen', 'Solara', 'Lyra', 'Vega', 'Altair', 'Caelum'],
+    rocky: ['Pyra', 'Cinder', 'Ferrum', 'Obsidia', 'Hestia', 'Basalto'],
+    desert: ['Sahra', 'Aurel', 'Ochra', 'Solara', 'Duna'],
+    terra: ['Gaia', 'Vespera', 'Miria', 'Eden', 'Thalassa', 'Nova'],
+    ocean: ['Nereida', 'Pelagia', 'Maris', 'Abyssia', 'Undina'],
+    lava: ['Magma', 'Inferna', 'Pyroclast', 'Hephaestia'],
+    gas: ['Kronos', 'Tempest', 'Zephyrus', 'Titanor', 'Jovian'],
+    ice: ['Nyx', 'Glacia', 'Khione', 'Boreal', 'Frost'],
+    hole: ['Abismo', 'Nyxar', 'Vórtice', 'Sombra', 'Evento'],
+    belt: ['Cinturão de Ícaros', 'Anel de Asteria', 'Faixa de Pó'],
+    comet: ['Mensageiro', 'Halix', 'Cauda de Prata'],
+    moon: ['Selene', 'Io', 'Callisto', 'Phobos', 'Nix', 'Dione']
+};
+
+const BLURBS = {
+    star: 'Fotosfera em ebulição, manchas e uma coroa que foge para o vazio.',
+    rocky: 'Crosta craterada, sem ar — um arquivo de impactos antigos.',
+    desert: 'Dunas de óxido e vento fino. O horizonte queima em ocre.',
+    terra: 'Continentes vivos, nuvens à deriva e cidades no hemisfério noturno.',
+    ocean: 'Um mundo de água. Tempestades rasas, gelo nos polos, brilho especular.',
+    lava: 'Crosta negra rachada por rios de magma que pulsam com o tempo.',
+    gas: 'Faixas de tempestade e um olho que nunca dorme. Anéis, às vezes.',
+    ice: 'Metano congelado, fendas azuladas e um brilho de porcelana.',
+    hole: 'Horizonte de eventos, disco de acreção e jatos que furam o céu.',
+    belt: 'Pedra residual da formação do sistema — um anel de ruínas.',
+    comet: 'Núcleo sujo de gelo. A cauda sempre aponta para longe da estrela.',
+    moon: 'Satélite cativo, craterado, preso à gravidade do mundo-mãe.'
+};
+
+const COMP = {
+    star: 'Hidrogênio · Hélio',
+    rocky: 'Silicatos · Ferro',
+    desert: 'Óxidos · Basalto',
+    terra: 'N₂ · O₂ · Água',
+    ocean: 'H₂O · Sais',
+    lava: 'Basalto · Magma',
+    gas: 'H₂ · He · Amônia',
+    ice: 'Gelo · Metano',
+    hole: 'Espaço-tempo',
+    belt: 'Condritos · Níquel',
+    comet: 'Gelo · Poeira',
+    moon: 'Regolito · Rocha'
+};
+
+function mulberry32(seed) {
+    let a = seed >>> 0;
+    return function rng() {
+        a |= 0;
+        a = (a + 0x6d2b79f5) | 0;
+        let t = Math.imul(a ^ (a >>> 15), 1 | a);
+        t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+        return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+    };
+}
+
+function pick(rng, list) {
+    return list[Math.floor(rng() * list.length)];
+}
+
+function pickStar(rng) {
+    const roll = rng();
+    if (roll < 0.3) return 'g';
+    if (roll < 0.52) return 'k';
+    if (roll < 0.7) return 'f';
+    if (roll < 0.86) return 'a';
+    return 'm';
+}
+
+function keplerPeriod(orbitRadius) {
+    const a = orbitRadius / AU;
+    return Math.pow(Math.max(a, 0.08), 1.5) * 24;
+}
+
+function orbitLine(radius, color, inclination) {
+    const pts = [];
+    const steps = 160;
+    for (let i = 0; i <= steps; i++) {
+        const a = (i / steps) * Math.PI * 2;
+        pts.push(new THREE.Vector3(
+            Math.cos(a) * radius,
+            Math.sin(a) * radius * inclination,
+            Math.sin(a) * radius
+        ));
+    }
+    const geo = new THREE.BufferGeometry().setFromPoints(pts);
+    const line = new THREE.Line(
+        geo,
+        new THREE.LineBasicMaterial({
+            color,
+            transparent: true,
+            opacity: 0.16
+        })
+    );
+    line.userData.orbit = true;
+    return line;
+}
+
+function disposeObject(root) {
+    root.traverse((child) => {
+        if (child.geometry) child.geometry.dispose();
+        const mats = child.material
+            ? (Array.isArray(child.material) ? child.material : [child.material])
+            : [];
+        for (const mat of mats) {
+            for (const key of Object.keys(mat)) {
+                const val = mat[key];
+                if (val && val.isTexture) val.dispose();
+            }
+            mat.dispose();
+        }
+    });
+}
+
+function planetColors(type, rng) {
+    if (type === 'terra') {
+        return {
+            uOcean: new THREE.Color().setHSL(0.58 + rng() * 0.04, 0.75, 0.18),
+            uLand: new THREE.Color().setHSL(0.28 + rng() * 0.08, 0.45, 0.28),
+            uCoast: new THREE.Color().setHSL(0.14, 0.35, 0.42),
+            uIce: new THREE.Color('#e8f0f8'),
+            uCity: new THREE.Color('#ffd18a'),
+            cloud: '#f4f7ff',
+            cloudCover: 0.48 + rng() * 0.12,
+            spin: 0.15
+        };
+    }
+    if (type === 'ocean') {
+        return {
+            uDeep: new THREE.Color().setHSL(0.58, 0.7, 0.12 + rng() * 0.05),
+            uShallow: new THREE.Color().setHSL(0.52, 0.55, 0.32),
+            uFoam: new THREE.Color('#d7f0ff'),
+            spin: 0.12
+        };
+    }
+    if (type === 'desert') {
+        return {
+            uDune: new THREE.Color().setHSL(0.08 + rng() * 0.04, 0.55, 0.42),
+            uRock: new THREE.Color().setHSL(0.05, 0.35, 0.28),
+            uDark: new THREE.Color().setHSL(0.06, 0.4, 0.18),
+            spin: 0.1
+        };
+    }
+    if (type === 'rocky') {
+        return {
+            uA: new THREE.Color().setHSL(0.05 + rng() * 0.08, 0.18, 0.32),
+            uB: new THREE.Color().setHSL(0.02, 0.12, 0.18),
+            uCrater: new THREE.Color('#1a1614'),
+            spin: 0.08
+        };
+    }
+    if (type === 'lava') {
+        return {
+            uCrust: new THREE.Color('#1a0e0a'),
+            uGlow: new THREE.Color().setHSL(0.04 + rng() * 0.03, 0.9, 0.52),
+            spin: 0.09
+        };
+    }
+    if (type === 'gas') {
+        return {
+            uA: new THREE.Color().setHSL(rng() * 0.15 + 0.05, 0.45, 0.42),
+            uB: new THREE.Color().setHSL(rng() * 0.12 + 0.55, 0.35, 0.38),
+            uStorm: new THREE.Color().setHSL(0.02, 0.7, 0.45),
+            spin: 0.22
+        };
+    }
+    return {
+        uIce: new THREE.Color().setHSL(0.55 + rng() * 0.08, 0.25, 0.78),
+        uDeep: new THREE.Color().setHSL(0.58, 0.35, 0.42),
+        uCrack: new THREE.Color('#9ad0e8'),
+        spin: 0.07
+    };
+}
+
+function hudColor(type, colors) {
+    if (type === 'terra') return '#' + colors.uLand.getHexString();
+    if (type === 'ocean') return '#' + colors.uShallow.getHexString();
+    if (type === 'desert') return '#' + colors.uDune.getHexString();
+    if (type === 'rocky') return '#' + colors.uA.getHexString();
+    if (type === 'lava') return '#' + colors.uGlow.getHexString();
+    if (type === 'gas') return '#' + colors.uA.getHexString();
+    if (type === 'ice') return '#' + colors.uIce.getHexString();
+    return '#9ad8ff';
+}
+
+export class StarSystem {
+    constructor(scene, quality) {
+        this.scene = scene;
+        this.quality = quality;
+        this.root = new THREE.Group();
+        this.scene.add(this.root);
+        this.bodies = [];
+        this.updaters = [];
+        this.seed = 1;
+        this.sky = null;
+    }
+
+    generate(seed = (Math.random() * 0xffffffff) >>> 0) {
+        this.clear();
+        this.seed = seed >>> 0;
+        const rng = mulberry32(this.seed);
+        const starKey = pickStar(rng);
+        const starDef = STAR_TYPES[starKey];
+        const segs = this.quality.planetSegs;
+
+        this.sky = createSky(rng, this.quality);
+        this.scene.add(this.sky.group);
+        this.updaters.push(this.sky);
+
+        const star = createStar({
+            radius: starDef.radius,
+            palette: starDef.palette,
+            segs
+        });
+        this.root.add(star.group);
+        this.updaters.push(star);
+        this.bodies.push({
+            id: 'star',
+            name: pick(rng, NAMES.star),
+            kind: 'star',
+            type: 'star',
+            subtitle: starDef.label,
+            radius: starDef.radius,
+            orbitRadius: 0,
+            period: 0,
+            group: star.group,
+            pickMesh: star.pickMesh,
+            color: starDef.palette.mid,
+            composition: COMP.star,
+            blurb: BLURBS.star,
+            focusDistance: starDef.radius * 4.2
+        });
+
+        const innerTypes = ['rocky', 'lava', 'desert'];
+        const habTypes = ['terra', 'ocean', 'desert'];
+        const outerTypes = ['gas', 'ice'];
+
+        const layout = [
+            { type: pick(rng, innerTypes), au: 0.38 + rng() * 0.12, r: 0.9 + rng() * 0.4 },
+            { type: pick(rng, innerTypes.filter((t) => t !== 'lava').concat(['desert'])), au: 0.62 + rng() * 0.14, r: 1.1 + rng() * 0.5 },
+            { type: pick(rng, habTypes), au: 0.95 + rng() * 0.18, r: 1.5 + rng() * 0.35 },
+            { type: rng() < 0.5 ? 'rocky' : 'desert', au: 1.38 + rng() * 0.16, r: 0.85 + rng() * 0.3 }
+        ];
+
+        if (rng() > 0.25) {
+            layout.push({ type: pick(rng, outerTypes), au: 2.35 + rng() * 0.35, r: 3.6 + rng() * 1.4, rings: rng() > 0.35 });
+        } else {
+            layout.push({ type: 'gas', au: 2.4 + rng() * 0.3, r: 4.2 + rng() * 1.1, rings: true });
+        }
+
+        layout.push({ type: 'ice', au: 3.35 + rng() * 0.35, r: 2.2 + rng() * 0.7, rings: rng() > 0.7 });
+
+        if (rng() > 0.45) {
+            layout.push({ type: rng() > 0.5 ? 'ice' : 'rocky', au: 4.2 + rng() * 0.4, r: 0.7 + rng() * 0.35 });
+        }
+
+        const usedNames = new Set();
+        const takeName = (type) => {
+            const pool = NAMES[type] || NAMES.rocky;
+            let name = pick(rng, pool);
+            let i = 0;
+            while (usedNames.has(name) && i++ < 8) name = pick(rng, pool);
+            usedNames.add(name);
+            return name;
+        };
+
+        for (let i = 0; i < layout.length; i++) {
+            const spec = layout[i];
+            const orbitRadius = spec.au * AU;
+            const inclination = (rng() - 0.5) * 0.08;
+            const colors = planetColors(spec.type, rng);
+            const radius = spec.r;
+            const hasClouds = spec.type === 'terra' || spec.type === 'ocean';
+            const atmo = spec.type === 'terra'
+                ? '#7ec8ff'
+                : spec.type === 'ocean'
+                    ? '#5ad0c8'
+                    : spec.type === 'gas'
+                        ? '#c9b07a'
+                        : spec.type === 'ice'
+                            ? '#9ad8ff'
+                            : spec.type === 'desert'
+                                ? '#e8b07a'
+                                : null;
+            const planet = createPlanet({
+                type: spec.type,
+                radius,
+                segs: spec.type === 'gas' ? segs : Math.max(32, segs - 16),
+                colors,
+                clouds: hasClouds,
+                atmosphere: atmo,
+                rings: spec.rings
+                    ? {
+                        inner: 1.45,
+                        outer: 2.35 + rng() * 0.4,
+                        a: '#d9c4a0',
+                        b: '#8a7355',
+                        tilt: 0.12 + rng() * 0.12
+                    }
+                    : null,
+                tilt: (rng() - 0.5) * 0.4
+            });
+
+            const holder = new THREE.Group();
+            holder.add(planet.group);
+            this.root.add(holder);
+            this.root.add(orbitLine(orbitRadius, 0x88aacc, inclination));
+
+            const body = {
+                id: `p${i}`,
+                name: takeName(spec.type),
+                kind: 'planet',
+                type: spec.type,
+                subtitle: subtitleFor(spec.type),
+                radius,
+                orbitRadius,
+                period: keplerPeriod(orbitRadius),
+                phase: rng() * Math.PI * 2,
+                inclination,
+                group: holder,
+                visual: planet,
+                pickMesh: planet.pickMesh,
+                color: hudColor(spec.type, colors),
+                composition: COMP[spec.type],
+                blurb: BLURBS[spec.type],
+                focusDistance: radius * 4.8 + 6
+            };
+            this.bodies.push(body);
+            this.updaters.push({
+                update: (time, dt) => planet.update(time, dt)
+            });
+
+            if ((spec.type === 'terra' || spec.type === 'gas' || spec.type === 'ice') && rng() > 0.35) {
+                const moonCount = spec.type === 'gas' ? 1 + Math.floor(rng() * 2) : 1;
+                for (let m = 0; m < moonCount; m++) {
+                    const moonR = 0.28 + rng() * 0.22;
+                    const moon = createPlanet({
+                        type: 'rocky',
+                        radius: moonR,
+                        segs: 24,
+                        colors: planetColors('rocky', rng),
+                        tilt: 0
+                    });
+                    const moonHold = new THREE.Group();
+                    moonHold.add(moon.group);
+                    holder.add(moonHold);
+                    const moonOrbit = radius * (2.4 + m * 0.9 + rng() * 0.4);
+                    const moonBody = {
+                        id: `p${i}m${m}`,
+                        name: takeName('moon'),
+                        kind: 'moon',
+                        type: 'moon',
+                        subtitle: `Lua de ${body.name}`,
+                        radius: moonR,
+                        orbitRadius: moonOrbit,
+                        period: 4 + rng() * 6,
+                        phase: rng() * Math.PI * 2,
+                        inclination: (rng() - 0.5) * 0.15,
+                        group: moonHold,
+                        visual: moon,
+                        pickMesh: moon.pickMesh,
+                        color: '#b9b3aa',
+                        composition: COMP.moon,
+                        blurb: BLURBS.moon,
+                        focusDistance: moonR * 8 + 4,
+                        parent: body
+                    };
+                    this.bodies.push(moonBody);
+                    this.updaters.push({
+                        update: (time, dt) => moon.update(time, dt)
+                    });
+                }
+            }
+        }
+
+        const beltInner = 1.72 * AU;
+        const beltOuter = 2.12 * AU;
+        const belt = createAsteroidBelt({
+            inner: beltInner,
+            outer: beltOuter,
+            count: this.quality.asteroids,
+            rng
+        });
+        this.root.add(belt.mesh);
+        this.updaters.push(belt);
+        this.bodies.push({
+            id: 'belt',
+            name: pick(rng, NAMES.belt),
+            kind: 'belt',
+            type: 'belt',
+            subtitle: 'Cinturão de asteroides',
+            radius: 4,
+            orbitRadius: (beltInner + beltOuter) * 0.5,
+            period: keplerPeriod((beltInner + beltOuter) * 0.5),
+            group: belt.mesh,
+            pickMesh: belt.mesh,
+            color: '#8a8178',
+            composition: COMP.belt,
+            blurb: BLURBS.belt,
+            focusDistance: 28
+        });
+        this.root.add(orbitLine((beltInner + beltOuter) * 0.5, 0x6a625c, 0.02));
+
+        const comet = createComet(rng);
+        this.root.add(comet.group);
+        const cometOrbit = 3.8 * AU + rng() * 0.8 * AU;
+        const cometBody = {
+            id: 'comet',
+            name: pick(rng, NAMES.comet),
+            kind: 'comet',
+            type: 'comet',
+            subtitle: 'Cometa periódico',
+            radius: 0.7,
+            orbitRadius: cometOrbit,
+            period: keplerPeriod(cometOrbit) * 0.7,
+            phase: rng() * Math.PI * 2,
+            inclination: 0.22 + rng() * 0.15,
+            ecc: 0.45,
+            group: comet.group,
+            pickMesh: comet.pickMesh,
+            color: '#c8e4ff',
+            composition: COMP.comet,
+            blurb: BLURBS.comet,
+            focusDistance: 14
+        };
+        this.bodies.push(cometBody);
+        this.updaters.push({
+            update: () => {
+                comet.update(comet.group.position);
+            }
+        });
+
+        if (rng() > 0.28) {
+            const hole = createBlackHole({
+                radius: 2.8 + rng() * 1.1,
+                segs: Math.max(32, segs * 0.6)
+            });
+            const holeHold = new THREE.Group();
+            holeHold.add(hole.group);
+            this.root.add(holeHold);
+            const holeOrbit = 5.6 * AU + rng() * 0.6 * AU;
+            this.root.add(orbitLine(holeOrbit, 0xff6a4a, 0.12));
+            this.updaters.push(hole);
+            this.bodies.push({
+                id: 'hole',
+                name: pick(rng, NAMES.hole),
+                kind: 'hole',
+                type: 'hole',
+                subtitle: 'Buraco negro companheiro',
+                radius: 3.4,
+                orbitRadius: holeOrbit,
+                period: keplerPeriod(holeOrbit) * 1.8,
+                phase: rng() * Math.PI * 2,
+                inclination: 0.12,
+                group: holeHold,
+                pickMesh: hole.pickMesh,
+                color: '#ff6a4a',
+                composition: COMP.hole,
+                blurb: BLURBS.hole,
+                focusDistance: 28
+            });
+        }
+
+        this._place(0);
+        for (const body of this.bodies) {
+            if (body.pickMesh) body.pickMesh.userData.bodyId = body.id;
+        }
+        return this.seed;
+    }
+
+    _place(simTime) {
+        for (const body of this.bodies) {
+            if (!body.orbitRadius || body.kind === 'belt' || body.kind === 'star') continue;
+            const period = Math.max(body.period, 0.01);
+            const angle = body.phase + (simTime / period) * Math.PI * 2;
+            const ecc = body.ecc || 0;
+            const r = body.orbitRadius * (1 - ecc * Math.cos(angle));
+            const x = Math.cos(angle) * r;
+            const z = Math.sin(angle) * r;
+            const y = Math.sin(angle) * r * (body.inclination || 0);
+            if (body.parent) {
+                body.group.position.set(x, y, z);
+            } else {
+                body.group.position.set(x, y, z);
+            }
+        }
+    }
+
+    update(simTime, dt) {
+        this._place(simTime);
+        for (const item of this.updaters) {
+            item.update(simTime, dt);
+        }
+    }
+
+    clear() {
+        for (const child of [...this.root.children]) {
+            disposeObject(child);
+            this.root.remove(child);
+        }
+        if (this.sky) {
+            disposeObject(this.sky.group);
+            this.scene.remove(this.sky.group);
+            this.sky = null;
+        }
+        this.bodies = [];
+        this.updaters = [];
+    }
+}
+
+function subtitleFor(type) {
+    return {
+        rocky: 'Planeta rochoso',
+        desert: 'Mundo desértico',
+        terra: 'Planeta terrestre',
+        ocean: 'Mundo oceânico',
+        lava: 'Mundo vulcânico',
+        gas: 'Gigante gasoso',
+        ice: 'Gigante de gelo'
+    }[type] || 'Mundo';
+}

--- a/labs/aetherion/style.css
+++ b/labs/aetherion/style.css
@@ -1,0 +1,698 @@
+/* ================================================================
+   Aetherion — observatório estelar
+   Paleta: vazio profundo, violeta de nebulosa, ciano estelar, ouro solar.
+   ================================================================ */
+
+:root {
+    --void: oklch(8% 0.03 275);
+    --void-deep: oklch(5% 0.025 275);
+    --star: oklch(92% 0.08 85);
+    --gold: oklch(82% 0.14 78);
+    --cyan: oklch(82% 0.12 210);
+    --violet: oklch(68% 0.18 305);
+    --magenta: oklch(70% 0.2 350);
+
+    --text: oklch(96% 0.01 260);
+    --text-soft: oklch(82% 0.02 260);
+    --text-dim: oklch(64% 0.02 260);
+
+    --panel: color-mix(in oklab, oklch(14% 0.04 275) 58%, transparent);
+    --panel-strong: color-mix(in oklab, oklch(10% 0.04 275) 82%, transparent);
+    --line: color-mix(in oklab, var(--cyan) 28%, transparent);
+    --line-soft: color-mix(in oklab, var(--text) 10%, transparent);
+
+    --radius: 16px;
+    --radius-lg: 24px;
+    --blur: 22px;
+
+    --safe-top: env(safe-area-inset-top, 0px);
+    --safe-bottom: env(safe-area-inset-bottom, 0px);
+    --safe-left: env(safe-area-inset-left, 0px);
+    --safe-right: env(safe-area-inset-right, 0px);
+
+    --ease: cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+[data-theme="light"] {
+    --text: oklch(18% 0.03 275);
+    --text-soft: oklch(32% 0.03 275);
+    --text-dim: oklch(46% 0.02 275);
+    --panel: color-mix(in oklab, oklch(98% 0.02 260) 72%, transparent);
+    --panel-strong: color-mix(in oklab, oklch(100% 0.01 260) 88%, transparent);
+    --line: color-mix(in oklab, oklch(50% 0.12 250) 30%, transparent);
+}
+
+*,
+*::before,
+*::after {
+    box-sizing: border-box;
+    -webkit-tap-highlight-color: transparent;
+}
+
+html,
+body {
+    margin: 0;
+    width: 100%;
+    height: 100%;
+    overflow: clip;
+    overscroll-behavior: none;
+    background: var(--void-deep);
+}
+
+body {
+    min-height: 100dvh;
+    padding: 0 !important;
+    display: block !important;
+    align-items: stretch !important;
+    color: var(--text);
+    font-family: 'Outfit', system-ui, -apple-system, 'Segoe UI', sans-serif;
+    user-select: none;
+    -webkit-user-select: none;
+    touch-action: none;
+}
+
+button,
+input,
+select {
+    font: inherit;
+    color: inherit;
+}
+
+button {
+    background: none;
+    border: 0;
+    cursor: pointer;
+}
+
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip-path: inset(50%);
+}
+
+:focus-visible {
+    outline: 2px solid var(--cyan);
+    outline-offset: 3px;
+}
+
+.game-shell {
+    position: fixed;
+    inset: 0;
+    overflow: hidden;
+    background: var(--void-deep);
+}
+
+.stage {
+    position: absolute;
+    inset: 0;
+}
+
+#scene {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    display: block;
+    cursor: grab;
+    touch-action: none;
+}
+
+#scene.is-dragging {
+    cursor: grabbing;
+}
+
+.vignette {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background:
+        radial-gradient(ellipse at 50% 42%, transparent 42%, oklch(4% 0.03 275 / 0.55) 100%),
+        linear-gradient(to top, oklch(4% 0.03 275 / 0.35), transparent 22%);
+    z-index: 2;
+}
+
+/* ===== header / footer (shared.css override) ===== */
+.game-shell > header {
+    position: absolute;
+    top: calc(0.85rem + var(--safe-top));
+    left: calc(1rem + var(--safe-left));
+    right: calc(1rem + var(--safe-right));
+    z-index: 40;
+    margin: 0;
+    padding: 0;
+    max-width: none;
+    width: auto;
+    pointer-events: none;
+    gap: 0.55rem;
+}
+
+.game-shell > header > * {
+    pointer-events: auto;
+}
+
+.game-shell > header .back-link {
+    background: var(--panel-strong);
+    backdrop-filter: blur(var(--blur));
+    -webkit-backdrop-filter: blur(var(--blur));
+    border-color: var(--line);
+    color: var(--text-soft);
+    box-shadow: 0 10px 30px oklch(0% 0 0 / 0.35);
+}
+
+.game-shell > header .back-link:hover {
+    color: var(--cyan);
+    border-color: var(--cyan);
+}
+
+.game-shell > header .app-logo {
+    font-family: 'Cormorant Garamond', Georgia, serif;
+    font-weight: 600;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    font-size: 1.05rem;
+    color: var(--star);
+    text-shadow: 0 2px 22px oklch(0% 0 0 / 0.7);
+}
+
+.game-shell > header .brand-mark {
+    color: var(--cyan);
+    filter: drop-shadow(0 0 10px color-mix(in oklab, var(--cyan) 70%, transparent));
+}
+
+.icon-btn {
+    width: 44px;
+    height: 44px;
+    display: grid;
+    place-items: center;
+    border-radius: 999px;
+    border: 1px solid var(--line);
+    background: var(--panel-strong);
+    color: var(--text-soft);
+    backdrop-filter: blur(var(--blur));
+    -webkit-backdrop-filter: blur(var(--blur));
+}
+
+.icon-btn:hover {
+    color: var(--cyan);
+    border-color: var(--cyan);
+}
+
+.lab-foot {
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: calc(0.35rem + var(--safe-bottom));
+    z-index: 30;
+    margin: 0;
+    padding: 0.4rem;
+    border: 0;
+    font-size: 0.72rem;
+    color: var(--text-dim);
+    opacity: 0.5;
+    pointer-events: none;
+}
+
+.lab-foot a {
+    color: var(--text-soft);
+    pointer-events: auto;
+}
+
+body[data-state="observing"] .lab-foot {
+    opacity: 0;
+}
+
+/* ===== HUD ===== */
+.hud {
+    position: absolute;
+    inset: 0;
+    z-index: 12;
+    pointer-events: none;
+}
+
+.hud > * {
+    pointer-events: auto;
+}
+
+.catalog,
+.dossier,
+.dock {
+    background: var(--panel);
+    backdrop-filter: blur(var(--blur));
+    -webkit-backdrop-filter: blur(var(--blur));
+    border: 1px solid var(--line-soft);
+    border-radius: var(--radius);
+    box-shadow: 0 18px 50px oklch(0% 0 0 / 0.28);
+}
+
+.panel-kicker {
+    font-size: 0.68rem;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--cyan);
+    margin-bottom: 0.35rem;
+}
+
+.catalog {
+    position: absolute;
+    top: calc(5.4rem + var(--safe-top));
+    left: calc(1rem + var(--safe-left));
+    width: min(220px, 38vw);
+    max-height: calc(100dvh - 12rem);
+    overflow: auto;
+    padding: 0.9rem 0.75rem;
+}
+
+.body-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+}
+
+.body-btn {
+    display: grid;
+    grid-template-columns: 10px 1fr;
+    align-items: center;
+    gap: 0.55rem;
+    text-align: left;
+    padding: 0.42rem 0.5rem;
+    border-radius: 10px;
+    color: var(--text-soft);
+    transition: background 0.2s var(--ease), color 0.2s var(--ease);
+}
+
+.body-btn .swatch {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    box-shadow: 0 0 10px color-mix(in oklab, var(--swatch, var(--cyan)) 70%, transparent);
+    background: var(--swatch, var(--cyan));
+}
+
+.body-btn:hover,
+.body-btn.is-on {
+    background: color-mix(in oklab, var(--cyan) 12%, transparent);
+    color: var(--text);
+}
+
+.body-btn small {
+    display: block;
+    font-size: 0.68rem;
+    color: var(--text-dim);
+    font-weight: 400;
+}
+
+.dossier {
+    position: absolute;
+    top: calc(5.4rem + var(--safe-top));
+    right: calc(1rem + var(--safe-right));
+    width: min(280px, 42vw);
+    padding: 1.05rem 1.15rem 1.2rem;
+}
+
+.dossier h2 {
+    font-family: 'Cormorant Garamond', Georgia, serif;
+    font-weight: 600;
+    font-size: 2rem;
+    line-height: 1.05;
+    letter-spacing: 0.02em;
+    margin: 0 0 0.85rem;
+    color: var(--star);
+}
+
+.stats {
+    display: grid;
+    gap: 0.45rem;
+    margin: 0 0 0.9rem;
+}
+
+.stats div {
+    display: flex;
+    justify-content: space-between;
+    gap: 0.8rem;
+    font-size: 0.82rem;
+    border-bottom: 1px solid var(--line-soft);
+    padding-bottom: 0.35rem;
+}
+
+.stats dt {
+    color: var(--text-dim);
+}
+
+.stats dd {
+    margin: 0;
+    font-variant-numeric: tabular-nums;
+    color: var(--text);
+    text-align: right;
+}
+
+.blurb {
+    margin: 0;
+    font-size: 0.88rem;
+    line-height: 1.45;
+    color: var(--text-soft);
+}
+
+.hint {
+    position: absolute;
+    left: 50%;
+    bottom: calc(6.2rem + var(--safe-bottom));
+    transform: translateX(-50%);
+    font-size: 0.75rem;
+    letter-spacing: 0.04em;
+    color: var(--text-dim);
+    text-align: center;
+    max-width: min(520px, 90vw);
+    pointer-events: none;
+    text-shadow: 0 2px 12px oklch(0% 0 0 / 0.8);
+    transition: opacity 0.6s var(--ease);
+}
+
+.hint.is-gone {
+    opacity: 0;
+}
+
+.dock {
+    position: absolute;
+    left: 50%;
+    bottom: calc(1.1rem + var(--safe-bottom));
+    transform: translateX(-50%);
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: center;
+    gap: 0.45rem;
+    padding: 0.5rem;
+    width: max-content;
+    max-width: calc(100vw - 1.5rem);
+}
+
+.dock-btn,
+.warp-btns button {
+    padding: 0.55rem 0.85rem;
+    border-radius: 999px;
+    border: 1px solid var(--line-soft);
+    color: var(--text-soft);
+    font-size: 0.78rem;
+    font-weight: 500;
+    min-height: 40px;
+    transition: background 0.2s var(--ease), color 0.2s, border-color 0.2s;
+}
+
+.dock-btn:hover,
+.warp-btns button:hover,
+.dock-btn.is-on,
+.warp-btns button.is-on {
+    color: var(--text);
+    border-color: var(--cyan);
+    background: color-mix(in oklab, var(--cyan) 14%, transparent);
+}
+
+.dock-btn.accent {
+    background: linear-gradient(135deg, color-mix(in oklab, var(--violet) 55%, transparent), color-mix(in oklab, var(--cyan) 40%, transparent));
+    border-color: color-mix(in oklab, var(--cyan) 45%, transparent);
+    color: var(--star);
+}
+
+.warp {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0 0.2rem;
+}
+
+.warp-label {
+    font-size: 0.68rem;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--text-dim);
+}
+
+.warp-btns {
+    display: flex;
+    gap: 0.2rem;
+}
+
+.warp-btns button {
+    min-width: 44px;
+    padding-inline: 0.55rem;
+}
+
+/* ===== overlays ===== */
+.overlay {
+    position: absolute;
+    inset: 0;
+    z-index: 50;
+    display: grid;
+    place-items: center;
+    padding: 1.2rem;
+    background:
+        radial-gradient(ellipse at 50% 20%, color-mix(in oklab, var(--violet) 22%, transparent), transparent 50%),
+        oklch(4% 0.03 275 / 0.55);
+    backdrop-filter: blur(8px);
+}
+
+.overlay[hidden] {
+    display: none !important;
+}
+
+.overlay-card {
+    width: min(520px, 100%);
+    padding: 2rem 1.8rem 1.6rem;
+    border-radius: var(--radius-lg);
+    background: var(--panel-strong);
+    border: 1px solid var(--line);
+    box-shadow:
+        0 30px 80px oklch(0% 0 0 / 0.45),
+        inset 0 1px 0 color-mix(in oklab, var(--star) 12%, transparent);
+    backdrop-filter: blur(28px);
+    -webkit-backdrop-filter: blur(28px);
+}
+
+.compact-card {
+    width: min(420px, 100%);
+}
+
+.eyebrow {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.72rem;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: var(--cyan);
+    margin: 0 0 0.7rem;
+}
+
+.eyebrow i {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: var(--cyan);
+    box-shadow: 0 0 12px var(--cyan);
+}
+
+.eyebrow--danger {
+    color: oklch(72% 0.18 25);
+}
+
+.eyebrow--danger i {
+    background: oklch(72% 0.18 25);
+    box-shadow: 0 0 12px oklch(72% 0.18 25);
+}
+
+.overlay-card h2 {
+    font-family: 'Cormorant Garamond', Georgia, serif;
+    font-size: clamp(2.4rem, 6vw, 3.4rem);
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    line-height: 0.95;
+    margin: 0 0 0.9rem;
+    color: var(--star);
+}
+
+.lede {
+    margin: 0 0 1.1rem;
+    color: var(--text-soft);
+    line-height: 1.55;
+    font-size: 0.98rem;
+}
+
+.feature-list {
+    margin: 0 0 1.3rem;
+    padding: 0;
+    list-style: none;
+    display: grid;
+    gap: 0.45rem;
+    color: var(--text-soft);
+    font-size: 0.9rem;
+}
+
+.feature-list li {
+    padding-left: 1.1rem;
+    position: relative;
+}
+
+.feature-list li::before {
+    content: '✦';
+    position: absolute;
+    left: 0;
+    color: var(--cyan);
+    font-size: 0.7rem;
+    top: 0.2rem;
+}
+
+.settings-row {
+    margin-bottom: 1.2rem;
+}
+
+.field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    font-size: 0.8rem;
+    color: var(--text-dim);
+}
+
+.field select {
+    appearance: none;
+    background: color-mix(in oklab, var(--void) 55%, transparent);
+    border: 1px solid var(--line);
+    border-radius: 12px;
+    padding: 0.7rem 0.9rem;
+    color: var(--text);
+}
+
+.card-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.6rem;
+}
+
+.primary-button {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.7rem;
+    padding: 0.85rem 1.25rem;
+    border-radius: 999px;
+    background: linear-gradient(135deg, var(--violet), var(--cyan));
+    color: oklch(12% 0.03 275);
+    font-weight: 650;
+    letter-spacing: 0.02em;
+    box-shadow: 0 10px 30px color-mix(in oklab, var(--violet) 40%, transparent);
+}
+
+.primary-button i {
+    font-style: normal;
+}
+
+.primary-button:hover {
+    transform: translateY(-1px);
+}
+
+.keys {
+    display: grid;
+    gap: 0.55rem;
+    margin: 0 0 1.2rem;
+    color: var(--text-soft);
+    font-size: 0.9rem;
+}
+
+kbd {
+    display: inline-block;
+    padding: 0.12rem 0.45rem;
+    border-radius: 6px;
+    border: 1px solid var(--line);
+    background: color-mix(in oklab, var(--void) 50%, transparent);
+    font-size: 0.75rem;
+    font-family: inherit;
+    color: var(--star);
+}
+
+/* ===== responsive ===== */
+@media (max-width: 820px) {
+    .catalog {
+        top: auto;
+        bottom: calc(6.6rem + var(--safe-bottom));
+        left: calc(0.7rem + var(--safe-left));
+        right: calc(0.7rem + var(--safe-right));
+        width: auto;
+        max-height: none;
+        padding: 0.55rem;
+    }
+
+    .body-list {
+        flex-direction: row;
+        overflow-x: auto;
+        gap: 0.3rem;
+        scrollbar-width: none;
+    }
+
+    .body-list::-webkit-scrollbar {
+        display: none;
+    }
+
+    .body-btn {
+        grid-template-columns: 8px auto;
+        white-space: nowrap;
+        padding: 0.45rem 0.7rem;
+    }
+
+    .body-btn small {
+        display: none;
+    }
+
+    .dossier {
+        top: calc(4.8rem + var(--safe-top));
+        right: calc(0.7rem + var(--safe-right));
+        left: auto;
+        width: min(230px, 56vw);
+        padding: 0.8rem 0.9rem;
+    }
+
+    .dossier h2 {
+        font-size: 1.45rem;
+        margin-bottom: 0.5rem;
+    }
+
+    .stats {
+        gap: 0.28rem;
+        margin-bottom: 0.5rem;
+    }
+
+    .blurb {
+        font-size: 0.78rem;
+        display: -webkit-box;
+        -webkit-line-clamp: 3;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+    }
+
+    .hint {
+        display: none;
+    }
+
+    .dock {
+        bottom: calc(0.7rem + var(--safe-bottom));
+        gap: 0.3rem;
+        padding: 0.4rem;
+    }
+
+    .warp-label {
+        display: none;
+    }
+}
+
+@media (max-width: 520px) {
+    .dossier {
+        width: auto;
+        left: calc(0.7rem + var(--safe-left));
+        right: calc(0.7rem + var(--safe-right));
+    }
+
+    .stats div:nth-child(3),
+    .stats div:nth-child(4) {
+        display: none;
+    }
+}

--- a/labs/index.html
+++ b/labs/index.html
@@ -55,6 +55,26 @@
     </div>
 
     <div class="projects-grid">
+      <a href="/labs/aetherion/" class="project-card" data-groups="creative,game">
+        <div class="project-icon">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+            stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <circle cx="12" cy="12" r="2.2" />
+            <ellipse cx="12" cy="12" rx="9" ry="4.2" />
+            <ellipse cx="12" cy="12" rx="9" ry="4.2" transform="rotate(60 12 12)" opacity="0.7" />
+            <ellipse cx="12" cy="12" rx="9" ry="4.2" transform="rotate(120 12 12)" opacity="0.45" />
+          </svg>
+        </div>
+        <div class="project-content">
+          <h2>Aetherion</h2>
+          <p>Observatório estelar 3D: voe por um sistema gerado em shaders, com mundos vivos e um buraco negro</p>
+          <div class="project-tags">
+            <span class="tag">three.js</span>
+            <span class="tag">Shaders</span>
+            <span class="tag">Espaço</span>
+          </div>
+        </div>
+      </a>
       <a href="/labs/ravi-123/" class="project-card" data-groups="game,creative">
         <div class="project-icon">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Novo laboratório **Aetherion** — um observatório 3D no navegador, com gráficos em three.js e shaders próprios.

## O que é
Um sistema estelar gerado por semente: estrela viva, planetas (terra, oceano, deserto, lava, gás, gelo), cinturão de asteroides, cometa e, na maior parte das vezes, um buraco negro com disco de acreção e jatos.

[Tela inicial do Aetherion](https://cursor.com/agents/bc-019ffdad-4404-702f-b991-7972db5bc3fc/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Faetherion-intro.webp)
[Sistema estelar em 3D](https://cursor.com/agents/bc-019ffdad-4404-702f-b991-7972db5bc3fc/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Faetherion-system.webp)
[Planeta vulcânico em close](https://cursor.com/agents/bc-019ffdad-4404-702f-b991-7972db5bc3fc/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Faetherion-planet.webp)
[Visão do sistema com buraco negro](https://cursor.com/agents/bc-019ffdad-4404-702f-b991-7972db5bc3fc/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Faetherion-overview.webp)

## Interação
- Arrastar para orbitar, scroll/pinch para zoom
- Clique num mundo (ou no catálogo) para viajar até ele
- Dilatação do tempo, visão do sistema e botão para forjar um sistema novo
- Trilha ambiente sintetizada na Web Audio API

## Arquivos
- `labs/aetherion/` — lab autocontido (HTML/CSS/JS + import map do three.js 0.185)
- `labs/index.html` — card na galeria

Sem build step; serve a raiz do repositório por HTTP.

## Teste
Validado no navegador: intro, cena 3D, foco em planeta, novo sistema, visão do sistema e card na galeria. Sem erros de shader/WebGL.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ffdad-4404-702f-b991-7972db5bc3fc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ffdad-4404-702f-b991-7972db5bc3fc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

