### PR TITLE
feat: Neon Rider — arcade 3D retrô em three.js

### DIFF
--- a/labs/index.html
+++ b/labs/index.html
@@ -55,6 +55,27 @@
     </div>
 
     <div class="projects-grid">
+      <a href="/labs/neon-rider/" class="project-card" data-groups="game,creative">
+        <div class="project-icon">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+            stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M4 17h3l2-5 3 1 2-4h3" />
+            <circle cx="7" cy="18" r="2" />
+            <circle cx="17" cy="18" r="2" />
+            <path d="M12 8V4M10 5h4" opacity="0.7" />
+            <path d="M3 12h3M18 11h3" opacity="0.45" />
+          </svg>
+        </div>
+        <div class="project-content">
+          <h2>Neon Rider</h2>
+          <p>Avenida infinita anos 80 em three.js: moto, néon, rádio synthwave e fitas VHS que retunam a cidade</p>
+          <div class="project-tags">
+            <span class="tag">three.js</span>
+            <span class="tag">Arcade</span>
+            <span class="tag">VHS</span>
+          </div>
+        </div>
+      </a>
       <a href="/labs/ravi-123/" class="project-card" data-groups="game,creative">
         <div class="project-icon">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"

--- a/labs/neon-rider/index.html
+++ b/labs/neon-rider/index.html
@@ -1,0 +1,222 @@
+<!DOCTYPE html>
+<html lang="pt-br" data-theme="dark">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport"
+        content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover">
+    <meta name="theme-color" content="#06010c">
+    <title>Neon Rider — avenida infinita dos anos 80 | Labs</title>
+    <meta name="description"
+        content="Corra de moto por uma avenida infinita à noite: néon, asfalto molhado, rádio synthwave e fitas VHS que retunam a cidade. Arcade 3D em three.js.">
+    <link rel="canonical" href="https://diogopaulino.com.br/labs/neon-rider/">
+
+    <meta property="og:type" content="website">
+    <meta property="og:site_name" content="Diogo Paulino · Labs">
+    <meta property="og:url" content="https://diogopaulino.com.br/labs/neon-rider/">
+    <meta property="og:title" content="Neon Rider">
+    <meta property="og:description"
+        content="Arcade 3D retrô: moto, distrito néon, fitas VHS e rádio procedural. Sem planetas — só avenida e madrugada.">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Neon Rider">
+    <meta name="twitter:description" content="Uma avenida infinita à noite, em three.js. Colete fitas e retune o néon.">
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Audiowide&family=Outfit:wght@400;500;600;700&family=Share+Tech+Mono&display=swap"
+        rel="stylesheet">
+    <link rel="stylesheet" href="/labs/shared.css?v=6">
+    <link rel="stylesheet" href="style.css?v=1">
+
+    <script type="importmap">
+    {
+        "imports": {
+            "three": "https://cdn.jsdelivr.net/npm/three@0.185.1/build/three.module.js",
+            "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.185.1/examples/jsm/"
+        }
+    }
+    </script>
+</head>
+
+<body>
+    <main class="game-shell">
+        <header data-lab-header data-title="Neon Rider" data-back-label="Labs">
+            <template data-slot="logo">
+                <div class="app-logo">
+                    <span class="brand-mark" aria-hidden="true">▣</span>
+                    <span>Neon Rider</span>
+                </div>
+            </template>
+        </header>
+
+        <canvas id="scene" aria-label="Avenida néon em 3D com a moto"></canvas>
+
+        <div class="crt-overlay" aria-hidden="true">
+            <div class="scanlines"></div>
+            <div class="vignette"></div>
+        </div>
+        <div id="glitchLayer" class="glitch-layer" aria-hidden="true"></div>
+
+        <div id="hud" class="hud" hidden>
+            <div class="hud-top">
+                <div class="panel speed-panel">
+                    <span class="hud-label">Velocidade</span>
+                    <strong id="speedValue" class="mono speed-num">000</strong>
+                    <span class="hud-unit">km/h</span>
+                </div>
+                <div class="panel radio-panel">
+                    <span class="hud-label">Rádio</span>
+                    <strong id="radioValue">WAVE 84</strong>
+                    <span id="radioTag" class="hud-tag">synth · meia-noite</span>
+                    <div class="boost-meter" title="Nitro">
+                        <i id="boostFill"></i>
+                    </div>
+                </div>
+                <div class="panel score-panel">
+                    <div class="score-row">
+                        <span class="hud-label">Avenida</span>
+                        <strong id="kmValue" class="mono">0 m</strong>
+                    </div>
+                    <div class="score-row">
+                        <span class="hud-label">Fitas</span>
+                        <strong id="tapeValue" class="mono">00</strong>
+                    </div>
+                    <div class="score-row lives-row">
+                        <span class="hud-label">Créditos</span>
+                        <strong id="livesValue" class="mono lives">■■■</strong>
+                    </div>
+                </div>
+            </div>
+
+            <p id="message" class="message" data-show="false" role="status" aria-live="polite"></p>
+
+            <div class="hud-actions">
+                <button id="soundButton" class="icon-button" type="button" aria-pressed="true"
+                    title="Som (M)" aria-label="Alternar som">♪</button>
+                <button id="pauseButton" class="icon-button" type="button" title="Pausar (P)"
+                    aria-label="Pausar">II</button>
+                <span id="fpsCounter" class="fps mono">—</span>
+            </div>
+
+            <div id="touchControls" class="touch-controls" hidden>
+                <div class="steer-zone" id="steerZone" aria-label="Arraste para esterçar">
+                    <span class="steer-hint">esterçar</span>
+                </div>
+                <div class="touch-buttons">
+                    <button type="button" class="pad pad-brake" id="touchBrake" aria-label="Frear">FREIO</button>
+                    <button type="button" class="pad pad-boost" id="touchBoost" aria-label="Nitro">NITRO</button>
+                </div>
+            </div>
+        </div>
+
+        <div id="loadingOverlay" class="overlay loading-overlay">
+            <div class="loading-card">
+                <span class="loading-mark" aria-hidden="true">▣</span>
+                <h1>NEON RIDER</h1>
+                <p id="loadingText">Ligando o tubo…</p>
+                <div class="loading-bar"><i id="loadingFill"></i></div>
+            </div>
+        </div>
+
+        <div id="menuOverlay" class="overlay menu-overlay" hidden>
+            <div class="overlay-card menu-card">
+                <header class="menu-head">
+                    <p class="eyebrow"><i></i> three.js · VHS · 1984</p>
+                    <h1>Neon <span>Rider</span></h1>
+                    <p class="lede">Uma avenida que não acaba, à meia-noite. Colete fitas VHS para
+                        retunar o néon da cidade e a rádio synthwave. Desvie do trânsito. Não olhe para o céu —
+                        o show está no asfalto.</p>
+                </header>
+
+                <div class="menu-grid">
+                    <section class="menu-section">
+                        <h2>Noite</h2>
+                        <div id="difficultyOptions" class="chip-row" role="radiogroup" aria-label="Dificuldade"></div>
+                        <p id="difficultyBlurb" class="section-note"></p>
+                    </section>
+
+                    <section class="menu-section">
+                        <h2>Comandos</h2>
+                        <div class="keys">
+                            <span><kbd>A</kbd><kbd>D</kbd> ou <kbd>←</kbd><kbd>→</kbd> esterçar</span>
+                            <span><kbd>W</kbd> / <kbd>Shift</kbd> nitro · <kbd>S</kbd> freio</span>
+                            <span><kbd>C</kbd> câmera · <kbd>R</kbd> rádio · <kbd>P</kbd> pausa</span>
+                            <span><kbd>M</kbd> mudo · <kbd>Enter</kbd> largar</span>
+                        </div>
+                    </section>
+
+                    <section class="menu-section">
+                        <h2>Ajustes</h2>
+                        <div class="settings-grid">
+                            <label class="field">
+                                <span>Qualidade</span>
+                                <select id="qualitySelect">
+                                    <option value="auto">Automática</option>
+                                    <option value="low">Performance</option>
+                                    <option value="medium">Equilibrada</option>
+                                    <option value="high">Cinemática</option>
+                                </select>
+                            </label>
+                            <label class="field">
+                                <span>Volume <b id="volumeValue">72</b></span>
+                                <input id="volumeSlider" type="range" min="0" max="100" step="1" value="72">
+                            </label>
+                        </div>
+                        <p class="section-note">Melhor avenida: <b id="bestScore" class="mono">—</b></p>
+                    </section>
+                </div>
+
+                <footer class="menu-foot">
+                    <button id="startButton" class="primary-button" type="button">
+                        <span>Insert coin</span>
+                        <i aria-hidden="true">→</i>
+                    </button>
+                </footer>
+            </div>
+        </div>
+
+        <div id="pauseOverlay" class="overlay" hidden>
+            <div class="overlay-card compact-card">
+                <p class="eyebrow"><i></i> PAUSE</p>
+                <h2>A avenida espera.</h2>
+                <div class="card-actions">
+                    <button id="resumeButton" class="primary-button" type="button">
+                        <span>Continuar</span><i aria-hidden="true">→</i>
+                    </button>
+                    <button id="pauseMenuButton" class="ghost-button" type="button">Voltar ao menu</button>
+                </div>
+            </div>
+        </div>
+
+        <div id="gameOverOverlay" class="overlay" hidden>
+            <div class="overlay-card compact-card defeat-card">
+                <p class="eyebrow eyebrow--danger"><i></i> GAME OVER</p>
+                <h2>O néon<br>apagou.</h2>
+                <div id="overStats" class="stats"></div>
+                <div class="card-actions">
+                    <button id="retryButton" class="primary-button" type="button">
+                        <span>Outra fita</span><i aria-hidden="true">↻</i>
+                    </button>
+                    <button id="overMenuButton" class="ghost-button" type="button">Voltar ao menu</button>
+                </div>
+            </div>
+        </div>
+
+        <div id="errorOverlay" class="overlay" hidden>
+            <div class="overlay-card compact-card">
+                <p class="eyebrow eyebrow--danger"><i></i> WebGL indisponível</p>
+                <h2>Seu navegador não<br>ligou o tubo.</h2>
+                <p class="lede" id="errorText">Este laboratório precisa de WebGL 2. Tente um navegador
+                    atualizado ou reative a aceleração de hardware.</p>
+            </div>
+        </div>
+
+        <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
+    </main>
+
+    <script src="/labs/shared.js?v=6" defer></script>
+    <script type="module" src="src/main.js?v=1"></script>
+</body>
+
+</html>

--- a/labs/neon-rider/index.html
+++ b/labs/neon-rider/index.html
@@ -27,7 +27,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Audiowide&family=Outfit:wght@400;500;600;700&family=Share+Tech+Mono&display=swap"
         rel="stylesheet">
     <link rel="stylesheet" href="/labs/shared.css?v=6">
-    <link rel="stylesheet" href="style.css?v=1">
+    <link rel="stylesheet" href="style.css?v=2">
 
     <script type="importmap">
     {
@@ -216,7 +216,7 @@
     </main>
 
     <script src="/labs/shared.js?v=6" defer></script>
-    <script type="module" src="src/main.js?v=1"></script>
+    <script type="module" src="src/main.js?v=2"></script>
 </body>
 
 </html>

--- a/labs/neon-rider/index.html
+++ b/labs/neon-rider/index.html
@@ -205,8 +205,8 @@
 
         <div id="errorOverlay" class="overlay" hidden>
             <div class="overlay-card compact-card">
-                <p class="eyebrow eyebrow--danger"><i></i> WebGL indisponível</p>
-                <h2>Seu navegador não<br>ligou o tubo.</h2>
+                <p class="eyebrow eyebrow--danger"><i></i> Falha ao ligar</p>
+                <h2>O tubo não<br>acendeu.</h2>
                 <p class="lede" id="errorText">Este laboratório precisa de WebGL 2. Tente um navegador
                     atualizado ou reative a aceleração de hardware.</p>
             </div>
@@ -216,7 +216,7 @@
     </main>
 
     <script src="/labs/shared.js?v=6" defer></script>
-    <script type="module" src="src/main.js?v=3"></script>
+    <script type="module" src="src/main.js?v=4"></script>
 </body>
 
 </html>

--- a/labs/neon-rider/index.html
+++ b/labs/neon-rider/index.html
@@ -216,7 +216,7 @@
     </main>
 
     <script src="/labs/shared.js?v=6" defer></script>
-    <script type="module" src="src/main.js?v=2"></script>
+    <script type="module" src="src/main.js?v=3"></script>
 </body>
 
 </html>

--- a/labs/neon-rider/src/audio.js
+++ b/labs/neon-rider/src/audio.js
@@ -1,0 +1,188 @@
+/**
+ * Trilha synthwave procedural + SFX de motor, coleta e batida.
+ * Osciladores nativos da Web Audio API — nenhuma amostra externa.
+ *
+ * Padrão: 108 BPM, baixo em lá menor, arpejo 16ths, kick/snare/hats.
+ */
+
+export class GameAudio {
+    constructor() {
+        this.ctx = null;
+        this.enabled = true;
+        this.volume = 0.72;
+        this.master = null;
+        this.music = null;
+        this.engine = null;
+        this.step = 0;
+        this.acc = 0;
+        this.bpm = 108;
+        this.station = 0;
+        this.started = false;
+    }
+
+    async resume() {
+        if (!this.enabled) return;
+        if (!this.ctx) this.boot();
+        if (this.ctx.state === 'suspended') await this.ctx.resume();
+        this.started = true;
+    }
+
+    boot() {
+        const AudioCtx = window.AudioContext || window.webkitAudioContext;
+        this.ctx = new AudioCtx();
+        this.master = this.ctx.createGain();
+        this.master.gain.value = this.volume;
+        this.master.connect(this.ctx.destination);
+
+        this.music = this.ctx.createGain();
+        this.music.gain.value = 0.55;
+        this.music.connect(this.master);
+
+        this.engine = this.ctx.createOscillator();
+        this.engine.type = 'sawtooth';
+        this.engine.frequency.value = 48;
+        this.engineGain = this.ctx.createGain();
+        this.engineGain.gain.value = 0;
+        const engineFilter = this.ctx.createBiquadFilter();
+        engineFilter.type = 'lowpass';
+        engineFilter.frequency.value = 900;
+        this.engine.connect(engineFilter);
+        engineFilter.connect(this.engineGain);
+        this.engineGain.connect(this.master);
+        this.engine.start();
+    }
+
+    setVolume(v) {
+        this.volume = v;
+        if (this.master) this.master.gain.value = this.enabled ? v : 0;
+    }
+
+    setEnabled(on) {
+        this.enabled = on;
+        if (this.master) this.master.gain.value = on ? this.volume : 0;
+    }
+
+    setStation(index) {
+        this.station = index % 4;
+        this.bpm = [108, 100, 116, 112][this.station];
+    }
+
+    update(dt, speed, boosting) {
+        if (!this.ctx || !this.enabled || !this.started) return;
+        const stepDur = 60 / this.bpm / 4;
+        this.acc += dt;
+        while (this.acc >= stepDur) {
+            this.acc -= stepDur;
+            this.tick(this.step);
+            this.step = (this.step + 1) % 16;
+        }
+        if (this.engine) {
+            this.engine.frequency.value = 42 + speed * 1.15;
+            this.engineGain.gain.value = 0.03 + Math.min(0.08, speed / 900) + (boosting ? 0.03 : 0);
+        }
+    }
+
+    tick(step) {
+        const t = this.ctx.currentTime;
+        const roots = [
+            [33, 33, 36, 33, 29, 29, 31, 33],
+            [29, 29, 32, 29, 24, 24, 26, 29],
+            [36, 36, 38, 36, 31, 31, 33, 36],
+            [28, 28, 31, 28, 24, 24, 26, 28]
+        ][this.station];
+        const bass = roots[Math.floor(step / 2) % roots.length];
+
+        if (step % 2 === 0) this.note(this.mtof(bass), 0.18, 0.09, 'sawtooth', 220, t);
+        if (step % 4 === 0) this.kick(t);
+        if (step === 4 || step === 12) this.snare(t);
+        if (step % 2 === 1) this.hat(t, 0.03);
+
+        const arp = [0, 3, 7, 12, 7, 3, 10, 7];
+        const a = this.mtof(bass + 12 + arp[step % arp.length]);
+        this.note(a, 0.09, 0.045, 'square', 1800, t);
+    }
+
+    mtof(m) {
+        return 440 * 2 ** ((m - 69) / 12);
+    }
+
+    note(freq, dur, gain, type, cutoff, t) {
+        const osc = this.ctx.createOscillator();
+        osc.type = type;
+        osc.frequency.value = freq;
+        const f = this.ctx.createBiquadFilter();
+        f.type = 'lowpass';
+        f.frequency.value = cutoff;
+        const g = this.ctx.createGain();
+        g.gain.setValueAtTime(0.0001, t);
+        g.gain.exponentialRampToValueAtTime(gain, t + 0.01);
+        g.gain.exponentialRampToValueAtTime(0.0001, t + dur);
+        osc.connect(f);
+        f.connect(g);
+        g.connect(this.music);
+        osc.start(t);
+        osc.stop(t + dur + 0.02);
+    }
+
+    kick(t) {
+        const osc = this.ctx.createOscillator();
+        osc.type = 'sine';
+        osc.frequency.setValueAtTime(140, t);
+        osc.frequency.exponentialRampToValueAtTime(40, t + 0.12);
+        const g = this.ctx.createGain();
+        g.gain.setValueAtTime(0.22, t);
+        g.gain.exponentialRampToValueAtTime(0.0001, t + 0.16);
+        osc.connect(g);
+        g.connect(this.music);
+        osc.start(t);
+        osc.stop(t + 0.18);
+    }
+
+    snare(t) {
+        const n = this.noise(t, 0.08, 0.12, 1800);
+        n.connect(this.music);
+    }
+
+    hat(t, gain) {
+        const n = this.noise(t, 0.03, gain, 7000);
+        n.connect(this.music);
+    }
+
+    noise(t, dur, gain, cutoff) {
+        const buffer = this.ctx.createBuffer(1, this.ctx.sampleRate * dur, this.ctx.sampleRate);
+        const data = buffer.getChannelData(0);
+        for (let i = 0; i < data.length; i++) data[i] = Math.random() * 2 - 1;
+        const src = this.ctx.createBufferSource();
+        src.buffer = buffer;
+        const f = this.ctx.createBiquadFilter();
+        f.type = 'highpass';
+        f.frequency.value = cutoff * 0.4;
+        const g = this.ctx.createGain();
+        g.gain.setValueAtTime(gain, t);
+        g.gain.exponentialRampToValueAtTime(0.0001, t + dur);
+        src.connect(f);
+        f.connect(g);
+        src.start(t);
+        return g;
+    }
+
+    collect() {
+        if (!this.ctx || !this.enabled) return;
+        const t = this.ctx.currentTime;
+        this.note(880, 0.08, 0.08, 'square', 2400, t);
+        this.note(1320, 0.12, 0.07, 'square', 2800, t + 0.06);
+    }
+
+    crash() {
+        if (!this.ctx || !this.enabled) return;
+        const t = this.ctx.currentTime;
+        this.noise(t, 0.28, 0.22, 900).connect(this.master);
+        this.note(90, 0.25, 0.12, 'sawtooth', 400, t);
+    }
+
+    boostWhoosh() {
+        if (!this.ctx || !this.enabled) return;
+        const t = this.ctx.currentTime;
+        this.note(220, 0.18, 0.05, 'sawtooth', 1200, t);
+    }
+}

--- a/labs/neon-rider/src/config.js
+++ b/labs/neon-rider/src/config.js
@@ -1,0 +1,190 @@
+/**
+ * Neon Rider — constantes, paletas (estações de rádio) e presets de qualidade.
+ * A cidade inteira retuna as cores quando o jogador coleta uma fita VHS.
+ */
+
+export const STORAGE_KEY = 'neon-rider-v1';
+
+export const ROAD = {
+    laneWidth: 3.6,
+    lanes: 4,
+    halfWidth: 7.4,
+    curb: 8.6,
+    buildingGap: 11.2
+};
+
+export const CHUNK = {
+    length: 52,
+    count: 14
+};
+
+export const BIKE = {
+    accel: 28,
+    brake: 38,
+    coast: 8,
+    maxSpeed: 62,
+    boostSpeed: 86,
+    steer: 22,
+    grip: 9.5,
+    lean: 0.42
+};
+
+/** Estações: cada fita troca o "broadcast" da cidade (néon + rádio). Sem astros. */
+export const STATIONS = [
+    {
+        id: 'wave',
+        name: 'WAVE 84',
+        tagline: 'synth · meia-noite',
+        neonA: 0xff2bd6,
+        neonB: 0x00f0ff,
+        fog: 0x14081f,
+        horizon: 0xff3eb5,
+        zenith: 0x06010c,
+        ground: 0x04020a,
+        asphalt: 0x12101c,
+        window: 0xffc4a0,
+        lamp: 0xffe7b0
+    },
+    {
+        id: 'vhs',
+        name: 'VHS FM',
+        tagline: 'chroma · tracking',
+        neonA: 0xff6a00,
+        neonB: 0xffd428,
+        fog: 0x1a0c08,
+        horizon: 0xff7a28,
+        zenith: 0x0c0604,
+        ground: 0x0a0402,
+        asphalt: 0x1a1210,
+        window: 0xffd9a0,
+        lamp: 0xffcc77
+    },
+    {
+        id: 'arcade',
+        name: 'ARCADE AM',
+        tagline: 'fósforo · 1-up',
+        neonA: 0x39ff14,
+        neonB: 0x00ffe0,
+        fog: 0x04140c,
+        horizon: 0x2dff9a,
+        zenith: 0x020a08,
+        ground: 0x02100a,
+        asphalt: 0x0c1412,
+        window: 0xc8ffd4,
+        lamp: 0xe8ffc8
+    },
+    {
+        id: 'disco',
+        name: 'DISCO 12',
+        tagline: 'esfera · glitter',
+        neonA: 0xff3ea5,
+        neonB: 0x7a5cff,
+        fog: 0x12081c,
+        horizon: 0xff5ad5,
+        zenith: 0x080414,
+        ground: 0x060310,
+        asphalt: 0x141018,
+        window: 0xffd0ff,
+        lamp: 0xf0d0ff
+    }
+];
+
+export const DIFFICULTY = {
+    cruise: {
+        id: 'cruise',
+        label: 'Passeio',
+        blurb: 'Trânsito leve, fitas por toda a avenida. Para curtir o néon.',
+        traffic: 0.55,
+        trafficSpeed: 0.42,
+        tapes: 1.35,
+        lives: 5,
+        maxSpeed: 54
+    },
+    night: {
+        id: 'night',
+        label: 'Madrugada',
+        blurb: 'Avenida cheia, táxis surpresa e boost curto. O ritmo certo.',
+        traffic: 1,
+        trafficSpeed: 0.58,
+        tapes: 1,
+        lives: 3,
+        maxSpeed: 66
+    },
+    turbo: {
+        id: 'turbo',
+        label: 'Turbo',
+        blurb: 'Nitro permanente, trânsito agressivo. Uma fita errada e acabou.',
+        traffic: 1.45,
+        trafficSpeed: 0.78,
+        tapes: 0.75,
+        lives: 2,
+        maxSpeed: 84
+    }
+};
+
+export const QUALITY = {
+    low: {
+        antialias: false,
+        pixelRatio: 1,
+        bloom: false,
+        shadows: false,
+        lamps: 0,
+        drawDistance: 220,
+        fogDensity: 0.012,
+        chunkProps: 0.55,
+        particles: 80
+    },
+    medium: {
+        antialias: true,
+        pixelRatio: 1.5,
+        bloom: true,
+        shadows: false,
+        lamps: 4,
+        drawDistance: 320,
+        fogDensity: 0.0085,
+        chunkProps: 0.85,
+        particles: 180
+    },
+    high: {
+        antialias: true,
+        pixelRatio: 2,
+        bloom: true,
+        shadows: true,
+        lamps: 8,
+        drawDistance: 420,
+        fogDensity: 0.0064,
+        chunkProps: 1,
+        particles: 280
+    }
+};
+
+export function loadSettings() {
+    const fallback = {
+        difficulty: 'night',
+        quality: 'auto',
+        volume: 72,
+        muted: false,
+        best: 0
+    };
+    try {
+        const raw = localStorage.getItem(STORAGE_KEY);
+        if (!raw) return fallback;
+        return { ...fallback, ...JSON.parse(raw) };
+    } catch (err) {
+        return fallback;
+    }
+}
+
+export function saveSettings(settings) {
+    try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify({
+            difficulty: settings.difficulty,
+            quality: settings.quality,
+            volume: settings.volume,
+            muted: settings.muted,
+            best: settings.best
+        }));
+    } catch (err) {
+        /* private mode */
+    }
+}

--- a/labs/neon-rider/src/effects.js
+++ b/labs/neon-rider/src/effects.js
@@ -29,6 +29,7 @@ export class Effects {
         this.points = new THREE.Points(geo, new THREE.ShaderMaterial({
             transparent: true,
             depthWrite: false,
+            fog: false,
             blending: THREE.AdditiveBlending,
             uniforms: {
                 uMap: { value: sparkTexture(THREE) },

--- a/labs/neon-rider/src/effects.js
+++ b/labs/neon-rider/src/effects.js
@@ -1,0 +1,111 @@
+/**
+ * Faíscas do nitro, estouro ao coletar fita e explosão no impacto.
+ * Buffer pré-alocado para não acordar o GC no meio da corrida.
+ */
+
+import * as THREE from 'three';
+import { sparkTexture } from './textures.js';
+
+export class Effects {
+    constructor(scene, quality) {
+        this.max = quality.particles;
+        this.cursor = 0;
+        this.pos = new Float32Array(this.max * 3);
+        this.col = new Float32Array(this.max * 3);
+        this.size = new Float32Array(this.max);
+        this.alpha = new Float32Array(this.max);
+        this.vel = new Float32Array(this.max * 3);
+        this.life = new Float32Array(this.max);
+        this.maxLife = new Float32Array(this.max);
+
+        const geo = new THREE.BufferGeometry();
+        geo.setAttribute('position', new THREE.BufferAttribute(this.pos, 3));
+        geo.setAttribute('aColor', new THREE.BufferAttribute(this.col, 3));
+        geo.setAttribute('aSize', new THREE.BufferAttribute(this.size, 1));
+        geo.setAttribute('aAlpha', new THREE.BufferAttribute(this.alpha, 1));
+        geo.boundingSphere = new THREE.Sphere(new THREE.Vector3(), 1e6);
+
+        this.geo = geo;
+        this.points = new THREE.Points(geo, new THREE.ShaderMaterial({
+            transparent: true,
+            depthWrite: false,
+            blending: THREE.AdditiveBlending,
+            uniforms: {
+                uMap: { value: sparkTexture(THREE) },
+                uScale: { value: 520 }
+            },
+            vertexShader: /* glsl */ `
+                attribute vec3 aColor;
+                attribute float aSize;
+                attribute float aAlpha;
+                varying vec3 vColor;
+                varying float vAlpha;
+                uniform float uScale;
+                void main() {
+                    vColor = aColor;
+                    vAlpha = aAlpha;
+                    vec4 mv = modelViewMatrix * vec4(position, 1.0);
+                    gl_PointSize = aSize * uScale / max(0.001, -mv.z);
+                    gl_Position = projectionMatrix * mv;
+                }
+            `,
+            fragmentShader: /* glsl */ `
+                uniform sampler2D uMap;
+                varying vec3 vColor;
+                varying float vAlpha;
+                void main() {
+                    if (vAlpha < 0.01) discard;
+                    vec4 tex = texture2D(uMap, gl_PointCoord);
+                    gl_FragColor = vec4(vColor * tex.rgb, tex.a * vAlpha);
+                    #include <tonemapping_fragment>
+                    #include <colorspace_fragment>
+                }
+            `
+        }));
+        scene.add(this.points);
+    }
+
+    spawn(x, y, z, { count = 12, color = [1, 0.3, 0.85], speed = 6, size = 0.7, life = 0.5 } = {}) {
+        for (let i = 0; i < count; i++) {
+            const id = this.cursor++ % this.max;
+            const i3 = id * 3;
+            this.pos[i3] = x;
+            this.pos[i3 + 1] = y;
+            this.pos[i3 + 2] = z;
+            this.vel[i3] = (Math.random() - 0.5) * speed;
+            this.vel[i3 + 1] = Math.random() * speed * 0.8;
+            this.vel[i3 + 2] = (Math.random() - 0.5) * speed;
+            this.col[i3] = color[0];
+            this.col[i3 + 1] = color[1];
+            this.col[i3 + 2] = color[2];
+            this.size[id] = size * (0.6 + Math.random() * 0.8);
+            this.life[id] = life;
+            this.maxLife[id] = life;
+            this.alpha[id] = 1;
+        }
+    }
+
+    trail(x, y, z, color) {
+        this.spawn(x, y, z, { count: 3, color, speed: 1.4, size: 0.45, life: 0.28 });
+    }
+
+    update(dt) {
+        for (let i = 0; i < this.max; i++) {
+            if (this.life[i] <= 0) {
+                this.alpha[i] = 0;
+                continue;
+            }
+            this.life[i] -= dt;
+            const i3 = i * 3;
+            this.pos[i3] += this.vel[i3] * dt;
+            this.pos[i3 + 1] += this.vel[i3 + 1] * dt;
+            this.pos[i3 + 2] += this.vel[i3 + 2] * dt;
+            this.vel[i3 + 1] -= 6 * dt;
+            this.alpha[i] = Math.max(0, this.life[i] / this.maxLife[i]);
+        }
+        this.geo.attributes.position.needsUpdate = true;
+        this.geo.attributes.aColor.needsUpdate = true;
+        this.geo.attributes.aSize.needsUpdate = true;
+        this.geo.attributes.aAlpha.needsUpdate = true;
+    }
+}

--- a/labs/neon-rider/src/hud.js
+++ b/labs/neon-rider/src/hud.js
@@ -1,0 +1,170 @@
+/**
+ * HUD, menus arcade e overlays. Sem lógica 3D aqui.
+ */
+
+import { DIFFICULTY } from './config.js';
+import { formatKm, formatTime } from './utils.js';
+
+const $ = (id) => document.getElementById(id);
+
+export class Hud {
+    constructor() {
+        this.el = {
+            hud: $('hud'),
+            speed: $('speedValue'),
+            km: $('kmValue'),
+            tapes: $('tapeValue'),
+            lives: $('livesValue'),
+            radio: $('radioValue'),
+            radioTag: $('radioTag'),
+            boostFill: $('boostFill'),
+            fps: $('fpsCounter'),
+            message: $('message'),
+            touch: $('touchControls'),
+            soundButton: $('soundButton'),
+            pauseButton: $('pauseButton'),
+            loading: $('loadingOverlay'),
+            loadingFill: $('loadingFill'),
+            loadingText: $('loadingText'),
+            menu: $('menuOverlay'),
+            pause: $('pauseOverlay'),
+            gameOver: $('gameOverOverlay'),
+            error: $('errorOverlay'),
+            errorText: $('errorText'),
+            difficultyOptions: $('difficultyOptions'),
+            difficultyBlurb: $('difficultyBlurb'),
+            qualitySelect: $('qualitySelect'),
+            volumeSlider: $('volumeSlider'),
+            volumeValue: $('volumeValue'),
+            bestScore: $('bestScore'),
+            overStats: $('overStats'),
+            crt: document.querySelector('.crt-overlay'),
+            glitch: $('glitchLayer')
+        };
+        this.msgTimer = 0;
+        this.buildDifficulties('night');
+    }
+
+    setState(state) {
+        document.body.dataset.state = state;
+    }
+
+    setLoading(p, text) {
+        if (text) this.el.loadingText.textContent = text;
+        this.el.loadingFill.style.width = `${Math.round(p * 100)}%`;
+    }
+
+    hideLoading() {
+        this.el.loading.hidden = true;
+    }
+
+    showError(msg) {
+        if (msg) this.el.errorText.textContent = msg;
+        this.el.error.hidden = false;
+        this.el.loading.hidden = true;
+    }
+
+    showMenu(on) {
+        this.el.menu.hidden = !on;
+        this.el.hud.hidden = on;
+    }
+
+    showPause(on) {
+        this.el.pause.hidden = !on;
+    }
+
+    showGameOver(on) {
+        this.el.gameOver.hidden = !on;
+    }
+
+    showHud(on) {
+        this.el.hud.hidden = !on;
+    }
+
+    setTouchVisible(on) {
+        this.el.touch.hidden = !on;
+    }
+
+    setMuted(on) {
+        this.el.soundButton.setAttribute('aria-pressed', String(!on));
+        this.el.soundButton.textContent = on ? '×♪' : '♪';
+    }
+
+    setFps(fps) {
+        if (!this.el.fps) return;
+        this.el.fps.textContent = `${fps | 0} fps`;
+    }
+
+    flashGlitch() {
+        this.el.glitch.classList.add('is-on');
+        clearTimeout(this._g);
+        this._g = setTimeout(() => this.el.glitch.classList.remove('is-on'), 420);
+    }
+
+    message(text, ms = 1600) {
+        this.el.message.textContent = text;
+        this.el.message.dataset.show = 'true';
+        clearTimeout(this.msgTimer);
+        this.msgTimer = setTimeout(() => {
+            this.el.message.dataset.show = 'false';
+        }, ms);
+    }
+
+    update({ speed, distance, tapes, lives, station, boost, time }) {
+        this.el.speed.textContent = String(Math.round(speed * 4.2)).padStart(3, '0');
+        this.el.km.textContent = formatKm(distance);
+        this.el.tapes.textContent = String(tapes).padStart(2, '0');
+        this.el.lives.textContent = '■'.repeat(lives) + '□'.repeat(Math.max(0, 5 - lives));
+        this.el.radio.textContent = station.name;
+        this.el.radioTag.textContent = station.tagline;
+        this.el.boostFill.style.width = `${Math.round(boost * 100)}%`;
+        this._time = time;
+    }
+
+    setBest(score) {
+        this.el.bestScore.textContent = score ? formatKm(score) : '—';
+    }
+
+    setOverStats({ distance, tapes, time, score }) {
+        this.el.overStats.innerHTML = `
+            <div><span>Distância</span><b>${formatKm(distance)}</b></div>
+            <div><span>Fitas</span><b>${tapes}</b></div>
+            <div><span>Tempo</span><b>${formatTime(time)}</b></div>
+            <div><span>Score</span><b>${score.toLocaleString('pt-BR')}</b></div>
+        `;
+    }
+
+    buildDifficulties(current, onPick) {
+        const root = this.el.difficultyOptions;
+        root.innerHTML = '';
+        Object.values(DIFFICULTY).forEach((d) => {
+            const btn = document.createElement('button');
+            btn.type = 'button';
+            btn.className = 'chip';
+            btn.textContent = d.label;
+            btn.dataset.id = d.id;
+            btn.setAttribute('aria-pressed', String(d.id === current));
+            btn.addEventListener('click', () => {
+                root.querySelectorAll('.chip').forEach((c) => c.setAttribute('aria-pressed', 'false'));
+                btn.setAttribute('aria-pressed', 'true');
+                this.el.difficultyBlurb.textContent = d.blurb;
+                onPick?.(d.id);
+            });
+            root.appendChild(btn);
+        });
+        this.el.difficultyBlurb.textContent = DIFFICULTY[current].blurb;
+        this._onPick = onPick;
+    }
+
+    bindSettings({ quality, volume, onQuality, onVolume }) {
+        this.el.qualitySelect.value = quality;
+        this.el.volumeSlider.value = String(volume);
+        this.el.volumeValue.textContent = String(volume);
+        this.el.qualitySelect.addEventListener('change', () => onQuality(this.el.qualitySelect.value));
+        this.el.volumeSlider.addEventListener('input', () => {
+            const v = Number(this.el.volumeSlider.value);
+            this.el.volumeValue.textContent = String(v);
+            onVolume(v);
+        });
+    }
+}

--- a/labs/neon-rider/src/input.js
+++ b/labs/neon-rider/src/input.js
@@ -1,0 +1,99 @@
+/**
+ * Teclado, toque e ações globais (pausa, mudo, câmera).
+ */
+
+const STEER = {
+    ArrowLeft: -1,
+    KeyA: -1,
+    ArrowRight: 1,
+    KeyD: 1
+};
+
+const HOLD = {
+    ArrowUp: 'boost',
+    KeyW: 'boost',
+    ShiftLeft: 'boost',
+    ShiftRight: 'boost',
+    ArrowDown: 'brake',
+    KeyS: 'brake',
+    Space: 'boost'
+};
+
+const ACTIONS = {
+    KeyP: 'pause',
+    Escape: 'pause',
+    KeyM: 'mute',
+    KeyC: 'camera',
+    Enter: 'confirm',
+    KeyR: 'radio'
+};
+
+export class Input {
+    constructor() {
+        this.steer = 0;
+        this.boost = false;
+        this.brake = false;
+        this.keys = new Set();
+        this.listeners = new Map();
+        this.touchSteer = 0;
+        this.touchBoost = false;
+        this.touchBrake = false;
+        this.enabled = true;
+
+        this._onKeyDown = (e) => {
+            if (ACTIONS[e.code]) {
+                if (ACTIONS[e.code] === 'confirm' && document.activeElement?.tagName === 'BUTTON') return;
+                this.emit(ACTIONS[e.code]);
+                e.preventDefault();
+            }
+            if (STEER[e.code] !== undefined || HOLD[e.code]) {
+                this.keys.add(e.code);
+                e.preventDefault();
+            }
+        };
+        this._onKeyUp = (e) => {
+            this.keys.delete(e.code);
+        };
+
+        window.addEventListener('keydown', this._onKeyDown);
+        window.addEventListener('keyup', this._onKeyUp);
+    }
+
+    on(action, fn) {
+        if (!this.listeners.has(action)) this.listeners.set(action, new Set());
+        this.listeners.get(action).add(fn);
+    }
+
+    emit(action) {
+        this.listeners.get(action)?.forEach((fn) => fn());
+    }
+
+    setTouchSteer(v) {
+        this.touchSteer = v;
+    }
+
+    setTouchBoost(v) {
+        this.touchBoost = v;
+    }
+
+    setTouchBrake(v) {
+        this.touchBrake = v;
+    }
+
+    sample() {
+        if (!this.enabled) {
+            this.steer = 0;
+            this.boost = false;
+            this.brake = false;
+            return this;
+        }
+        let s = this.touchSteer;
+        for (const code of this.keys) {
+            if (STEER[code] !== undefined) s += STEER[code];
+        }
+        this.steer = Math.max(-1, Math.min(1, s));
+        this.boost = this.touchBoost || [...this.keys].some((c) => HOLD[c] === 'boost');
+        this.brake = this.touchBrake || [...this.keys].some((c) => HOLD[c] === 'brake');
+        return this;
+    }
+}

--- a/labs/neon-rider/src/main.js
+++ b/labs/neon-rider/src/main.js
@@ -419,12 +419,14 @@ class Game {
         const playing = this.state === 'playing';
         this.input.sample();
         const auto = (!playing || this.player.auto) ? this.traffic.autoSteer(this.player) : 0;
-        const input = playing ? this.input : { steer: auto, boost: false, brake: false };
+        const input = playing
+            ? this.input
+            : { steer: auto, boost: false, brake: false };
 
         if (playing && this.input.boost && !this.boostHeld) this.audio.boostWhoosh();
         this.boostHeld = playing && this.input.boost;
 
-        this.player.update(dt, input, playing ? 0 : auto);
+        this.player.update(dt, input, 0);
         this.city.recycle(this.player.z);
         this.city.updateLights(this.player.z);
         this.traffic.update(dt, this.player);

--- a/labs/neon-rider/src/main.js
+++ b/labs/neon-rider/src/main.js
@@ -119,7 +119,7 @@ class Game {
         this.mats = createSharedMaterials(st);
 
         this.hud.setLoading(0.4, 'Asfaltando a avenida…');
-        this.road = createRoad(st);
+            this.road = createRoad(st, this.quality.fogDensity);
         this.scene.add(this.road.group);
 
         this.hud.setLoading(0.55, 'Erguendo o distrito…');
@@ -209,6 +209,7 @@ class Game {
         this.road?.uniforms.uNeonA.value.setHex(st.neonA);
         this.road?.uniforms.uNeonB.value.setHex(st.neonB);
         this.road?.uniforms.uAsphalt.value.setHex(st.asphalt);
+        this.road?.uniforms.uFogColor.value.setHex(st.fog);
         if (this.hemi) {
             this.hemi.color.setHex(st.horizon);
             this.hemi.groundColor.setHex(st.ground);

--- a/labs/neon-rider/src/main.js
+++ b/labs/neon-rider/src/main.js
@@ -96,9 +96,9 @@ class Game {
         this.scene.background = new THREE.Color(st.zenith);
 
         this.hud.setLoading(0.22, 'Pintando a madrugada…');
-        this.sky = createSky();
-        this.scene.add(this.sky.mesh);
-        this.applyStation(st, true);
+        try {
+            this.sky = createSky();
+            this.scene.add(this.sky.mesh);
 
         this.hemi = new THREE.HemisphereLight(st.horizon, st.ground, 0.55);
         this.scene.add(this.hemi);
@@ -139,6 +139,8 @@ class Game {
         this.audio.volume = this.settings.volume / 100;
         this.input = new Input();
 
+        this.applyStation(st, true);
+
         this.hud.setLoading(0.86, 'Ligando o bloom…');
         await this.setupPostProcessing();
 
@@ -155,9 +157,13 @@ class Game {
         this.lastFrame = performance.now();
         this.renderer.setAnimationLoop((now) => this.frame(now));
         window.addEventListener('resize', () => this.resize());
-        document.addEventListener('visibilitychange', () => {
-            if (document.hidden && this.state === 'playing') this.pause();
-        });
+            document.addEventListener('visibilitychange', () => {
+                if (document.hidden && this.state === 'playing') this.pause();
+            });
+        } catch (err) {
+            console.error(err);
+            this.hud.showError(err?.message || 'Falha ao montar a avenida 3D.');
+        }
     }
 
     async setupPostProcessing() {
@@ -197,12 +203,12 @@ class Game {
     flushStation(st) {
         this.scene.fog.color.setHex(st.fog);
         this.scene.background.setHex(st.zenith);
-        this.sky.uniforms.uHorizon.value.setHex(st.horizon);
-        this.sky.uniforms.uZenith.value.setHex(st.zenith);
-        this.sky.uniforms.uGround.value.setHex(st.ground);
-        this.road.uniforms.uNeonA.value.setHex(st.neonA);
-        this.road.uniforms.uNeonB.value.setHex(st.neonB);
-        this.road.uniforms.uAsphalt.value.setHex(st.asphalt);
+        this.sky?.uniforms.uHorizon.value.setHex(st.horizon);
+        this.sky?.uniforms.uZenith.value.setHex(st.zenith);
+        this.sky?.uniforms.uGround.value.setHex(st.ground);
+        this.road?.uniforms.uNeonA.value.setHex(st.neonA);
+        this.road?.uniforms.uNeonB.value.setHex(st.neonB);
+        this.road?.uniforms.uAsphalt.value.setHex(st.asphalt);
         if (this.hemi) {
             this.hemi.color.setHex(st.horizon);
             this.hemi.groundColor.setHex(st.ground);
@@ -538,4 +544,7 @@ function hexToArr(hex) {
 }
 
 const game = new Game();
-game.init();
+game.init().catch((err) => {
+    console.error(err);
+    game.hud.showError(err?.message || 'Falha ao iniciar o Neon Rider.');
+});

--- a/labs/neon-rider/src/main.js
+++ b/labs/neon-rider/src/main.js
@@ -1,0 +1,539 @@
+/**
+ * Neon Rider — laço principal.
+ * Avenida infinita à noite: a moto corre no −Z, quarteirões reciclam,
+ * e cada fita VHS retuna o néon e a rádio.
+ */
+
+import * as THREE from 'three';
+
+import {
+    QUALITY, DIFFICULTY, STATIONS, loadSettings, saveSettings
+} from './config.js';
+import { clamp, damp, detectMobile, detectSoftwareGL } from './utils.js';
+import { createSharedMaterials, tintMaterials } from './models.js';
+import { City, createSky, createRoad } from './world.js';
+import { Player } from './player.js';
+import { Traffic } from './traffic.js';
+import { Effects } from './effects.js';
+import { GameAudio } from './audio.js';
+import { Input } from './input.js';
+import { Hud } from './hud.js';
+
+const CAMERAS = [
+    { name: 'perseguição', offset: new THREE.Vector3(0, 2.55, 7.4), look: new THREE.Vector3(0, 1.15, -12) },
+    { name: 'capacete', offset: new THREE.Vector3(0, 1.48, 0.55), look: new THREE.Vector3(0, 1.22, -14) },
+    { name: 'cinema', offset: new THREE.Vector3(3.4, 1.15, 5.1), look: new THREE.Vector3(-0.4, 0.95, -9) }
+];
+
+const LOOK = new THREE.Vector3();
+const CAM = new THREE.Vector3();
+
+class Game {
+    constructor() {
+        this.settings = loadSettings();
+        this.state = 'boot';
+        this.hud = new Hud();
+        this.canvas = document.getElementById('scene');
+        this.stationIndex = 0;
+        this.tapes = 0;
+        this.lives = 3;
+        this.distance = 0;
+        this.time = 0;
+        this.cameraMode = 0;
+        this.fpsAccum = 0;
+        this.fpsFrames = 0;
+        this.boostHeld = false;
+        this.paletteMix = 1;
+    }
+
+    resolveQuality() {
+        const choice = this.settings.quality;
+        if (choice !== 'auto' && QUALITY[choice]) return QUALITY[choice];
+        if (detectMobile() || detectSoftwareGL()) return QUALITY.low;
+        const big = Math.min(window.innerWidth, window.innerHeight) >= 900;
+        return big ? QUALITY.high : QUALITY.medium;
+    }
+
+    station() {
+        return STATIONS[this.stationIndex % STATIONS.length];
+    }
+
+    async init() {
+        this.hud.setLoading(0.08, 'Aquecendo o CRT…');
+        if (document.fonts?.ready) await document.fonts.ready;
+        this.quality = this.resolveQuality();
+
+        try {
+            this.renderer = new THREE.WebGLRenderer({
+                canvas: this.canvas,
+                antialias: this.quality.antialias,
+                powerPreference: 'high-performance',
+                stencil: false
+            });
+        } catch (err) {
+            this.hud.showError('Não foi possível iniciar o WebGL neste navegador.');
+            return;
+        }
+
+        const pr = Math.min(window.devicePixelRatio || 1, this.quality.pixelRatio);
+        this.renderer.setPixelRatio(pr);
+        this.renderer.setSize(window.innerWidth, window.innerHeight, false);
+        this.renderer.toneMapping = THREE.ACESFilmicToneMapping;
+        this.renderer.toneMappingExposure = 1.12;
+        this.renderer.shadowMap.enabled = this.quality.shadows;
+        this.renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+
+        this.scene = new THREE.Scene();
+        this.camera = new THREE.PerspectiveCamera(
+            58,
+            window.innerWidth / window.innerHeight,
+            0.2,
+            this.quality.drawDistance * 1.6
+        );
+
+        const st = this.station();
+        this.scene.fog = new THREE.FogExp2(st.fog, this.quality.fogDensity);
+        this.scene.background = new THREE.Color(st.zenith);
+
+        this.hud.setLoading(0.22, 'Pintando a madrugada…');
+        this.sky = createSky();
+        this.scene.add(this.sky.mesh);
+        this.applyStation(st, true);
+
+        this.hemi = new THREE.HemisphereLight(st.horizon, st.ground, 0.55);
+        this.scene.add(this.hemi);
+        this.sun = new THREE.DirectionalLight(st.neonB, 0.55);
+        this.sun.position.set(-8, 18, 10);
+        this.sun.castShadow = this.quality.shadows;
+        if (this.quality.shadows) {
+            this.sun.shadow.mapSize.set(1024, 1024);
+            this.sun.shadow.camera.near = 2;
+            this.sun.shadow.camera.far = 80;
+            this.sun.shadow.camera.left = -20;
+            this.sun.shadow.camera.right = 20;
+            this.sun.shadow.camera.top = 20;
+            this.sun.shadow.camera.bottom = -20;
+        }
+        this.scene.add(this.sun, this.sun.target);
+
+        this.mats = createSharedMaterials(st);
+
+        this.hud.setLoading(0.4, 'Asfaltando a avenida…');
+        this.road = createRoad(st);
+        this.scene.add(this.road.group);
+
+        this.hud.setLoading(0.55, 'Erguendo o distrito…');
+        this.city = new City(this.scene, this.quality, this.mats);
+
+        this.hud.setLoading(0.7, 'Montando a moto…');
+        this.player = new Player(this.scene, this.mats);
+        this.headlight = new THREE.SpotLight(0xfff2d8, 3.2, 48, 0.42, 0.45, 1.1);
+        this.headlight.position.set(0, 1.1, 0);
+        this.headlight.target.position.set(0, 0.4, -16);
+        this.scene.add(this.headlight, this.headlight.target);
+
+        this.traffic = new Traffic(this.scene, this.mats, this.quality);
+        this.effects = new Effects(this.scene, this.quality);
+        this.audio = new GameAudio();
+        this.audio.enabled = !this.settings.muted;
+        this.audio.volume = this.settings.volume / 100;
+        this.input = new Input();
+
+        this.hud.setLoading(0.86, 'Ligando o bloom…');
+        await this.setupPostProcessing();
+
+        this.bindUi();
+        this.isTouch = detectMobile();
+
+        this.enterAttract();
+        this.renderer.compile(this.scene, this.camera);
+        this.render();
+
+        this.hud.setLoading(1, 'INSERT COIN');
+        setTimeout(() => this.hud.hideLoading(), 280);
+
+        this.lastFrame = performance.now();
+        this.renderer.setAnimationLoop((now) => this.frame(now));
+        window.addEventListener('resize', () => this.resize());
+        document.addEventListener('visibilitychange', () => {
+            if (document.hidden && this.state === 'playing') this.pause();
+        });
+    }
+
+    async setupPostProcessing() {
+        if (!this.quality.bloom) return;
+        try {
+            const [{ EffectComposer }, { RenderPass }, { UnrealBloomPass }, { OutputPass }] = await Promise.all([
+                import('three/addons/postprocessing/EffectComposer.js'),
+                import('three/addons/postprocessing/RenderPass.js'),
+                import('three/addons/postprocessing/UnrealBloomPass.js'),
+                import('three/addons/postprocessing/OutputPass.js')
+            ]);
+            const composer = new EffectComposer(this.renderer);
+            composer.setPixelRatio(this.renderer.getPixelRatio());
+            composer.setSize(window.innerWidth, window.innerHeight);
+            composer.addPass(new RenderPass(this.scene, this.camera));
+            const bloom = new UnrealBloomPass(
+                new THREE.Vector2(window.innerWidth, window.innerHeight),
+                0.42,
+                0.55,
+                0.42
+            );
+            composer.addPass(bloom);
+            composer.addPass(new OutputPass());
+            this.composer = composer;
+            this.bloom = bloom;
+        } catch (err) {
+            this.composer = null;
+        }
+    }
+
+    applyStation(st, instant = false) {
+        this.targetStation = st;
+        this.paletteMix = instant ? 1 : 0;
+        if (instant) this.flushStation(st);
+    }
+
+    flushStation(st) {
+        this.scene.fog.color.setHex(st.fog);
+        this.scene.background.setHex(st.zenith);
+        this.sky.uniforms.uHorizon.value.setHex(st.horizon);
+        this.sky.uniforms.uZenith.value.setHex(st.zenith);
+        this.sky.uniforms.uGround.value.setHex(st.ground);
+        this.road.uniforms.uNeonA.value.setHex(st.neonA);
+        this.road.uniforms.uNeonB.value.setHex(st.neonB);
+        this.road.uniforms.uAsphalt.value.setHex(st.asphalt);
+        if (this.hemi) {
+            this.hemi.color.setHex(st.horizon);
+            this.hemi.groundColor.setHex(st.ground);
+        }
+        if (this.sun) this.sun.color.setHex(st.neonB);
+        if (this.mats) tintMaterials(this.mats, st);
+        this.city?.setStation(st);
+        if (this.player) {
+            this.player.root.userData.glow.material.color.setHex(st.neonA);
+            this.player.root.userData.paint.emissive.setHex(st.neonA);
+            this.player.root.userData.paint.emissiveIntensity = 0.35;
+        }
+        this.audio?.setStation(this.stationIndex);
+        document.documentElement.style.setProperty('--neon-a', '#' + st.neonA.toString(16).padStart(6, '0'));
+        document.documentElement.style.setProperty('--neon-b', '#' + st.neonB.toString(16).padStart(6, '0'));
+    }
+
+    bindUi() {
+        const hud = this.hud;
+        hud.buildDifficulties(this.settings.difficulty, (id) => {
+            this.settings.difficulty = id;
+            saveSettings(this.settings);
+        });
+        hud.bindSettings({
+            quality: this.settings.quality,
+            volume: this.settings.volume,
+            onQuality: (q) => {
+                this.settings.quality = q;
+                saveSettings(this.settings);
+            },
+            onVolume: (v) => {
+                this.settings.volume = v;
+                this.audio.setVolume(v / 100);
+                saveSettings(this.settings);
+            }
+        });
+        hud.setBest(this.settings.best);
+        hud.setMuted(this.settings.muted);
+
+        document.getElementById('startButton').addEventListener('click', () => this.start());
+        document.getElementById('resumeButton').addEventListener('click', () => this.resume());
+        document.getElementById('pauseMenuButton').addEventListener('click', () => this.enterAttract());
+        document.getElementById('retryButton').addEventListener('click', () => this.start());
+        document.getElementById('overMenuButton').addEventListener('click', () => this.enterAttract());
+        hud.el.soundButton.addEventListener('click', () => this.toggleMute());
+        hud.el.pauseButton.addEventListener('click', () => {
+            if (this.state === 'playing') this.pause();
+            else if (this.state === 'paused') this.resume();
+        });
+
+        this.input.on('pause', () => {
+            if (this.state === 'playing') this.pause();
+            else if (this.state === 'paused') this.resume();
+        });
+        this.input.on('mute', () => this.toggleMute());
+        this.input.on('camera', () => {
+            this.cameraMode = (this.cameraMode + 1) % CAMERAS.length;
+            this.hud.message(CAMERAS[this.cameraMode].name, 900);
+        });
+        this.input.on('confirm', () => {
+            if (this.state === 'menu') this.start();
+            else if (this.state === 'over') this.start();
+            else if (this.state === 'paused') this.resume();
+        });
+        this.input.on('radio', () => {
+            if (this.state !== 'playing' && this.state !== 'menu') return;
+            this.cycleStation();
+        });
+
+        this.bindTouch();
+    }
+
+    bindTouch() {
+        const zone = document.getElementById('steerZone');
+        const boost = document.getElementById('touchBoost');
+        const brake = document.getElementById('touchBrake');
+        if (!zone) return;
+
+        const readSteer = (e) => {
+            const t = e.touches?.[0] || e.changedTouches?.[0];
+            if (!t) return;
+            const r = zone.getBoundingClientRect();
+            const x = ((t.clientX - r.left) / r.width) * 2 - 1;
+            this.input.setTouchSteer(clamp(x * 1.4, -1, 1));
+        };
+        zone.addEventListener('touchstart', (e) => { e.preventDefault(); readSteer(e); }, { passive: false });
+        zone.addEventListener('touchmove', (e) => { e.preventDefault(); readSteer(e); }, { passive: false });
+        zone.addEventListener('touchend', () => this.input.setTouchSteer(0));
+
+        const hold = (el, setter) => {
+            el.addEventListener('touchstart', (e) => { e.preventDefault(); setter(true); }, { passive: false });
+            el.addEventListener('touchend', () => setter(false));
+            el.addEventListener('touchcancel', () => setter(false));
+        };
+        hold(boost, (v) => this.input.setTouchBoost(v));
+        hold(brake, (v) => this.input.setTouchBrake(v));
+    }
+
+    toggleMute() {
+        this.settings.muted = !this.settings.muted;
+        this.audio.setEnabled(!this.settings.muted);
+        this.hud.setMuted(this.settings.muted);
+        saveSettings(this.settings);
+        if (!this.settings.muted) this.audio.resume();
+    }
+
+    cycleStation() {
+        this.stationIndex = (this.stationIndex + 1) % STATIONS.length;
+        this.applyStation(this.station(), false);
+        this.hud.message(this.station().name, 1200);
+        this.audio.collect();
+    }
+
+    enterAttract() {
+        this.state = 'menu';
+        this.hud.setState('menu');
+        this.hud.showMenu(true);
+        this.hud.showPause(false);
+        this.hud.showGameOver(false);
+        this.hud.setTouchVisible(false);
+        this.resetRun(true);
+        this.player.auto = true;
+    }
+
+    start() {
+        this.audio.resume();
+        this.resetRun(false);
+        this.state = 'playing';
+        this.hud.setState('playing');
+        this.hud.showMenu(false);
+        this.hud.showGameOver(false);
+        this.hud.showPause(false);
+        this.hud.showHud(true);
+        this.hud.setTouchVisible(this.isTouch);
+        this.hud.message('NOITE AFORA', 1400);
+    }
+
+    resetRun(attract) {
+        const diff = DIFFICULTY[this.settings.difficulty];
+        this.lives = attract ? 99 : diff.lives;
+        this.tapes = 0;
+        this.distance = 0;
+        this.time = 0;
+        this.stationIndex = 0;
+        this.applyStation(this.station(), true);
+        this.player.reset({ maxSpeed: diff.maxSpeed });
+        this.player.auto = attract;
+        this.city.reset((Math.random() * 9999) | 0);
+        this.traffic.setDifficulty(diff);
+        this.traffic.reset(this.player.z);
+        this.updateCamera(1, true);
+    }
+
+    pause() {
+        if (this.state !== 'playing') return;
+        this.state = 'paused';
+        this.hud.setState('paused');
+        this.hud.showPause(true);
+    }
+
+    resume() {
+        if (this.state !== 'paused') return;
+        this.state = 'playing';
+        this.hud.setState('playing');
+        this.hud.showPause(false);
+        this.lastFrame = performance.now();
+        this.audio.resume();
+    }
+
+    gameOver() {
+        this.state = 'over';
+        this.player.alive = false;
+        const score = Math.floor(this.distance + this.tapes * 480);
+        if (this.distance > (this.settings.best || 0)) {
+            this.settings.best = Math.floor(this.distance);
+            saveSettings(this.settings);
+            this.hud.setBest(this.settings.best);
+        }
+        this.hud.setOverStats({
+            distance: this.distance,
+            tapes: this.tapes,
+            time: this.time,
+            score
+        });
+        this.hud.showGameOver(true);
+        this.hud.showHud(false);
+        this.hud.setTouchVisible(false);
+        this.hud.setState('over');
+    }
+
+    frame(now) {
+        const dt = clamp((now - this.lastFrame) / 1000, 0, 0.05);
+        this.lastFrame = now;
+
+        if (this.paletteMix < 1 && this.targetStation) {
+            this.paletteMix = Math.min(1, this.paletteMix + dt * 2.4);
+            this.flushStation(this.targetStation);
+        }
+
+        if (this.state === 'playing' || this.state === 'menu') this.simulate(dt);
+        this.updateCamera(dt, false);
+        this.render();
+
+        this.fpsAccum += dt;
+        this.fpsFrames += 1;
+        if (this.fpsAccum >= 0.4) {
+            this.hud.setFps(this.fpsFrames / this.fpsAccum);
+            this.fpsAccum = 0;
+            this.fpsFrames = 0;
+        }
+    }
+
+    simulate(dt) {
+        const playing = this.state === 'playing';
+        this.input.sample();
+        const auto = (!playing || this.player.auto) ? this.traffic.autoSteer(this.player) : 0;
+        const input = playing ? this.input : { steer: auto, boost: false, brake: false };
+
+        if (playing && this.input.boost && !this.boostHeld) this.audio.boostWhoosh();
+        this.boostHeld = playing && this.input.boost;
+
+        this.player.update(dt, input, playing ? 0 : auto);
+        this.city.recycle(this.player.z);
+        this.city.updateLights(this.player.z);
+        this.traffic.update(dt, this.player);
+
+        this.road.group.position.z = this.player.z - 80;
+        this.road.uniforms.uZ.value = this.player.z;
+        this.sky.mesh.position.set(this.player.x * 0.05, 0, this.player.z);
+        this.sun.position.set(this.player.x - 8, 18, this.player.z + 10);
+        this.sun.target.position.set(this.player.x, 0, this.player.z - 20);
+        this.headlight.position.set(this.player.x, 1.15, this.player.z + 0.6);
+        this.headlight.target.position.set(this.player.x, 0.3, this.player.z - 18);
+
+        if (playing) {
+            this.time += dt;
+            this.distance += this.player.speed * dt * 2.4;
+
+            const collected = this.traffic.collectTapes(this.player);
+            if (collected.length) {
+                this.tapes += collected.length;
+                this.stationIndex = this.tapes % STATIONS.length;
+                this.applyStation(this.station(), false);
+                this.audio.collect();
+                this.hud.message(this.station().name, 1100);
+                for (const tape of collected) {
+                    this.effects.spawn(tape.x, 1.2, tape.z, {
+                        count: 22,
+                        color: hexToArr(this.station().neonB),
+                        speed: 8,
+                        size: 0.8,
+                        life: 0.55
+                    });
+                }
+            }
+
+            const crash = this.traffic.collideCars(this.player);
+            if (crash && this.player.hit()) {
+                this.lives -= 1;
+                this.audio.crash();
+                this.hud.flashGlitch();
+                this.effects.spawn(this.player.x, 0.8, this.player.z, {
+                    count: 40,
+                    color: [1, 0.4, 0.2],
+                    speed: 10,
+                    size: 0.9,
+                    life: 0.6
+                });
+                if (this.lives <= 0) this.gameOver();
+                else this.hud.message('BATIDA', 700);
+            }
+
+            if (this.input.boost && this.player.boost > 0.05) {
+                this.effects.trail(
+                    this.player.x,
+                    0.2,
+                    this.player.z + 1.1,
+                    hexToArr(this.station().neonA)
+                );
+            }
+
+            this.hud.update({
+                speed: this.player.speed,
+                distance: this.distance,
+                tapes: this.tapes,
+                lives: this.lives,
+                station: this.station(),
+                boost: this.player.boost,
+                time: this.time
+            });
+        }
+
+        this.effects.update(dt);
+        this.audio.update(dt, this.player.speed, this.input.boost && playing);
+    }
+
+    updateCamera(dt, instant) {
+        const rig = CAMERAS[this.cameraMode];
+        CAM.copy(rig.offset);
+        CAM.x += this.player.x;
+        CAM.z += this.player.z;
+        LOOK.copy(rig.look);
+        LOOK.x += this.player.x;
+        LOOK.z += this.player.z;
+        const k = instant ? 1 : 1 - Math.exp(-dt * (this.cameraMode === 1 ? 14 : 6));
+        this.camera.position.lerp(CAM, k);
+        if (!this._look) this._look = LOOK.clone();
+        this._look.lerp(LOOK, k);
+        this.camera.lookAt(this._look);
+        this.camera.fov = damp(this.camera.fov, 56 + this.player.speed * 0.18, 4, dt);
+        this.camera.updateProjectionMatrix();
+    }
+
+    render() {
+        if (this.composer) this.composer.render();
+        else this.renderer.render(this.scene, this.camera);
+    }
+
+    resize() {
+        const w = window.innerWidth;
+        const h = window.innerHeight;
+        this.camera.aspect = w / h;
+        this.camera.updateProjectionMatrix();
+        this.renderer.setSize(w, h, false);
+        this.composer?.setSize(w, h);
+    }
+}
+
+function hexToArr(hex) {
+    return [((hex >> 16) & 255) / 255, ((hex >> 8) & 255) / 255, (hex & 255) / 255];
+}
+
+const game = new Game();
+game.init();

--- a/labs/neon-rider/src/models.js
+++ b/labs/neon-rider/src/models.js
@@ -262,19 +262,17 @@ export function createLamp(mats) {
     return g;
 }
 
-export function createBuilding(mats, rng, density) {
+export function createBuilding(mats, rng, density, side = 1) {
     const g = new THREE.Group();
     const w = 5.5 + rng() * 7.5;
     const d = 7 + rng() * 11;
     const h = 8 + rng() ** 1.4 * (28 + density * 18);
 
     const body = mesh(BOX, mats.body, w, h, d, 0, h / 2, 0);
-    body.material = mats.body;
     g.add(body);
 
-    const stripSide = rng() > 0.5 ? 1 : -1;
     const strip = mesh(BOX, rng() > 0.5 ? mats.neonA : mats.neonB, 0.16, h * 0.92, 0.16,
-        stripSide * (w / 2 + 0.08), h / 2, d / 2 + 0.08);
+        -side * (w / 2 + 0.08), h / 2, (rng() - 0.5) * d * 0.6);
     g.add(strip);
 
     if (rng() > 0.35) {
@@ -288,7 +286,8 @@ export function createBuilding(mats, rng, density) {
             side: THREE.DoubleSide
         });
         const sign = new THREE.Mesh(new THREE.PlaneGeometry(Math.min(w * 0.9, 6.5), 1.15), signMat);
-        sign.position.set(0, 3.2 + rng() * (h * 0.4), d / 2 + 0.12);
+        sign.position.set(-side * (w / 2 + 0.12), 3.2 + rng() * (h * 0.4), 0);
+        sign.rotation.y = side > 0 ? Math.PI / 2 : -Math.PI / 2;
         g.add(sign);
         g.userData.signMat = signMat;
         g.userData.signColor = color;

--- a/labs/neon-rider/src/models.js
+++ b/labs/neon-rider/src/models.js
@@ -1,0 +1,322 @@
+/**
+ * Modelos low-poly: moto cromada, carros 80s, prédios, palmeiras, postes e fitas VHS.
+ * Tudo é primitiva + material emissivo — o bloom cuida do brilho.
+ */
+
+import * as THREE from 'three';
+import { neonSignTexture, SIGN_WORDS, windowTexture } from './textures.js';
+import { pick } from './utils.js';
+
+const BOX = new THREE.BoxGeometry(1, 1, 1);
+const CYL = new THREE.CylinderGeometry(1, 1, 1, 10);
+const SPH = new THREE.SphereGeometry(1, 12, 8);
+const CONE = new THREE.ConeGeometry(1, 1, 7);
+
+function mesh(geo, mat, sx, sy, sz, x, y, z) {
+    const m = new THREE.Mesh(geo, mat);
+    m.scale.set(sx, sy, sz);
+    m.position.set(x, y, z);
+    m.castShadow = true;
+    m.receiveShadow = true;
+    return m;
+}
+
+function hexColor(n) {
+    return '#' + n.toString(16).padStart(6, '0');
+}
+
+export function createSharedMaterials(station) {
+    const windows = windowTexture(THREE);
+    return {
+        windows,
+        body: new THREE.MeshStandardMaterial({
+            color: 0x0c0b14,
+            roughness: 0.78,
+            metalness: 0.22,
+            map: windows,
+            emissiveMap: windows,
+            emissive: new THREE.Color(station.window),
+            emissiveIntensity: 0.85
+        }),
+        dark: new THREE.MeshStandardMaterial({
+            color: 0x0a0912,
+            roughness: 0.9,
+            metalness: 0.1
+        }),
+        chrome: new THREE.MeshStandardMaterial({
+            color: 0xc5d0e8,
+            roughness: 0.22,
+            metalness: 0.95
+        }),
+        rubber: new THREE.MeshStandardMaterial({
+            color: 0x111114,
+            roughness: 0.95,
+            metalness: 0.05
+        }),
+        neonA: new THREE.MeshBasicMaterial({
+            color: station.neonA,
+            toneMapped: false
+        }),
+        neonB: new THREE.MeshBasicMaterial({
+            color: station.neonB,
+            toneMapped: false
+        }),
+        glass: new THREE.MeshStandardMaterial({
+            color: 0x081018,
+            roughness: 0.08,
+            metalness: 0.4,
+            transparent: true,
+            opacity: 0.72,
+            emissive: 0x112244,
+            emissiveIntensity: 0.4
+        }),
+        palm: new THREE.MeshStandardMaterial({
+            color: 0x0d2a18,
+            roughness: 0.8,
+            emissive: 0x032010,
+            emissiveIntensity: 0.35
+        }),
+        trunk: new THREE.MeshStandardMaterial({
+            color: 0x3a2614,
+            roughness: 0.9
+        }),
+        lamp: new THREE.MeshBasicMaterial({
+            color: station.lamp,
+            toneMapped: false
+        }),
+        tapeBody: new THREE.MeshStandardMaterial({
+            color: 0x1a1520,
+            roughness: 0.45,
+            metalness: 0.2
+        }),
+        tapeWindow: new THREE.MeshStandardMaterial({
+            color: 0x8aa0c8,
+            roughness: 0.15,
+            metalness: 0.3,
+            emissive: 0x334466,
+            emissiveIntensity: 0.6
+        })
+    };
+}
+
+export function tintMaterials(mats, station) {
+    mats.body.emissive.setHex(station.window);
+    mats.neonA.color.setHex(station.neonA);
+    mats.neonB.color.setHex(station.neonB);
+    mats.lamp.color.setHex(station.lamp);
+}
+
+export function createBike(mats) {
+    const root = new THREE.Group();
+    const lean = new THREE.Group();
+    root.add(lean);
+
+    const paint = new THREE.MeshStandardMaterial({
+        color: 0x1a1028,
+        roughness: 0.35,
+        metalness: 0.7,
+        emissive: 0x2a1038,
+        emissiveIntensity: 0.4
+    });
+
+    const fairing = mesh(BOX, paint, 0.72, 0.42, 1.55, 0, 0.72, 0.05);
+    lean.add(fairing);
+    lean.add(mesh(BOX, paint, 0.55, 0.28, 0.7, 0, 0.95, 0.35));
+    lean.add(mesh(BOX, mats.chrome, 0.42, 0.16, 0.7, 0, 0.88, -0.55));
+
+    const tank = mesh(SPH, paint, 0.38, 0.22, 0.55, 0, 0.98, 0.15);
+    lean.add(tank);
+
+    const seat = mesh(BOX, new THREE.MeshStandardMaterial({
+        color: 0x1a0c14,
+        roughness: 0.7
+    }), 0.42, 0.1, 0.55, 0, 0.86, -0.42);
+    lean.add(seat);
+
+    const fork = mesh(BOX, mats.chrome, 0.08, 0.55, 0.08, 0.16, 0.7, 0.72);
+    const fork2 = fork.clone();
+    fork2.position.x = -0.16;
+    lean.add(fork, fork2);
+
+    const bars = mesh(BOX, mats.chrome, 0.78, 0.05, 0.05, 0, 1.12, 0.62);
+    lean.add(bars);
+    lean.add(mesh(SPH, mats.rubber, 0.07, 0.07, 0.07, 0.38, 1.12, 0.62));
+    lean.add(mesh(SPH, mats.rubber, 0.07, 0.07, 0.07, -0.38, 1.12, 0.62));
+
+    const head = mesh(SPH, mats.neonB, 0.14, 0.14, 0.1, 0, 0.82, 0.88);
+    lean.add(head);
+    const tail = mesh(BOX, mats.neonA, 0.28, 0.08, 0.06, 0, 0.78, -0.92);
+    lean.add(tail);
+
+    const glow = mesh(BOX, new THREE.MeshBasicMaterial({
+        color: 0xff2bd6,
+        transparent: true,
+        opacity: 0.55,
+        toneMapped: false,
+        side: THREE.DoubleSide
+    }), 0.9, 0.02, 1.8, 0, 0.08, 0);
+    lean.add(glow);
+
+    const wheels = [];
+    for (const z of [0.78, -0.72]) {
+        const w = new THREE.Group();
+        w.position.set(0, 0.38, z);
+        const tire = new THREE.Mesh(CYL, mats.rubber);
+        tire.scale.set(0.38, 0.16, 0.38);
+        tire.rotation.z = Math.PI / 2;
+        const rim = new THREE.Mesh(CYL, mats.neonB);
+        rim.scale.set(0.22, 0.18, 0.22);
+        rim.rotation.z = Math.PI / 2;
+        w.add(tire, rim);
+        lean.add(w);
+        wheels.push(w);
+    }
+
+    const rider = new THREE.Group();
+    rider.add(mesh(BOX, paint, 0.36, 0.38, 0.32, 0, 1.22, -0.18));
+    const helmet = mesh(SPH, mats.chrome, 0.18, 0.16, 0.18, 0, 1.52, -0.02);
+    rider.add(helmet);
+    rider.add(mesh(BOX, mats.glass, 0.16, 0.08, 0.04, 0, 1.52, 0.14));
+    rider.add(mesh(BOX, paint, 0.12, 0.12, 0.45, 0.22, 1.18, 0.22));
+    rider.add(mesh(BOX, paint, 0.12, 0.12, 0.45, -0.22, 1.18, 0.22));
+    lean.add(rider);
+
+    root.userData = { lean, wheels, glow, paint, head, tail };
+    return root;
+}
+
+export function createCar(mats, kind = 0) {
+    const g = new THREE.Group();
+    const bodyCol = [0x1a2030, 0x2a1520, 0x102028, 0x241810, 0x181828][kind % 5];
+    const body = new THREE.MeshStandardMaterial({
+        color: bodyCol,
+        roughness: 0.45,
+        metalness: 0.55
+    });
+
+    if (kind % 3 === 0) {
+        g.add(mesh(BOX, body, 1.7, 0.55, 4.2, 0, 0.55, 0));
+        g.add(mesh(BOX, mats.glass, 1.55, 0.42, 1.6, 0, 1.05, -0.2));
+        g.add(mesh(BOX, body, 1.7, 0.22, 1.4, 0, 0.95, -1.2));
+    } else if (kind % 3 === 1) {
+        g.add(mesh(BOX, body, 1.85, 0.7, 4.6, 0, 0.7, 0));
+        g.add(mesh(BOX, mats.glass, 1.7, 0.38, 1.4, 0, 1.18, 0.4));
+        g.add(mesh(BOX, body, 1.85, 0.5, 1.6, 0, 1.1, -1.3));
+    } else {
+        g.add(mesh(BOX, body, 1.6, 0.45, 3.6, 0, 0.5, 0));
+        g.add(mesh(BOX, mats.glass, 1.45, 0.32, 1.2, 0, 0.88, 0.15));
+        g.add(mesh(BOX, body, 1.6, 0.18, 1.1, 0, 0.72, -1.1));
+    }
+
+    g.add(mesh(BOX, mats.neonB, 0.35, 0.12, 0.08, 0.45, 0.55, 2.12));
+    g.add(mesh(BOX, mats.neonB, 0.35, 0.12, 0.08, -0.45, 0.55, 2.12));
+    g.add(mesh(BOX, mats.neonA, 0.4, 0.1, 0.08, 0.5, 0.5, -2.15));
+    g.add(mesh(BOX, mats.neonA, 0.4, 0.1, 0.08, -0.5, 0.5, -2.15));
+
+    for (const [x, z] of [[0.7, 1.35], [-0.7, 1.35], [0.7, -1.4], [-0.7, -1.4]]) {
+        const tire = mesh(CYL, mats.rubber, 0.28, 0.18, 0.28, x, 0.28, z);
+        tire.rotation.z = Math.PI / 2;
+        g.add(tire);
+    }
+
+    g.userData.length = kind % 3 === 1 ? 4.8 : 4.2;
+    g.userData.width = 1.9;
+    return g;
+}
+
+export function createCassette(mats) {
+    const g = new THREE.Group();
+    g.add(mesh(BOX, mats.tapeBody, 0.9, 0.55, 0.18, 0, 0, 0));
+    g.add(mesh(BOX, mats.tapeWindow, 0.55, 0.28, 0.06, 0, 0.02, 0.08));
+    const reel = mesh(CYL, mats.chrome, 0.12, 0.08, 0.12, -0.16, 0.02, 0.1);
+    reel.rotation.x = Math.PI / 2;
+    const reel2 = reel.clone();
+    reel2.position.x = 0.16;
+    g.add(reel, reel2);
+    const label = mesh(BOX, mats.neonA, 0.7, 0.12, 0.04, 0, -0.16, 0.1);
+    g.add(label);
+    g.userData.reels = [reel, reel2];
+    return g;
+}
+
+export function createPalm(mats) {
+    const g = new THREE.Group();
+    const trunk = mesh(CYL, mats.trunk, 0.16, 4.4, 0.16, 0, 2.2, 0);
+    g.add(trunk);
+    for (let i = 0; i < 7; i++) {
+        const leaf = mesh(CONE, mats.palm, 1.1, 2.2, 0.18, 0, 4.3, 0);
+        leaf.rotation.z = 0.85;
+        leaf.rotation.y = (i / 7) * Math.PI * 2;
+        g.add(leaf);
+    }
+    return g;
+}
+
+export function createLamp(mats) {
+    const g = new THREE.Group();
+    g.add(mesh(CYL, mats.dark, 0.08, 5.2, 0.08, 0, 2.6, 0));
+    g.add(mesh(BOX, mats.dark, 1.4, 0.08, 0.12, 0.5, 5.15, 0));
+    const bulb = mesh(BOX, mats.lamp, 0.45, 0.12, 0.25, 1.05, 5.0, 0);
+    g.add(bulb);
+    g.userData.bulb = bulb;
+    return g;
+}
+
+export function createBuilding(mats, rng, density) {
+    const g = new THREE.Group();
+    const w = 5.5 + rng() * 7.5;
+    const d = 7 + rng() * 11;
+    const h = 8 + rng() ** 1.4 * (28 + density * 18);
+
+    const body = mesh(BOX, mats.body, w, h, d, 0, h / 2, 0);
+    body.material = mats.body;
+    g.add(body);
+
+    const stripSide = rng() > 0.5 ? 1 : -1;
+    const strip = mesh(BOX, rng() > 0.5 ? mats.neonA : mats.neonB, 0.16, h * 0.92, 0.16,
+        stripSide * (w / 2 + 0.08), h / 2, d / 2 + 0.08);
+    g.add(strip);
+
+    if (rng() > 0.35) {
+        const word = pick(SIGN_WORDS);
+        const color = rng() > 0.5 ? 0xff2bd6 : 0x00f0ff;
+        const tex = neonSignTexture(THREE, word, hexColor(color));
+        const signMat = new THREE.MeshBasicMaterial({
+            map: tex,
+            transparent: true,
+            toneMapped: false,
+            side: THREE.DoubleSide
+        });
+        const sign = new THREE.Mesh(new THREE.PlaneGeometry(Math.min(w * 0.9, 6.5), 1.15), signMat);
+        sign.position.set(0, 3.2 + rng() * (h * 0.4), d / 2 + 0.12);
+        g.add(sign);
+        g.userData.signMat = signMat;
+        g.userData.signColor = color;
+    }
+
+    if (rng() > 0.7) {
+        const dish = mesh(CYL, mats.chrome, 0.55, 0.08, 0.55, rng() * 1.4 - 0.7, h + 0.2, rng() * 1.4 - 0.7);
+        g.add(dish);
+    }
+
+    g.userData.height = h;
+    return g;
+}
+
+export function createBillboard(mats, title = 'NEON RIDER') {
+    const g = new THREE.Group();
+    g.add(mesh(CYL, mats.dark, 0.1, 6.2, 0.1, -1.6, 3.1, 0));
+    g.add(mesh(CYL, mats.dark, 0.1, 6.2, 0.1, 1.6, 3.1, 0));
+    const tex = neonSignTexture(THREE, title, '#00f0ff');
+    const mat = new THREE.MeshBasicMaterial({
+        map: tex,
+        transparent: true,
+        toneMapped: false,
+        side: THREE.DoubleSide
+    });
+    const board = new THREE.Mesh(new THREE.PlaneGeometry(5.4, 1.4), mat);
+    board.position.set(0, 6.4, 0);
+    g.add(board);
+    g.add(mesh(BOX, mats.dark, 5.6, 1.6, 0.12, 0, 6.4, -0.08));
+    return g;
+}

--- a/labs/neon-rider/src/player.js
+++ b/labs/neon-rider/src/player.js
@@ -1,0 +1,106 @@
+/**
+ * Física simples da moto: aceleração, esterço, inclinação visual e nitro.
+ * A moto avança no eixo −Z (para dentro da câmera padrão).
+ */
+
+import { BIKE, ROAD } from './config.js';
+import { clamp, damp } from './utils.js';
+import { createBike } from './models.js';
+
+export class Player {
+    constructor(scene, mats) {
+        this.root = createBike(mats);
+        scene.add(this.root);
+        this.x = 0;
+        this.z = 0;
+        this.vx = 0;
+        this.speed = 18;
+        this.boost = 0;
+        this.lean = 0;
+        this.invuln = 0;
+        this.alive = true;
+        this.auto = false;
+        this.maxSpeed = BIKE.maxSpeed;
+        this.wheelSpin = 0;
+    }
+
+    reset({ maxSpeed }) {
+        this.x = 0;
+        this.z = 0;
+        this.vx = 0;
+        this.speed = 16;
+        this.boost = 1;
+        this.lean = 0;
+        this.invuln = 0;
+        this.alive = true;
+        this.maxSpeed = maxSpeed || BIKE.maxSpeed;
+        this.root.position.set(0, 0, 0);
+        this.root.rotation.set(0, 0, 0);
+        this.root.userData.lean.rotation.z = 0;
+    }
+
+    update(dt, input, autoSteer = 0) {
+        if (!this.alive) {
+            this.speed = damp(this.speed, 0, 3, dt);
+            this.applyPose(dt);
+            return;
+        }
+
+        const throttle = input.boost ? 1 : input.brake ? -1 : 0.35;
+        const cap = this.maxSpeed + (input.boost && this.boost > 0.05 ? 22 : 0);
+        const accel = throttle > 0
+            ? (input.boost ? BIKE.accel * 1.45 : BIKE.accel * 0.55)
+            : throttle < 0 ? -BIKE.brake : -BIKE.coast * 0.15;
+
+        this.speed = clamp(this.speed + accel * dt, 8, cap);
+
+        if (input.boost && this.boost > 0) {
+            this.boost = Math.max(0, this.boost - dt * 0.28);
+        } else {
+            this.boost = Math.min(1, this.boost + dt * 0.12);
+        }
+
+        const steer = clamp(input.steer + autoSteer, -1, 1);
+        const grip = BIKE.steer * (0.45 + this.speed / this.maxSpeed);
+        this.vx = damp(this.vx, steer * grip, BIKE.grip, dt);
+        this.x = clamp(this.x + this.vx * dt, -ROAD.halfWidth, ROAD.halfWidth);
+
+        this.z -= this.speed * dt;
+        this.invuln = Math.max(0, this.invuln - dt);
+
+        const leanTarget = -steer * BIKE.lean * (0.35 + this.speed / this.maxSpeed);
+        this.lean = damp(this.lean, leanTarget, 10, dt);
+        this.wheelSpin += (this.speed / 0.38) * dt;
+
+        this.applyPose(dt);
+    }
+
+    applyPose() {
+        this.root.position.set(this.x, 0, this.z);
+        this.root.userData.lean.rotation.z = this.lean;
+        this.root.rotation.y = this.vx * 0.012;
+        for (const w of this.root.userData.wheels) {
+            w.rotation.x = this.wheelSpin;
+        }
+        const glow = this.root.userData.glow;
+        glow.material.opacity = 0.28 + this.speed / 140 + (this.boost > 0 && this.speed > 40 ? 0.25 : 0);
+        glow.scale.x = 0.9 + Math.abs(this.lean) * 1.4;
+    }
+
+    hit() {
+        if (this.invuln > 0 || !this.alive) return false;
+        this.invuln = 1.8;
+        this.speed *= 0.45;
+        this.vx *= -0.6;
+        return true;
+    }
+
+    bounds() {
+        return {
+            x: this.x,
+            z: this.z,
+            w: 0.85,
+            l: 2.1
+        };
+    }
+}

--- a/labs/neon-rider/src/textures.js
+++ b/labs/neon-rider/src/textures.js
@@ -1,0 +1,94 @@
+/**
+ * Texturas geradas em canvas: janelas de prédios, placas néon, asfalto e sprites.
+ * Nada de assets externos — o lab continua autocontido.
+ */
+
+export function makeCanvas(size, draw) {
+    const canvas = document.createElement('canvas');
+    canvas.width = size;
+    canvas.height = size;
+    const ctx = canvas.getContext('2d');
+    draw(ctx, size);
+    return canvas;
+}
+
+export function canvasTexture(THREE, canvas, { repeatX = 1, repeatY = 1, colorSpace } = {}) {
+    const tex = new THREE.CanvasTexture(canvas);
+    tex.wrapS = THREE.RepeatWrapping;
+    tex.wrapT = THREE.RepeatWrapping;
+    tex.repeat.set(repeatX, repeatY);
+    tex.anisotropy = 8;
+    tex.needsUpdate = true;
+    if (colorSpace && THREE.SRGBColorSpace) tex.colorSpace = THREE.SRGBColorSpace;
+    return tex;
+}
+
+export function windowTexture(THREE) {
+    const canvas = makeCanvas(256, (ctx, s) => {
+        ctx.fillStyle = '#07060d';
+        ctx.fillRect(0, 0, s, s);
+        const cols = 6;
+        const rows = 8;
+        const pad = 8;
+        const bw = (s - pad * (cols + 1)) / cols;
+        const bh = (s - pad * (rows + 1)) / rows;
+        for (let y = 0; y < rows; y++) {
+            for (let x = 0; x < cols; x++) {
+                const on = Math.random() > 0.28;
+                const shade = on ? 180 + Math.random() * 75 : 18 + Math.random() * 14;
+                const r = shade;
+                const g = shade * (0.72 + Math.random() * 0.2);
+                const b = shade * (0.55 + Math.random() * 0.25);
+                ctx.fillStyle = `rgb(${r | 0},${g | 0},${b | 0})`;
+                ctx.fillRect(pad + x * (bw + pad), pad + y * (bh + pad), bw, bh);
+            }
+        }
+    });
+    return canvasTexture(THREE, canvas, { repeatX: 1, repeatY: 2 });
+}
+
+export function neonSignTexture(THREE, text, color) {
+    const canvas = document.createElement('canvas');
+    canvas.width = 512;
+    canvas.height = 128;
+    const ctx = canvas.getContext('2d');
+    ctx.clearRect(0, 0, 512, 128);
+    ctx.fillStyle = 'rgba(4, 2, 10, 0.72)';
+    ctx.fillRect(0, 0, 512, 128);
+    ctx.font = '700 64px "Audiowide", "Outfit", sans-serif';
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.shadowColor = color;
+    ctx.shadowBlur = 24;
+    ctx.fillStyle = color;
+    ctx.fillText(text, 256, 68);
+    ctx.shadowBlur = 0;
+    ctx.strokeStyle = color;
+    ctx.lineWidth = 1.5;
+    ctx.strokeText(text, 256, 68);
+    const tex = new THREE.CanvasTexture(canvas);
+    tex.needsUpdate = true;
+    if (THREE.SRGBColorSpace) tex.colorSpace = THREE.SRGBColorSpace;
+    return tex;
+}
+
+export function sparkTexture(THREE) {
+    const canvas = makeCanvas(64, (ctx, s) => {
+        const g = ctx.createRadialGradient(s / 2, s / 2, 0, s / 2, s / 2, s / 2);
+        g.addColorStop(0, 'rgba(255,255,255,1)');
+        g.addColorStop(0.25, 'rgba(255,220,255,0.9)');
+        g.addColorStop(0.6, 'rgba(255,80,200,0.35)');
+        g.addColorStop(1, 'rgba(0,0,0,0)');
+        ctx.fillStyle = g;
+        ctx.fillRect(0, 0, s, s);
+    });
+    const tex = new THREE.CanvasTexture(canvas);
+    tex.needsUpdate = true;
+    return tex;
+}
+
+export const SIGN_WORDS = [
+    'ARCADE', 'VIDEO', 'HOTEL', 'DISCO', 'SUSHI', 'RADIO', 'PIZZA',
+    'KARAOKE', 'CINEMA', 'BAR', 'TAXI', 'LASER', 'PIXEL', 'WALKMAN',
+    'CASSETTE', 'NIGHT', '24H', 'BOWL', 'DINER', 'CLUB'
+];

--- a/labs/neon-rider/src/traffic.js
+++ b/labs/neon-rider/src/traffic.js
@@ -1,0 +1,175 @@
+/**
+ * Trânsito e fitas VHS: pools reciclados à frente da moto.
+ * Colisão é AABB no plano XZ — suficiente para um arcade.
+ */
+
+import { createCar, createCassette } from './models.js';
+import { hash, randRange } from './utils.js';
+
+const LANES = [-5.4, -1.8, 1.8, 5.4];
+
+function aabbHit(a, b) {
+    return Math.abs(a.x - b.x) < (a.w + b.w) * 0.5
+        && Math.abs(a.z - b.z) < (a.l + b.l) * 0.5;
+}
+
+export class Traffic {
+    constructor(scene, mats, quality) {
+        this.scene = scene;
+        this.cars = [];
+        this.tapes = [];
+        this.difficulty = { traffic: 1, trafficSpeed: 0.55, tapes: 1 };
+
+        const carCount = quality.chunkProps > 0.7 ? 18 : 12;
+        for (let i = 0; i < carCount; i++) {
+            const car = createCar(mats, i);
+            car.visible = false;
+            scene.add(car);
+            this.cars.push({
+                mesh: car,
+                x: 0,
+                z: 0,
+                speed: 20,
+                lane: 0,
+                live: false,
+                w: 1.8,
+                l: 4.2
+            });
+        }
+
+        for (let i = 0; i < 8; i++) {
+            const mesh = createCassette(mats);
+            mesh.visible = false;
+            scene.add(mesh);
+            this.tapes.push({
+                mesh,
+                x: 0,
+                z: 0,
+                live: false,
+                phase: Math.random() * Math.PI * 2
+            });
+        }
+    }
+
+    setDifficulty(diff) {
+        this.difficulty = diff;
+    }
+
+    reset(playerZ) {
+        for (const car of this.cars) this.despawnCar(car);
+        for (const tape of this.tapes) this.despawnTape(tape);
+        for (let i = 0; i < this.cars.length; i++) {
+            this.placeCar(this.cars[i], playerZ - 40 - i * (18 / this.difficulty.traffic));
+        }
+        for (let i = 0; i < this.tapes.length; i++) {
+            this.placeTape(this.tapes[i], playerZ - 30 - i * 42);
+        }
+    }
+
+    placeCar(car, z) {
+        const lane = Math.floor(hash(z * 13.1) * LANES.length);
+        car.lane = lane;
+        car.x = LANES[lane] + (hash(z * 7.7) - 0.5) * 0.35;
+        car.z = z;
+        car.speed = 12 + hash(z * 3.1) * 22 * this.difficulty.trafficSpeed;
+        car.live = true;
+        car.l = car.mesh.userData.length || 4.2;
+        car.mesh.visible = true;
+        car.mesh.position.set(car.x, 0, car.z);
+        car.mesh.rotation.y = Math.PI;
+    }
+
+    placeTape(tape, z) {
+        const lane = Math.floor(hash(z * 21.3) * LANES.length);
+        tape.x = LANES[lane];
+        tape.z = z;
+        tape.live = true;
+        tape.mesh.visible = true;
+        tape.mesh.position.set(tape.x, 1.15, tape.z);
+    }
+
+    despawnCar(car) {
+        car.live = false;
+        car.mesh.visible = false;
+    }
+
+    despawnTape(tape) {
+        tape.live = false;
+        tape.mesh.visible = false;
+    }
+
+    update(dt, player) {
+        const ahead = player.z - 210;
+        const behind = player.z + 28;
+
+        for (const car of this.cars) {
+            if (!car.live) {
+                this.placeCar(car, ahead - randRange(10, 80));
+                continue;
+            }
+            // Mesmo sentido da moto, mais lentos — o jogador os ultrapassa.
+            car.z -= car.speed * dt;
+            car.mesh.position.set(car.x, 0, car.z);
+            if (car.z > behind || car.z < ahead - 40) {
+                this.placeCar(car, ahead - randRange(8, 70));
+            }
+        }
+
+        for (const tape of this.tapes) {
+            if (!tape.live) {
+                this.placeTape(tape, ahead - randRange(20, 90));
+                continue;
+            }
+            tape.phase += dt * 2.4;
+            tape.mesh.position.set(tape.x, 1.05 + Math.sin(tape.phase) * 0.18, tape.z);
+            tape.mesh.rotation.y += dt * 1.6;
+            if (tape.mesh.userData.reels) {
+                for (const reel of tape.mesh.userData.reels) reel.rotation.z += dt * 4;
+            }
+            if (tape.z > behind) this.placeTape(tape, ahead - randRange(20, 90));
+        }
+    }
+
+    collideCars(player) {
+        const pb = player.bounds();
+        for (const car of this.cars) {
+            if (!car.live) continue;
+            if (aabbHit(pb, { x: car.x, z: car.z, w: car.w, l: car.l })) return car;
+        }
+        return null;
+    }
+
+    collectTapes(player) {
+        const pb = { x: player.x, z: player.z, w: 1.6, l: 2.4 };
+        const got = [];
+        for (const tape of this.tapes) {
+            if (!tape.live) continue;
+            if (aabbHit(pb, { x: tape.x, z: tape.z, w: 1.1, l: 1.1 })) {
+                tape.live = false;
+                tape.mesh.visible = false;
+                got.push(tape);
+            }
+        }
+        return got;
+    }
+
+    /** Desvia a moto no modo atração: olha um pouco à frente e escolhe a faixa livre. */
+    autoSteer(player) {
+        let best = 0;
+        let bestScore = -1e9;
+        for (const laneX of LANES) {
+            let score = -Math.abs(laneX - player.x) * 0.15;
+            for (const car of this.cars) {
+                if (!car.live) continue;
+                const dz = car.z - player.z;
+                if (dz < 2 && dz > -20 && Math.abs(car.x - laneX) < 2.2) score -= 8;
+            }
+            if (score > bestScore) {
+                bestScore = score;
+                best = laneX;
+            }
+        }
+        const delta = best - player.x;
+        return Math.max(-1, Math.min(1, delta * 0.35));
+    }
+}

--- a/labs/neon-rider/src/utils.js
+++ b/labs/neon-rider/src/utils.js
@@ -1,0 +1,60 @@
+/** Utilitários numéricos, detecção de dispositivo e RNG determinístico. */
+
+export const clamp = (v, min, max) => (v < min ? min : v > max ? max : v);
+export const lerp = (a, b, t) => a + (b - a) * t;
+export const damp = (current, target, lambda, dt) =>
+    lerp(current, target, 1 - Math.exp(-lambda * dt));
+
+export const randRange = (min, max) => min + Math.random() * (max - min);
+export const randInt = (min, max) => Math.floor(min + Math.random() * (max - min + 1));
+export const pick = (arr) => arr[Math.floor(Math.random() * arr.length)];
+
+/** Hash 32-bit barato para variar prédios sem Math.random a cada recycle. */
+export function hash(n) {
+    n = (n | 0) * 374761393 + 668265263;
+    n = (n ^ (n >>> 13)) * 1274126177;
+    return ((n ^ (n >>> 16)) >>> 0) / 4294967296;
+}
+
+export function mulberry32(seed) {
+    let a = seed | 0;
+    return () => {
+        a |= 0;
+        a = (a + 0x6d2b79f5) | 0;
+        let t = Math.imul(a ^ (a >>> 15), 1 | a);
+        t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+        return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+    };
+}
+
+export function formatKm(meters) {
+    if (meters < 1000) return `${Math.floor(meters)} m`;
+    return `${(meters / 1000).toFixed(2)} km`;
+}
+
+export function formatTime(seconds) {
+    const s = Math.max(0, Math.floor(seconds));
+    const m = Math.floor(s / 60);
+    const r = s % 60;
+    return `${m}:${r.toString().padStart(2, '0')}`;
+}
+
+export function detectMobile() {
+    if (typeof navigator === 'undefined') return false;
+    const coarse = window.matchMedia?.('(pointer: coarse)')?.matches;
+    const narrow = Math.min(window.innerWidth, window.innerHeight) < 760;
+    return Boolean(coarse && narrow) || /Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
+}
+
+export function detectSoftwareGL() {
+    try {
+        const canvas = document.createElement('canvas');
+        const gl = canvas.getContext('webgl2') || canvas.getContext('webgl');
+        if (!gl) return true;
+        const info = gl.getExtension('WEBGL_debug_renderer_info');
+        const name = info ? String(gl.getParameter(info.UNMASKED_RENDERER_WEBGL) || '') : '';
+        return /swiftshader|llvmpipe|softpipe|microsoft basic render|\bcpu\b/i.test(name);
+    } catch (err) {
+        return true;
+    }
+}

--- a/labs/neon-rider/src/world.js
+++ b/labs/neon-rider/src/world.js
@@ -61,10 +61,12 @@ export function createRoad(station) {
     const mat = new THREE.ShaderMaterial({
         uniforms,
         lights: false,
+        fog: true,
         vertexShader: /* glsl */ `
             varying vec3 vWorld;
             varying vec3 vView;
             varying vec3 vNormal;
+            #include <fog_pars_vertex>
             void main() {
                 vec4 world = modelMatrix * vec4(position, 1.0);
                 vWorld = world.xyz;
@@ -72,6 +74,7 @@ export function createRoad(station) {
                 vec4 mv = viewMatrix * world;
                 vView = -mv.xyz;
                 gl_Position = projectionMatrix * mv;
+                #include <fog_vertex>
             }
         `,
         fragmentShader: /* glsl */ `
@@ -82,6 +85,7 @@ export function createRoad(station) {
             uniform vec3 uNeonA;
             uniform vec3 uNeonB;
             uniform vec3 uAsphalt;
+            #include <fog_pars_fragment>
             void main() {
                 float x = vWorld.x;
                 float z = vWorld.z + uZ;
@@ -117,6 +121,7 @@ export function createRoad(station) {
                 gl_FragColor = vec4(col, 1.0);
                 #include <tonemapping_fragment>
                 #include <colorspace_fragment>
+                #include <fog_fragment>
             }
         `
     });
@@ -191,10 +196,9 @@ export class City {
         const addSide = (side) => {
             const count = 1 + Math.floor(rng() * 2 * density + 0.4);
             for (let i = 0; i < count; i++) {
-                const b = createBuilding(this.mats, rng, density);
+                const b = createBuilding(this.mats, rng, density, side);
                 const z = (i - (count - 1) / 2) * (CHUNK.length / Math.max(count, 1)) * 0.7;
                 b.position.set(side * (ROAD.buildingGap + 4 + rng() * 3.5), 0, z);
-                b.rotation.y = side > 0 ? 0 : Math.PI;
                 group.add(b);
             }
 
@@ -208,7 +212,7 @@ export class City {
             if (rng() < 0.85) {
                 const lamp = createLamp(this.mats);
                 lamp.position.set(side * 8.9, 0, (rng() - 0.5) * CHUNK.length * 0.5);
-                lamp.rotation.y = side > 0 ? 0 : Math.PI;
+                lamp.rotation.y = side > 0 ? Math.PI : 0;
                 lamp.userData.isLamp = true;
                 group.add(lamp);
             }
@@ -258,7 +262,8 @@ export class City {
             const world = lamp.getWorldPosition(light.position);
             light.position.copy(world);
             light.position.y = 5.05;
-            light.position.x += lamp.rotation.y > 1 ? -1.05 : 1.05;
+            const towardRoad = lamp.position.x > 0 ? -1.05 : 1.05;
+            light.position.x += towardRoad;
             light.intensity = 2.2;
         }
     }

--- a/labs/neon-rider/src/world.js
+++ b/labs/neon-rider/src/world.js
@@ -74,6 +74,7 @@ export function createRoad(station) {
                 vec4 mv = viewMatrix * world;
                 vView = -mv.xyz;
                 gl_Position = projectionMatrix * mv;
+                vec4 mvPosition = mv;
                 #include <fog_vertex>
             }
         `,

--- a/labs/neon-rider/src/world.js
+++ b/labs/neon-rider/src/world.js
@@ -1,0 +1,295 @@
+/**
+ * Cidade infinita: o chão e o céu seguem a moto; quarteirões são reciclados
+ * para a frente quando ficam para trás da câmera.
+ */
+
+import * as THREE from 'three';
+import { CHUNK, ROAD } from './config.js';
+import { hash, mulberry32 } from './utils.js';
+import {
+    createBuilding, createLamp, createPalm, createBillboard, tintMaterials
+} from './models.js';
+
+export function createSky() {
+    const uniforms = {
+        uHorizon: { value: new THREE.Color(0xff3eb5) },
+        uZenith: { value: new THREE.Color(0x06010c) },
+        uGround: { value: new THREE.Color(0x04020a) }
+    };
+    const mat = new THREE.ShaderMaterial({
+        side: THREE.BackSide,
+        depthWrite: false,
+        fog: false,
+        uniforms,
+        vertexShader: /* glsl */ `
+            varying vec3 vPos;
+            void main() {
+                vPos = position;
+                gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+            }
+        `,
+        fragmentShader: /* glsl */ `
+            varying vec3 vPos;
+            uniform vec3 uHorizon;
+            uniform vec3 uZenith;
+            uniform vec3 uGround;
+            void main() {
+                float h = normalize(vPos).y;
+                vec3 col = mix(uHorizon, uZenith, smoothstep(0.0, 0.55, h));
+                col = mix(uGround, col, smoothstep(-0.22, 0.04, h));
+                float band = exp(-pow((h - 0.015) * 9.0, 2.0));
+                col += uHorizon * band * 0.5;
+                gl_FragColor = vec4(col, 1.0);
+                #include <tonemapping_fragment>
+                #include <colorspace_fragment>
+            }
+        `
+    });
+    const mesh = new THREE.Mesh(new THREE.SphereGeometry(480, 24, 16), mat);
+    mesh.frustumCulled = false;
+    return { mesh, uniforms };
+}
+
+export function createRoad(station) {
+    const uniforms = {
+        uZ: { value: 0 },
+        uNeonA: { value: new THREE.Color(station.neonA) },
+        uNeonB: { value: new THREE.Color(station.neonB) },
+        uAsphalt: { value: new THREE.Color(station.asphalt) }
+    };
+
+    const mat = new THREE.ShaderMaterial({
+        uniforms,
+        lights: false,
+        vertexShader: /* glsl */ `
+            varying vec3 vWorld;
+            varying vec3 vView;
+            varying vec3 vNormal;
+            void main() {
+                vec4 world = modelMatrix * vec4(position, 1.0);
+                vWorld = world.xyz;
+                vNormal = normalize(mat3(modelMatrix) * normal);
+                vec4 mv = viewMatrix * world;
+                vView = -mv.xyz;
+                gl_Position = projectionMatrix * mv;
+            }
+        `,
+        fragmentShader: /* glsl */ `
+            varying vec3 vWorld;
+            varying vec3 vView;
+            varying vec3 vNormal;
+            uniform float uZ;
+            uniform vec3 uNeonA;
+            uniform vec3 uNeonB;
+            uniform vec3 uAsphalt;
+            void main() {
+                float x = vWorld.x;
+                float z = vWorld.z + uZ;
+                vec3 col = uAsphalt;
+
+                float n = fract(sin(dot(floor(vWorld.xz * 2.4), vec2(12.9898, 78.233))) * 43758.5453);
+                col += (n - 0.5) * 0.035;
+
+                float curb = smoothstep(7.55, 7.85, abs(x)) * (1.0 - smoothstep(8.7, 9.1, abs(x)));
+                col = mix(col, vec3(0.18, 0.16, 0.22), curb);
+
+                float edge = 1.0 - smoothstep(0.08, 0.16, abs(abs(x) - 7.35));
+                col = mix(col, uNeonB, edge * 0.85);
+
+                float center = 1.0 - smoothstep(0.05, 0.12, abs(abs(x) - 0.14));
+                col = mix(col, uNeonA, center * step(0.45, fract(z * 0.12)));
+
+                float lane = min(abs(x - 3.6), abs(x + 3.6));
+                float dash = step(0.5, fract(z * 0.09));
+                float mark = (1.0 - smoothstep(0.04, 0.1, lane)) * dash;
+                col = mix(col, vec3(0.85, 0.9, 1.0), mark * 0.75);
+
+                float block = mod(-z, 104.0);
+                float xwalk = step(block, 7.5) * step(abs(x), 7.4);
+                float stripe = step(0.45, fract(x * 0.55));
+                col = mix(col, vec3(0.92, 0.92, 1.0), xwalk * stripe * 0.7);
+
+                vec3 N = normalize(vNormal);
+                vec3 V = normalize(vView);
+                float fres = pow(1.0 - max(dot(N, V), 0.0), 3.2);
+                col = mix(col, mix(uNeonA, uNeonB, 0.45), fres * 0.55);
+
+                gl_FragColor = vec4(col, 1.0);
+                #include <tonemapping_fragment>
+                #include <colorspace_fragment>
+            }
+        `
+    });
+
+    const mesh = new THREE.Mesh(new THREE.PlaneGeometry(22, 420, 1, 1), mat);
+    mesh.rotation.x = -Math.PI / 2;
+    mesh.receiveShadow = true;
+
+    const sidewalkMat = new THREE.MeshStandardMaterial({
+        color: 0x16141f,
+        roughness: 0.9,
+        metalness: 0.05
+    });
+    const left = new THREE.Mesh(new THREE.BoxGeometry(9, 0.28, 420), sidewalkMat);
+    left.position.set(-13.2, 0.12, 0);
+    left.receiveShadow = true;
+    const right = left.clone();
+    right.position.x = 13.2;
+
+    const group = new THREE.Group();
+    group.add(mesh, left, right);
+    return { group, uniforms, sidewalkMat };
+}
+
+export class City {
+    constructor(scene, quality, mats) {
+        this.scene = scene;
+        this.quality = quality;
+        this.mats = mats;
+        this.chunks = [];
+        this.lampLights = [];
+        this.seed = 1;
+
+        for (let i = 0; i < CHUNK.count; i++) {
+            const chunk = this.buildChunk(i);
+            chunk.position.z = -i * CHUNK.length;
+            scene.add(chunk);
+            this.chunks.push(chunk);
+        }
+
+        const lampCount = quality.lamps;
+        for (let i = 0; i < lampCount; i++) {
+            const light = new THREE.PointLight(0xffe7b0, 2.4, 22, 1.8);
+            light.castShadow = false;
+            scene.add(light);
+            this.lampLights.push(light);
+        }
+    }
+
+    buildChunk(index) {
+        const group = new THREE.Group();
+        group.userData.index = index;
+        this.populateChunk(group, index);
+        return group;
+    }
+
+    populateChunk(group, index) {
+        while (group.children.length) {
+            const child = group.children[0];
+            child.traverse((obj) => {
+                if (obj.userData?.signMat) {
+                    obj.userData.signMat.map?.dispose();
+                    obj.userData.signMat.dispose();
+                }
+            });
+            group.remove(child);
+        }
+
+        const rng = mulberry32((this.seed * 104729 + index * 7919) | 0);
+        const density = this.quality.chunkProps;
+
+        const addSide = (side) => {
+            const count = 1 + Math.floor(rng() * 2 * density + 0.4);
+            for (let i = 0; i < count; i++) {
+                const b = createBuilding(this.mats, rng, density);
+                const z = (i - (count - 1) / 2) * (CHUNK.length / Math.max(count, 1)) * 0.7;
+                b.position.set(side * (ROAD.buildingGap + 4 + rng() * 3.5), 0, z);
+                b.rotation.y = side > 0 ? 0 : Math.PI;
+                group.add(b);
+            }
+
+            if (rng() < 0.7 * density) {
+                const palm = createPalm(this.mats);
+                palm.position.set(side * 9.6, 0, (rng() - 0.5) * CHUNK.length * 0.6);
+                palm.scale.setScalar(0.75 + rng() * 0.45);
+                group.add(palm);
+            }
+
+            if (rng() < 0.85) {
+                const lamp = createLamp(this.mats);
+                lamp.position.set(side * 8.9, 0, (rng() - 0.5) * CHUNK.length * 0.5);
+                lamp.rotation.y = side > 0 ? 0 : Math.PI;
+                lamp.userData.isLamp = true;
+                group.add(lamp);
+            }
+        };
+
+        addSide(-1);
+        addSide(1);
+
+        if (hash(index + this.seed * 13) > 0.72) {
+            const board = createBillboard(this.mats, pickBillboard(index));
+            board.position.set((hash(index) > 0.5 ? 1 : -1) * 9.8, 0, 0);
+            group.add(board);
+        }
+    }
+
+    recycle(playerZ) {
+        const span = CHUNK.count * CHUNK.length;
+        for (const chunk of this.chunks) {
+            if (chunk.position.z > playerZ + CHUNK.length * 1.2) {
+                chunk.position.z -= span;
+                chunk.userData.index += CHUNK.count;
+                this.populateChunk(chunk, chunk.userData.index);
+            }
+        }
+    }
+
+    updateLights(playerZ) {
+        if (!this.lampLights.length) return;
+        const lamps = [];
+        for (const chunk of this.chunks) {
+            for (const child of chunk.children) {
+                if (child.userData.isLamp) lamps.push(child);
+            }
+        }
+        lamps.sort((a, b) => {
+            const da = Math.abs(a.parent.position.z + a.position.z - playerZ);
+            const db = Math.abs(b.parent.position.z + b.position.z - playerZ);
+            return da - db;
+        });
+        for (let i = 0; i < this.lampLights.length; i++) {
+            const lamp = lamps[i];
+            const light = this.lampLights[i];
+            if (!lamp) {
+                light.intensity = 0;
+                continue;
+            }
+            const world = lamp.getWorldPosition(light.position);
+            light.position.copy(world);
+            light.position.y = 5.05;
+            light.position.x += lamp.rotation.y > 1 ? -1.05 : 1.05;
+            light.intensity = 2.2;
+        }
+    }
+
+    setStation(station) {
+        tintMaterials(this.mats, station);
+        for (const light of this.lampLights) {
+            light.color.setHex(station.lamp);
+        }
+        for (const chunk of this.chunks) {
+            for (const child of chunk.children) {
+                const sign = child.userData.signMat;
+                if (!sign) continue;
+                const next = hash(child.id) > 0.5 ? station.neonA : station.neonB;
+                child.userData.signColor = next;
+            }
+        }
+    }
+
+    reset(seed = 1) {
+        this.seed = seed;
+        for (let i = 0; i < this.chunks.length; i++) {
+            const chunk = this.chunks[i];
+            chunk.position.z = -i * CHUNK.length;
+            chunk.userData.index = i;
+            this.populateChunk(chunk, i);
+        }
+    }
+}
+
+function pickBillboard(index) {
+    const words = ['NEON RIDER', 'WAVE 84', 'ARCADE', 'VHS NIGHT', 'INSERT COIN', 'WALKMAN'];
+    return words[index % words.length];
+}

--- a/labs/neon-rider/src/world.js
+++ b/labs/neon-rider/src/world.js
@@ -50,23 +50,24 @@ export function createSky() {
     return { mesh, uniforms };
 }
 
-export function createRoad(station) {
+export function createRoad(station, fogDensity = 0.008) {
     const uniforms = {
         uZ: { value: 0 },
         uNeonA: { value: new THREE.Color(station.neonA) },
         uNeonB: { value: new THREE.Color(station.neonB) },
-        uAsphalt: { value: new THREE.Color(station.asphalt) }
+        uAsphalt: { value: new THREE.Color(station.asphalt) },
+        uFogColor: { value: new THREE.Color(station.fog) },
+        uFogDensity: { value: fogDensity }
     };
 
     const mat = new THREE.ShaderMaterial({
         uniforms,
         lights: false,
-        fog: true,
+        fog: false,
         vertexShader: /* glsl */ `
             varying vec3 vWorld;
             varying vec3 vView;
             varying vec3 vNormal;
-            #include <fog_pars_vertex>
             void main() {
                 vec4 world = modelMatrix * vec4(position, 1.0);
                 vWorld = world.xyz;
@@ -74,8 +75,6 @@ export function createRoad(station) {
                 vec4 mv = viewMatrix * world;
                 vView = -mv.xyz;
                 gl_Position = projectionMatrix * mv;
-                vec4 mvPosition = mv;
-                #include <fog_vertex>
             }
         `,
         fragmentShader: /* glsl */ `
@@ -86,7 +85,8 @@ export function createRoad(station) {
             uniform vec3 uNeonA;
             uniform vec3 uNeonB;
             uniform vec3 uAsphalt;
-            #include <fog_pars_fragment>
+            uniform vec3 uFogColor;
+            uniform float uFogDensity;
             void main() {
                 float x = vWorld.x;
                 float z = vWorld.z + uZ;
@@ -119,10 +119,13 @@ export function createRoad(station) {
                 float fres = pow(1.0 - max(dot(N, V), 0.0), 3.2);
                 col = mix(col, mix(uNeonA, uNeonB, 0.45), fres * 0.55);
 
+                float dist = length(vView);
+                float fogAmt = 1.0 - exp(-uFogDensity * uFogDensity * dist * dist);
+                col = mix(col, uFogColor, clamp(fogAmt, 0.0, 1.0));
+
                 gl_FragColor = vec4(col, 1.0);
                 #include <tonemapping_fragment>
                 #include <colorspace_fragment>
-                #include <fog_fragment>
             }
         `
     });

--- a/labs/neon-rider/style.css
+++ b/labs/neon-rider/style.css
@@ -1,0 +1,747 @@
+/* ================================================================
+   Neon Rider — CRT + synthwave
+   Paleta: magenta, ciano, asfalto, fósforo.
+   ================================================================ */
+
+:root {
+    --neon-a: #ff2bd6;
+    --neon-b: #00f0ff;
+    --ink: #06010c;
+    --ink-deep: #040008;
+    --text: #f4f0ff;
+    --text-soft: #c9c0e0;
+    --text-dim: #8a809c;
+
+    --panel: color-mix(in oklab, #12081c 62%, transparent);
+    --panel-strong: color-mix(in oklab, #0c0614 82%, transparent);
+    --line: color-mix(in oklab, var(--neon-b) 38%, transparent);
+    --line-soft: color-mix(in oklab, #ffffff 10%, transparent);
+
+    --radius: 14px;
+    --radius-lg: 22px;
+    --blur: 18px;
+
+    --safe-top: env(safe-area-inset-top, 0px);
+    --safe-bottom: env(safe-area-inset-bottom, 0px);
+    --safe-left: env(safe-area-inset-left, 0px);
+    --safe-right: env(safe-area-inset-right, 0px);
+
+    --ease: cubic-bezier(0.22, 1, 0.36, 1);
+    --font-display: 'Audiowide', 'Outfit', sans-serif;
+    --font-mono: 'Share Tech Mono', ui-monospace, monospace;
+}
+
+*, *::before, *::after {
+    box-sizing: border-box;
+    -webkit-tap-highlight-color: transparent;
+}
+
+html, body {
+    margin: 0;
+    width: 100%;
+    height: 100%;
+    overflow: clip;
+    overscroll-behavior: none;
+    background: var(--ink-deep);
+}
+
+body {
+    min-height: 100dvh;
+    padding: 0;
+    color: var(--text);
+    font-family: 'Outfit', system-ui, sans-serif;
+    user-select: none;
+    -webkit-user-select: none;
+    touch-action: none;
+}
+
+button, input, select {
+    font: inherit;
+    color: inherit;
+}
+
+button {
+    background: none;
+    border: 0;
+    cursor: pointer;
+}
+
+.mono {
+    font-family: var(--font-mono);
+    font-variant-numeric: tabular-nums;
+}
+
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip-path: inset(50%);
+}
+
+:focus-visible {
+    outline: 2px solid var(--neon-b);
+    outline-offset: 3px;
+}
+
+.game-shell {
+    position: fixed;
+    inset: 0;
+    overflow: hidden;
+    background: var(--ink-deep);
+}
+
+#scene {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    display: block;
+    touch-action: none;
+}
+
+/* CRT */
+.crt-overlay {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    z-index: 15;
+}
+
+.scanlines {
+    position: absolute;
+    inset: 0;
+    background: repeating-linear-gradient(
+        to bottom,
+        rgba(255, 255, 255, 0.035) 0 1px,
+        transparent 1px 3px
+    );
+    mix-blend-mode: overlay;
+    opacity: 0.55;
+}
+
+.vignette {
+    position: absolute;
+    inset: 0;
+    background:
+        radial-gradient(120% 90% at 50% 45%, transparent 50%, rgba(0, 0, 0, 0.55) 100%),
+        linear-gradient(90deg, rgba(255, 43, 214, 0.06), transparent 18%, transparent 82%, rgba(0, 240, 255, 0.06));
+    box-shadow: inset 0 0 80px rgba(0, 0, 0, 0.45);
+}
+
+.glitch-layer {
+    position: absolute;
+    inset: 0;
+    z-index: 26;
+    pointer-events: none;
+    opacity: 0;
+    background:
+        repeating-linear-gradient(
+            180deg,
+            transparent 0 2px,
+            rgba(0, 240, 255, 0.08) 2px 3px
+        ),
+        linear-gradient(90deg, rgba(255, 43, 214, 0.25), transparent 40%, rgba(0, 240, 255, 0.25));
+    mix-blend-mode: screen;
+}
+
+.glitch-layer.is-on {
+    animation: vhsHit 0.42s steps(3) both;
+}
+
+@keyframes vhsHit {
+    0% { opacity: 0.9; transform: translateX(-6px); }
+    30% { opacity: 0.5; transform: translateX(8px); }
+    60% { opacity: 0.8; transform: translateX(-3px); }
+    100% { opacity: 0; transform: none; }
+}
+
+/* header */
+.game-shell > header {
+    position: absolute;
+    top: calc(0.9rem + var(--safe-top));
+    left: calc(1rem + var(--safe-left));
+    right: calc(1rem + var(--safe-right));
+    z-index: 40;
+    margin: 0;
+    padding: 0;
+    max-width: none;
+    width: auto;
+    pointer-events: none;
+    gap: 0.6rem;
+}
+
+.game-shell > header > * {
+    pointer-events: auto;
+}
+
+.game-shell > header .back-link {
+    background: var(--panel-strong);
+    backdrop-filter: blur(var(--blur));
+    -webkit-backdrop-filter: blur(var(--blur));
+    border-color: var(--line);
+    color: var(--text-soft);
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.45);
+}
+
+.game-shell > header .back-link:hover {
+    color: var(--neon-b);
+    border-color: var(--neon-b);
+}
+
+.game-shell > header .app-logo {
+    font-family: var(--font-display);
+    font-weight: 400;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    font-size: 0.95rem;
+    color: var(--text);
+    text-shadow: 0 0 18px color-mix(in oklab, var(--neon-a) 70%, transparent);
+}
+
+.game-shell > header .brand-mark {
+    color: var(--neon-b);
+    filter: drop-shadow(0 0 10px var(--neon-b));
+}
+
+.lab-foot {
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: calc(0.4rem + var(--safe-bottom));
+    z-index: 30;
+    margin: 0;
+    padding: 0.4rem;
+    border: 0;
+    font-size: 0.72rem;
+    color: var(--text-dim);
+    opacity: 0.55;
+    pointer-events: none;
+}
+
+.lab-foot a {
+    color: var(--text-soft);
+    pointer-events: auto;
+}
+
+body[data-state="playing"] .lab-foot,
+body[data-state="playing"] .game-shell > header .app-logo {
+    opacity: 0;
+    transition: opacity 0.5s var(--ease);
+}
+
+/* HUD */
+.hud {
+    position: absolute;
+    inset: 0;
+    z-index: 20;
+    pointer-events: none;
+    display: grid;
+    grid-template-rows: auto 1fr auto;
+    padding: calc(4.2rem + var(--safe-top)) calc(1rem + var(--safe-right)) calc(1rem + var(--safe-bottom))
+        calc(1rem + var(--safe-left));
+    gap: 0.75rem;
+}
+
+.hud[hidden] { display: none; }
+
+.panel {
+    background: var(--panel);
+    backdrop-filter: blur(var(--blur)) saturate(1.2);
+    -webkit-backdrop-filter: blur(var(--blur)) saturate(1.2);
+    border: 1px solid var(--line-soft);
+    border-radius: var(--radius);
+    box-shadow: 0 12px 34px rgba(0, 0, 0, 0.45), inset 0 1px 0 rgba(255, 255, 255, 0.06);
+    padding: 0.6rem 0.85rem;
+}
+
+.hud-label {
+    font-family: var(--font-display);
+    font-size: 0.55rem;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: var(--neon-b);
+    opacity: 0.9;
+}
+
+.hud-top {
+    display: grid;
+    grid-template-columns: minmax(140px, 1fr) minmax(200px, 1.4fr) minmax(140px, 1fr);
+    align-items: start;
+    gap: 0.75rem;
+}
+
+.speed-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 0.1rem;
+}
+
+.speed-num {
+    font-size: 2.1rem;
+    line-height: 1;
+    color: var(--text);
+    text-shadow: 0 0 16px var(--neon-a);
+}
+
+.hud-unit {
+    font-size: 0.68rem;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--text-dim);
+}
+
+.radio-panel {
+    justify-self: center;
+    width: min(280px, 100%);
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+}
+
+.radio-panel strong {
+    font-family: var(--font-display);
+    letter-spacing: 0.12em;
+    font-size: 1.05rem;
+    color: var(--neon-a);
+    text-shadow: 0 0 14px var(--neon-a);
+}
+
+.hud-tag {
+    font-size: 0.72rem;
+    color: var(--text-dim);
+}
+
+.boost-meter {
+    margin-top: 0.35rem;
+    height: 7px;
+    border-radius: 99px;
+    background: rgba(255, 255, 255, 0.08);
+    overflow: hidden;
+    border: 1px solid var(--line-soft);
+}
+
+.boost-meter i {
+    display: block;
+    height: 100%;
+    width: 0%;
+    background: linear-gradient(90deg, var(--neon-a), var(--neon-b));
+    box-shadow: 0 0 12px var(--neon-b);
+}
+
+.score-panel {
+    justify-self: end;
+    min-width: 148px;
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+}
+
+.score-row {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 0.6rem;
+}
+
+.score-row strong {
+    font-size: 1.05rem;
+    color: var(--text);
+}
+
+.lives {
+    letter-spacing: 0.12em;
+    color: var(--neon-a);
+    text-shadow: 0 0 10px var(--neon-a);
+}
+
+.message {
+    position: absolute;
+    left: 50%;
+    top: 42%;
+    translate: -50% 0;
+    margin: 0;
+    font-family: var(--font-display);
+    font-size: clamp(1.4rem, 4vw, 2.6rem);
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--text);
+    text-shadow: 0 0 22px var(--neon-b), 0 0 40px var(--neon-a);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.25s var(--ease);
+}
+
+.message[data-show="true"] { opacity: 1; }
+
+.hud-actions {
+    grid-row: 3;
+    justify-self: end;
+    align-self: end;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    pointer-events: auto;
+}
+
+.icon-button {
+    width: 40px;
+    height: 40px;
+    display: grid;
+    place-items: center;
+    border-radius: 12px;
+    background: var(--panel);
+    backdrop-filter: blur(var(--blur));
+    border: 1px solid var(--line-soft);
+    color: var(--text-soft);
+    transition: all 0.22s var(--ease);
+}
+
+.icon-button:hover {
+    color: var(--neon-b);
+    border-color: var(--neon-b);
+}
+
+.icon-button[aria-pressed="false"] { opacity: 0.45; }
+
+.fps {
+    font-size: 0.7rem;
+    color: var(--text-dim);
+}
+
+.touch-controls {
+    position: absolute;
+    inset: auto 0 0 0;
+    height: 42%;
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between;
+    padding: 0 calc(1rem + var(--safe-left)) calc(1.2rem + var(--safe-bottom)) calc(1rem + var(--safe-right));
+    pointer-events: none;
+}
+
+.touch-controls[hidden] { display: none; }
+
+.steer-zone {
+    pointer-events: auto;
+    width: 46%;
+    height: 100%;
+    display: grid;
+    place-items: end start;
+    padding: 1rem;
+}
+
+.steer-hint {
+    font-size: 0.68rem;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: var(--text-dim);
+    opacity: 0.5;
+}
+
+.touch-buttons {
+    display: flex;
+    gap: 0.7rem;
+    pointer-events: auto;
+}
+
+.pad {
+    width: 78px;
+    height: 78px;
+    border-radius: 50%;
+    background: var(--panel-strong);
+    border: 1px solid var(--line);
+    font-family: var(--font-display);
+    font-size: 0.62rem;
+    letter-spacing: 0.1em;
+}
+
+.pad-boost {
+    width: 92px;
+    height: 92px;
+    color: var(--neon-a);
+    box-shadow: 0 0 24px color-mix(in oklab, var(--neon-a) 40%, transparent);
+}
+
+.pad:active { transform: scale(0.92); }
+
+/* overlays */
+.overlay {
+    position: absolute;
+    inset: 0;
+    z-index: 50;
+    display: grid;
+    place-items: center;
+    padding: calc(1.2rem + var(--safe-top)) 1.2rem calc(1.2rem + var(--safe-bottom));
+    background:
+        radial-gradient(80% 60% at 50% 0%, color-mix(in oklab, var(--neon-a) 18%, transparent), transparent 55%),
+        rgba(4, 0, 8, 0.42);
+    backdrop-filter: blur(6px);
+}
+
+.overlay[hidden] { display: none; }
+
+.overlay-card {
+    width: min(760px, 100%);
+    background: color-mix(in oklab, #0c0614 78%, transparent);
+    border: 1px solid var(--line);
+    border-radius: var(--radius-lg);
+    box-shadow: 0 30px 80px rgba(0, 0, 0, 0.55), 0 0 40px color-mix(in oklab, var(--neon-a) 20%, transparent);
+    padding: 1.4rem 1.5rem 1.2rem;
+    backdrop-filter: blur(18px);
+}
+
+.compact-card {
+    width: min(440px, 100%);
+    text-align: center;
+}
+
+.menu-head h1,
+.compact-card h2 {
+    font-family: var(--font-display);
+    font-weight: 400;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    margin: 0.2rem 0 0.6rem;
+    font-size: clamp(1.8rem, 5vw, 3.1rem);
+    line-height: 1.05;
+}
+
+.menu-head h1 span,
+.compact-card h2 {
+    color: var(--neon-b);
+    text-shadow: 0 0 24px var(--neon-b);
+}
+
+.eyebrow {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin: 0;
+    font-family: var(--font-mono);
+    font-size: 0.78rem;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--neon-a);
+}
+
+.eyebrow i {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--neon-a);
+    box-shadow: 0 0 10px var(--neon-a);
+    animation: pulse 1.4s ease-in-out infinite;
+}
+
+@keyframes pulse {
+    50% { opacity: 0.35; }
+}
+
+.eyebrow--danger { color: #ff6b8a; }
+.eyebrow--danger i { background: #ff6b8a; box-shadow: 0 0 10px #ff6b8a; }
+
+.lede {
+    margin: 0;
+    color: var(--text-soft);
+    line-height: 1.55;
+    max-width: 52ch;
+}
+
+.menu-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 1rem;
+    margin: 1.2rem 0 1rem;
+}
+
+.menu-section h2 {
+    font-family: var(--font-display);
+    font-size: 0.72rem;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--neon-b);
+    margin: 0 0 0.55rem;
+}
+
+.chip-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+}
+
+.chip {
+    padding: 0.4rem 0.7rem;
+    border-radius: 99px;
+    border: 1px solid var(--line-soft);
+    background: rgba(255, 255, 255, 0.04);
+    font-size: 0.82rem;
+}
+
+.chip[aria-pressed="true"] {
+    border-color: var(--neon-a);
+    color: var(--ink);
+    background: linear-gradient(120deg, var(--neon-a), var(--neon-b));
+    box-shadow: 0 0 16px color-mix(in oklab, var(--neon-a) 45%, transparent);
+}
+
+.section-note {
+    margin: 0.55rem 0 0;
+    font-size: 0.82rem;
+    color: var(--text-dim);
+    line-height: 1.45;
+}
+
+.keys {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    font-size: 0.8rem;
+    color: var(--text-soft);
+}
+
+kbd {
+    display: inline-block;
+    min-width: 1.4em;
+    padding: 0.08rem 0.32rem;
+    margin-right: 0.15rem;
+    border-radius: 6px;
+    border: 1px solid var(--line);
+    background: rgba(0, 0, 0, 0.35);
+    font-family: var(--font-mono);
+    font-size: 0.75rem;
+}
+
+.settings-grid {
+    display: grid;
+    gap: 0.7rem;
+}
+
+.field {
+    display: grid;
+    gap: 0.3rem;
+    font-size: 0.82rem;
+    color: var(--text-soft);
+}
+
+.field select,
+.field input[type="range"] {
+    width: 100%;
+    accent-color: var(--neon-a);
+}
+
+.field select {
+    background: rgba(0, 0, 0, 0.35);
+    border: 1px solid var(--line-soft);
+    border-radius: 10px;
+    padding: 0.4rem 0.55rem;
+}
+
+.menu-foot {
+    display: flex;
+    justify-content: flex-end;
+}
+
+.primary-button,
+.ghost-button {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.55rem;
+    padding: 0.75rem 1.15rem;
+    border-radius: 999px;
+    font-family: var(--font-display);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    font-size: 0.85rem;
+}
+
+.primary-button {
+    background: linear-gradient(120deg, var(--neon-a), var(--neon-b));
+    color: #14010c;
+    box-shadow: 0 10px 30px color-mix(in oklab, var(--neon-a) 40%, transparent);
+}
+
+.primary-button:hover { transform: translateY(-2px); }
+
+.ghost-button {
+    border: 1px solid var(--line-soft);
+    color: var(--text-soft);
+}
+
+.card-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.6rem;
+    justify-content: center;
+    margin-top: 1rem;
+}
+
+.stats {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.55rem 1rem;
+    margin: 1rem 0 0.2rem;
+    text-align: left;
+}
+
+.stats span {
+    display: block;
+    font-size: 0.68rem;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--text-dim);
+}
+
+.stats b {
+    font-family: var(--font-mono);
+    font-size: 1.15rem;
+}
+
+.loading-card {
+    text-align: center;
+}
+
+.loading-card h1 {
+    font-family: var(--font-display);
+    letter-spacing: 0.18em;
+    font-size: 1.8rem;
+    margin: 0.4rem 0;
+    text-shadow: 0 0 22px var(--neon-a);
+}
+
+.loading-mark {
+    font-size: 2rem;
+    color: var(--neon-b);
+    filter: drop-shadow(0 0 12px var(--neon-b));
+}
+
+.loading-bar {
+    width: min(280px, 70vw);
+    height: 6px;
+    margin: 1rem auto 0;
+    border-radius: 99px;
+    background: rgba(255, 255, 255, 0.08);
+    overflow: hidden;
+}
+
+.loading-bar i {
+    display: block;
+    height: 100%;
+    width: 0;
+    background: linear-gradient(90deg, var(--neon-a), var(--neon-b));
+}
+
+@media (max-width: 860px) {
+    .menu-grid { grid-template-columns: 1fr; }
+    .hud-top { grid-template-columns: 1fr 1fr; }
+    .radio-panel { grid-column: 1 / -1; justify-self: stretch; width: auto; }
+    .speed-num { font-size: 1.6rem; }
+}
+
+@media (max-width: 560px) {
+    .overlay-card { padding: 1rem; }
+    .menu-head h1 { font-size: 1.7rem; }
+    .hud-top { gap: 0.45rem; }
+    .panel { padding: 0.45rem 0.6rem; }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Novo laboratório **Neon Rider**: uma avenida infinita à meia-noite, com moto cromada, distrito néon, rádio synthwave procedural e fitas VHS que retunam as cores da cidade.

## Por que este lab
Pedido de um app novo com three.js, gráficos fortes e visual **retrô** — e explicitamente **sem planetas**. Em vez de espaço, o recorte é Outrun/Akira de asfalto: CRT, bloom, placas de néon e trânsito dos anos 80.

## O que entra
- Cidade low-poly reciclada à frente da câmera (prédios, palmeiras, postes, outdoors)
- Asfalto com shader (faixas, faixa de pedestres, fresnel molhado, fog no fragment)
- Moto com inclinação, nitro, farol e underglow
- Trânsito para desviar + fitas VHS coletáveis
- Quatro estações de rádio (WAVE 84, VHS FM, ARCADE AM, DISCO 12) que trocam néon, névoa e a trilha
- Overlay CRT/VHS, bloom, HUD arcade, controles de toque
- Card na galeria de labs

## Como jogar
`A/D` esterça, `W`/`Shift` nitro, `S` freia, `C` câmera, `R` rádio, `Enter` largar.

## Correções de boot
1. `flushStation` lia `road.uniforms` antes do asfalto existir.
2. `ShaderMaterial` com `fog: true` quebrava em `refreshFogUniforms` — a névoa do asfalto agora é feita no próprio fragment shader.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ffdb1-4003-7de6-a402-2099f6cfe30b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ffdb1-4003-7de6-a402-2099f6cfe30b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

