### PR TITLE
feat: A Jornada do Anel — aventura 3D em three.js

### DIFF
--- a/labs/index.html
+++ b/labs/index.html
@@ -588,6 +588,26 @@
           </div>
         </div>
       </a>
+      <a href="/labs/jornada-do-anel/" class="project-card" data-groups="game,creative">
+        <div class="project-icon">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+            stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <circle cx="12" cy="12" r="7.2" />
+            <circle cx="12" cy="12" r="3.1" />
+            <path d="M12 2v2.4M12 19.6V22M2 12h2.4M19.6 12H22" opacity="0.55" />
+          </svg>
+        </div>
+        <div class="project-content">
+          <h2>A Jornada do Anel</h2>
+          <p>Aventura 3D em three.js inspirada no primeiro filme: o Condado, a fuga dos
+            Cavaleiros, o vale élfico, as minas e o Monte da Visão</p>
+          <div class="project-tags">
+            <span class="tag">three.js</span>
+            <span class="tag">3D</span>
+            <span class="tag">Fantasia</span>
+          </div>
+        </div>
+      </a>
       <a href="/labs/santos-games/" class="project-card" data-groups="game">
         <div class="project-icon">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"

--- a/labs/jornada-do-anel/index.html
+++ b/labs/jornada-do-anel/index.html
@@ -1,0 +1,266 @@
+<!DOCTYPE html>
+<html lang="pt-br" data-theme="dark">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport"
+        content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover">
+    <meta name="theme-color" content="#0c0a08">
+    <title>A Jornada do Anel — aventura 3D | Labs</title>
+    <meta name="description"
+        content="Jogo 3D em three.js inspirado no primeiro filme da trilogia: o Condado, a fuga dos Cavaleiros, o vale élfico, as minas e o Monte da Visão.">
+    <link rel="canonical" href="https://diogopaulino.com.br/labs/jornada-do-anel/">
+
+    <meta property="og:type" content="website">
+    <meta property="og:site_name" content="Diogo Paulino · Labs">
+    <meta property="og:url" content="https://diogopaulino.com.br/labs/jornada-do-anel/">
+    <meta property="og:title" content="A Jornada do Anel">
+    <meta property="og:description"
+        content="Cinco cenas em third-person: colinas douradas, floresta noturna, conselho élfico, ponte nas minas e o cume ao entardecer.">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="A Jornada do Anel">
+    <meta name="twitter:description" content="Aventura 3D no navegador, homenagem ao primeiro filme. three.js.">
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;600;700;800&family=Outfit:wght@300;400;500;600;700&display=swap"
+        rel="stylesheet">
+    <link rel="stylesheet" href="/labs/shared.css?v=6">
+    <link rel="stylesheet" href="style.css?v=1">
+
+    <script type="importmap">
+    {
+        "imports": {
+            "three": "https://cdn.jsdelivr.net/npm/three@0.185.1/build/three.module.js",
+            "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.185.1/examples/jsm/"
+        }
+    }
+    </script>
+</head>
+
+<body>
+    <main class="game-shell">
+        <header data-lab-header data-title="A Jornada do Anel" data-back-label="Labs">
+            <template data-slot="logo">
+                <div class="app-logo">
+                    <span class="brand-mark" aria-hidden="true">○</span>
+                    <span>A Jornada do Anel</span>
+                </div>
+            </template>
+        </header>
+
+        <canvas id="scene" aria-label="Mundo 3D da jornada"></canvas>
+        <div id="fade" class="fade" aria-hidden="true"></div>
+        <div id="vignette" class="vignette" aria-hidden="true"></div>
+        <div id="hitFlash" class="hit-flash" aria-hidden="true"></div>
+
+        <div id="chapterCard" class="chapter-card" hidden>
+            <span id="chapterRoman" class="chapter-roman">I</span>
+            <h2 id="chapterTitle">O Condado</h2>
+            <p id="chapterSub">A toca redonda</p>
+        </div>
+
+        <div id="hud" class="hud" hidden>
+            <div class="hud-top">
+                <div class="panel heart-panel">
+                    <span class="hud-label">Portador</span>
+                    <div id="hearts" class="hearts" aria-label="Vida"></div>
+                    <span id="ringBadge" class="ring-badge" data-on="false" title="O Anel">○ Anel</span>
+                </div>
+                <div class="panel quest-panel">
+                    <span id="chapterTag" class="hud-label">I · O Condado</span>
+                    <p id="objective" class="objective">Encontre a toca de porta verde e pegue o Anel.</p>
+                </div>
+                <div class="panel score-panel">
+                    <div class="score-row">
+                        <span class="hud-label">Crônica</span>
+                        <strong id="pagesValue" class="mono">0/5</strong>
+                    </div>
+                    <div class="score-row score-row--sub">
+                        <span id="timeValue" class="mono">0:00</span>
+                    </div>
+                </div>
+            </div>
+
+            <div id="stealthMeter" class="stealth" hidden data-danger="false">
+                <span>Os Cavaleiros farejam</span>
+                <i><b id="stealthFill"></b></i>
+            </div>
+
+            <p id="message" class="message" role="status" aria-live="polite" data-show="false"></p>
+            <p id="prompt" class="prompt" hidden></p>
+
+            <div class="hud-actions">
+                <button id="soundButton" class="icon-button" type="button" aria-pressed="true"
+                    title="Som (M)" aria-label="Alternar som">♪</button>
+                <button id="pauseButton" class="icon-button" type="button" title="Pausar (P)"
+                    aria-label="Pausar">II</button>
+                <span id="fpsCounter" class="fps mono">—</span>
+            </div>
+
+            <div id="touchControls" class="touch-controls" hidden>
+                <div id="moveStick" class="stick" aria-label="Andar">
+                    <i id="moveKnob"></i>
+                    <span>andar</span>
+                </div>
+                <div id="lookZone" class="look-zone" aria-label="Olhar"></div>
+                <div class="touch-buttons">
+                    <button type="button" id="btnSprint" class="pad">correr</button>
+                    <button type="button" id="btnAttack" class="pad pad-atk">⚔</button>
+                    <button type="button" id="btnInteract" class="pad pad-use">E</button>
+                </div>
+            </div>
+        </div>
+
+        <div id="loadingOverlay" class="overlay loading-overlay">
+            <div class="loading-card">
+                <span class="ring-loader" aria-hidden="true"></span>
+                <h1>A Jornada do Anel</h1>
+                <p id="loadingText">Acendendo as lanternas…</p>
+                <div class="loading-bar"><i id="loadingFill"></i></div>
+            </div>
+        </div>
+
+        <div id="menuOverlay" class="overlay menu-overlay" hidden>
+            <div class="overlay-card menu-card">
+                <header class="menu-head">
+                    <p class="eyebrow"><i></i> three.js · third-person · cinco cenas</p>
+                    <h1>A Jornada <span>do Anel</span></h1>
+                    <p class="lede">Uma homenagem visual ao primeiro filme: do Condado dourado à fuga noturna,
+                        do conselho élfico às minas e ao cume ao entardecer. Textos e música originais.</p>
+                </header>
+
+                <div class="menu-grid">
+                    <section class="menu-section">
+                        <h2>Capítulo</h2>
+                        <div id="chapterList" class="chapter-list" role="list"></div>
+                    </section>
+
+                    <section class="menu-section">
+                        <h2>Comandos</h2>
+                        <div class="keys">
+                            <span><kbd>W</kbd><kbd>A</kbd><kbd>S</kbd><kbd>D</kbd> andar</span>
+                            <span><kbd>Shift</kbd> correr · mouse olhar</span>
+                            <span><kbd>E</kbd> interagir · <kbd>Espaço</kbd> atacar</span>
+                            <span><kbd>P</kbd> pausa · <kbd>M</kbd> som · <kbd>C</kbd> câmera</span>
+                        </div>
+                    </section>
+
+                    <section class="menu-section">
+                        <h2>Ajustes</h2>
+                        <div class="settings-grid">
+                            <label class="field">
+                                <span>Qualidade</span>
+                                <select id="qualitySelect">
+                                    <option value="auto">Automática</option>
+                                    <option value="low">Performance</option>
+                                    <option value="medium">Equilibrada</option>
+                                    <option value="high">Cinemática</option>
+                                </select>
+                            </label>
+                            <label class="field">
+                                <span>Volume <b id="volumeValue">70</b></span>
+                                <input id="volumeSlider" type="range" min="0" max="100" step="1" value="70">
+                            </label>
+                        </div>
+                        <p class="section-note">Melhor glória: <b id="bestScore" class="mono">—</b>
+                            · qualidade vale na próxima jornada</p>
+                    </section>
+                </div>
+
+                <footer class="menu-foot">
+                    <button id="startButton" class="primary-button" type="button">
+                        <span>Seguir a estrada</span>
+                        <i aria-hidden="true">→</i>
+                    </button>
+                </footer>
+            </div>
+        </div>
+
+        <div id="pauseOverlay" class="overlay" hidden>
+            <div class="overlay-card compact-card">
+                <p class="eyebrow"><i></i> A estrada espera</p>
+                <h2>A jornada<br>está pausada.</h2>
+                <div class="card-actions">
+                    <button id="resumeButton" class="primary-button" type="button">
+                        <span>Continuar</span><i aria-hidden="true">→</i>
+                    </button>
+                    <button id="pauseMenuButton" class="ghost-button" type="button">Voltar ao mapa</button>
+                </div>
+            </div>
+        </div>
+
+        <div id="dialogueOverlay" class="overlay dialogue-overlay" hidden>
+            <div class="dialogue-card">
+                <p id="dialogueSpeaker" class="dialogue-speaker">O Cinzento</p>
+                <p id="dialogueText" class="dialogue-text"></p>
+                <button id="dialogueContinue" class="ghost-button" type="button">Continuar</button>
+            </div>
+        </div>
+
+        <div id="gameOverOverlay" class="overlay" hidden>
+            <div class="overlay-card compact-card defeat-card">
+                <p class="eyebrow eyebrow--danger"><i></i> A sombra venceu</p>
+                <h2>A jornada<br>se quebrou.</h2>
+                <p id="defeatReason" class="lede"></p>
+                <div id="defeatStats" class="stats"></div>
+                <div class="card-actions">
+                    <button id="retryButton" class="primary-button" type="button">
+                        <span>Tentar de novo</span><i aria-hidden="true">↻</i>
+                    </button>
+                    <button id="defeatMenuButton" class="ghost-button" type="button">Voltar ao mapa</button>
+                </div>
+            </div>
+        </div>
+
+        <div id="victoryOverlay" class="overlay" hidden>
+            <div class="overlay-card compact-card victory-card">
+                <p class="eyebrow eyebrow--gold"><i></i> A companhia se parte</p>
+                <h2>O Anel segue<br>para o leste.</h2>
+                <p class="lede">Você atravessou cinco cenas do primeiro ato. A estrada não acaba aqui — mas esta jornada, sim.</p>
+                <div id="victoryStats" class="stats"></div>
+                <div class="card-actions">
+                    <button id="replayButton" class="primary-button" type="button">
+                        <span>Recomeçar no Condado</span><i aria-hidden="true">→</i>
+                    </button>
+                    <button id="victoryMenuButton" class="ghost-button" type="button">Voltar ao mapa</button>
+                </div>
+            </div>
+        </div>
+
+        <div id="errorOverlay" class="overlay" hidden>
+            <div class="overlay-card compact-card">
+                <p class="eyebrow eyebrow--danger"><i></i> WebGL indisponível</p>
+                <h2>O mapa não<br>pôde abrir.</h2>
+                <p class="lede" id="errorText">Este laboratório precisa de WebGL. Tente um navegador
+                    atualizado ou reative a aceleração de hardware.</p>
+            </div>
+        </div>
+
+        <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
+    </main>
+
+    <script src="/labs/shared.js?v=6" defer></script>
+    <script>
+        (function () {
+            function hasGpu() {
+                try {
+                    var c = document.createElement('canvas');
+                    return !!(c.getContext('webgl2') || c.getContext('webgl'));
+                } catch (e) { return false; }
+            }
+            if (!hasGpu()) {
+                document.addEventListener('DOMContentLoaded', function () {
+                    var err = document.getElementById('errorOverlay');
+                    var load = document.getElementById('loadingOverlay');
+                    if (load) load.hidden = true;
+                    if (err) err.hidden = false;
+                });
+            }
+        })();
+    </script>
+    <script type="module" src="src/main.js?v=1"></script>
+</body>
+
+</html>

--- a/labs/jornada-do-anel/index.html
+++ b/labs/jornada-do-anel/index.html
@@ -260,7 +260,7 @@
             }
         })();
     </script>
-    <script type="module" src="src/main.js?v=1"></script>
+    <script type="module" src="src/main.js?v=2"></script>
 </body>
 
 </html>

--- a/labs/jornada-do-anel/src/audio.js
+++ b/labs/jornada-do-anel/src/audio.js
@@ -1,0 +1,226 @@
+/**
+ * Trilha e efeitos — Web Audio, temas originais (nada da trilha do filme).
+ */
+
+import { clamp } from './utils.js';
+
+const THEMES = {
+    shire: { base: 196, mode: [0, 2, 4, 7, 9], tempo: 0.9, filter: 900, drone: 98 },
+    forest: { base: 110, mode: [0, 3, 5, 7, 10], tempo: 0.55, filter: 420, drone: 55 },
+    rivendell: { base: 262, mode: [0, 2, 4, 5, 7, 9], tempo: 0.75, filter: 1400, drone: 131 },
+    moria: { base: 73, mode: [0, 3, 5, 6, 10], tempo: 0.4, filter: 280, drone: 36.5 },
+    amonhen: { base: 147, mode: [0, 2, 3, 7, 9], tempo: 0.62, filter: 700, drone: 73.5 }
+};
+
+export class GameAudio {
+    constructor() {
+        this.ctx = null;
+        this.master = null;
+        this.muted = false;
+        this.volume = 0.7;
+        this.theme = 'shire';
+        this._t = 0;
+        this._step = 0;
+        this._enabled = false;
+    }
+
+    async unlock() {
+        if (this.ctx) {
+            if (this.ctx.state === 'suspended') await this.ctx.resume();
+            return;
+        }
+        const Ctx = window.AudioContext || window.webkitAudioContext;
+        if (!Ctx) return;
+        this.ctx = new Ctx();
+        this.master = this.ctx.createGain();
+        this.master.gain.value = this.muted ? 0 : this.volume;
+        this.master.connect(this.ctx.destination);
+
+        this.filter = this.ctx.createBiquadFilter();
+        this.filter.type = 'lowpass';
+        this.filter.frequency.value = 900;
+        this.filter.connect(this.master);
+
+        this.delay = this.ctx.createDelay();
+        this.delay.delayTime.value = 0.28;
+        const fb = this.ctx.createGain();
+        fb.gain.value = 0.22;
+        this.filter.connect(this.delay);
+        this.delay.connect(fb);
+        fb.connect(this.delay);
+        this.delay.connect(this.master);
+
+        this._startDrone();
+        this._enabled = true;
+    }
+
+    setMuted(muted) {
+        this.muted = muted;
+        if (this.master) this.master.gain.setTargetAtTime(muted ? 0 : this.volume, this.ctx.currentTime, 0.05);
+    }
+
+    setVolume(v) {
+        this.volume = clamp(v, 0, 1);
+        if (!this.muted && this.master) this.master.gain.setTargetAtTime(this.volume, this.ctx.currentTime, 0.05);
+    }
+
+    setTheme(id) {
+        this.theme = THEMES[id] ? id : 'shire';
+        const t = THEMES[this.theme];
+        if (this.filter) this.filter.frequency.setTargetAtTime(t.filter, this.ctx?.currentTime ?? 0, 0.4);
+        if (this.droneOsc) {
+            this.droneOsc.frequency.setTargetAtTime(t.drone, this.ctx.currentTime, 0.8);
+            this.droneOsc2.frequency.setTargetAtTime(t.drone * 1.5, this.ctx.currentTime, 0.8);
+        }
+    }
+
+    _startDrone() {
+        const t = THEMES[this.theme];
+        this.droneOsc = this.ctx.createOscillator();
+        this.droneOsc.type = 'sine';
+        this.droneOsc.frequency.value = t.drone;
+        this.droneGain = this.ctx.createGain();
+        this.droneGain.gain.value = 0.07;
+        this.droneOsc.connect(this.droneGain).connect(this.filter);
+        this.droneOsc.start();
+
+        this.droneOsc2 = this.ctx.createOscillator();
+        this.droneOsc2.type = 'triangle';
+        this.droneOsc2.frequency.value = t.drone * 1.5;
+        const g2 = this.ctx.createGain();
+        g2.gain.value = 0.03;
+        this.droneOsc2.connect(g2).connect(this.filter);
+        this.droneOsc2.start();
+    }
+
+    update(dt) {
+        if (!this._enabled || this.muted) return;
+        const theme = THEMES[this.theme];
+        this._t += dt;
+        this._step += dt;
+        const interval = theme.tempo;
+        if (this._step >= interval) {
+            this._step -= interval;
+            if (Math.random() > 0.35) this._note(theme);
+        }
+        if (this.theme === 'moria' && Math.random() < dt * 0.35) this._drum();
+    }
+
+    _note(theme) {
+        const now = this.ctx.currentTime;
+        const deg = theme.mode[(Math.random() * theme.mode.length) | 0];
+        const oct = Math.random() > 0.7 ? 2 : 1;
+        const freq = theme.base * oct * Math.pow(2, deg / 12);
+        const osc = this.ctx.createOscillator();
+        osc.type = this.theme === 'rivendell' ? 'sine' : this.theme === 'shire' ? 'triangle' : 'sawtooth';
+        osc.frequency.value = freq;
+        const g = this.ctx.createGain();
+        g.gain.setValueAtTime(0.0001, now);
+        g.gain.exponentialRampToValueAtTime(this.theme === 'moria' ? 0.04 : 0.07, now + 0.04);
+        g.gain.exponentialRampToValueAtTime(0.0001, now + 1.4);
+        osc.connect(g).connect(this.filter);
+        osc.start(now);
+        osc.stop(now + 1.5);
+    }
+
+    _drum() {
+        const now = this.ctx.currentTime;
+        const osc = this.ctx.createOscillator();
+        osc.type = 'sine';
+        osc.frequency.setValueAtTime(90, now);
+        osc.frequency.exponentialRampToValueAtTime(28, now + 0.25);
+        const g = this.ctx.createGain();
+        g.gain.setValueAtTime(0.18, now);
+        g.gain.exponentialRampToValueAtTime(0.0001, now + 0.4);
+        osc.connect(g).connect(this.master);
+        osc.start(now);
+        osc.stop(now + 0.42);
+    }
+
+    footstep() {
+        if (!this._enabled || this.muted) return;
+        const now = this.ctx.currentTime;
+        const buf = this.ctx.createBuffer(1, 2200, this.ctx.sampleRate);
+        const data = buf.getChannelData(0);
+        for (let i = 0; i < data.length; i++) data[i] = (Math.random() * 2 - 1) * (1 - i / data.length);
+        const src = this.ctx.createBufferSource();
+        src.buffer = buf;
+        const f = this.ctx.createBiquadFilter();
+        f.type = 'lowpass';
+        f.frequency.value = 500;
+        const g = this.ctx.createGain();
+        g.gain.value = 0.12;
+        src.connect(f).connect(g).connect(this.master);
+        src.start(now);
+    }
+
+    pickup() {
+        this._chime([523, 659, 784], 0.12);
+    }
+
+    chime() {
+        this._chime([392, 523, 659], 0.1);
+    }
+
+    danger() {
+        if (!this._enabled || this.muted) return;
+        const now = this.ctx.currentTime;
+        const osc = this.ctx.createOscillator();
+        osc.type = 'sawtooth';
+        osc.frequency.setValueAtTime(80, now);
+        osc.frequency.linearRampToValueAtTime(40, now + 0.8);
+        const g = this.ctx.createGain();
+        g.gain.setValueAtTime(0.12, now);
+        g.gain.exponentialRampToValueAtTime(0.0001, now + 0.9);
+        osc.connect(g).connect(this.filter);
+        osc.start(now);
+        osc.stop(now + 1);
+    }
+
+    hit() {
+        if (!this._enabled || this.muted) return;
+        const now = this.ctx.currentTime;
+        const osc = this.ctx.createOscillator();
+        osc.type = 'square';
+        osc.frequency.value = 140;
+        const g = this.ctx.createGain();
+        g.gain.setValueAtTime(0.1, now);
+        g.gain.exponentialRampToValueAtTime(0.0001, now + 0.15);
+        osc.connect(g).connect(this.master);
+        osc.start(now);
+        osc.stop(now + 0.16);
+    }
+
+    roar() {
+        if (!this._enabled || this.muted) return;
+        const now = this.ctx.currentTime;
+        const osc = this.ctx.createOscillator();
+        osc.type = 'sawtooth';
+        osc.frequency.setValueAtTime(55, now);
+        osc.frequency.linearRampToValueAtTime(28, now + 1.6);
+        const g = this.ctx.createGain();
+        g.gain.setValueAtTime(0.16, now);
+        g.gain.exponentialRampToValueAtTime(0.0001, now + 1.8);
+        osc.connect(g).connect(this.filter);
+        osc.start(now);
+        osc.stop(now + 1.9);
+    }
+
+    _chime(freqs, gain) {
+        if (!this._enabled || this.muted) return;
+        const now = this.ctx.currentTime;
+        freqs.forEach((f, i) => {
+            const osc = this.ctx.createOscillator();
+            osc.type = 'sine';
+            osc.frequency.value = f;
+            const g = this.ctx.createGain();
+            const t = now + i * 0.08;
+            g.gain.setValueAtTime(0.0001, t);
+            g.gain.exponentialRampToValueAtTime(gain, t + 0.03);
+            g.gain.exponentialRampToValueAtTime(0.0001, t + 0.5);
+            osc.connect(g).connect(this.filter);
+            osc.start(t);
+            osc.stop(t + 0.55);
+        });
+    }
+}

--- a/labs/jornada-do-anel/src/config.js
+++ b/labs/jornada-do-anel/src/config.js
@@ -1,0 +1,149 @@
+/**
+ * A Jornada do Anel — constantes, capítulos e presets de qualidade.
+ *
+ * Homenagem visual ao primeiro filme da trilogia: cinco cenas, cada uma
+ * com um objetivo, uma paleta e um clima sonoro próprios.
+ */
+
+export const STORAGE_KEY = 'jornada-do-anel-v1';
+
+export const PLAYER = {
+    walk: 4.35,
+    sprint: 7.15,
+    radius: 0.42,
+    height: 1.12,
+    eye: 0.92,
+    jump: 5.4,
+    gravity: 18,
+    turnSpeed: 10,
+    invuln: 1.4
+};
+
+export const CAMERA = {
+    distance: 6.4,
+    minDistance: 3.2,
+    maxDistance: 11,
+    height: 1.55,
+    pitchMin: -0.42,
+    pitchMax: 0.72,
+    defaultPitch: 0.18,
+    lookY: 1.05
+};
+
+export const QUALITY = {
+    low: {
+        id: 'low',
+        pixelRatio: 1,
+        antialias: false,
+        shadows: false,
+        shadowSize: 512,
+        trees: 0.45,
+        grass: 0.35,
+        particles: 0.4,
+        lights: false
+    },
+    medium: {
+        id: 'medium',
+        pixelRatio: 1.35,
+        antialias: true,
+        shadows: true,
+        shadowSize: 1024,
+        trees: 0.75,
+        grass: 0.7,
+        particles: 0.75,
+        lights: true
+    },
+    high: {
+        id: 'high',
+        pixelRatio: 1.75,
+        antialias: true,
+        shadows: true,
+        shadowSize: 2048,
+        trees: 1,
+        grass: 1,
+        particles: 1,
+        lights: true
+    }
+};
+
+/**
+ * Cinco capítulos alinhados às batidas do primeiro filme.
+ * Textos originais — nenhum diálogo copiado.
+ */
+export const CHAPTERS = [
+    {
+        id: 'shire',
+        roman: 'I',
+        title: 'O Condado',
+        subtitle: 'A toca redonda',
+        blurb: 'Colinas verdes, a árvore da festa e um anel que não deveria existir.',
+        objective: 'Encontre a toca de porta verde e pegue o Anel.',
+        hint: 'Siga as lanternas até a colina mais alta.',
+        music: 'shire',
+        fog: { color: 0xc8d6a8, near: 28, far: 118 },
+        clear: 0x8eb4d4,
+        ambient: 0xffe2b0,
+        sun: { color: 0xffd39a, intensity: 2.05, dir: [-0.55, 0.72, 0.38] },
+        hemi: { sky: 0xffe8c4, ground: 0x6a8a3a, intensity: 0.72 }
+    },
+    {
+        id: 'forest',
+        roman: 'II',
+        title: 'A Fuga',
+        subtitle: 'Cavaleiros na estrada',
+        blurb: 'A floresta fecha. Capas negras farejam o Anel. Não seja visto.',
+        objective: 'Alcance o vau do rio sem ser pego pelos Cavaleiros.',
+        hint: 'Esconda-se atrás das árvores. Eles enxergam à frente.',
+        music: 'forest',
+        fog: { color: 0x1a2230, near: 8, far: 62 },
+        clear: 0x0c1018,
+        ambient: 0x2a3348,
+        sun: { color: 0x8aa0c8, intensity: 0.35, dir: [0.2, 0.85, -0.4] },
+        hemi: { sky: 0x1c2740, ground: 0x0a120c, intensity: 0.45 }
+    },
+    {
+        id: 'rivendell',
+        roman: 'III',
+        title: 'O Vale Élfico',
+        subtitle: 'O conselho',
+        blurb: 'Quedas d’água, pedra clara e um círculo de pedras. Alguém precisa levar o Anel.',
+        objective: 'Entre no círculo do conselho e aceite a jornada.',
+        hint: 'Suba as terraces até o pavilhão dourado.',
+        music: 'rivendell',
+        fog: { color: 0xb7d4d8, near: 35, far: 130 },
+        clear: 0x9ec8d6,
+        ambient: 0xdcecff,
+        sun: { color: 0xfff1d2, intensity: 1.55, dir: [0.35, 0.8, 0.45] },
+        hemi: { sky: 0xd8f0ff, ground: 0x5a7a4a, intensity: 0.8 }
+    },
+    {
+        id: 'moria',
+        roman: 'IV',
+        title: 'As Minas',
+        subtitle: 'A ponte',
+        blurb: 'Pilares sem fim, tambores na escuridão e uma fenda que não perdoa.',
+        objective: 'Atravesse o salão e a ponte antes que a Sombra chegue.',
+        hint: 'Espaço para atacar. Corra quando a ponte tremer.',
+        music: 'moria',
+        fog: { color: 0x0a0706, near: 6, far: 48 },
+        clear: 0x070504,
+        ambient: 0x3a2214,
+        sun: { color: 0xff7a32, intensity: 0.15, dir: [0, 1, 0] },
+        hemi: { sky: 0x2a1810, ground: 0x140804, intensity: 0.35 }
+    },
+    {
+        id: 'amonhen',
+        roman: 'V',
+        title: 'O Monte da Visão',
+        subtitle: 'A partida',
+        blurb: 'Ruínas no alto, o grande rio abaixo. A companhia se parte — e a jornada continua.',
+        objective: 'Sente-se no trono de pedra e escolha seguir adiante.',
+        hint: 'Suba até o assento no cume.',
+        music: 'amonhen',
+        fog: { color: 0xd08a5a, near: 40, far: 140 },
+        clear: 0xe8a060,
+        ambient: 0xffc080,
+        sun: { color: 0xff8a3a, intensity: 1.7, dir: [-0.75, 0.35, 0.2] },
+        hemi: { sky: 0xffc090, ground: 0x4a3020, intensity: 0.7 }
+    }
+];

--- a/labs/jornada-do-anel/src/config.js
+++ b/labs/jornada-do-anel/src/config.js
@@ -83,8 +83,10 @@ export const CHAPTERS = [
         fog: { color: 0xc8d6a8, near: 28, far: 118 },
         clear: 0x8eb4d4,
         ambient: 0xffe2b0,
-        sun: { color: 0xffd39a, intensity: 2.05, dir: [-0.55, 0.72, 0.38] },
-        hemi: { sky: 0xffe8c4, ground: 0x6a8a3a, intensity: 0.72 }
+        ambientIntensity: 0.62,
+        exposure: 1.32,
+        sun: { color: 0xffd39a, intensity: 2.55, dir: [-0.45, 0.82, 0.32] },
+        hemi: { sky: 0xffe8c4, ground: 0x6a8a3a, intensity: 1.05 }
     },
     {
         id: 'forest',
@@ -98,6 +100,8 @@ export const CHAPTERS = [
         fog: { color: 0x1a2230, near: 8, far: 62 },
         clear: 0x0c1018,
         ambient: 0x2a3348,
+        ambientIntensity: 0.4,
+        exposure: 0.92,
         sun: { color: 0x8aa0c8, intensity: 0.35, dir: [0.2, 0.85, -0.4] },
         hemi: { sky: 0x1c2740, ground: 0x0a120c, intensity: 0.45 }
     },
@@ -113,6 +117,8 @@ export const CHAPTERS = [
         fog: { color: 0xb7d4d8, near: 35, far: 130 },
         clear: 0x9ec8d6,
         ambient: 0xdcecff,
+        ambientIntensity: 0.55,
+        exposure: 1.22,
         sun: { color: 0xfff1d2, intensity: 1.55, dir: [0.35, 0.8, 0.45] },
         hemi: { sky: 0xd8f0ff, ground: 0x5a7a4a, intensity: 0.8 }
     },
@@ -128,6 +134,8 @@ export const CHAPTERS = [
         fog: { color: 0x0a0706, near: 6, far: 48 },
         clear: 0x070504,
         ambient: 0x3a2214,
+        ambientIntensity: 0.45,
+        exposure: 0.88,
         sun: { color: 0xff7a32, intensity: 0.15, dir: [0, 1, 0] },
         hemi: { sky: 0x2a1810, ground: 0x140804, intensity: 0.35 }
     },
@@ -143,6 +151,8 @@ export const CHAPTERS = [
         fog: { color: 0xd08a5a, near: 40, far: 140 },
         clear: 0xe8a060,
         ambient: 0xffc080,
+        ambientIntensity: 0.58,
+        exposure: 1.18,
         sun: { color: 0xff8a3a, intensity: 1.7, dir: [-0.75, 0.35, 0.2] },
         hemi: { sky: 0xffc090, ground: 0x4a3020, intensity: 0.7 }
     }

--- a/labs/jornada-do-anel/src/hud.js
+++ b/labs/jornada-do-anel/src/hud.js
@@ -1,0 +1,233 @@
+/**
+ * HUD, menus e overlays — tudo que é DOM.
+ */
+
+import { CHAPTERS } from './config.js';
+import { formatTime } from './utils.js';
+
+const $ = (id) => document.getElementById(id);
+
+export class Hud {
+    constructor() {
+        this.el = {
+            hud: $('hud'),
+            hearts: $('hearts'),
+            chapterTag: $('chapterTag'),
+            objective: $('objective'),
+            prompt: $('prompt'),
+            message: $('message'),
+            stealth: $('stealthMeter'),
+            stealthFill: $('stealthFill'),
+            ringBadge: $('ringBadge'),
+            pages: $('pagesValue'),
+            time: $('timeValue'),
+            fps: $('fpsCounter'),
+            hitFlash: $('hitFlash'),
+            vignette: $('vignette'),
+            chapterCard: $('chapterCard'),
+            chapterRoman: $('chapterRoman'),
+            chapterTitle: $('chapterTitle'),
+            chapterSub: $('chapterSub'),
+            touch: $('touchControls'),
+            soundButton: $('soundButton'),
+            pauseButton: $('pauseButton'),
+
+            loading: $('loadingOverlay'),
+            loadingFill: $('loadingFill'),
+            loadingText: $('loadingText'),
+            menu: $('menuOverlay'),
+            pause: $('pauseOverlay'),
+            dialogue: $('dialogueOverlay'),
+            dialogueSpeaker: $('dialogueSpeaker'),
+            dialogueText: $('dialogueText'),
+            gameOver: $('gameOverOverlay'),
+            victory: $('victoryOverlay'),
+            error: $('errorOverlay'),
+            errorText: $('errorText'),
+            qualitySelect: $('qualitySelect'),
+            volumeSlider: $('volumeSlider'),
+            volumeValue: $('volumeValue'),
+            chapterList: $('chapterList'),
+            bestScore: $('bestScore'),
+            defeatStats: $('defeatStats'),
+            victoryStats: $('victoryStats')
+        };
+        this.messageTimer = 0;
+        this.cardTimer = 0;
+    }
+
+    setState(state) {
+        document.body.dataset.state = state;
+    }
+
+    setLoading(progress, text) {
+        if (text) this.el.loadingText.textContent = text;
+        this.el.loadingFill.style.width = `${Math.round(progress * 100)}%`;
+    }
+
+    hideLoading() {
+        this.el.loading.hidden = true;
+    }
+
+    showError(message) {
+        if (message) this.el.errorText.textContent = message;
+        this.el.error.hidden = false;
+        this.el.loading.hidden = true;
+    }
+
+    showHud(v) {
+        this.el.hud.hidden = !v;
+    }
+
+    setTouchVisible(v) {
+        this.el.touch.hidden = !v;
+    }
+
+    setHearts(cur, max) {
+        let html = '';
+        for (let i = 0; i < max; i++) {
+            html += `<i class="heart${i < cur ? ' is-on' : ''}"></i>`;
+        }
+        this.el.hearts.innerHTML = html;
+    }
+
+    setChapter(ch) {
+        this.el.chapterTag.textContent = `${ch.roman} · ${ch.title}`;
+        this.el.objective.textContent = ch.objective;
+    }
+
+    setPrompt(text) {
+        if (!text) {
+            this.el.prompt.hidden = true;
+            return;
+        }
+        this.el.prompt.hidden = false;
+        this.el.prompt.innerHTML = `<kbd>E</kbd> ${text}`;
+    }
+
+    say(text, seconds = 4) {
+        this.el.message.textContent = text;
+        this.el.message.dataset.show = 'true';
+        this.messageTimer = seconds;
+    }
+
+    setStealth(alert) {
+        const on = alert > 0.02;
+        this.el.stealth.hidden = !on;
+        this.el.stealthFill.style.transform = `scaleX(${Math.min(1, alert)})`;
+        this.el.stealth.dataset.danger = alert > 0.55 ? 'true' : 'false';
+        this.el.vignette.style.opacity = String(Math.min(0.55, alert * 0.6));
+    }
+
+    setRing(has) {
+        this.el.ringBadge.dataset.on = has ? 'true' : 'false';
+    }
+
+    setPages(n, total) {
+        this.el.pages.textContent = `${n}/${total}`;
+    }
+
+    setTime(s) {
+        this.el.time.textContent = formatTime(s);
+    }
+
+    setFps(n) {
+        this.el.fps.textContent = `${n} fps`;
+    }
+
+    setMuted(m) {
+        this.el.soundButton.setAttribute('aria-pressed', m ? 'false' : 'true');
+        this.el.soundButton.textContent = m ? '♪̸' : '♪';
+    }
+
+    flashHit() {
+        this.el.hitFlash.classList.remove('is-on');
+        void this.el.hitFlash.offsetWidth;
+        this.el.hitFlash.classList.add('is-on');
+    }
+
+    showChapterCard(ch) {
+        this.el.chapterRoman.textContent = ch.roman;
+        this.el.chapterTitle.textContent = ch.title;
+        this.el.chapterSub.textContent = ch.subtitle;
+        this.el.chapterCard.hidden = false;
+        this.el.chapterCard.classList.add('is-on');
+        this.cardTimer = 3.6;
+    }
+
+    tick(dt) {
+        if (this.messageTimer > 0) {
+            this.messageTimer -= dt;
+            if (this.messageTimer <= 0) this.el.message.dataset.show = 'false';
+        }
+        if (this.cardTimer > 0) {
+            this.cardTimer -= dt;
+            if (this.cardTimer <= 0) {
+                this.el.chapterCard.classList.remove('is-on');
+                this.el.chapterCard.hidden = true;
+            }
+        }
+    }
+
+    showMenu(show) {
+        this.el.menu.hidden = !show;
+    }
+
+    showPause(show) {
+        this.el.pause.hidden = !show;
+    }
+
+    showDialogue(speaker, text) {
+        this.el.dialogue.hidden = false;
+        this.el.dialogueSpeaker.textContent = speaker;
+        this.el.dialogueText.textContent = text;
+    }
+
+    hideDialogue() {
+        this.el.dialogue.hidden = true;
+    }
+
+    showDefeat(statsHtml) {
+        this.el.defeatStats.innerHTML = statsHtml;
+        this.el.gameOver.hidden = false;
+    }
+
+    hideDefeat() {
+        this.el.gameOver.hidden = true;
+    }
+
+    showVictory(statsHtml) {
+        this.el.victoryStats.innerHTML = statsHtml;
+        this.el.victory.hidden = false;
+    }
+
+    hideVictory() {
+        this.el.victory.hidden = true;
+    }
+
+    fillChapters(unlocked, currentId, onPick) {
+        this.el.chapterList.innerHTML = '';
+        CHAPTERS.forEach((ch, i) => {
+            const btn = document.createElement('button');
+            btn.type = 'button';
+            btn.className = 'chapter-chip';
+            btn.disabled = i > unlocked;
+            btn.dataset.active = ch.id === currentId ? 'true' : 'false';
+            btn.innerHTML = `<b>${ch.roman}</b><span>${ch.title}</span>`;
+            btn.addEventListener('click', () => onPick(i));
+            this.el.chapterList.appendChild(btn);
+        });
+    }
+
+    setBest(n) {
+        this.el.bestScore.textContent = n ? String(n) : '—';
+    }
+
+    setVolumeLabel(v) {
+        this.el.volumeValue.textContent = String(Math.round(v));
+    }
+}
+
+export function statsBlock(rows) {
+    return rows.map(([k, v]) => `<div><span>${k}</span><strong>${v}</strong></div>`).join('');
+}

--- a/labs/jornada-do-anel/src/input.js
+++ b/labs/jornada-do-anel/src/input.js
@@ -1,0 +1,164 @@
+/**
+ * Teclado, mouse (pointer lock), toque e atalhos de HUD.
+ */
+
+import { clamp } from './utils.js';
+
+const MOVE = {
+    KeyW: 'forward',
+    ArrowUp: 'forward',
+    KeyS: 'back',
+    ArrowDown: 'back',
+    KeyA: 'left',
+    ArrowLeft: 'left',
+    KeyD: 'right',
+    ArrowRight: 'right',
+    ShiftLeft: 'sprint',
+    ShiftRight: 'sprint',
+    Space: 'attack',
+    KeyE: 'interact',
+    KeyF: 'interact'
+};
+
+const ACTIONS = {
+    KeyP: 'pause',
+    Escape: 'pause',
+    KeyM: 'mute',
+    KeyC: 'camera',
+    Enter: 'confirm'
+};
+
+export class Input {
+    constructor(canvas) {
+        this.canvas = canvas;
+        this.keys = new Set();
+        this.lookX = 0;
+        this.lookY = 0;
+        this.zoomDelta = 0;
+        this.locked = false;
+        this.enabled = true;
+        this.listeners = new Map();
+        this.touchMove = { x: 0, y: 0 };
+        this.touchLook = { x: 0, y: 0 };
+        this.touchSprint = false;
+        this.interactPressed = false;
+        this.attackPressed = false;
+        this._bind();
+    }
+
+    on(action, handler) {
+        if (!this.listeners.has(action)) this.listeners.set(action, new Set());
+        this.listeners.get(action).add(handler);
+        return () => this.listeners.get(action).delete(handler);
+    }
+
+    emit(action, payload) {
+        this.listeners.get(action)?.forEach((fn) => fn(payload));
+    }
+
+    consumeLook() {
+        const x = this.lookX;
+        const y = this.lookY;
+        this.lookX = 0;
+        this.lookY = 0;
+        return { x, y };
+    }
+
+    consumeZoom() {
+        const z = this.zoomDelta;
+        this.zoomDelta = 0;
+        return z;
+    }
+
+    consumeInteract() {
+        const v = this.interactPressed;
+        this.interactPressed = false;
+        return v;
+    }
+
+    consumeAttack() {
+        const v = this.attackPressed;
+        this.attackPressed = false;
+        return v;
+    }
+
+    get move() {
+        const f = this.keys.has('forward') ? 1 : 0;
+        const b = this.keys.has('back') ? 1 : 0;
+        const r = this.keys.has('right') ? 1 : 0;
+        const l = this.keys.has('left') ? 1 : 0;
+        return {
+            x: clamp(r - l + this.touchMove.x, -1, 1),
+            z: clamp(f - b + this.touchMove.y, -1, 1),
+            sprint: this.keys.has('sprint') || this.touchSprint
+        };
+    }
+
+    requestLock() {
+        if (this.locked) return;
+        this.canvas.requestPointerLock?.();
+    }
+
+    exitLock() {
+        if (document.pointerLockElement) document.exitPointerLock?.();
+    }
+
+    _bind() {
+        this._onKeyDown = (e) => {
+            if (!this.enabled) return;
+            const action = ACTIONS[e.code];
+            if (action) {
+                if (action === 'confirm' && document.activeElement?.tagName === 'BUTTON') return;
+                this.emit(action);
+                if (action !== 'confirm') e.preventDefault();
+            }
+            const key = MOVE[e.code];
+            if (!key) return;
+            e.preventDefault();
+            this.keys.add(key);
+            if (key === 'interact') this.interactPressed = true;
+            if (key === 'attack') this.attackPressed = true;
+        };
+
+        this._onKeyUp = (e) => {
+            const key = MOVE[e.code];
+            if (key) this.keys.delete(key);
+        };
+
+        this._onMouseMove = (e) => {
+            if (!this.enabled) return;
+            if (this.locked) {
+                this.lookX += e.movementX;
+                this.lookY += e.movementY;
+            }
+        };
+
+        this._onMouseDown = (e) => {
+            if (!this.enabled) return;
+            if (e.button === 0) {
+                this.attackPressed = true;
+                this.emit('pointerdown');
+            }
+        };
+
+        this._onWheel = (e) => {
+            if (!this.enabled) return;
+            this.zoomDelta += Math.sign(e.deltaY);
+            e.preventDefault();
+        };
+
+        this._onLock = () => {
+            this.locked = document.pointerLockElement === this.canvas;
+        };
+
+        this._onContext = (e) => e.preventDefault();
+
+        window.addEventListener('keydown', this._onKeyDown);
+        window.addEventListener('keyup', this._onKeyUp);
+        window.addEventListener('mousemove', this._onMouseMove);
+        this.canvas.addEventListener('mousedown', this._onMouseDown);
+        this.canvas.addEventListener('wheel', this._onWheel, { passive: false });
+        this.canvas.addEventListener('contextmenu', this._onContext);
+        document.addEventListener('pointerlockchange', this._onLock);
+    }
+}

--- a/labs/jornada-do-anel/src/input.js
+++ b/labs/jornada-do-anel/src/input.js
@@ -96,7 +96,8 @@ export class Input {
 
     requestLock() {
         if (this.locked) return;
-        this.canvas.requestPointerLock?.();
+        const result = this.canvas.requestPointerLock?.();
+        if (result && typeof result.catch === 'function') result.catch(() => {});
     }
 
     exitLock() {

--- a/labs/jornada-do-anel/src/main.js
+++ b/labs/jornada-do-anel/src/main.js
@@ -1,0 +1,691 @@
+/**
+ * A Jornada do Anel — laço principal, capítulos e câmera cinematográfica.
+ */
+
+import * as THREE from 'three';
+import { CHAPTERS, QUALITY, STORAGE_KEY } from './config.js';
+import { clamp, detectMobile, detectSoftwareGL, formatTime } from './utils.js';
+import { Input } from './input.js';
+import { GameAudio } from './audio.js';
+import { Hud, statsBlock } from './hud.js';
+import { Player } from './player.js';
+import { createSky, applyChapterSky, createLights } from './sky.js';
+import { buildChapter } from './world.js';
+import { nearestInteractable } from './npcs.js';
+
+const LOOK = new THREE.Vector3();
+const CAM = new THREE.Vector3();
+
+class Game {
+    constructor() {
+        this.hud = new Hud();
+        this.canvas = document.getElementById('scene');
+        this.settings = this.loadSettings();
+        this.state = 'loading';
+        this.chapterIndex = 0;
+        this.time = 0;
+        this.elapsed = 0;
+        this.pages = 0;
+        this.score = 0;
+        this.caught = 0;
+        this.kills = 0;
+        this.introT = 0;
+        this.fade = 1;
+        this.fadeDir = -1;
+        this.dialogue = null;
+        this.fpsAccum = 0;
+        this.fpsFrames = 0;
+        this.hudAccum = 0;
+        this.orbit = 0;
+        this.pendingChapter = 0;
+    }
+
+    loadSettings() {
+        const fallback = {
+            quality: 'auto',
+            volume: 70,
+            muted: false,
+            best: 0,
+            unlocked: 0
+        };
+        try {
+            const raw = localStorage.getItem(STORAGE_KEY);
+            return raw ? { ...fallback, ...JSON.parse(raw) } : fallback;
+        } catch (err) {
+            return fallback;
+        }
+    }
+
+    saveSettings() {
+        try {
+            localStorage.setItem(STORAGE_KEY, JSON.stringify(this.settings));
+        } catch (err) { /* privado */ }
+    }
+
+    resolveQuality() {
+        const choice = this.settings.quality;
+        if (choice !== 'auto' && QUALITY[choice]) return QUALITY[choice];
+        if (detectMobile() || detectSoftwareGL()) return QUALITY.low;
+        const big = Math.min(window.innerWidth, window.innerHeight) >= 900;
+        return big ? QUALITY.high : QUALITY.medium;
+    }
+
+    async init() {
+        this.hud.setLoading(0.12, 'Abrindo o mapa da Terra Média…');
+        this.quality = this.resolveQuality();
+        this.mobile = detectMobile();
+
+        try {
+            this.renderer = new THREE.WebGLRenderer({
+                canvas: this.canvas,
+                antialias: this.quality.antialias,
+                powerPreference: 'high-performance',
+                alpha: false
+            });
+        } catch (err) {
+            this.hud.showError('Não foi possível criar o contexto WebGL.');
+            return;
+        }
+
+        this.renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, this.quality.pixelRatio));
+        this.renderer.setSize(window.innerWidth, window.innerHeight);
+        this.renderer.outputColorSpace = THREE.SRGBColorSpace;
+        this.renderer.toneMapping = THREE.ACESFilmicToneMapping;
+        this.renderer.toneMappingExposure = 1.05;
+        this.renderer.shadowMap.enabled = this.quality.shadows;
+        this.renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+        this.renderer.setClearColor(CHAPTERS[0].clear);
+
+        this.scene = new THREE.Scene();
+        this.camera = new THREE.PerspectiveCamera(52, window.innerWidth / window.innerHeight, 0.12, 520);
+        this.sky = createSky();
+        this.scene.add(this.sky.mesh);
+
+        this.hud.setLoading(0.4, 'Erguendo as colinas do Condado…');
+        this.input = new Input(this.canvas);
+        this.audio = new GameAudio();
+        this.player = new Player(this.scene);
+        this.player.root.visible = false;
+
+        this.clock = new THREE.Clock();
+        this._bindUi();
+        window.addEventListener('resize', () => this._resize());
+
+        await this._loadChapter(0, { menu: true });
+        this.hud.setLoading(1, 'A estrada espera.');
+        this.hud.hideLoading();
+        this._refreshChapterList();
+
+        this.hud.el.qualitySelect.value = this.settings.quality;
+        this.hud.el.volumeSlider.value = String(this.settings.volume);
+        this.hud.setVolumeLabel(this.settings.volume);
+        this.hud.setBest(this.settings.best);
+        this.hud.setMuted(this.settings.muted);
+        this.hud.showMenu(true);
+        this.state = 'menu';
+        this.hud.setState('menu');
+        this._loop();
+    }
+
+    _refreshChapterList() {
+        this.hud.fillChapters(this.settings.unlocked, CHAPTERS[this.pendingChapter].id, (i) => {
+            this.pendingChapter = i;
+            this._refreshChapterList();
+        });
+    }
+
+    _bindUi() {
+        this.hud.el.qualitySelect.addEventListener('change', () => {
+            this.settings.quality = this.hud.el.qualitySelect.value;
+            this.saveSettings();
+        });
+        this.hud.el.volumeSlider.addEventListener('input', () => {
+            this.settings.volume = Number(this.hud.el.volumeSlider.value);
+            this.hud.setVolumeLabel(this.settings.volume);
+            this.audio.setVolume(this.settings.volume / 100);
+            this.saveSettings();
+        });
+        document.getElementById('startButton').addEventListener('click', () => this.start(this.pendingChapter));
+        document.getElementById('resumeButton').addEventListener('click', () => this.resume());
+        document.getElementById('pauseMenuButton').addEventListener('click', () => this.toMenu());
+        document.getElementById('retryButton').addEventListener('click', () => this.start(this.chapterIndex));
+        document.getElementById('defeatMenuButton').addEventListener('click', () => this.toMenu());
+        document.getElementById('replayButton').addEventListener('click', () => this.start(0));
+        document.getElementById('victoryMenuButton').addEventListener('click', () => this.toMenu());
+        document.getElementById('dialogueContinue').addEventListener('click', () => this._advanceDialogue());
+        this.hud.el.soundButton.addEventListener('click', () => this.toggleMute());
+        this.hud.el.pauseButton.addEventListener('click', () => this.pause());
+
+        this.input.on('pause', () => {
+            if (this.state === 'playing') this.pause();
+            else if (this.state === 'pause') this.resume();
+        });
+        this.input.on('camera', () => {
+            const dists = [4.4, 6.4, 9.4];
+            const i = dists.findIndex((d) => Math.abs(this.player.camDist - d) < 0.3);
+            this.player.camDist = dists[(i + 1) % dists.length];
+        });
+        this.input.on('mute', () => this.toggleMute());
+        this.input.on('confirm', () => {
+            if (this.state === 'dialogue') this._advanceDialogue();
+        });
+        this.input.on('pointerdown', () => {
+            if (this.state === 'playing') this.input.requestLock();
+            if (this.state === 'dialogue') this._advanceDialogue();
+        });
+
+        this._bindTouch();
+    }
+
+    _bindTouch() {
+        const stick = document.getElementById('moveStick');
+        const knob = document.getElementById('moveKnob');
+        if (!stick) return;
+        const setFrom = (clientX, clientY) => {
+            const r = stick.getBoundingClientRect();
+            const cx = r.left + r.width / 2;
+            const cy = r.top + r.height / 2;
+            let dx = (clientX - cx) / (r.width * 0.42);
+            let dy = (clientY - cy) / (r.height * 0.42);
+            const len = Math.hypot(dx, dy) || 1;
+            if (len > 1) {
+                dx /= len;
+                dy /= len;
+            }
+            this.input.touchMove.x = dx;
+            this.input.touchMove.y = -dy;
+            knob.style.transform = `translate(${dx * 22}px, ${dy * 22}px)`;
+        };
+        const end = () => {
+            this.input.touchMove.x = 0;
+            this.input.touchMove.y = 0;
+            knob.style.transform = 'translate(0,0)';
+        };
+        stick.addEventListener('pointerdown', (e) => {
+            stick.setPointerCapture(e.pointerId);
+            setFrom(e.clientX, e.clientY);
+        });
+        stick.addEventListener('pointermove', (e) => {
+            if (stick.hasPointerCapture(e.pointerId)) setFrom(e.clientX, e.clientY);
+        });
+        stick.addEventListener('pointerup', end);
+        stick.addEventListener('pointercancel', end);
+
+        const lookZone = document.getElementById('lookZone');
+        let lx = 0;
+        let ly = 0;
+        lookZone?.addEventListener('pointerdown', (e) => {
+            lookZone.setPointerCapture(e.pointerId);
+            lx = e.clientX;
+            ly = e.clientY;
+        });
+        lookZone?.addEventListener('pointermove', (e) => {
+            if (!lookZone.hasPointerCapture(e.pointerId)) return;
+            this.input.lookX += e.clientX - lx;
+            this.input.lookY += e.clientY - ly;
+            lx = e.clientX;
+            ly = e.clientY;
+        });
+
+        document.getElementById('btnInteract')?.addEventListener('click', () => {
+            this.input.interactPressed = true;
+        });
+        document.getElementById('btnAttack')?.addEventListener('click', () => {
+            this.input.attackPressed = true;
+        });
+        document.getElementById('btnSprint')?.addEventListener('pointerdown', () => {
+            this.input.touchSprint = true;
+        });
+        document.getElementById('btnSprint')?.addEventListener('pointerup', () => {
+            this.input.touchSprint = false;
+        });
+    }
+
+    async _loadChapter(index, { menu = false } = {}) {
+        const ch = CHAPTERS[index];
+        this.chapterIndex = index;
+        this.chapter = ch;
+
+        if (this.world) {
+            this.scene.remove(this.world.group);
+            this.world = null;
+        }
+        if (this.lights) {
+            this.scene.remove(this.lights.group);
+            this.lights = null;
+        }
+
+        this.world = buildChapter(ch.id, this.quality);
+        this.scene.add(this.world.group);
+        this.lights = createLights(this.scene, ch, this.quality);
+        applyChapterSky(this.sky, ch);
+        this.scene.fog = new THREE.Fog(ch.fog.color, ch.fog.near, ch.fog.far);
+        this.renderer.setClearColor(ch.clear);
+        this.audio.setTheme(ch.music);
+
+        if (this.lights.dir && this.quality.shadows) {
+            this.lights.dir.target.position.set(0, 0, 0);
+        }
+
+        if (!menu) {
+            const s = this.world.spawn;
+            this.player.spawn(s.x, s.z, s.yaw, this.world.heightAt);
+            this.player.setHasRing(index > 0 || this.player.hasRing);
+            if (index > 0) this.player.setHasRing(true);
+        } else {
+            this.player.root.visible = false;
+        }
+    }
+
+    async start(index = 0) {
+        await this.audio.unlock();
+        this.audio.setVolume(this.settings.volume / 100);
+        this.audio.setMuted(this.settings.muted);
+
+        this.quality = this.resolveQuality();
+        this.renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, this.quality.pixelRatio));
+        this.renderer.shadowMap.enabled = this.quality.shadows;
+
+        this.pendingChapter = index;
+        this.chapterIndex = index;
+        this.elapsed = 0;
+        this.pages = 0;
+        this.score = 0;
+        this.caught = 0;
+        this.kills = 0;
+        this.player.hasRing = index > 0;
+        this.player.maxHealth = 3;
+        this.hud.hideDefeat();
+        this.hud.hideVictory();
+        this.hud.showMenu(false);
+        this.hud.hideDialogue();
+        this.hud.showPause(false);
+
+        await this._loadChapter(index);
+        this._beginIntro();
+    }
+
+    _beginIntro() {
+        this.state = 'intro';
+        this.hud.setState('intro');
+        this.introT = 0;
+        this.player.root.visible = true;
+        this.hud.showHud(true);
+        this.hud.setTouchVisible(this.mobile);
+        this.hud.setChapter(this.chapter);
+        this.hud.setHearts(this.player.health, this.player.maxHealth);
+        this.hud.setRing(this.player.hasRing);
+        this.hud.setPages(this.pages, CHAPTERS.length);
+        this.hud.showChapterCard(this.chapter);
+        this.hud.say(this.chapter.objective, 5);
+        this.input.enabled = false;
+        this.fade = 1;
+        this.fadeDir = -1;
+    }
+
+    pause() {
+        if (this.state !== 'playing') return;
+        this.state = 'pause';
+        this.hud.setState('pause');
+        this.hud.showPause(true);
+        this.input.exitLock();
+        this.input.enabled = false;
+    }
+
+    resume() {
+        if (this.state !== 'pause') return;
+        this.state = 'playing';
+        this.hud.setState('playing');
+        this.hud.showPause(false);
+        this.input.enabled = true;
+        if (!this.mobile) this.input.requestLock();
+    }
+
+    async toMenu() {
+        this.hud.showPause(false);
+        this.hud.hideDefeat();
+        this.hud.hideVictory();
+        this.hud.hideDialogue();
+        this.hud.showHud(false);
+        this.player.root.visible = false;
+        this.input.exitLock();
+        this.input.enabled = true;
+        await this._loadChapter(0, { menu: true });
+        this._refreshChapterList();
+        this.hud.showMenu(true);
+        this.state = 'menu';
+        this.hud.setState('menu');
+    }
+
+    toggleMute() {
+        this.settings.muted = !this.settings.muted;
+        this.audio.setMuted(this.settings.muted);
+        this.hud.setMuted(this.settings.muted);
+        this.saveSettings();
+    }
+
+    _loop() {
+        requestAnimationFrame(() => this._loop());
+        const dt = Math.min(0.05, this.clock.getDelta());
+        this.time += dt;
+        this._update(dt);
+        this.renderer.render(this.scene, this.camera);
+        this.fpsFrames += 1;
+        this.fpsAccum += dt;
+        if (this.fpsAccum >= 0.5) {
+            this.hud.setFps(Math.round(this.fpsFrames / this.fpsAccum));
+            this.fpsFrames = 0;
+            this.fpsAccum = 0;
+        }
+    }
+
+    _update(dt) {
+        this.hud.tick(dt);
+        this.audio.update(dt);
+        this.world?.updateFns.forEach((fn) => fn(this.time, dt));
+        for (const w of this.world?.waterMeshes || []) {
+            if (w.userData.baseY == null) w.userData.baseY = w.position.y;
+            if (w.material.map) w.material.map.offset.x = this.time * 0.02;
+            w.position.y = w.userData.baseY + Math.sin(this.time * 1.4) * 0.05;
+        }
+
+        this.fade = clamp(this.fade + this.fadeDir * dt * 0.85, 0, 1);
+        document.getElementById('fade').style.opacity = String(this.fade);
+
+        if (this.state === 'menu') {
+            this._updateMenuCam(dt);
+            return;
+        }
+        if (this.state === 'intro') {
+            this._updateIntro(dt);
+            return;
+        }
+        if (this.state === 'pause' || this.state === 'dialogue' || this.state === 'defeat' || this.state === 'victory') {
+            this._followCamera(1);
+            return;
+        }
+        if (this.state !== 'playing') return;
+
+        this.elapsed += dt;
+        this.hudAccum += dt;
+        if (this.hudAccum > 0.2) {
+            this.hud.setTime(this.elapsed);
+            this.hudAccum = 0;
+        }
+
+        const info = this.player.update(dt, this.input, this.world);
+        if (info.footstep) this.audio.footstep();
+        if (info.attacking) {
+            const hits = this.player.attackHit(this.world.goblins);
+            for (const g of hits) {
+                this.audio.hit();
+                if (g.hit()) {
+                    this.kills += 1;
+                    this.score += 40;
+                }
+            }
+        }
+
+        this._updateNpcs(dt);
+        this._updateInteract();
+        this._checkHazards();
+        this._followCamera(dt);
+        this.sky.mesh.position.copy(this.camera.position);
+        if (this.quality.shadows && this.lights?.dir) {
+            this.lights.dir.position.set(
+                this.player.x + this.chapter.sun.dir[0] * 40,
+                this.player.y + this.chapter.sun.dir[1] * 40,
+                this.player.z + this.chapter.sun.dir[2] * 40
+            );
+            this.lights.dir.target.position.set(this.player.x, this.player.y, this.player.z);
+            this.lights.dir.target.updateMatrixWorld();
+        }
+    }
+
+    _updateMenuCam(dt) {
+        this.orbit += dt * 0.12;
+        const o = this.world.overview;
+        this.camera.position.set(
+            Math.sin(this.orbit) * o.x,
+            o.y,
+            Math.cos(this.orbit) * o.z
+        );
+        this.camera.lookAt(0, 2.5, 0);
+        this.sky.mesh.position.copy(this.camera.position);
+    }
+
+    _updateIntro(dt) {
+        this.introT += dt;
+        const t = clamp(this.introT / 3.4, 0, 1);
+        const e = t * t * (3 - 2 * t);
+        const o = this.world.overview;
+        this.player.cameraPosition(CAM);
+        this.player.lookAt(LOOK);
+        this.camera.position.set(
+            lerp(o.x, CAM.x, e),
+            lerp(o.y, CAM.y, e),
+            lerp(o.z, CAM.z, e)
+        );
+        const look = new THREE.Vector3(
+            lerp(0, LOOK.x, e),
+            lerp(3, LOOK.y, e),
+            lerp(0, LOOK.z, e)
+        );
+        this.camera.lookAt(look);
+        if (t >= 1) {
+            this.state = 'playing';
+            this.hud.setState('playing');
+            this.input.enabled = true;
+            if (!this.mobile) this.input.requestLock();
+        }
+    }
+
+    _followCamera(dt) {
+        this.player.cameraPosition(CAM);
+        this.player.lookAt(LOOK);
+        // Evita a câmera enterrar no chão.
+        const gy = this.world.heightAt(CAM.x, CAM.z) + 1.1;
+        if (CAM.y < gy) CAM.y = gy;
+        const k = 1 - Math.exp(-10 * (dt || 0.016));
+        this.camera.position.lerp(CAM, k);
+        this.camera.lookAt(LOOK);
+    }
+
+    _updateNpcs(dt) {
+        let maxAlert = 0;
+        for (const r of this.world.riders) {
+            const ev = r.update(dt, this.player, this.world.heightAt);
+            maxAlert = Math.max(maxAlert, r.alert, ev === 'chase' ? 0.85 : 0);
+            if (ev === 'caught') {
+                this.caught += 1;
+                this.audio.danger();
+                this.hud.flashHit();
+                if (this.player.hurt(1)) {
+                    this.hud.setHearts(this.player.health, this.player.maxHealth);
+                    this.hud.say('Os Cavaleiros alcançaram você.', 3);
+                    if (!this.player.alive) this._defeat('Os Cavaleiros levaram o portador.');
+                    else {
+                        // Empurra de volta.
+                        this.player.x -= Math.sin(r.yaw) * 2.4;
+                        this.player.z -= Math.cos(r.yaw) * 2.4;
+                    }
+                }
+            } else if (ev === 'chase' && Math.random() < dt * 0.4) {
+                this.audio.danger();
+            }
+        }
+        this.hud.setStealth(this.world.riders.length ? maxAlert : 0);
+
+        for (const g of this.world.goblins) {
+            const ev = g.update(dt, this.player, this.world.heightAt);
+            if (ev === 'hit') {
+                this.audio.hit();
+                this.hud.flashHit();
+                if (this.player.hurt(1)) {
+                    this.hud.setHearts(this.player.health, this.player.maxHealth);
+                    if (!this.player.alive) this._defeat('A escuridão das minas venceu.');
+                }
+            }
+        }
+    }
+
+    _updateInteract() {
+        const near = nearestInteractable(this.player, this.world.interactables);
+        this.hud.setPrompt(near ? near.label : '');
+        if (!near || !this.input.consumeInteract()) return;
+
+        if (near.kind === 'talk') {
+            this._openDialogue(near.id === 'wizard' ? 'O Cinzento' : 'O jardineiro', near.lines, near);
+            return;
+        }
+        if (near.kind === 'page') {
+            near.done = true;
+            near.mesh.visible = false;
+            this.pages += 1;
+            this.score += 80;
+            this.audio.pickup();
+            this.hud.setPages(this.pages, CHAPTERS.length);
+            this.hud.say('Uma página da crônica.', 2.5);
+            return;
+        }
+        if (near.kind === 'ring') {
+            near.done = true;
+            near.mesh.visible = false;
+            this.player.setHasRing(true);
+            this.hud.setRing(true);
+            this.score += 120;
+            this.audio.pickup();
+            this.hud.say('O Anel é seu. Não o use.', 4);
+            this._completeChapter();
+            return;
+        }
+        if (near.kind === 'goal') {
+            near.done = true;
+            this.audio.chime();
+            this.score += 100;
+            this._completeChapter();
+        }
+    }
+
+    _openDialogue(speaker, lines, item) {
+        this.dialogue = { speaker, lines: [...lines], item };
+        this.state = 'dialogue';
+        this.hud.setState('dialogue');
+        this.input.exitLock();
+        this.input.enabled = true;
+        this.hud.showDialogue(speaker, lines[0]);
+        this.dialogue.lines.shift();
+    }
+
+    _advanceDialogue() {
+        if (!this.dialogue) return;
+        if (this.dialogue.lines.length) {
+            this.hud.showDialogue(this.dialogue.speaker, this.dialogue.lines.shift());
+            this.audio.chime();
+            return;
+        }
+        if (this.dialogue.item) this.dialogue.item.done = true;
+        this.dialogue = null;
+        this.hud.hideDialogue();
+        this.state = 'playing';
+        this.hud.setState('playing');
+        if (!this.mobile) this.input.requestLock();
+    }
+
+    _checkHazards() {
+        if (this.chapter.id === 'moria') {
+            if (this.player.z > 72 && !this.world.balrogAwake) {
+                this.world.balrogAwake = true;
+                this.audio.roar();
+                this.hud.say('A Sombra acordou. Corra pela ponte!', 4);
+            }
+            if (this.player.y < -2) {
+                this._defeat('A fenda engoliu o portador.');
+            }
+        }
+    }
+
+    async _completeChapter() {
+        if (this.state === 'transition') return;
+        this.state = 'transition';
+        this.hud.setState('transition');
+        this.input.enabled = false;
+        this.input.exitLock();
+        this.score += 200;
+        this.fadeDir = 1;
+        this.hud.say(this.chapterIndex === CHAPTERS.length - 1 ? 'A jornada segue…' : 'A estrada continua.', 2.5);
+        await wait(1400);
+
+        const next = this.chapterIndex + 1;
+        this.settings.unlocked = Math.max(this.settings.unlocked, next);
+        this.saveSettings();
+
+        if (next >= CHAPTERS.length) {
+            this._victory();
+            return;
+        }
+        await this._loadChapter(next);
+        this._beginIntro();
+    }
+
+    _defeat(reason) {
+        if (this.state === 'defeat') return;
+        this.state = 'defeat';
+        this.hud.setState('defeat');
+        this.input.exitLock();
+        this.input.enabled = true;
+        this.audio.danger();
+        this.hud.showDefeat(statsBlock([
+            ['Capítulo', this.chapter.title],
+            ['Tempo', formatTime(this.elapsed)],
+            ['Páginas', `${this.pages}/${CHAPTERS.length}`]
+        ]));
+        document.querySelector('#gameOverOverlay .lede')?.replaceChildren();
+        const p = document.querySelector('#defeatReason');
+        if (p) p.textContent = reason;
+    }
+
+    _victory() {
+        this.state = 'victory';
+        this.hud.setState('victory');
+        this.input.exitLock();
+        const total = this.score + this.pages * 50 + Math.max(0, 600 - Math.floor(this.elapsed));
+        if (total > this.settings.best) {
+            this.settings.best = total;
+            this.saveSettings();
+        }
+        this.hud.showVictory(statsBlock([
+            ['Glória', String(total)],
+            ['Tempo', formatTime(this.elapsed)],
+            ['Páginas', `${this.pages}/${CHAPTERS.length}`],
+            ['Cavaleiros evadidos', this.caught === 0 ? 'nenhum encontro fatal' : `${this.caught} vezes`]
+        ]));
+        this.hud.setBest(this.settings.best);
+    }
+
+    _resize() {
+        const w = window.innerWidth;
+        const h = window.innerHeight;
+        this.camera.aspect = w / h;
+        this.camera.updateProjectionMatrix();
+        this.renderer.setSize(w, h);
+    }
+}
+
+function lerp(a, b, t) {
+    return a + (b - a) * t;
+}
+
+function wait(ms) {
+    return new Promise((r) => setTimeout(r, ms));
+}
+
+function boot() {
+    const game = new Game();
+    game.init().catch((err) => {
+        console.error(err);
+        game.hud.showError(err?.message || 'Falha ao iniciar a jornada.');
+    });
+}
+
+boot();

--- a/labs/jornada-do-anel/src/main.js
+++ b/labs/jornada-do-anel/src/main.js
@@ -4,7 +4,7 @@
 
 import * as THREE from 'three';
 import { CHAPTERS, QUALITY, STORAGE_KEY } from './config.js';
-import { clamp, detectMobile, detectSoftwareGL, formatTime } from './utils.js';
+import { clamp, detectMobile, detectSoftwareGL, rendererIsSoftware, formatTime } from './utils.js';
 import { Input } from './input.js';
 import { GameAudio } from './audio.js';
 import { Hud, statsBlock } from './hud.js';
@@ -91,10 +91,16 @@ class Game {
         this.renderer.setSize(window.innerWidth, window.innerHeight);
         this.renderer.outputColorSpace = THREE.SRGBColorSpace;
         this.renderer.toneMapping = THREE.ACESFilmicToneMapping;
-        this.renderer.toneMappingExposure = 1.05;
+        this.renderer.toneMappingExposure = CHAPTERS[0].exposure ?? 1.2;
         this.renderer.shadowMap.enabled = this.quality.shadows;
         this.renderer.shadowMap.type = THREE.PCFSoftShadowMap;
         this.renderer.setClearColor(CHAPTERS[0].clear);
+
+        if (rendererIsSoftware(this.renderer) && this.quality.id !== 'low') {
+            this.quality = QUALITY.low;
+            this.renderer.setPixelRatio(1);
+            this.renderer.shadowMap.enabled = false;
+        }
 
         this.scene = new THREE.Scene();
         this.camera = new THREE.PerspectiveCamera(52, window.innerWidth / window.innerHeight, 0.12, 520);
@@ -107,7 +113,8 @@ class Game {
         this.player = new Player(this.scene);
         this.player.root.visible = false;
 
-        this.clock = new THREE.Clock();
+        this.timer = new THREE.Timer();
+        this.timer.connect(document);
         this._bindUi();
         window.addEventListener('resize', () => this._resize());
 
@@ -256,6 +263,7 @@ class Game {
         applyChapterSky(this.sky, ch);
         this.scene.fog = new THREE.Fog(ch.fog.color, ch.fog.near, ch.fog.far);
         this.renderer.setClearColor(ch.clear);
+        this.renderer.toneMappingExposure = ch.exposure ?? 1.15;
         this.audio.setTheme(ch.music);
 
         if (this.lights.dir && this.quality.shadows) {
@@ -278,6 +286,7 @@ class Game {
         this.audio.setMuted(this.settings.muted);
 
         this.quality = this.resolveQuality();
+        if (rendererIsSoftware(this.renderer)) this.quality = QUALITY.low;
         this.renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, this.quality.pixelRatio));
         this.renderer.shadowMap.enabled = this.quality.shadows;
 
@@ -359,9 +368,10 @@ class Game {
         this.saveSettings();
     }
 
-    _loop() {
-        requestAnimationFrame(() => this._loop());
-        const dt = Math.min(0.05, this.clock.getDelta());
+    _loop(timestamp) {
+        requestAnimationFrame((t) => this._loop(t));
+        this.timer.update(timestamp);
+        const dt = Math.min(0.05, this.timer.getDelta());
         this.time += dt;
         this._update(dt);
         this.renderer.render(this.scene, this.camera);
@@ -471,7 +481,7 @@ class Game {
             this.state = 'playing';
             this.hud.setState('playing');
             this.input.enabled = true;
-            if (!this.mobile) this.input.requestLock();
+            this.hud.say('Clique no mundo para olhar com o mouse.', 3.2);
         }
     }
 

--- a/labs/jornada-do-anel/src/main.js
+++ b/labs/jornada-do-anel/src/main.js
@@ -246,18 +246,13 @@ class Game {
         this.chapterIndex = index;
         this.chapter = ch;
 
-        if (this.world) {
-            this.scene.remove(this.world.group);
-            this.world = null;
-        }
-        if (this.lights) {
-            this.scene.remove(this.lights.group);
-            this.lights = null;
-        }
-
-        this.world = buildChapter(ch.id, this.quality);
+        const world = buildChapter(ch.id, this.quality);
+        const lights = createLights(this.scene, ch, this.quality);
+        if (this.world) this.scene.remove(this.world.group);
+        if (this.lights) this.scene.remove(this.lights.group);
+        this.world = world;
+        this.lights = lights;
         this.scene.add(this.world.group);
-        this.lights = createLights(this.scene, ch, this.quality);
         applyChapterSky(this.sky, ch);
         this.scene.fog = new THREE.Fog(ch.fog.color, ch.fog.near, ch.fog.far);
         this.renderer.setClearColor(ch.clear);
@@ -393,7 +388,7 @@ class Game {
         document.getElementById('fade').style.opacity = String(this.fade);
 
         if (this.state === 'menu') {
-            this._updateMenuCam(dt);
+            if (this.world) this._updateMenuCam(dt);
             return;
         }
         if (this.state === 'intro') {

--- a/labs/jornada-do-anel/src/models.js
+++ b/labs/jornada-do-anel/src/models.js
@@ -1,0 +1,660 @@
+/**
+ * Modelos 3D construídos por código — nenhum GLB externo.
+ * Hobbit, mago, cavaleiro negro, goblin, tocas, árvores e arquitetura.
+ */
+
+import * as THREE from 'three';
+import {
+    grassTexture, barkTexture, leafTexture, stoneTexture, marbleTexture,
+    woodTexture, goldTexture, doorTexture, brickTexture
+} from './textures.js';
+
+const matCache = new Map();
+
+function mat(key, factory) {
+    if (!matCache.has(key)) matCache.set(key, factory());
+    return matCache.get(key);
+}
+
+export function std(color, roughness = 0.78, metalness = 0.04, extra = {}) {
+    return mat(`std:${color}:${roughness}:${metalness}:${JSON.stringify(extra)}`, () =>
+        new THREE.MeshStandardMaterial({ color, roughness, metalness, ...extra }));
+}
+
+function mapped(map, color = 0xffffff, roughness = 0.88) {
+    return new THREE.MeshStandardMaterial({ map, color, roughness, metalness: 0.02 });
+}
+
+function enableShadows(root) {
+    root.traverse((c) => {
+        if (c.isMesh) {
+            c.castShadow = true;
+            c.receiveShadow = true;
+        }
+    });
+}
+
+/* ------------------------------------------------------------------ */
+/* Personagens                                                         */
+/* ------------------------------------------------------------------ */
+
+export function buildHobbit({ vest = 0xc45a2a, pants = 0x3d4a28 } = {}) {
+    const group = new THREE.Group();
+    const skin = std(0xe8b889, 0.72);
+    const hair = std(0x6b3a18, 0.9);
+    const clothV = std(vest, 0.86);
+    const clothP = std(pants, 0.88);
+    const foot = std(0xd4a07a, 0.8);
+
+    const hips = new THREE.Group();
+    group.add(hips);
+
+    const parts = { legs: [], arms: [], feet: [] };
+
+    for (const sx of [-1, 1]) {
+        const leg = new THREE.Group();
+        leg.position.set(sx * 0.12, 0.38, 0);
+        hips.add(leg);
+        const thigh = new THREE.Mesh(new THREE.CylinderGeometry(0.08, 0.07, 0.34, 8), clothP);
+        thigh.position.y = -0.17;
+        leg.add(thigh);
+        const footM = new THREE.Mesh(new THREE.SphereGeometry(0.09, 8, 6), foot);
+        footM.scale.set(1.15, 0.55, 1.55);
+        footM.position.set(0, -0.36, 0.05);
+        leg.add(footM);
+        parts.legs.push(leg);
+        parts.feet.push(footM);
+    }
+
+    const torso = new THREE.Group();
+    torso.position.y = 0.4;
+    hips.add(torso);
+
+    const belly = new THREE.Mesh(new THREE.SphereGeometry(0.28, 12, 10), clothV);
+    belly.scale.set(1.05, 0.85, 0.9);
+    belly.position.y = 0.22;
+    torso.add(belly);
+
+    const shirt = new THREE.Mesh(new THREE.CylinderGeometry(0.2, 0.24, 0.18, 10), std(0xf2e4c4, 0.9));
+    shirt.position.y = 0.38;
+    torso.add(shirt);
+
+    const belt = new THREE.Mesh(new THREE.TorusGeometry(0.22, 0.03, 6, 14), std(0x5a3a18, 0.7, 0.1));
+    belt.rotation.x = Math.PI / 2;
+    belt.position.y = 0.12;
+    torso.add(belt);
+
+    const head = new THREE.Group();
+    head.position.y = 0.58;
+    torso.add(head);
+    const skull = new THREE.Mesh(new THREE.SphereGeometry(0.16, 12, 10), skin);
+    head.add(skull);
+
+    for (const sx of [-1, 1]) {
+        const ear = new THREE.Mesh(new THREE.SphereGeometry(0.055, 8, 6), skin);
+        ear.scale.set(0.7, 1.1, 0.5);
+        ear.position.set(sx * 0.16, 0.02, 0);
+        head.add(ear);
+        const eye = new THREE.Mesh(new THREE.SphereGeometry(0.025, 8, 6), std(0xf7f2ea, 0.4));
+        eye.position.set(sx * 0.05, 0.02, 0.14);
+        head.add(eye);
+        const iris = new THREE.Mesh(new THREE.SphereGeometry(0.014, 6, 5), std(0x2a4a18, 0.45));
+        iris.position.set(sx * 0.05, 0.02, 0.16);
+        head.add(iris);
+    }
+
+    for (let i = 0; i < 14; i++) {
+        const curl = new THREE.Mesh(new THREE.SphereGeometry(0.055, 8, 6), hair);
+        const a = (i / 14) * Math.PI * 2;
+        curl.position.set(Math.cos(a) * 0.14, 0.1 + Math.sin(i * 2.1) * 0.04, Math.sin(a) * 0.12);
+        head.add(curl);
+    }
+    const bang = new THREE.Mesh(new THREE.SphereGeometry(0.08, 8, 6), hair);
+    bang.position.set(0, 0.12, 0.1);
+    head.add(bang);
+
+    const armGeo = new THREE.CylinderGeometry(0.055, 0.048, 0.32, 8);
+    for (const sx of [-1, 1]) {
+        const arm = new THREE.Group();
+        arm.position.set(sx * 0.26, 0.42, 0);
+        torso.add(arm);
+        const mesh = new THREE.Mesh(armGeo, skin);
+        mesh.position.y = -0.16;
+        arm.add(mesh);
+        parts.arms.push(arm);
+    }
+
+    const ringGlow = new THREE.Mesh(
+        new THREE.TorusGeometry(0.07, 0.018, 8, 20),
+        new THREE.MeshStandardMaterial({
+            map: goldTexture(),
+            color: 0xffe08a,
+            emissive: 0xffaa22,
+            emissiveIntensity: 0.8,
+            metalness: 1,
+            roughness: 0.22
+        })
+    );
+    ringGlow.rotation.x = Math.PI / 2;
+    ringGlow.position.set(0.08, 0.28, 0.22);
+    ringGlow.visible = false;
+    torso.add(ringGlow);
+
+    enableShadows(group);
+    group.userData.parts = { ...parts, torso, head, hips, ring: ringGlow };
+    return { group, parts: group.userData.parts };
+}
+
+export function buildWizard() {
+    const group = new THREE.Group();
+    const robe = std(0x9aa3ad, 0.9);
+    const skin = std(0xe0c4a0, 0.7);
+    const beard = std(0xe8e4d8, 0.92);
+
+    const body = new THREE.Mesh(new THREE.ConeGeometry(0.42, 1.7, 10), robe);
+    body.position.y = 0.85;
+    group.add(body);
+
+    const head = new THREE.Mesh(new THREE.SphereGeometry(0.16, 10, 8), skin);
+    head.position.y = 1.72;
+    group.add(head);
+
+    const hat = new THREE.Mesh(new THREE.ConeGeometry(0.22, 0.7, 8), robe);
+    hat.position.y = 2.12;
+    hat.rotation.z = 0.12;
+    group.add(hat);
+    const brim = new THREE.Mesh(new THREE.CylinderGeometry(0.38, 0.38, 0.04, 12), robe);
+    brim.position.y = 1.82;
+    group.add(brim);
+
+    const beardM = new THREE.Mesh(new THREE.ConeGeometry(0.14, 0.55, 8), beard);
+    beardM.position.set(0, 1.42, 0.08);
+    beardM.rotation.x = Math.PI;
+    group.add(beardM);
+
+    const staff = new THREE.Group();
+    staff.position.set(0.38, 0, 0.1);
+    group.add(staff);
+    const shaft = new THREE.Mesh(new THREE.CylinderGeometry(0.03, 0.04, 2.15, 6), std(0x5a3a22, 0.85));
+    shaft.position.y = 1.05;
+    staff.add(shaft);
+    const crystal = new THREE.Mesh(
+        new THREE.OctahedronGeometry(0.1),
+        new THREE.MeshStandardMaterial({
+            color: 0xa8d8ff,
+            emissive: 0x4aa0ff,
+            emissiveIntensity: 2.2,
+            roughness: 0.2,
+            metalness: 0.3
+        })
+    );
+    crystal.position.y = 2.18;
+    staff.add(crystal);
+
+    enableShadows(group);
+    group.userData.parts = { staff, crystal };
+    return { group, parts: group.userData.parts };
+}
+
+export function buildElf({ robe = 0xc8d8c0 } = {}) {
+    const group = new THREE.Group();
+    const skin = std(0xf0d8c0, 0.65);
+    const cloth = std(robe, 0.82);
+    const hair = std(0xe8d080, 0.55);
+
+    const body = new THREE.Mesh(new THREE.CylinderGeometry(0.16, 0.2, 1.35, 8), cloth);
+    body.position.y = 0.72;
+    group.add(body);
+    const head = new THREE.Mesh(new THREE.SphereGeometry(0.13, 10, 8), skin);
+    head.position.y = 1.52;
+    group.add(head);
+    for (const sx of [-1, 1]) {
+        const ear = new THREE.Mesh(new THREE.ConeGeometry(0.03, 0.14, 6), skin);
+        ear.position.set(sx * 0.12, 1.54, 0);
+        ear.rotation.z = sx * -0.9;
+        group.add(ear);
+    }
+    const hairM = new THREE.Mesh(new THREE.SphereGeometry(0.14, 8, 8), hair);
+    hairM.position.y = 1.6;
+    hairM.scale.set(1, 0.7, 1.1);
+    group.add(hairM);
+    enableShadows(group);
+    return { group };
+}
+
+export function buildCompanion() {
+    return buildHobbit({ vest: 0x3a6a38, pants: 0x4a3a22 });
+}
+
+export function buildGoblin() {
+    const group = new THREE.Group();
+    const skin = std(0x5a7a3a, 0.8);
+    const dark = std(0x2a2218, 0.9);
+
+    const body = new THREE.Mesh(new THREE.SphereGeometry(0.28, 8, 6), dark);
+    body.position.y = 0.55;
+    body.scale.set(1, 1.2, 0.8);
+    group.add(body);
+    const head = new THREE.Mesh(new THREE.SphereGeometry(0.2, 8, 6), skin);
+    head.position.y = 0.95;
+    group.add(head);
+    for (const sx of [-1, 1]) {
+        const ear = new THREE.Mesh(new THREE.ConeGeometry(0.06, 0.18, 5), skin);
+        ear.position.set(sx * 0.18, 1.05, 0);
+        ear.rotation.z = sx * -0.7;
+        group.add(ear);
+        const eye = new THREE.Mesh(
+            new THREE.SphereGeometry(0.04, 6, 5),
+            new THREE.MeshStandardMaterial({ color: 0xffee88, emissive: 0xffcc33, emissiveIntensity: 2 })
+        );
+        eye.position.set(sx * 0.07, 0.98, 0.16);
+        group.add(eye);
+        const arm = new THREE.Mesh(new THREE.CylinderGeometry(0.05, 0.04, 0.4, 6), skin);
+        arm.position.set(sx * 0.28, 0.55, 0);
+        arm.rotation.z = sx * 0.4;
+        group.add(arm);
+    }
+    const blade = new THREE.Mesh(new THREE.ConeGeometry(0.04, 0.45, 5), std(0xb0b8c0, 0.3, 0.85));
+    blade.position.set(0.38, 0.45, 0.1);
+    blade.rotation.x = 0.4;
+    group.add(blade);
+    enableShadows(group);
+    group.userData.hp = 2;
+    return { group };
+}
+
+export function buildNazgul() {
+    const group = new THREE.Group();
+    const black = std(0x0a0a0c, 0.95, 0.05, { emissive: 0x050508, emissiveIntensity: 0.2 });
+
+    const horse = new THREE.Group();
+    group.add(horse);
+    const body = new THREE.Mesh(new THREE.SphereGeometry(0.55, 10, 8), black);
+    body.scale.set(1.6, 0.85, 0.7);
+    body.position.y = 0.85;
+    horse.add(body);
+    const neck = new THREE.Mesh(new THREE.CylinderGeometry(0.14, 0.18, 0.7, 8), black);
+    neck.position.set(0.7, 1.2, 0);
+    neck.rotation.z = -0.7;
+    horse.add(neck);
+    const head = new THREE.Mesh(new THREE.SphereGeometry(0.18, 8, 6), black);
+    head.scale.set(1.4, 0.7, 0.6);
+    head.position.set(1.05, 1.48, 0);
+    horse.add(head);
+    for (const sx of [-1, 1]) {
+        for (const z of [-0.22, 0.22]) {
+            const leg = new THREE.Mesh(new THREE.CylinderGeometry(0.07, 0.05, 0.85, 6), black);
+            leg.position.set(sx * 0.35, 0.42, z);
+            horse.add(leg);
+        }
+    }
+
+    const rider = new THREE.Group();
+    rider.position.set(-0.05, 1.15, 0);
+    group.add(rider);
+    const cloak = new THREE.Mesh(new THREE.ConeGeometry(0.42, 1.15, 8), black);
+    cloak.position.y = 0.55;
+    rider.add(cloak);
+    const hood = new THREE.Mesh(new THREE.SphereGeometry(0.2, 8, 6), black);
+    hood.position.y = 1.12;
+    rider.add(hood);
+    for (const sx of [-1, 1]) {
+        const eye = new THREE.Mesh(
+            new THREE.SphereGeometry(0.035, 6, 5),
+            new THREE.MeshStandardMaterial({
+                color: 0xffe8a0,
+                emissive: 0xffcc66,
+                emissiveIntensity: 3.5
+            })
+        );
+        eye.position.set(sx * 0.06, 1.14, 0.16);
+        rider.add(eye);
+    }
+
+    enableShadows(group);
+    group.userData.parts = { horse, rider };
+    return { group, parts: group.userData.parts };
+}
+
+/* ------------------------------------------------------------------ */
+/* Cenário                                                             */
+/* ------------------------------------------------------------------ */
+
+export function buildHobbitHole({ doorColor = '#2d6b38', scale = 1 } = {}) {
+    const group = new THREE.Group();
+    const hill = new THREE.Mesh(
+        new THREE.SphereGeometry(2.4, 16, 12),
+        mapped(grassTexture(), 0x7aab48)
+    );
+    hill.scale.set(1.35, 0.72, 1.15);
+    hill.position.y = 0.4;
+    group.add(hill);
+
+    const facade = new THREE.Mesh(
+        new THREE.CylinderGeometry(1.05, 1.05, 0.18, 20),
+        mapped(woodTexture(), 0xc4a06a)
+    );
+    facade.rotation.x = Math.PI / 2;
+    facade.position.set(0, 0.85, 1.55);
+    group.add(facade);
+
+    const door = new THREE.Mesh(
+        new THREE.CylinderGeometry(0.72, 0.72, 0.08, 22),
+        new THREE.MeshStandardMaterial({ map: doorTexture(doorColor), roughness: 0.7 })
+    );
+    door.rotation.x = Math.PI / 2;
+    door.position.set(0, 0.85, 1.66);
+    group.add(door);
+
+    const window = new THREE.Mesh(
+        new THREE.CylinderGeometry(0.22, 0.22, 0.06, 12),
+        new THREE.MeshStandardMaterial({
+            color: 0xffe8a8,
+            emissive: 0xffcc66,
+            emissiveIntensity: 0.7,
+            roughness: 0.3
+        })
+    );
+    window.rotation.x = Math.PI / 2;
+    window.position.set(1.15, 1.15, 0.9);
+    group.add(window);
+
+    const chimney = new THREE.Mesh(new THREE.CylinderGeometry(0.12, 0.14, 0.7, 8), mapped(brickTexture()));
+    chimney.position.set(-0.6, 2.0, -0.2);
+    group.add(chimney);
+
+    const smoke = new THREE.Mesh(
+        new THREE.SphereGeometry(0.22, 8, 6),
+        new THREE.MeshStandardMaterial({ color: 0xccc8c0, transparent: true, opacity: 0.35, depthWrite: false })
+    );
+    smoke.position.set(-0.6, 2.5, -0.2);
+    group.add(smoke);
+
+    group.scale.setScalar(scale);
+    enableShadows(group);
+    group.userData.parts = { door, smoke };
+    return { group, parts: group.userData.parts };
+}
+
+export function buildOak({ autumn = false } = {}) {
+    const group = new THREE.Group();
+    const trunk = new THREE.Mesh(
+        new THREE.CylinderGeometry(0.28, 0.4, 2.4, 8),
+        mapped(barkTexture(), 0x8a6a48)
+    );
+    trunk.position.y = 1.2;
+    group.add(trunk);
+    const leafMat = mapped(leafTexture(autumn ? '#c45a22' : '#2f6a24'), autumn ? 0xd47830 : 0x4a8a32);
+    const canopy = new THREE.Mesh(new THREE.IcosahedronGeometry(1.55, 1), leafMat);
+    canopy.position.y = 2.7;
+    canopy.scale.set(1.2, 0.9, 1.15);
+    group.add(canopy);
+    const canopy2 = new THREE.Mesh(new THREE.IcosahedronGeometry(1.1, 1), leafMat);
+    canopy2.position.set(0.6, 2.4, 0.3);
+    group.add(canopy2);
+    enableShadows(group);
+    return group;
+}
+
+export function buildPine() {
+    const group = new THREE.Group();
+    const trunk = new THREE.Mesh(
+        new THREE.CylinderGeometry(0.16, 0.22, 2.1, 7),
+        mapped(barkTexture(), 0x6a4a32)
+    );
+    trunk.position.y = 1.05;
+    group.add(trunk);
+    const leaf = mapped(leafTexture('#1e4a28'), 0x2a5a30);
+    for (let i = 0; i < 4; i++) {
+        const cone = new THREE.Mesh(new THREE.ConeGeometry(1.15 - i * 0.18, 1.15, 8), leaf);
+        cone.position.y = 1.7 + i * 0.7;
+        group.add(cone);
+    }
+    enableShadows(group);
+    return group;
+}
+
+export function buildPartyTree() {
+    const group = new THREE.Group();
+    const trunk = new THREE.Mesh(
+        new THREE.CylinderGeometry(0.55, 0.8, 4.2, 10),
+        mapped(barkTexture(), 0x8a6a48)
+    );
+    trunk.position.y = 2.1;
+    group.add(trunk);
+    const leaf = mapped(leafTexture('#2f6a24'), 0x4a8a32);
+    for (let i = 0; i < 5; i++) {
+        const blob = new THREE.Mesh(new THREE.IcosahedronGeometry(1.8, 1), leaf);
+        const a = (i / 5) * Math.PI * 2;
+        blob.position.set(Math.cos(a) * 1.3, 4.4 + (i % 2) * 0.5, Math.sin(a) * 1.3);
+        blob.scale.setScalar(0.85 + (i % 3) * 0.12);
+        group.add(blob);
+    }
+    const lanterns = [];
+    for (let i = 0; i < 8; i++) {
+        const a = (i / 8) * Math.PI * 2;
+        const lantern = new THREE.Mesh(
+            new THREE.SphereGeometry(0.12, 8, 6),
+            new THREE.MeshStandardMaterial({
+                color: 0xffe8a0,
+                emissive: 0xffaa44,
+                emissiveIntensity: 1.8,
+                roughness: 0.3
+            })
+        );
+        lantern.position.set(Math.cos(a) * 2.1, 3.1, Math.sin(a) * 2.1);
+        group.add(lantern);
+        lanterns.push(lantern);
+    }
+    enableShadows(group);
+    group.userData.lanterns = lanterns;
+    return group;
+}
+
+export function buildRing(scale = 1) {
+    const group = new THREE.Group();
+    const torus = new THREE.Mesh(
+        new THREE.TorusGeometry(0.28, 0.07, 12, 32),
+        new THREE.MeshStandardMaterial({
+            map: goldTexture(),
+            color: 0xffe08a,
+            metalness: 1,
+            roughness: 0.18,
+            emissive: 0xffaa22,
+            emissiveIntensity: 0.65
+        })
+    );
+    torus.rotation.x = Math.PI / 2;
+    group.add(torus);
+    const glow = new THREE.Mesh(
+        new THREE.TorusGeometry(0.32, 0.12, 8, 24),
+        new THREE.MeshBasicMaterial({
+            color: 0xffcc55,
+            transparent: true,
+            opacity: 0.22,
+            depthWrite: false,
+            side: THREE.DoubleSide
+        })
+    );
+    glow.rotation.x = Math.PI / 2;
+    group.add(glow);
+    group.scale.setScalar(scale);
+    group.userData.glow = glow;
+    return group;
+}
+
+export function buildRock(seed = 1) {
+    const geo = new THREE.IcosahedronGeometry(1, 1);
+    const pos = geo.attributes.position;
+    for (let i = 0; i < pos.count; i++) {
+        const n = 0.82 + ((Math.sin(i * 12.9898 + seed) * 43758.5453) % 1) * 0.35;
+        pos.setXYZ(i, pos.getX(i) * n, pos.getY(i) * n * 0.7, pos.getZ(i) * n);
+    }
+    geo.computeVertexNormals();
+    const mesh = new THREE.Mesh(geo, mapped(stoneTexture(), 0x8a8680));
+    mesh.castShadow = true;
+    mesh.receiveShadow = true;
+    return mesh;
+}
+
+export function buildPavilion() {
+    const group = new THREE.Group();
+    const marble = mapped(marbleTexture(), 0xf2eee4, 0.45);
+    const gold = new THREE.MeshStandardMaterial({
+        map: goldTexture(),
+        metalness: 0.85,
+        roughness: 0.28,
+        color: 0xffe8a8
+    });
+
+    const floor = new THREE.Mesh(new THREE.CylinderGeometry(6.5, 6.5, 0.25, 16), marble);
+    floor.position.y = 0.12;
+    group.add(floor);
+
+    for (let i = 0; i < 8; i++) {
+        const a = (i / 8) * Math.PI * 2;
+        const col = new THREE.Mesh(new THREE.CylinderGeometry(0.18, 0.22, 4.2, 10), marble);
+        col.position.set(Math.cos(a) * 5.2, 2.2, Math.sin(a) * 5.2);
+        group.add(col);
+        const cap = new THREE.Mesh(new THREE.SphereGeometry(0.28, 8, 6), gold);
+        cap.position.set(Math.cos(a) * 5.2, 4.4, Math.sin(a) * 5.2);
+        group.add(cap);
+    }
+
+    const roof = new THREE.Mesh(new THREE.ConeGeometry(6.8, 2.4, 8), gold);
+    roof.position.y = 5.4;
+    group.add(roof);
+
+    const arch = new THREE.Mesh(new THREE.TorusGeometry(1.6, 0.12, 8, 16, Math.PI), marble);
+    arch.position.set(0, 2.2, 6.3);
+    arch.rotation.x = Math.PI;
+    group.add(arch);
+
+    enableShadows(group);
+    return group;
+}
+
+export function buildCouncilRing() {
+    const group = new THREE.Group();
+    const stone = mapped(marbleTexture(), 0xe8e0d0);
+    const ring = new THREE.Mesh(new THREE.TorusGeometry(4.2, 0.22, 8, 32), stone);
+    ring.rotation.x = Math.PI / 2;
+    ring.position.y = 0.2;
+    group.add(ring);
+    for (let i = 0; i < 9; i++) {
+        const a = (i / 9) * Math.PI * 2;
+        const seat = new THREE.Mesh(new THREE.BoxGeometry(0.7, 0.55, 0.7), stone);
+        seat.position.set(Math.cos(a) * 3.4, 0.28, Math.sin(a) * 3.4);
+        seat.lookAt(0, 0.28, 0);
+        group.add(seat);
+    }
+    enableShadows(group);
+    return group;
+}
+
+export function buildPillar(height = 14) {
+    const group = new THREE.Group();
+    const stone = mapped(stoneTexture('#6a5a48'), 0x7a6a58);
+    const col = new THREE.Mesh(new THREE.CylinderGeometry(0.7, 0.85, height, 8), stone);
+    col.position.y = height / 2;
+    group.add(col);
+    const base = new THREE.Mesh(new THREE.BoxGeometry(2.1, 0.5, 2.1), stone);
+    base.position.y = 0.25;
+    group.add(base);
+    const cap = new THREE.Mesh(new THREE.BoxGeometry(1.9, 0.4, 1.9), stone);
+    cap.position.y = height;
+    group.add(cap);
+    enableShadows(group);
+    return group;
+}
+
+export function buildBridge() {
+    const group = new THREE.Group();
+    const stone = mapped(stoneTexture('#5a5048'), 0x6a6058);
+    const plank = new THREE.Mesh(new THREE.BoxGeometry(2.4, 0.28, 16), stone);
+    plank.position.y = 0.14;
+    group.add(plank);
+    for (const z of [-7, 7]) {
+        for (const x of [-1.1, 1.1]) {
+            const post = new THREE.Mesh(new THREE.BoxGeometry(0.18, 1.1, 0.18), stone);
+            post.position.set(x, 0.7, z);
+            group.add(post);
+        }
+    }
+    enableShadows(group);
+    return group;
+}
+
+export function buildSeat() {
+    const group = new THREE.Group();
+    const stone = mapped(stoneTexture('#9a8a78'), 0xb0a090);
+    const base = new THREE.Mesh(new THREE.CylinderGeometry(1.6, 1.8, 0.5, 12), stone);
+    base.position.y = 0.25;
+    group.add(base);
+    const back = new THREE.Mesh(new THREE.BoxGeometry(1.5, 2.2, 0.28), stone);
+    back.position.set(0, 1.4, -0.55);
+    group.add(back);
+    const sit = new THREE.Mesh(new THREE.BoxGeometry(1.4, 0.28, 1.1), stone);
+    sit.position.set(0, 0.62, 0.1);
+    group.add(sit);
+    enableShadows(group);
+    return group;
+}
+
+export function buildRuinArch() {
+    const group = new THREE.Group();
+    const stone = mapped(stoneTexture('#8a7a68'), 0x9a8a78);
+    for (const sx of [-1, 1]) {
+        const p = new THREE.Mesh(new THREE.BoxGeometry(0.55, 3.4, 0.55), stone);
+        p.position.set(sx * 1.4, 1.7, 0);
+        group.add(p);
+    }
+    const lintel = new THREE.Mesh(new THREE.BoxGeometry(3.4, 0.45, 0.6), stone);
+    lintel.position.y = 3.5;
+    group.add(lintel);
+    enableShadows(group);
+    return group;
+}
+
+export function buildSword() {
+    const group = new THREE.Group();
+    const blade = new THREE.Mesh(
+        new THREE.BoxGeometry(0.05, 0.7, 0.12),
+        std(0xd8dee8, 0.25, 0.9)
+    );
+    blade.position.y = 0.4;
+    group.add(blade);
+    const guard = new THREE.Mesh(new THREE.BoxGeometry(0.28, 0.05, 0.08), std(0xc9a227, 0.35, 0.8));
+    group.add(guard);
+    const hilt = new THREE.Mesh(new THREE.CylinderGeometry(0.03, 0.035, 0.22, 8), std(0x4a3020, 0.8));
+    hilt.position.y = -0.12;
+    group.add(hilt);
+    return group;
+}
+
+/** Geometria de tufo de grama (dois planos cruzados) para InstancedMesh. */
+export function grassBladeGeometry() {
+    const geo = new THREE.PlaneGeometry(0.35, 0.55);
+    geo.translate(0, 0.27, 0);
+    return geo;
+}
+
+export function applyGrassWind(material, strength = 1) {
+    material.userData.uTime = { value: 0 };
+    material.onBeforeCompile = (shader) => {
+        shader.uniforms.uTime = material.userData.uTime;
+        shader.vertexShader = shader.vertexShader
+            .replace(
+                '#include <common>',
+                /* glsl */ `#include <common>
+                uniform float uTime;`
+            )
+            .replace(
+                '#include <begin_vertex>',
+                /* glsl */ `#include <begin_vertex>
+                float h = uv.y;
+                transformed.x += sin(uTime * 1.6 + position.x * 0.4) * 0.12 * h * ${strength.toFixed(2)};
+                transformed.z += cos(uTime * 1.3 + position.z * 0.35) * 0.08 * h * ${strength.toFixed(2)};`
+            );
+    };
+}

--- a/labs/jornada-do-anel/src/npcs.js
+++ b/labs/jornada-do-anel/src/npcs.js
@@ -1,0 +1,159 @@
+/**
+ * IA dos Cavaleiros Negros (visão + perseguição) e dos goblins (aggro).
+ */
+
+import { clamp } from './utils.js';
+
+export class Rider {
+    constructor(group, x, z, waypoints) {
+        this.group = group;
+        this.x = x;
+        this.z = z;
+        this.yaw = 0;
+        this.waypoints = waypoints;
+        this.wp = 0;
+        this.state = 'patrol';
+        this.speed = 3.6;
+        this.chaseSpeed = 7.4;
+        this.vision = 16;
+        this.fov = 0.62;
+        this.alive = true;
+        this.catchR = 1.35;
+        this.alert = 0;
+    }
+
+    update(dt, player, heightAt) {
+        if (!this.alive) return null;
+        const dx = player.x - this.x;
+        const dz = player.z - this.z;
+        const dist = Math.hypot(dx, dz);
+        const fx = Math.sin(this.yaw);
+        const fz = Math.cos(this.yaw);
+        const facing = dist > 0.01 ? (dx * fx + dz * fz) / dist : 0;
+        const seen = dist < this.vision && facing > this.fov && !this._occluded(player);
+
+        if (seen) {
+            this.state = 'chase';
+            this.alert = 1;
+        } else if (this.state === 'chase' && dist > this.vision * 1.6) {
+            this.state = 'patrol';
+        }
+
+        let tx;
+        let tz;
+        if (this.state === 'chase') {
+            tx = player.x;
+            tz = player.z;
+        } else {
+            const w = this.waypoints[this.wp];
+            tx = w.x;
+            tz = w.z;
+            if (Math.hypot(this.x - tx, this.z - tz) < 1.4) {
+                this.wp = (this.wp + 1) % this.waypoints.length;
+            }
+        }
+
+        const sp = this.state === 'chase' ? this.chaseSpeed : this.speed;
+        const ax = tx - this.x;
+        const az = tz - this.z;
+        const al = Math.hypot(ax, az) || 1;
+        this.x += (ax / al) * sp * dt;
+        this.z += (az / al) * sp * dt;
+        this.yaw = Math.atan2(ax / al, az / al);
+        this.alert = Math.max(0, this.alert - dt * 0.35);
+
+        const y = heightAt(this.x, this.z);
+        this.group.position.set(this.x, y, this.z);
+        this.group.rotation.y = this.yaw;
+        const gait = Date.now() * 0.008;
+        this.group.position.y = y + Math.abs(Math.sin(gait)) * 0.06;
+
+        if (dist < this.catchR) return 'caught';
+        if (this.state === 'chase') return 'chase';
+        return null;
+    }
+
+    _occluded() {
+        return false;
+    }
+}
+
+export class GoblinAI {
+    constructor(group, x, z) {
+        this.group = group;
+        this.x = x;
+        this.z = z;
+        this.yaw = Math.random() * Math.PI * 2;
+        this.hp = 2;
+        this.alive = true;
+        this.speed = 3.2;
+        this.aggro = 11;
+        this.hitR = 1.15;
+        this.cooldown = 0;
+        this.wanderT = 0;
+    }
+
+    hit() {
+        this.hp -= 1;
+        if (this.hp <= 0) {
+            this.alive = false;
+            this.group.visible = false;
+            return true;
+        }
+        return false;
+    }
+
+    update(dt, player, heightAt) {
+        if (!this.alive) return null;
+        this.cooldown = Math.max(0, this.cooldown - dt);
+        const dx = player.x - this.x;
+        const dz = player.z - this.z;
+        const dist = Math.hypot(dx, dz);
+
+        if (dist < this.aggro) {
+            const sp = this.speed;
+            this.x += (dx / dist) * sp * dt;
+            this.z += (dz / dist) * sp * dt;
+            this.yaw = Math.atan2(dx, dz);
+        } else {
+            this.wanderT -= dt;
+            if (this.wanderT <= 0) {
+                this.yaw += (Math.random() - 0.5) * 1.6;
+                this.wanderT = 1.4 + Math.random();
+            }
+            this.x += Math.sin(this.yaw) * 1.1 * dt;
+            this.z += Math.cos(this.yaw) * 1.1 * dt;
+        }
+
+        const y = heightAt(this.x, this.z);
+        this.group.position.set(this.x, y, this.z);
+        this.group.rotation.y = this.yaw;
+
+        if (dist < this.hitR && this.cooldown <= 0) {
+            this.cooldown = 1.15;
+            return 'hit';
+        }
+        return null;
+    }
+}
+
+export function nearestInteractable(player, list, extra = 0.2) {
+    let best = null;
+    let bestD = Infinity;
+    for (const it of list) {
+        if (it.done) continue;
+        const d = Math.hypot(player.x - it.x, player.z - it.z);
+        if (d < it.r + extra && d < bestD) {
+            best = it;
+            bestD = d;
+        }
+    }
+    return best;
+}
+
+export function clampToBounds(x, z, bounds) {
+    return {
+        x: clamp(x, bounds.minX, bounds.maxX),
+        z: clamp(z, bounds.minZ, bounds.maxZ)
+    };
+}

--- a/labs/jornada-do-anel/src/player.js
+++ b/labs/jornada-do-anel/src/player.js
@@ -1,0 +1,213 @@
+/**
+ * Controlador em terceira pessoa do hobbit: movimento relativo à câmera,
+ * seguimento do terreno, colisão cilíndrica e animação de passada.
+ */
+
+import * as THREE from 'three';
+import { PLAYER, CAMERA } from './config.js';
+import { clamp, damp } from './utils.js';
+import { buildHobbit, buildSword } from './models.js';
+
+export class Player {
+    constructor(scene) {
+        const { group, parts } = buildHobbit();
+        this.root = group;
+        scene.add(group);
+        this.parts = parts;
+
+        this.sword = buildSword();
+        this.sword.position.set(0.02, -0.28, 0.02);
+        this.sword.rotation.z = 0.2;
+        this.parts.arms[1].add(this.sword);
+
+        this.x = 0;
+        this.y = 0;
+        this.z = 0;
+        this.vy = 0;
+        this.yaw = 0;
+        this.facing = 0;
+        this.grounded = true;
+        this.health = 3;
+        this.maxHealth = 3;
+        this.invuln = 0;
+        this.hasRing = false;
+        this.attackT = 0;
+        this.walkPhase = 0;
+        this.footTimer = 0;
+        this.alive = true;
+        this.camYaw = 0;
+        this.camPitch = CAMERA.defaultPitch;
+        this.camDist = CAMERA.distance;
+        this.bob = 0;
+    }
+
+    spawn(x, z, yaw, heightAt) {
+        this.x = x;
+        this.z = z;
+        this.y = heightAt(x, z);
+        this.yaw = yaw;
+        this.facing = yaw;
+        this.camYaw = yaw + Math.PI;
+        this.camPitch = CAMERA.defaultPitch;
+        this.vy = 0;
+        this.health = this.maxHealth;
+        this.invuln = 0;
+        this.alive = true;
+        this.attackT = 0;
+        this.root.visible = true;
+        this.sync();
+    }
+
+    setHasRing(v) {
+        this.hasRing = v;
+        this.parts.ring.visible = v;
+    }
+
+    hurt(amount = 1) {
+        if (this.invuln > 0 || !this.alive) return false;
+        this.health -= amount;
+        this.invuln = PLAYER.invuln;
+        if (this.health <= 0) {
+            this.health = 0;
+            this.alive = false;
+        }
+        return true;
+    }
+
+    /**
+     * @returns {{footstep: boolean, attacking: boolean}}
+     */
+    update(dt, input, world) {
+        this.invuln = Math.max(0, this.invuln - dt);
+        this.attackT = Math.max(0, this.attackT - dt);
+
+        const look = input.consumeLook();
+        this.camYaw -= look.x * 0.0022;
+        this.camPitch = clamp(this.camPitch - look.y * 0.0020, CAMERA.pitchMin, CAMERA.pitchMax);
+        this.camDist = clamp(this.camDist + input.consumeZoom() * 0.55, CAMERA.minDistance, CAMERA.maxDistance);
+
+        const move = input.move;
+        let mx = move.x;
+        let mz = move.z;
+        const len = Math.hypot(mx, mz);
+        if (len > 1) {
+            mx /= len;
+            mz /= len;
+        }
+
+        const speed = (move.sprint ? PLAYER.sprint : PLAYER.walk) * (this.hasRing ? 1.06 : 1);
+        const sin = Math.sin(this.camYaw);
+        const cos = Math.cos(this.camYaw);
+        // Frente da câmera no XZ (do jogador para longe da câmera).
+        const fx = -sin;
+        const fz = -cos;
+        const rx = cos;
+        const rz = -sin;
+
+        let vx = (fx * mz + rx * mx) * speed;
+        let vz = (fz * mz + rz * mx) * speed;
+
+        if (len > 0.08) {
+            this.facing = Math.atan2(vx, vz);
+            this.walkPhase += dt * speed * 2.6;
+            this.footTimer += dt * speed;
+        } else {
+            this.walkPhase = damp(this.walkPhase, 0, 8, dt);
+            this.footTimer = 0;
+        }
+
+        let nx = this.x + vx * dt;
+        let nz = this.z + vz * dt;
+
+        const b = world.bounds;
+        nx = clamp(nx, b.minX, b.maxX);
+        nz = clamp(nz, b.minZ, b.maxZ);
+
+        if (!this._blocked(nx, this.z, world)) this.x = nx;
+        if (!this._blocked(this.x, nz, world)) this.z = nz;
+
+        const ground = world.heightAt(this.x, this.z);
+        this.vy -= PLAYER.gravity * dt;
+        this.y += this.vy * dt;
+        if (this.y <= ground) {
+            this.y = ground;
+            this.vy = 0;
+            this.grounded = true;
+        } else {
+            this.grounded = false;
+        }
+
+        let attacking = false;
+        if (input.consumeAttack() && this.attackT <= 0) {
+            this.attackT = 0.42;
+            attacking = true;
+        }
+
+        this.yaw = damp(this.yaw, this.facing, PLAYER.turnSpeed, dt);
+        this.bob = Math.abs(Math.sin(this.walkPhase)) * (len > 0.08 ? 0.05 : 0);
+
+        const swing = this.attackT > 0 ? Math.sin((1 - this.attackT / 0.42) * Math.PI) : 0;
+        const gait = len > 0.08 ? Math.sin(this.walkPhase) : 0;
+        this.parts.legs[0].rotation.x = gait * 0.7;
+        this.parts.legs[1].rotation.x = -gait * 0.7;
+        this.parts.arms[0].rotation.x = -gait * 0.5;
+        this.parts.arms[1].rotation.x = gait * 0.5 - swing * 1.4;
+        this.parts.torso.rotation.y = gait * 0.08;
+        this.parts.head.rotation.y = gait * 0.06;
+
+        this.root.visible = this.invuln <= 0 || Math.sin(this.invuln * 28) > 0;
+        this.sync();
+
+        const footstep = this.footTimer > 0.36;
+        if (footstep) this.footTimer = 0;
+        return { footstep, attacking, moving: len > 0.08 };
+    }
+
+    _blocked(x, z, world) {
+        const r = PLAYER.radius;
+        for (const c of world.colliders) {
+            const dx = x - c.x;
+            const dz = z - c.z;
+            if (dx * dx + dz * dz < (r + c.r) * (r + c.r)) return true;
+        }
+        return false;
+    }
+
+    sync() {
+        this.root.position.set(this.x, this.y + this.bob, this.z);
+        this.root.rotation.y = this.yaw;
+    }
+
+    cameraPosition(target) {
+        const dist = this.camDist;
+        const cp = this.camPitch;
+        const cy = this.camYaw;
+        target.set(
+            this.x + Math.sin(cy) * Math.cos(cp) * dist,
+            this.y + CAMERA.height + Math.sin(cp) * dist,
+            this.z + Math.cos(cy) * Math.cos(cp) * dist
+        );
+        return target;
+    }
+
+    lookAt(target) {
+        target.set(this.x, this.y + CAMERA.lookY, this.z);
+        return target;
+    }
+
+    attackHit(npcs, range = 2.1) {
+        const hits = [];
+        const fx = Math.sin(this.yaw);
+        const fz = Math.cos(this.yaw);
+        for (const n of npcs) {
+            if (!n.alive) continue;
+            const dx = n.x - this.x;
+            const dz = n.z - this.z;
+            const d = Math.hypot(dx, dz);
+            if (d > range) continue;
+            const dot = (dx * fx + dz * fz) / (d || 1);
+            if (dot > 0.15) hits.push(n);
+        }
+        return hits;
+    }
+}

--- a/labs/jornada-do-anel/src/sky.js
+++ b/labs/jornada-do-anel/src/sky.js
@@ -1,0 +1,80 @@
+/**
+ * Céu procedural (gradiente em esfera) e rig de iluminação por capítulo.
+ */
+
+import * as THREE from 'three';
+
+export function createSky() {
+    const geo = new THREE.SphereGeometry(420, 24, 16);
+    const uniforms = {
+        top: { value: new THREE.Color(0x87b8e0) },
+        mid: { value: new THREE.Color(0xc8dce8) },
+        bot: { value: new THREE.Color(0xe8d8b0) }
+    };
+    const mat = new THREE.ShaderMaterial({
+        uniforms,
+        side: THREE.BackSide,
+        depthWrite: false,
+        vertexShader: /* glsl */ `
+            varying vec3 vPos;
+            void main() {
+                vPos = position;
+                gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+            }
+        `,
+        fragmentShader: /* glsl */ `
+            varying vec3 vPos;
+            uniform vec3 top;
+            uniform vec3 mid;
+            uniform vec3 bot;
+            void main() {
+                float h = normalize(vPos).y * 0.5 + 0.5;
+                vec3 col = mix(bot, mid, smoothstep(0.0, 0.45, h));
+                col = mix(col, top, smoothstep(0.4, 1.0, h));
+                gl_FragColor = vec4(col, 1.0);
+            }
+        `
+    });
+    const mesh = new THREE.Mesh(geo, mat);
+    mesh.frustumCulled = false;
+    return { mesh, uniforms };
+}
+
+export function applyChapterSky(sky, chapter) {
+    const fog = new THREE.Color(chapter.fog.color);
+    const sun = new THREE.Color(chapter.sun.color);
+    sky.uniforms.top.value.copy(new THREE.Color(chapter.clear)).multiplyScalar(1.05);
+    sky.uniforms.mid.value.copy(fog).lerp(sun, 0.25);
+    sky.uniforms.bot.value.copy(fog).lerp(new THREE.Color(chapter.hemi.ground), 0.35);
+}
+
+export function createLights(scene, chapter, quality) {
+    const group = new THREE.Group();
+    scene.add(group);
+
+    const amb = new THREE.AmbientLight(chapter.ambient, 0.35);
+    group.add(amb);
+
+    const hemi = new THREE.HemisphereLight(chapter.hemi.sky, chapter.hemi.ground, chapter.hemi.intensity);
+    group.add(hemi);
+
+    const dir = new THREE.DirectionalLight(chapter.sun.color, chapter.sun.intensity);
+    const d = chapter.sun.dir;
+    dir.position.set(d[0] * 80, d[1] * 80, d[2] * 80);
+    dir.castShadow = quality.shadows;
+    if (quality.shadows) {
+        dir.shadow.mapSize.set(quality.shadowSize, quality.shadowSize);
+        const s = 48;
+        dir.shadow.camera.left = -s;
+        dir.shadow.camera.right = s;
+        dir.shadow.camera.top = s;
+        dir.shadow.camera.bottom = -s;
+        dir.shadow.camera.near = 10;
+        dir.shadow.camera.far = 180;
+        dir.shadow.bias = -0.0008;
+    }
+    group.add(dir);
+    group.add(dir.target);
+
+    return { group, dir, hemi, amb };
+}

--- a/labs/jornada-do-anel/src/sky.js
+++ b/labs/jornada-do-anel/src/sky.js
@@ -52,7 +52,7 @@ export function createLights(scene, chapter, quality) {
     const group = new THREE.Group();
     scene.add(group);
 
-    const amb = new THREE.AmbientLight(chapter.ambient, 0.35);
+    const amb = new THREE.AmbientLight(chapter.ambient, chapter.ambientIntensity ?? 0.5);
     group.add(amb);
 
     const hemi = new THREE.HemisphereLight(chapter.hemi.sky, chapter.hemi.ground, chapter.hemi.intensity);

--- a/labs/jornada-do-anel/src/textures.js
+++ b/labs/jornada-do-anel/src/textures.js
@@ -1,0 +1,279 @@
+/**
+ * Texturas procedurais em canvas — o lab não depende de PNG externos.
+ */
+
+import * as THREE from 'three';
+import { hash2 } from './utils.js';
+
+const cache = new Map();
+
+function canvas(size, height = size) {
+    const el = document.createElement('canvas');
+    el.width = size;
+    el.height = height;
+    return el;
+}
+
+function toTexture(el, { repeat = [1, 1], srgb = true, aniso = 4 } = {}) {
+    const tex = new THREE.CanvasTexture(el);
+    tex.wrapS = tex.wrapT = THREE.RepeatWrapping;
+    tex.repeat.set(repeat[0], repeat[1]);
+    tex.anisotropy = aniso;
+    if (srgb) tex.colorSpace = THREE.SRGBColorSpace;
+    tex.needsUpdate = true;
+    return tex;
+}
+
+function cached(key, factory) {
+    if (!cache.has(key)) cache.set(key, factory());
+    return cache.get(key);
+}
+
+function grain(ctx, w, h, amount, seed = 0) {
+    const img = ctx.getImageData(0, 0, w, h);
+    const data = img.data;
+    for (let i = 0, p = 0; i < data.length; i += 4, p++) {
+        const x = p % w;
+        const y = (p / w) | 0;
+        const n = (hash2(x, y, seed) - 0.5) * amount;
+        data[i] = Math.max(0, Math.min(255, data[i] + n));
+        data[i + 1] = Math.max(0, Math.min(255, data[i + 1] + n));
+        data[i + 2] = Math.max(0, Math.min(255, data[i + 2] + n));
+    }
+    ctx.putImageData(img, 0, 0);
+}
+
+export function grassTexture() {
+    return cached('grass', () => {
+        const size = 256;
+        const el = canvas(size);
+        const ctx = el.getContext('2d');
+        ctx.fillStyle = '#4a7a28';
+        ctx.fillRect(0, 0, size, size);
+        for (let i = 0; i < 900; i++) {
+            const x = hash2(i, 2) * size;
+            const y = hash2(i, 9) * size;
+            ctx.strokeStyle = hash2(i, 4) > 0.5 ? '#6a9a38' : '#3a6218';
+            ctx.globalAlpha = 0.45;
+            ctx.beginPath();
+            ctx.moveTo(x, y);
+            ctx.lineTo(x + (hash2(i, 5) - 0.5) * 4, y - 6 - hash2(i, 6) * 8);
+            ctx.stroke();
+        }
+        grain(ctx, size, size, 22, 3);
+        return toTexture(el, { repeat: [18, 18] });
+    });
+}
+
+export function dirtTexture() {
+    return cached('dirt', () => {
+        const size = 256;
+        const el = canvas(size);
+        const ctx = el.getContext('2d');
+        ctx.fillStyle = '#6a4a2c';
+        ctx.fillRect(0, 0, size, size);
+        grain(ctx, size, size, 48, 8);
+        return toTexture(el, { repeat: [10, 10] });
+    });
+}
+
+export function mossTexture() {
+    return cached('moss', () => {
+        const size = 256;
+        const el = canvas(size);
+        const ctx = el.getContext('2d');
+        ctx.fillStyle = '#3d5a28';
+        ctx.fillRect(0, 0, size, size);
+        for (let i = 0; i < 80; i++) {
+            ctx.fillStyle = `rgba(${40 + hash2(i, 1) * 40},${90 + hash2(i, 2) * 50},${20},0.4)`;
+            ctx.beginPath();
+            ctx.arc(hash2(i, 3) * size, hash2(i, 4) * size, 8 + hash2(i, 5) * 22, 0, Math.PI * 2);
+            ctx.fill();
+        }
+        grain(ctx, size, size, 30, 2);
+        return toTexture(el, { repeat: [6, 6] });
+    });
+}
+
+export function barkTexture() {
+    return cached('bark', () => {
+        const size = 256;
+        const el = canvas(size);
+        const ctx = el.getContext('2d');
+        ctx.fillStyle = '#3a2618';
+        ctx.fillRect(0, 0, size, size);
+        for (let x = 0; x < size; x += 7) {
+            ctx.strokeStyle = hash2(x, 1) > 0.5 ? '#5a3a24' : '#2a1810';
+            ctx.lineWidth = 2 + hash2(x, 2) * 3;
+            ctx.beginPath();
+            ctx.moveTo(x, 0);
+            ctx.lineTo(x + (hash2(x, 3) - 0.5) * 8, size);
+            ctx.stroke();
+        }
+        grain(ctx, size, size, 28, 4);
+        return toTexture(el, { repeat: [2, 4] });
+    });
+}
+
+export function leafTexture(tint = '#2f6a24') {
+    return cached(`leaf:${tint}`, () => {
+        const size = 256;
+        const el = canvas(size);
+        const ctx = el.getContext('2d');
+        ctx.fillStyle = tint;
+        ctx.fillRect(0, 0, size, size);
+        for (let i = 0; i < 400; i++) {
+            ctx.fillStyle = hash2(i, 1) > 0.5 ? '#4a8a32' : '#1e4a16';
+            ctx.globalAlpha = 0.35;
+            ctx.beginPath();
+            ctx.ellipse(hash2(i, 2) * size, hash2(i, 3) * size, 4, 8, hash2(i, 4) * 6, 0, Math.PI * 2);
+            ctx.fill();
+        }
+        grain(ctx, size, size, 24, 5);
+        return toTexture(el, { repeat: [2, 2] });
+    });
+}
+
+export function stoneTexture(tint = '#8a8680') {
+    return cached(`stone:${tint}`, () => {
+        const size = 256;
+        const el = canvas(size);
+        const ctx = el.getContext('2d');
+        ctx.fillStyle = tint;
+        ctx.fillRect(0, 0, size, size);
+        for (let i = 0; i < 40; i++) {
+            ctx.strokeStyle = `rgba(0,0,0,${0.08 + hash2(i, 1) * 0.12})`;
+            ctx.beginPath();
+            ctx.moveTo(hash2(i, 2) * size, hash2(i, 3) * size);
+            ctx.lineTo(hash2(i, 4) * size, hash2(i, 5) * size);
+            ctx.stroke();
+        }
+        grain(ctx, size, size, 36, 6);
+        return toTexture(el, { repeat: [4, 4] });
+    });
+}
+
+export function marbleTexture() {
+    return cached('marble', () => {
+        const size = 256;
+        const el = canvas(size);
+        const ctx = el.getContext('2d');
+        ctx.fillStyle = '#e8e4d8';
+        ctx.fillRect(0, 0, size, size);
+        for (let i = 0; i < 18; i++) {
+            ctx.strokeStyle = `rgba(160,150,120,${0.15 + hash2(i, 1) * 0.2})`;
+            ctx.lineWidth = 1 + hash2(i, 2) * 2;
+            ctx.beginPath();
+            ctx.moveTo(0, hash2(i, 3) * size);
+            ctx.bezierCurveTo(
+                size * 0.3, hash2(i, 4) * size,
+                size * 0.6, hash2(i, 5) * size,
+                size, hash2(i, 6) * size
+            );
+            ctx.stroke();
+        }
+        grain(ctx, size, size, 18, 7);
+        return toTexture(el, { repeat: [3, 3] });
+    });
+}
+
+export function woodTexture() {
+    return cached('wood', () => {
+        const size = 256;
+        const el = canvas(size);
+        const ctx = el.getContext('2d');
+        ctx.fillStyle = '#6b4428';
+        ctx.fillRect(0, 0, size, size);
+        const planks = 6;
+        const ph = size / planks;
+        for (let i = 0; i < planks; i++) {
+            ctx.fillStyle = i % 2 ? '#7a5130' : '#5c3a20';
+            ctx.fillRect(0, i * ph + 1, size, ph - 2);
+        }
+        grain(ctx, size, size, 26, 9);
+        return toTexture(el, { repeat: [2, 2] });
+    });
+}
+
+export function goldTexture() {
+    return cached('gold', () => {
+        const size = 128;
+        const el = canvas(size);
+        const ctx = el.getContext('2d');
+        const g = ctx.createLinearGradient(0, 0, size, size);
+        g.addColorStop(0, '#fff3b0');
+        g.addColorStop(0.4, '#d4a017');
+        g.addColorStop(0.7, '#8a5a10');
+        g.addColorStop(1, '#f0d060');
+        ctx.fillStyle = g;
+        ctx.fillRect(0, 0, size, size);
+        grain(ctx, size, size, 20, 11);
+        return toTexture(el, { repeat: [1, 1] });
+    });
+}
+
+export function doorTexture(color = '#2d6b38') {
+    return cached(`door:${color}`, () => {
+        const size = 256;
+        const el = canvas(size);
+        const ctx = el.getContext('2d');
+        ctx.fillStyle = color;
+        ctx.fillRect(0, 0, size, size);
+        ctx.strokeStyle = 'rgba(0,0,0,0.25)';
+        ctx.lineWidth = 6;
+        for (let i = 1; i < 5; i++) {
+            ctx.beginPath();
+            ctx.arc(size / 2, size / 2, (size / 2) * (i / 5), 0, Math.PI * 2);
+            ctx.stroke();
+        }
+        ctx.fillStyle = '#c9a227';
+        ctx.beginPath();
+        ctx.arc(size * 0.72, size * 0.5, 10, 0, Math.PI * 2);
+        ctx.fill();
+        grain(ctx, size, size, 18, 12);
+        return toTexture(el, { repeat: [1, 1] });
+    });
+}
+
+export function waterTexture() {
+    return cached('water', () => {
+        const size = 256;
+        const el = canvas(size);
+        const ctx = el.getContext('2d');
+        const g = ctx.createLinearGradient(0, 0, size, size);
+        g.addColorStop(0, '#1a4a6a');
+        g.addColorStop(0.5, '#2a7a88');
+        g.addColorStop(1, '#163a58');
+        ctx.fillStyle = g;
+        ctx.fillRect(0, 0, size, size);
+        for (let i = 0; i < 20; i++) {
+            ctx.strokeStyle = `rgba(200,230,255,${0.08 + hash2(i, 1) * 0.1})`;
+            ctx.beginPath();
+            ctx.moveTo(0, hash2(i, 2) * size);
+            ctx.bezierCurveTo(size * 0.4, hash2(i, 3) * size, size * 0.7, hash2(i, 4) * size, size, hash2(i, 5) * size);
+            ctx.stroke();
+        }
+        return toTexture(el, { repeat: [8, 8] });
+    });
+}
+
+export function brickTexture() {
+    return cached('brick', () => {
+        const size = 256;
+        const el = canvas(size);
+        const ctx = el.getContext('2d');
+        ctx.fillStyle = '#4a4038';
+        ctx.fillRect(0, 0, size, size);
+        const bw = 42;
+        const bh = 18;
+        for (let y = 0, row = 0; y < size; y += bh, row++) {
+            const off = row % 2 ? bw / 2 : 0;
+            for (let x = -bw; x < size; x += bw) {
+                ctx.fillStyle = hash2(x, y) > 0.5 ? '#6a5a4a' : '#5a4a3a';
+                ctx.fillRect(x + off + 1, y + 1, bw - 2, bh - 2);
+            }
+        }
+        grain(ctx, size, size, 22, 14);
+        return toTexture(el, { repeat: [4, 4] });
+    });
+}

--- a/labs/jornada-do-anel/src/utils.js
+++ b/labs/jornada-do-anel/src/utils.js
@@ -1,0 +1,92 @@
+/** Utilitários numéricos, ruído e detecção de dispositivo. */
+
+export const clamp = (v, min, max) => (v < min ? min : v > max ? max : v);
+export const lerp = (a, b, t) => a + (b - a) * t;
+export const damp = (current, target, lambda, dt) =>
+    lerp(current, target, 1 - Math.exp(-lambda * dt));
+
+export const smoothstep = (edge0, edge1, x) => {
+    const t = clamp((x - edge0) / (edge1 - edge0), 0, 1);
+    return t * t * (3 - 2 * t);
+};
+
+export const randRange = (min, max) => min + Math.random() * (max - min);
+export const pick = (arr) => arr[Math.floor(Math.random() * arr.length)];
+
+export function formatTime(seconds) {
+    const s = Math.max(0, Math.floor(seconds));
+    const m = Math.floor(s / 60);
+    return `${m}:${String(s % 60).padStart(2, '0')}`;
+}
+
+/** Hash 2D determinístico em [0, 1). */
+export function hash2(x, y, seed = 0) {
+    const n = Math.sin(x * 127.1 + y * 311.7 + seed * 74.7) * 43758.5453;
+    return n - Math.floor(n);
+}
+
+/** Ruído de valor interpolado (suave o bastante para colinas). */
+export function valueNoise(x, y, seed = 0) {
+    const x0 = Math.floor(x);
+    const y0 = Math.floor(y);
+    const fx = x - x0;
+    const fy = y - y0;
+    const sx = fx * fx * (3 - 2 * fx);
+    const sy = fy * fy * (3 - 2 * fy);
+    const a = hash2(x0, y0, seed);
+    const b = hash2(x0 + 1, y0, seed);
+    const c = hash2(x0, y0 + 1, seed);
+    const d = hash2(x0 + 1, y0 + 1, seed);
+    return lerp(lerp(a, b, sx), lerp(c, d, sx), sy);
+}
+
+/** FBM curto — 4 oitavas. */
+export function fbm(x, y, seed = 0) {
+    let sum = 0;
+    let amp = 0.5;
+    let freq = 1;
+    for (let i = 0; i < 4; i++) {
+        sum += valueNoise(x * freq, y * freq, seed + i * 19) * amp;
+        amp *= 0.5;
+        freq *= 2;
+    }
+    return sum;
+}
+
+export function seeded(seed) {
+    let s = seed >>> 0;
+    return () => {
+        s = (s * 1664525 + 1013904223) >>> 0;
+        return s / 4294967296;
+    };
+}
+
+export function detectMobile() {
+    if (typeof navigator === 'undefined') return false;
+    const coarse = window.matchMedia?.('(pointer: coarse)')?.matches;
+    const narrow = Math.min(window.innerWidth, window.innerHeight) < 760;
+    return Boolean(coarse && narrow) || /Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
+}
+
+export function detectSoftwareGL() {
+    try {
+        const canvas = document.createElement('canvas');
+        const gl = canvas.getContext('webgl2') || canvas.getContext('webgl');
+        if (!gl) return true;
+        const info = gl.getExtension('WEBGL_debug_renderer_info');
+        const name = info ? String(gl.getParameter(info.UNMASKED_RENDERER_WEBGL) || '') : '';
+        return /swiftshader|llvmpipe|softpipe|microsoft basic render|\bcpu\b/i.test(name);
+    } catch (err) {
+        return false;
+    }
+}
+
+export function disposeObject(obj) {
+    obj.traverse((child) => {
+        if (child.geometry) child.geometry.dispose();
+        const mat = child.material;
+        if (Array.isArray(mat)) mat.forEach((m) => m.dispose());
+        else if (mat) mat.dispose();
+    });
+    obj.parent?.remove(obj);
+}

--- a/labs/jornada-do-anel/src/utils.js
+++ b/labs/jornada-do-anel/src/utils.js
@@ -68,6 +68,12 @@ export function detectMobile() {
     return Boolean(coarse && narrow) || /Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
 }
 
+const SOFTWARE_GL = /swiftshader|llvmpipe|softpipe|microsoft basic render|\bcpu\b|software/i;
+
+export function isSoftwareGLName(name) {
+    return SOFTWARE_GL.test(String(name || ''));
+}
+
 export function detectSoftwareGL() {
     try {
         const canvas = document.createElement('canvas');
@@ -75,7 +81,19 @@ export function detectSoftwareGL() {
         if (!gl) return true;
         const info = gl.getExtension('WEBGL_debug_renderer_info');
         const name = info ? String(gl.getParameter(info.UNMASKED_RENDERER_WEBGL) || '') : '';
-        return /swiftshader|llvmpipe|softpipe|microsoft basic render|\bcpu\b/i.test(name);
+        return isSoftwareGLName(name);
+    } catch (err) {
+        return false;
+    }
+}
+
+/** Usa o contexto real do renderer — mais fiel que um canvas de probe. */
+export function rendererIsSoftware(renderer) {
+    try {
+        const gl = renderer.getContext();
+        const info = gl.getExtension('WEBGL_debug_renderer_info');
+        const name = info ? String(gl.getParameter(info.UNMASKED_RENDERER_WEBGL) || '') : '';
+        return isSoftwareGLName(name);
     } catch (err) {
         return false;
     }

--- a/labs/jornada-do-anel/src/world.js
+++ b/labs/jornada-do-anel/src/world.js
@@ -174,16 +174,32 @@ export function buildShire(quality) {
     const doorZ = -3.6;
     ring.position.set(doorX, world.heightAt(doorX, doorZ) + 1.15, doorZ);
     world.group.add(ring);
-    world.addInteract({
+    const ringIt = {
         x: doorX, z: doorZ, r: 1.8, id: 'ring', kind: 'ring',
         label: 'Pegar o Anel', mesh: ring, done: false
-    });
+    };
+    world.addInteract(ringIt);
     world.goal = 'ring';
+    const beacon = new THREE.Mesh(
+        new THREE.CylinderGeometry(0.12, 0.45, 6.5, 8, 1, true),
+        new THREE.MeshBasicMaterial({
+            color: 0xffcc55,
+            transparent: true,
+            opacity: 0.18,
+            side: THREE.DoubleSide,
+            depthWrite: false
+        })
+    );
+    beacon.position.set(doorX, world.heightAt(doorX, doorZ) + 3.4, doorZ);
+    world.group.add(beacon);
     world.updateFns.push((t) => {
-        if (ring.parent) {
-            ring.rotation.y = t * 0.9;
-            ring.position.y = world.heightAt(doorX, doorZ) + 1.15 + Math.sin(t * 2) * 0.08;
+        if (ringIt.done) {
+            beacon.visible = false;
+            return;
         }
+        ring.rotation.y = t * 0.9;
+        ring.position.y = world.heightAt(doorX, doorZ) + 1.15 + Math.sin(t * 2) * 0.08;
+        beacon.material.opacity = 0.12 + Math.sin(t * 2.4) * 0.06;
     });
 
     const colors = ['#2d6b38', '#6b3a2d', '#3a4a8a', '#8a5a2a', '#4a6b3a'];

--- a/labs/jornada-do-anel/src/world.js
+++ b/labs/jornada-do-anel/src/world.js
@@ -1,0 +1,711 @@
+/**
+ * Constrói cada capítulo: terreno, vegetação, marcos e objetivos.
+ * Tudo vive num Group para poder ser trocado com fade entre cenas.
+ */
+
+import * as THREE from 'three';
+import { fbm, hash2, seeded, smoothstep } from './utils.js';
+import {
+    grassTexture, mossTexture, stoneTexture, waterTexture, brickTexture
+} from './textures.js';
+import {
+    buildHobbitHole, buildOak, buildPine, buildPartyTree, buildRing,
+    buildRock, buildPavilion, buildCouncilRing, buildPillar, buildBridge,
+    buildSeat, buildRuinArch, buildWizard, buildElf, buildNazgul, buildGoblin,
+    buildCompanion, grassBladeGeometry, applyGrassWind, std
+} from './models.js';
+import { Rider, GoblinAI } from './npcs.js';
+
+export class ChapterWorld {
+    constructor() {
+        this.group = new THREE.Group();
+        this.colliders = [];
+        this.interactables = [];
+        this.riders = [];
+        this.goblins = [];
+        this.particles = [];
+        this.heightAt = () => 0;
+        this.bounds = { minX: -40, maxX: 40, minZ: -40, maxZ: 40 };
+        this.spawn = { x: 0, z: 0, yaw: 0 };
+        this.goal = null;
+        this.updateFns = [];
+        this.overview = new THREE.Vector3(18, 14, 22);
+        this.waterMeshes = [];
+        this.balrog = null;
+        this.balrogAwake = false;
+        this.page = null;
+    }
+
+    addCollider(x, z, r) {
+        this.colliders.push({ x, z, r });
+    }
+
+    addInteract(it) {
+        this.interactables.push(it);
+    }
+}
+
+function terrainMesh(heightAt, size, segs, material, ox = 0, oz = 0) {
+    const geo = new THREE.PlaneGeometry(size, size, segs, segs);
+    geo.rotateX(-Math.PI / 2);
+    const pos = geo.attributes.position;
+    for (let i = 0; i < pos.count; i++) {
+        const x = pos.getX(i);
+        const z = pos.getZ(i);
+        pos.setY(i, heightAt(x + ox, z + oz));
+    }
+    geo.computeVertexNormals();
+    const mesh = new THREE.Mesh(geo, material);
+    mesh.position.set(ox, 0, oz);
+    mesh.receiveShadow = true;
+    return mesh;
+}
+
+function scatterTrees(world, proto, count, rng, opts) {
+    const { minR = 8, maxR = 48, minScale = 0.8, maxScale = 1.5, avoid = [] } = opts;
+    for (let i = 0; i < count; i++) {
+        const a = rng() * Math.PI * 2;
+        const r = minR + rng() * (maxR - minR);
+        const x = Math.cos(a) * r + (opts.cx || 0);
+        const z = Math.sin(a) * r + (opts.cz || 0);
+        if (avoid.some((p) => Math.hypot(x - p.x, z - p.z) < p.r)) continue;
+        if (x < world.bounds.minX + 2 || x > world.bounds.maxX - 2) continue;
+        const tree = proto();
+        const s = minScale + rng() * (maxScale - minScale);
+        tree.scale.setScalar(s);
+        const y = world.heightAt(x, z);
+        tree.position.set(x, y, z);
+        tree.rotation.y = rng() * Math.PI * 2;
+        world.group.add(tree);
+        world.addCollider(x, z, 0.55 * s);
+    }
+}
+
+function scatterGrass(world, count, quality) {
+    const geo = grassBladeGeometry();
+    const mat = new THREE.MeshStandardMaterial({
+        color: 0x5a8a32,
+        side: THREE.DoubleSide,
+        roughness: 0.95
+    });
+    applyGrassWind(mat, 1);
+    const mesh = new THREE.InstancedMesh(geo, mat, count);
+    mesh.instanceMatrix.setUsage(THREE.DynamicDrawUsage);
+    const dummy = new THREE.Object3D();
+    const b = world.bounds;
+    for (let i = 0; i < count; i++) {
+        const x = b.minX + hash2(i, 1) * (b.maxX - b.minX);
+        const z = b.minZ + hash2(i, 2) * (b.maxZ - b.minZ);
+        dummy.position.set(x, world.heightAt(x, z), z);
+        dummy.rotation.y = hash2(i, 3) * Math.PI * 2;
+        dummy.scale.setScalar(0.7 + hash2(i, 4) * 0.8);
+        dummy.updateMatrix();
+        mesh.setMatrixAt(i, dummy.matrix);
+    }
+    mesh.receiveShadow = true;
+    world.group.add(mesh);
+    world.updateFns.push((t) => {
+        if (mat.userData.uTime) mat.userData.uTime.value = t;
+    });
+    return mesh;
+}
+
+function makePage(world, x, z, id) {
+    const mesh = new THREE.Mesh(
+        new THREE.BoxGeometry(0.35, 0.02, 0.5),
+        new THREE.MeshStandardMaterial({
+            color: 0xf2e4c0,
+            emissive: 0xc8a050,
+            emissiveIntensity: 0.45
+        })
+    );
+    const y = world.heightAt(x, z) + 0.7;
+    mesh.position.set(x, y, z);
+    world.group.add(mesh);
+    world.page = { x, z, r: 1.3, id, mesh, kind: 'page', label: 'Recolher página da crônica', done: false };
+    world.addInteract(world.page);
+    world.updateFns.push((t) => {
+        if (world.page.done) return;
+        mesh.position.y = y + Math.sin(t * 2.2) * 0.12;
+        mesh.rotation.y = t * 0.8;
+    });
+}
+
+/* ================================================================== */
+/* I — O Condado                                                       */
+/* ================================================================== */
+
+export function buildShire(quality) {
+    const world = new ChapterWorld();
+    world.bounds = { minX: -52, maxX: 52, minZ: -52, maxZ: 52 };
+    world.spawn = { x: 18, z: 22, yaw: -2.4 };
+    world.overview.set(22, 16, 28);
+
+    world.heightAt = (x, z) => {
+        const hills = fbm(x * 0.035, z * 0.035, 2) * 7.5
+            + Math.sin(x * 0.04) * 2.2
+            + Math.cos(z * 0.033) * 1.8;
+        const bag = Math.hypot(x + 20, z + 6);
+        const mound = smoothstep(10, 0, bag) * 4.2;
+        const party = Math.hypot(x, z);
+        const flat = 1 - smoothstep(6, 16, party) * 0.35;
+        return hills * flat + mound;
+    };
+
+    const ground = terrainMesh(
+        world.heightAt, 120, quality.id === 'low' ? 48 : 96,
+        new THREE.MeshStandardMaterial({ map: grassTexture(), roughness: 0.95, color: 0x8fbc5a })
+    );
+    world.group.add(ground);
+
+    const party = buildPartyTree();
+    party.position.set(0, world.heightAt(0, 0), 0);
+    world.group.add(party);
+    world.addCollider(0, 0, 1.2);
+
+    const hole = buildHobbitHole({ doorColor: '#2d6b38', scale: 1.35 });
+    hole.group.position.set(-20, world.heightAt(-20, -6), -6);
+    hole.group.lookAt(new THREE.Vector3(-12, hole.group.position.y, 2));
+    world.group.add(hole.group);
+    world.addCollider(-20, -6, 1.85);
+
+    const ring = buildRing(1.15);
+    const doorX = -18.2;
+    const doorZ = -3.6;
+    ring.position.set(doorX, world.heightAt(doorX, doorZ) + 1.15, doorZ);
+    world.group.add(ring);
+    world.addInteract({
+        x: doorX, z: doorZ, r: 1.8, id: 'ring', kind: 'ring',
+        label: 'Pegar o Anel', mesh: ring, done: false
+    });
+    world.goal = 'ring';
+    world.updateFns.push((t) => {
+        if (ring.parent) {
+            ring.rotation.y = t * 0.9;
+            ring.position.y = world.heightAt(doorX, doorZ) + 1.15 + Math.sin(t * 2) * 0.08;
+        }
+    });
+
+    const colors = ['#2d6b38', '#6b3a2d', '#3a4a8a', '#8a5a2a', '#4a6b3a'];
+    const rng = seeded(42);
+    for (let i = 0; i < 9; i++) {
+        const a = (i / 9) * Math.PI * 2 + 0.4;
+        const r = 16 + rng() * 18;
+        const x = Math.cos(a) * r;
+        const z = Math.sin(a) * r;
+        if (Math.hypot(x + 20, z + 6) < 10) continue;
+        const h = buildHobbitHole({ doorColor: colors[i % colors.length], scale: 0.75 + rng() * 0.35 });
+        h.group.position.set(x, world.heightAt(x, z) - 0.2, z);
+        h.group.rotation.y = a + Math.PI;
+        world.group.add(h.group);
+        world.addCollider(x, z, 1.6);
+    }
+
+    const wiz = buildWizard();
+    wiz.group.position.set(8, world.heightAt(8, -12), -12);
+    world.group.add(wiz.group);
+    world.addCollider(8, -12, 0.7);
+    world.addInteract({
+        x: 8, z: -12, r: 2.2, id: 'wizard', kind: 'talk',
+        label: 'Falar com o Cinzento', done: false,
+        lines: [
+            'O Condado dorme em paz — por enquanto.',
+            'Leve o Anel. Não o use. A estrada já está à escuta.'
+        ]
+    });
+
+    const fireworks = [];
+    const fGeo = new THREE.SphereGeometry(0.08, 6, 5);
+    for (let i = 0; i < Math.floor(28 * quality.particles); i++) {
+        const p = new THREE.Mesh(fGeo, new THREE.MeshBasicMaterial({
+            color: new THREE.Color().setHSL(hash2(i, 2), 0.75, 0.6)
+        }));
+        world.group.add(p);
+        fireworks.push({ mesh: p, t: rng() * 4, life: 2 + rng() * 2 });
+    }
+    world.updateFns.push((t) => {
+        wiz.parts.crystal.rotation.y = t * 2;
+        for (const fw of fireworks) {
+            const u = (t + fw.t) % fw.life;
+            const k = u / fw.life;
+            const ang = fw.t * 6;
+            fw.mesh.position.set(
+                8 + Math.cos(ang) * k * 3.5,
+                world.heightAt(8, -12) + 2.2 + k * 7,
+                -12 + Math.sin(ang) * k * 3.5
+            );
+            fw.mesh.scale.setScalar(1 - k);
+            fw.mesh.material.opacity = 1 - k;
+            fw.mesh.material.transparent = true;
+        }
+    });
+
+    scatterTrees(world, () => buildOak(), Math.floor(38 * quality.trees), rng, {
+        minR: 12, maxR: 48, avoid: [{ x: 0, z: 0, r: 8 }, { x: -20, z: -6, r: 8 }, { x: 18, z: 22, r: 6 }]
+    });
+    scatterGrass(world, Math.floor(900 * quality.grass), quality);
+    makePage(world, 4, 10, 'shire-page');
+    return world;
+}
+
+/* ================================================================== */
+/* II — A Fuga                                                         */
+/* ================================================================== */
+
+export function buildForest(quality) {
+    const world = new ChapterWorld();
+    world.bounds = { minX: -22, maxX: 22, minZ: -8, maxZ: 132 };
+    world.spawn = { x: 0, z: 4, yaw: 0 };
+    world.overview.set(8, 10, -6);
+
+    world.heightAt = (x, z) => {
+        const path = smoothstep(5, 11, Math.abs(x));
+        const bumps = fbm(x * 0.08, z * 0.05, 7) * 2.4;
+        return bumps * path;
+    };
+
+    world.group.add(terrainMesh(
+        world.heightAt, 140, quality.id === 'low' ? 40 : 80,
+        new THREE.MeshStandardMaterial({ map: mossTexture(), color: 0x3a5a32, roughness: 0.96 }),
+        0, 62
+    ));
+
+    const rng = seeded(99);
+    const protoPine = () => buildPine();
+    const protoOak = () => buildOak();
+    const treeCount = Math.floor(90 * quality.trees);
+    for (let i = 0; i < treeCount; i++) {
+        const z = rng() * 120 + 4;
+        const side = rng() < 0.5 ? -1 : 1;
+        const x = side * (7 + rng() * 12);
+        const tree = rng() < 0.65 ? protoPine() : protoOak();
+        tree.scale.setScalar(0.9 + rng() * 1.1);
+        tree.position.set(x, world.heightAt(x, z), z);
+        tree.rotation.y = rng() * 6;
+        world.group.add(tree);
+        world.addCollider(x, z, 0.7);
+    }
+
+    for (let i = 0; i < 10; i++) {
+        const rock = buildRock(i + 3);
+        const x = (rng() - 0.5) * 16;
+        const z = 10 + rng() * 100;
+        rock.position.set(x, world.heightAt(x, z), z);
+        rock.scale.setScalar(0.5 + rng() * 0.9);
+        world.group.add(rock);
+        world.addCollider(x, z, 0.6);
+    }
+
+    const riderSpawns = [
+        { x: -4, z: 38, wps: [{ x: -6, z: 32 }, { x: 5, z: 48 }, { x: -4, z: 38 }] },
+        { x: 3, z: 68, wps: [{ x: 6, z: 60 }, { x: -5, z: 78 }, { x: 3, z: 68 }] },
+        { x: -2, z: 98, wps: [{ x: -7, z: 92 }, { x: 4, z: 108 }, { x: -2, z: 98 }] }
+    ];
+    for (const s of riderSpawns) {
+        const n = buildNazgul();
+        n.group.position.set(s.x, world.heightAt(s.x, s.z), s.z);
+        world.group.add(n.group);
+        world.riders.push(new Rider(n.group, s.x, s.z, s.wps));
+    }
+
+    // Vau
+    const water = new THREE.Mesh(
+        new THREE.PlaneGeometry(48, 22),
+        new THREE.MeshStandardMaterial({
+            map: waterTexture(),
+            color: 0x4aa0c8,
+            transparent: true,
+            opacity: 0.78,
+            roughness: 0.2,
+            metalness: 0.3
+        })
+    );
+    water.rotation.x = -Math.PI / 2;
+    water.position.set(0, -0.15, 122);
+    world.group.add(water);
+    world.waterMeshes.push(water);
+
+    const fordMarker = new THREE.Mesh(
+        new THREE.CylinderGeometry(0.2, 0.2, 2.2, 8),
+        new THREE.MeshStandardMaterial({ color: 0xd8e8ff, emissive: 0x88aaff, emissiveIntensity: 1.2 })
+    );
+    fordMarker.position.set(0, 1.4, 124);
+    world.group.add(fordMarker);
+    world.addInteract({
+        x: 0, z: 124, r: 3.2, id: 'ford', kind: 'goal',
+        label: 'Atravessar o vau', mesh: fordMarker, done: false
+    });
+    world.goal = 'ford';
+
+    const elf = buildElf({ robe: 0xd8e8f0 });
+    elf.group.position.set(3.5, world.heightAt(3.5, 126), 126);
+    world.group.add(elf.group);
+
+    scatterGrass(world, Math.floor(400 * quality.grass), quality);
+    makePage(world, -8, 20, 'forest-page');
+    return world;
+}
+
+/* ================================================================== */
+/* III — O Vale Élfico                                                 */
+/* ================================================================== */
+
+export function buildRivendell(quality) {
+    const world = new ChapterWorld();
+    world.bounds = { minX: -48, maxX: 48, minZ: -40, maxZ: 48 };
+    world.spawn = { x: 0, z: -30, yaw: 0 };
+    world.overview.set(16, 18, -22);
+
+    world.heightAt = (x, z) => {
+        const valley = Math.abs(x) * 0.18;
+        const rise = smoothstep(-8, 20, z) * 3.4;
+        const noise = fbm(x * 0.03, z * 0.03, 11) * 2.2;
+        return valley + rise + noise * 0.5;
+    };
+
+    world.group.add(terrainMesh(
+        world.heightAt, 120, quality.id === 'low' ? 48 : 90,
+        new THREE.MeshStandardMaterial({ map: mossTexture(), color: 0x6a9a58, roughness: 0.9 })
+    ));
+
+    const stream = new THREE.Mesh(
+        new THREE.PlaneGeometry(8, 90),
+        new THREE.MeshStandardMaterial({
+            map: waterTexture(),
+            color: 0x6ad0e0,
+            transparent: true,
+            opacity: 0.8,
+            roughness: 0.15,
+            metalness: 0.25
+        })
+    );
+    stream.rotation.x = -Math.PI / 2;
+    stream.position.set(0, 0.05, 0);
+    world.group.add(stream);
+    world.waterMeshes.push(stream);
+
+    const pav = buildPavilion();
+    pav.position.set(0, world.heightAt(0, 8), 8);
+    world.group.add(pav);
+    world.addCollider(0, 8, 5.4);
+
+    const council = buildCouncilRing();
+    council.position.set(0, world.heightAt(0, 18) + 0.05, 18);
+    world.group.add(council);
+
+    const ring = buildRing(1.4);
+    ring.position.set(0, world.heightAt(0, 18) + 1.35, 18);
+    world.group.add(ring);
+    world.addInteract({
+        x: 0, z: 18, r: 2.4, id: 'oath', kind: 'goal',
+        label: 'Aceitar levar o Anel', mesh: ring, done: false
+    });
+    world.goal = 'oath';
+    world.updateFns.push((t) => {
+        ring.rotation.y = t * 0.7;
+        ring.position.y = world.heightAt(0, 18) + 1.35 + Math.sin(t * 1.6) * 0.1;
+    });
+
+    const robes = [0xc8d8c0, 0xd8c8a0, 0xb0c8d8, 0xe8dcc8, 0x9ab090];
+    for (let i = 0; i < 5; i++) {
+        const a = (i / 5) * Math.PI * 2;
+        const elf = buildElf({ robe: robes[i] });
+        const x = Math.cos(a) * 3.2;
+        const z = 18 + Math.sin(a) * 3.2;
+        elf.group.position.set(x, world.heightAt(x, z), z);
+        elf.group.lookAt(0, elf.group.position.y, 18);
+        world.group.add(elf.group);
+    }
+
+    // Quedas — partículas.
+    const dropGeo = new THREE.SphereGeometry(0.07, 4, 4);
+    const dropMat = new THREE.MeshBasicMaterial({ color: 0xc8f0ff, transparent: true, opacity: 0.55 });
+    const drops = [];
+    const nDrops = Math.floor(80 * quality.particles);
+    for (let i = 0; i < nDrops; i++) {
+        const m = new THREE.Mesh(dropGeo, dropMat);
+        world.group.add(m);
+        drops.push({ mesh: m, side: i % 2 ? -1 : 1, t: hash2(i, 4) });
+    }
+    world.updateFns.push((t) => {
+        for (const d of drops) {
+            const u = (t * 0.35 + d.t) % 1;
+            const x = d.side * 36;
+            const y = 16 - u * 18;
+            const z = -4 + Math.sin((d.t + t) * 8) * 0.4;
+            d.mesh.position.set(x, y, z);
+        }
+    });
+
+    for (const sx of [-1, 1]) {
+        const cliff = new THREE.Mesh(
+            new THREE.BoxGeometry(8, 18, 28),
+            new THREE.MeshStandardMaterial({ map: stoneTexture('#8aa0a8'), color: 0xc8d8d0, roughness: 0.85 })
+        );
+        cliff.position.set(sx * 40, 6, 0);
+        world.group.add(cliff);
+    }
+
+    const rng = seeded(21);
+    scatterTrees(world, () => buildOak({ autumn: true }), Math.floor(28 * quality.trees), rng, {
+        minR: 14, maxR: 42, cx: 0, cz: 0, avoid: [{ x: 0, z: 8, r: 10 }, { x: 0, z: 18, r: 8 }]
+    });
+    scatterGrass(world, Math.floor(500 * quality.grass), quality);
+    makePage(world, -12, -16, 'rivendell-page');
+    return world;
+}
+
+/* ================================================================== */
+/* IV — As Minas                                                       */
+/* ================================================================== */
+
+export function buildMoria(quality) {
+    const world = new ChapterWorld();
+    world.bounds = { minX: -16, maxX: 16, minZ: -4, maxZ: 108 };
+    world.spawn = { x: 0, z: 2, yaw: 0 };
+    world.overview.set(0, 8, -8);
+
+    world.heightAt = (x, z) => {
+        if (z > 74 && z < 90 && Math.abs(x) > 1.15) return -40;
+        return 0;
+    };
+
+    const floorMat = new THREE.MeshStandardMaterial({
+        map: brickTexture(),
+        color: 0x5a4a3a,
+        roughness: 0.92
+    });
+    const floor = new THREE.Mesh(new THREE.PlaneGeometry(36, 78), floorMat);
+    floor.rotation.x = -Math.PI / 2;
+    floor.position.set(0, 0, 36);
+    floor.receiveShadow = true;
+    world.group.add(floor);
+
+    const exitFloor = new THREE.Mesh(new THREE.PlaneGeometry(10, 22), floorMat);
+    exitFloor.rotation.x = -Math.PI / 2;
+    exitFloor.position.set(0, 0, 98);
+    exitFloor.receiveShadow = true;
+    world.group.add(exitFloor);
+
+    // Paredes e teto
+    const wallMat = new THREE.MeshStandardMaterial({
+        map: stoneTexture('#3a3028'),
+        color: 0x3a3028,
+        roughness: 0.95
+    });
+    for (const sx of [-1, 1]) {
+        const wall = new THREE.Mesh(new THREE.BoxGeometry(2, 16, 110), wallMat);
+        wall.position.set(sx * 18, 8, 50);
+        world.group.add(wall);
+        world.addCollider(sx * 17, 50, 3);
+    }
+    const ceiling = new THREE.Mesh(new THREE.BoxGeometry(38, 1.2, 110), wallMat);
+    ceiling.position.set(0, 15.2, 50);
+    world.group.add(ceiling);
+
+    const pillarN = quality.id === 'low' ? 8 : 12;
+    for (let i = 0; i < pillarN; i++) {
+        const z = 8 + i * 5.5;
+        for (const sx of [-1, 1]) {
+            const p = buildPillar(13);
+            p.position.set(sx * 8.5, 0, z);
+            world.group.add(p);
+            world.addCollider(sx * 8.5, z, 1.0);
+        }
+    }
+
+    // Tochas
+    const torchCount = quality.lights ? 10 : 4;
+    for (let i = 0; i < torchCount; i++) {
+        const z = 6 + i * 9;
+        const sx = i % 2 ? 1 : -1;
+        const flame = new THREE.Mesh(
+            new THREE.SphereGeometry(0.18, 8, 6),
+            new THREE.MeshStandardMaterial({
+                color: 0xffaa44,
+                emissive: 0xff6622,
+                emissiveIntensity: 3
+            })
+        );
+        flame.position.set(sx * 15.5, 3.4, z);
+        world.group.add(flame);
+        if (quality.lights) {
+            const light = new THREE.PointLight(0xff7a30, 2.2, 16, 2);
+            light.position.copy(flame.position);
+            world.group.add(light);
+        }
+    }
+
+    const goblinSpawns = [
+        { x: -3, z: 28 }, { x: 4, z: 42 }, { x: -5, z: 55 }, { x: 2, z: 66 }
+    ];
+    for (const s of goblinSpawns) {
+        const g = buildGoblin();
+        g.group.position.set(s.x, 0, s.z);
+        world.group.add(g.group);
+        world.goblins.push(new GoblinAI(g.group, s.x, s.z));
+    }
+
+    // Abismo
+    const glow = new THREE.Mesh(
+        new THREE.PlaneGeometry(40, 20),
+        new THREE.MeshBasicMaterial({ color: 0xff4a12, transparent: true, opacity: 0.35, side: THREE.DoubleSide })
+    );
+    glow.rotation.x = -Math.PI / 2;
+    glow.position.set(0, -8, 82);
+    world.group.add(glow);
+
+    const bridge = buildBridge();
+    bridge.position.set(0, 0, 82);
+    world.group.add(bridge);
+
+    const exit = new THREE.Mesh(
+        new THREE.BoxGeometry(4, 5, 0.4),
+        new THREE.MeshStandardMaterial({
+            color: 0xffe8a0,
+            emissive: 0xffaa44,
+            emissiveIntensity: 0.8
+        })
+    );
+    exit.position.set(0, 2.5, 104);
+    world.group.add(exit);
+    world.addInteract({
+        x: 0, z: 104, r: 2.6, id: 'exit', kind: 'goal',
+        label: 'Escapar das minas', mesh: exit, done: false
+    });
+    world.goal = 'exit';
+
+    // A Sombra — aparece quando o jogador pisa na ponte.
+    const shadow = new THREE.Group();
+    const body = new THREE.Mesh(
+        new THREE.ConeGeometry(2.4, 8, 6),
+        new THREE.MeshStandardMaterial({
+            color: 0x1a0804,
+            emissive: 0xff3300,
+            emissiveIntensity: 0.45,
+            roughness: 0.9
+        })
+    );
+    body.position.y = 4;
+    shadow.add(body);
+    const hornL = new THREE.Mesh(new THREE.ConeGeometry(0.35, 2.2, 6), std(0x2a1008, 0.8));
+    hornL.position.set(-1.1, 8.2, 0);
+    hornL.rotation.z = 0.5;
+    shadow.add(hornL);
+    const hornR = hornL.clone();
+    hornR.position.x = 1.1;
+    hornR.rotation.z = -0.5;
+    shadow.add(hornR);
+    const eye = new THREE.Mesh(
+        new THREE.SphereGeometry(0.35, 8, 6),
+        new THREE.MeshStandardMaterial({ color: 0xffee88, emissive: 0xffaa00, emissiveIntensity: 4 })
+    );
+    eye.position.set(0, 6.2, 1.4);
+    shadow.add(eye);
+    shadow.position.set(0, -12, 70);
+    shadow.visible = false;
+    world.group.add(shadow);
+    world.balrog = shadow;
+    world.updateFns.push((t, dt) => {
+        if (!world.balrogAwake) return;
+        shadow.visible = true;
+        const k = 1 - Math.exp(-1.8 * dt);
+        shadow.position.z += (78 - shadow.position.z) * k;
+        shadow.position.y += (0 - shadow.position.y) * k;
+        eye.scale.setScalar(1 + Math.sin(t * 8) * 0.15);
+    });
+
+    makePage(world, 5, 14, 'moria-page');
+    return world;
+}
+
+/* ================================================================== */
+/* V — O Monte da Visão                                                */
+/* ================================================================== */
+
+export function buildAmonHen(quality) {
+    const world = new ChapterWorld();
+    world.bounds = { minX: -55, maxX: 40, minZ: -40, maxZ: 40 };
+    world.spawn = { x: 4, z: 28, yaw: Math.PI };
+    world.overview.set(12, 18, 32);
+
+    world.heightAt = (x, z) => {
+        const d = Math.hypot(x, z);
+        const hill = smoothstep(38, 4, d) * 9.5;
+        const river = x < -28 ? -2.5 : 0;
+        const noise = fbm(x * 0.04, z * 0.04, 15) * 1.4;
+        return Math.max(river, hill + noise * 0.4);
+    };
+
+    world.group.add(terrainMesh(
+        world.heightAt, 130, quality.id === 'low' ? 48 : 90,
+        new THREE.MeshStandardMaterial({ map: grassTexture(), color: 0x8a7a48, roughness: 0.92 })
+    ));
+
+    const river = new THREE.Mesh(
+        new THREE.PlaneGeometry(40, 130),
+        new THREE.MeshStandardMaterial({
+            map: waterTexture(),
+            color: 0x3a7aaa,
+            transparent: true,
+            opacity: 0.85,
+            roughness: 0.18,
+            metalness: 0.3
+        })
+    );
+    river.rotation.x = -Math.PI / 2;
+    river.position.set(-42, -0.4, 0);
+    world.group.add(river);
+    world.waterMeshes.push(river);
+
+    const seat = buildSeat();
+    seat.position.set(0, world.heightAt(0, 0), 0);
+    world.group.add(seat);
+    world.addCollider(0, 0, 1.4);
+    world.addInteract({
+        x: 0, z: 0, r: 2.2, id: 'seat', kind: 'goal',
+        label: 'Sentar no trono e seguir adiante', done: false
+    });
+    world.goal = 'seat';
+
+    const arch = buildRuinArch();
+    arch.position.set(6, world.heightAt(6, 10), 10);
+    arch.rotation.y = 0.4;
+    world.group.add(arch);
+
+    const arch2 = buildRuinArch();
+    arch2.position.set(-8, world.heightAt(-8, 8), 8);
+    arch2.rotation.y = -0.6;
+    world.group.add(arch2);
+
+    const companion = buildCompanion();
+    companion.group.position.set(3.2, world.heightAt(3.2, 5), 5);
+    world.group.add(companion.group);
+    world.addInteract({
+        x: 3.2, z: 5, r: 2, id: 'sam', kind: 'talk',
+        label: 'Falar com o jardineiro', done: false,
+        lines: [
+            'Não posso carregar o Anel por você.',
+            'Mas posso ir até o fim. Não o deixe sozinho.'
+        ]
+    });
+
+    const rng = seeded(5);
+    scatterTrees(world, () => buildOak({ autumn: true }), Math.floor(22 * quality.trees), rng, {
+        minR: 12, maxR: 36, avoid: [{ x: 0, z: 0, r: 8 }]
+    });
+    scatterGrass(world, Math.floor(600 * quality.grass), quality);
+    makePage(world, -6, 16, 'hen-page');
+    return world;
+}
+
+export function buildChapter(id, quality) {
+    switch (id) {
+        case 'shire': return buildShire(quality);
+        case 'forest': return buildForest(quality);
+        case 'rivendell': return buildRivendell(quality);
+        case 'moria': return buildMoria(quality);
+        case 'amonhen': return buildAmonHen(quality);
+        default: return buildShire(quality);
+    }
+}

--- a/labs/jornada-do-anel/style.css
+++ b/labs/jornada-do-anel/style.css
@@ -1,0 +1,792 @@
+/* ================================================================
+   A Jornada do Anel — interface
+   Paleta: pergaminho, ouro do Anel, musgo do Condado, sombra das minas.
+   ================================================================ */
+
+:root {
+    --ink: oklch(12% 0.03 70);
+    --ink-deep: oklch(8% 0.025 70);
+    --parchment: oklch(92% 0.04 90);
+    --gold: oklch(79% 0.14 82);
+    --gold-deep: oklch(62% 0.13 68);
+    --moss: oklch(52% 0.12 140);
+    --ember: oklch(58% 0.19 38);
+    --blood: oklch(52% 0.19 22);
+
+    --text: oklch(95% 0.015 90);
+    --text-soft: oklch(80% 0.03 85);
+    --text-dim: oklch(62% 0.03 80);
+
+    --panel: color-mix(in oklab, oklch(16% 0.03 70) 64%, transparent);
+    --panel-strong: color-mix(in oklab, oklch(11% 0.03 70) 84%, transparent);
+    --line: color-mix(in oklab, var(--gold) 28%, transparent);
+    --line-soft: color-mix(in oklab, var(--parchment) 12%, transparent);
+
+    --radius: 14px;
+    --radius-lg: 22px;
+    --blur: 20px;
+    --safe-top: env(safe-area-inset-top, 0px);
+    --safe-bottom: env(safe-area-inset-bottom, 0px);
+    --safe-left: env(safe-area-inset-left, 0px);
+    --safe-right: env(safe-area-inset-right, 0px);
+    --ease: cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+*, *::before, *::after {
+    box-sizing: border-box;
+    -webkit-tap-highlight-color: transparent;
+}
+
+html, body {
+    margin: 0;
+    width: 100%;
+    height: 100%;
+    overflow: clip;
+    overscroll-behavior: none;
+    background: var(--ink-deep);
+}
+
+body {
+    min-height: 100dvh;
+    color: var(--text);
+    font-family: 'Outfit', system-ui, sans-serif;
+    user-select: none;
+    touch-action: none;
+}
+
+button, input, select { font: inherit; color: inherit; }
+button { background: none; border: 0; cursor: pointer; }
+
+.mono {
+    font-variant-numeric: tabular-nums;
+    font-feature-settings: 'tnum' 1;
+}
+
+:focus-visible {
+    outline: 2px solid var(--gold);
+    outline-offset: 3px;
+}
+
+.game-shell {
+    position: fixed;
+    inset: 0;
+    overflow: hidden;
+    background: radial-gradient(120% 90% at 50% 0%, oklch(22% 0.05 70) 0%, var(--ink-deep) 70%);
+}
+
+#scene {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    display: block;
+    touch-action: none;
+}
+
+.fade {
+    position: absolute;
+    inset: 0;
+    z-index: 25;
+    background: #050301;
+    opacity: 0;
+    pointer-events: none;
+    transition: none;
+}
+
+.vignette {
+    position: absolute;
+    inset: 0;
+    z-index: 18;
+    pointer-events: none;
+    opacity: 0;
+    background: radial-gradient(ellipse at 50% 50%, transparent 40%, oklch(20% 0.12 25 / 0.85) 100%);
+    transition: opacity 0.3s ease;
+}
+
+.hit-flash {
+    position: absolute;
+    inset: 0;
+    z-index: 19;
+    pointer-events: none;
+    background: oklch(55% 0.22 25 / 0.35);
+    opacity: 0;
+}
+
+.hit-flash.is-on {
+    animation: hitFlash 0.45s ease-out;
+}
+
+@keyframes hitFlash {
+    0% { opacity: 1; }
+    100% { opacity: 0; }
+}
+
+/* header */
+.game-shell > header {
+    position: absolute;
+    top: calc(0.9rem + var(--safe-top));
+    left: calc(1rem + var(--safe-left));
+    right: calc(1rem + var(--safe-right));
+    z-index: 40;
+    margin: 0;
+    padding: 0;
+    max-width: none;
+    width: auto;
+    pointer-events: none;
+    gap: 0.6rem;
+}
+
+.game-shell > header > * { pointer-events: auto; }
+
+.game-shell > header .back-link {
+    background: var(--panel-strong);
+    backdrop-filter: blur(var(--blur));
+    border-color: var(--line);
+    color: var(--text-soft);
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.4);
+}
+
+.game-shell > header .back-link:hover {
+    color: var(--gold);
+    border-color: var(--gold);
+}
+
+.game-shell > header .app-logo {
+    font-family: 'Cinzel', Georgia, serif;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    font-size: 0.95rem;
+    color: var(--parchment);
+    text-shadow: 0 2px 18px rgba(0, 0, 0, 0.7);
+}
+
+.brand-mark {
+    display: inline-grid;
+    place-items: center;
+    width: 1.35rem;
+    height: 1.35rem;
+    margin-right: 0.35rem;
+    border: 2px solid var(--gold);
+    border-radius: 50%;
+    color: var(--gold);
+    box-shadow: 0 0 12px oklch(75% 0.16 82 / 0.55);
+}
+
+.lab-foot {
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: calc(0.4rem + var(--safe-bottom));
+    z-index: 30;
+    margin: 0;
+    padding: 0.4rem;
+    border: 0;
+    font-size: 0.72rem;
+    color: var(--text-dim);
+    opacity: 0.5;
+    pointer-events: none;
+}
+
+.lab-foot a { color: var(--text-soft); pointer-events: auto; }
+
+body[data-state="playing"] .lab-foot,
+body[data-state="intro"] .lab-foot,
+body[data-state="playing"] .game-shell > header .app-logo {
+    opacity: 0;
+    transition: opacity 0.5s var(--ease);
+}
+
+/* HUD */
+.hud {
+    position: absolute;
+    inset: 0;
+    z-index: 20;
+    pointer-events: none;
+    padding: calc(4.2rem + var(--safe-top)) calc(1rem + var(--safe-right)) calc(1rem + var(--safe-bottom))
+        calc(1rem + var(--safe-left));
+}
+
+.hud[hidden] { display: none; }
+
+.panel {
+    background: var(--panel);
+    backdrop-filter: blur(var(--blur)) saturate(1.15);
+    border: 1px solid var(--line-soft);
+    border-radius: var(--radius);
+    box-shadow: 0 12px 34px rgba(0, 0, 0, 0.42), inset 0 1px 0 rgba(255, 255, 255, 0.06);
+    padding: 0.6rem 0.85rem;
+}
+
+.hud-label {
+    font-family: 'Cinzel', Georgia, serif;
+    font-size: 0.62rem;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--gold);
+    opacity: 0.85;
+}
+
+.hud-top {
+    display: grid;
+    grid-template-columns: minmax(140px, 1fr) minmax(220px, 2fr) minmax(120px, 1fr);
+    gap: 0.75rem;
+    pointer-events: none;
+}
+
+.hearts { display: flex; gap: 0.28rem; margin: 0.35rem 0 0.4rem; }
+
+.heart {
+    width: 16px;
+    height: 16px;
+    display: inline-block;
+    background: transparent;
+    border: 1.5px solid var(--line);
+    border-radius: 50% 50% 50% 0;
+    transform: rotate(-45deg);
+    opacity: 0.35;
+}
+
+.heart.is-on {
+    background: linear-gradient(160deg, oklch(72% 0.18 25), var(--blood));
+    opacity: 1;
+    box-shadow: 0 0 10px oklch(60% 0.2 25 / 0.5);
+}
+
+.ring-badge {
+    font-size: 0.72rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--text-dim);
+}
+
+.ring-badge[data-on="true"] {
+    color: var(--gold);
+    text-shadow: 0 0 12px oklch(75% 0.16 82 / 0.7);
+}
+
+.quest-panel { justify-self: center; width: min(460px, 100%); }
+
+.objective {
+    margin: 0.35rem 0 0;
+    font-size: 0.92rem;
+    color: var(--parchment);
+    line-height: 1.35;
+}
+
+.score-panel { justify-self: end; min-width: 110px; }
+.score-row { display: flex; justify-content: space-between; gap: 0.8rem; align-items: baseline; }
+.score-row--sub { margin-top: 0.25rem; color: var(--text-dim); }
+
+.stealth {
+    position: absolute;
+    top: calc(8.5rem + var(--safe-top));
+    left: 50%;
+    translate: -50% 0;
+    width: min(280px, 70vw);
+    text-align: center;
+    font-size: 0.75rem;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: oklch(85% 0.08 80);
+}
+
+.stealth i {
+    display: block;
+    height: 6px;
+    margin-top: 0.35rem;
+    border-radius: 99px;
+    background: rgba(255, 255, 255, 0.1);
+    overflow: hidden;
+}
+
+.stealth b {
+    display: block;
+    height: 100%;
+    width: 100%;
+    transform-origin: left center;
+    transform: scaleX(0);
+    background: linear-gradient(90deg, var(--gold), var(--ember));
+}
+
+.stealth[data-danger="true"] {
+    color: oklch(78% 0.16 25);
+}
+
+.stealth[data-danger="true"] b {
+    background: var(--blood);
+    box-shadow: 0 0 12px oklch(55% 0.2 25 / 0.8);
+}
+
+.message {
+    position: absolute;
+    left: 50%;
+    bottom: calc(6.5rem + var(--safe-bottom));
+    translate: -50% 0;
+    margin: 0;
+    max-width: min(520px, 86vw);
+    text-align: center;
+    font-family: 'Cinzel', Georgia, serif;
+    font-size: 1.05rem;
+    color: var(--parchment);
+    text-shadow: 0 2px 18px #000;
+    opacity: 0;
+    pointer-events: none;
+}
+
+.message[data-show="true"] { opacity: 1; transition: opacity 0.35s ease; }
+
+.prompt {
+    position: absolute;
+    left: 50%;
+    bottom: calc(4.4rem + var(--safe-bottom));
+    translate: -50% 0;
+    margin: 0;
+    padding: 0.45rem 0.85rem;
+    border-radius: 999px;
+    background: var(--panel-strong);
+    border: 1px solid var(--line);
+    color: var(--parchment);
+    font-size: 0.88rem;
+    pointer-events: none;
+}
+
+.prompt kbd {
+    display: inline-grid;
+    place-items: center;
+    min-width: 1.3rem;
+    margin-right: 0.35rem;
+    padding: 0.05rem 0.3rem;
+    border-radius: 5px;
+    border: 1px solid var(--line);
+    font-size: 0.72rem;
+    color: var(--gold);
+}
+
+.hud-actions {
+    position: absolute;
+    right: calc(1rem + var(--safe-right));
+    bottom: calc(1.1rem + var(--safe-bottom));
+    display: flex;
+    gap: 0.45rem;
+    align-items: center;
+    pointer-events: auto;
+}
+
+.icon-button {
+    width: 42px;
+    height: 42px;
+    border-radius: 12px;
+    background: var(--panel-strong);
+    border: 1px solid var(--line-soft);
+    color: var(--text-soft);
+}
+
+.icon-button:hover { color: var(--gold); border-color: var(--gold); }
+.fps { font-size: 0.72rem; color: var(--text-dim); }
+
+/* chapter title card */
+.chapter-card {
+    position: absolute;
+    inset: 0;
+    z-index: 22;
+    display: grid;
+    place-content: center;
+    text-align: center;
+    pointer-events: none;
+    opacity: 0;
+    background: radial-gradient(ellipse at 50% 50%, oklch(10% 0.03 70 / 0.35), transparent 60%);
+}
+
+.chapter-card.is-on {
+    animation: cardIn 3.4s var(--ease) forwards;
+}
+
+.chapter-roman {
+    font-family: 'Cinzel', Georgia, serif;
+    letter-spacing: 0.4em;
+    color: var(--gold);
+    font-size: 0.85rem;
+}
+
+.chapter-card h2 {
+    margin: 0.4rem 0 0.2rem;
+    font-family: 'Cinzel', Georgia, serif;
+    font-size: clamp(2rem, 6vw, 3.6rem);
+    font-weight: 700;
+    color: var(--parchment);
+    text-shadow: 0 8px 40px #000;
+}
+
+.chapter-card p {
+    margin: 0;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    font-size: 0.82rem;
+    color: var(--text-soft);
+}
+
+@keyframes cardIn {
+    0% { opacity: 0; transform: translateY(12px); }
+    12% { opacity: 1; transform: none; }
+    78% { opacity: 1; }
+    100% { opacity: 0; }
+}
+
+/* overlays */
+.overlay {
+    position: absolute;
+    inset: 0;
+    z-index: 35;
+    display: grid;
+    place-items: center;
+    padding: calc(4.5rem + var(--safe-top)) 1rem 1.5rem;
+    background: color-mix(in oklab, var(--ink-deep) 42%, transparent);
+    backdrop-filter: blur(8px);
+}
+
+.overlay[hidden] { display: none; }
+
+.overlay-card {
+    width: min(860px, 100%);
+    background: color-mix(in oklab, oklch(14% 0.03 70) 78%, transparent);
+    border: 1px solid var(--line);
+    border-radius: var(--radius-lg);
+    box-shadow: 0 30px 80px rgba(0, 0, 0, 0.55), inset 0 1px 0 rgba(255, 255, 255, 0.06);
+    padding: 1.6rem 1.7rem 1.4rem;
+}
+
+.compact-card { width: min(440px, 100%); text-align: center; }
+
+.eyebrow {
+    display: flex;
+    align-items: center;
+    gap: 0.55rem;
+    margin: 0 0 0.6rem;
+    font-size: 0.72rem;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--gold);
+}
+
+.eyebrow i {
+    width: 28px;
+    height: 1px;
+    background: var(--gold);
+    display: inline-block;
+}
+
+.eyebrow--danger { color: oklch(72% 0.16 25); }
+.eyebrow--gold { color: var(--gold); }
+
+.menu-head h1, .overlay-card h2 {
+    font-family: 'Cinzel', Georgia, serif;
+    font-weight: 700;
+    margin: 0 0 0.5rem;
+    line-height: 1.15;
+    color: var(--parchment);
+}
+
+.menu-head h1 {
+    font-size: clamp(2rem, 5vw, 3.1rem);
+}
+
+.menu-head h1 span { color: var(--gold); }
+
+.lede {
+    margin: 0;
+    color: var(--text-soft);
+    line-height: 1.5;
+    max-width: 52ch;
+}
+
+.menu-grid {
+    display: grid;
+    grid-template-columns: 1.1fr 1fr 1fr;
+    gap: 1.1rem;
+    margin: 1.3rem 0 1.1rem;
+}
+
+.menu-section h2 {
+    font-family: 'Cinzel', Georgia, serif;
+    font-size: 0.78rem;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--gold);
+    margin: 0 0 0.55rem;
+}
+
+.chapter-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+}
+
+.chapter-chip {
+    display: flex;
+    align-items: baseline;
+    gap: 0.65rem;
+    text-align: left;
+    padding: 0.5rem 0.7rem;
+    border-radius: 10px;
+    border: 1px solid var(--line-soft);
+    background: rgba(255, 255, 255, 0.03);
+    color: var(--text-soft);
+}
+
+.chapter-chip b {
+    font-family: 'Cinzel', Georgia, serif;
+    color: var(--gold);
+    min-width: 1.4rem;
+}
+
+.chapter-chip[data-active="true"] {
+    border-color: var(--gold);
+    background: color-mix(in oklab, var(--gold) 12%, transparent);
+    color: var(--parchment);
+}
+
+.chapter-chip:disabled { opacity: 0.35; cursor: not-allowed; }
+
+.keys {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    font-size: 0.85rem;
+    color: var(--text-soft);
+}
+
+kbd {
+    display: inline-block;
+    min-width: 1.3rem;
+    padding: 0.08rem 0.32rem;
+    margin-right: 0.15rem;
+    border-radius: 5px;
+    border: 1px solid var(--line);
+    font-size: 0.72rem;
+    color: var(--parchment);
+}
+
+.settings-grid { display: grid; gap: 0.7rem; }
+
+.field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+    font-size: 0.82rem;
+    color: var(--text-soft);
+}
+
+.field select, .field input[type="range"] {
+    width: 100%;
+    background: rgba(0, 0, 0, 0.25);
+    border: 1px solid var(--line-soft);
+    border-radius: 8px;
+    padding: 0.4rem 0.5rem;
+}
+
+.section-note {
+    margin: 0.7rem 0 0;
+    font-size: 0.78rem;
+    color: var(--text-dim);
+}
+
+.menu-foot { display: flex; justify-content: flex-end; }
+
+.primary-button, .ghost-button {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.55rem;
+    padding: 0.75rem 1.15rem;
+    border-radius: 999px;
+    pointer-events: auto;
+}
+
+.primary-button {
+    background: linear-gradient(180deg, oklch(78% 0.14 82), oklch(58% 0.13 68));
+    color: oklch(16% 0.04 70);
+    font-weight: 650;
+    box-shadow: 0 10px 28px oklch(60% 0.14 82 / 0.35);
+}
+
+.primary-button:hover { filter: brightness(1.08); }
+
+.ghost-button {
+    margin-top: 0.55rem;
+    border: 1px solid var(--line);
+    color: var(--text-soft);
+}
+
+.ghost-button:hover { color: var(--gold); border-color: var(--gold); }
+
+.card-actions { display: flex; flex-direction: column; align-items: center; margin-top: 1rem; }
+
+.stats {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.55rem 1rem;
+    margin: 1rem 0 0;
+    text-align: left;
+}
+
+.stats div {
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+    padding: 0.45rem 0.55rem;
+    border-radius: 10px;
+    background: rgba(255, 255, 255, 0.04);
+}
+
+.stats span { font-size: 0.7rem; letter-spacing: 0.12em; text-transform: uppercase; color: var(--text-dim); }
+.stats strong { color: var(--parchment); }
+
+.dialogue-overlay { align-items: end; background: linear-gradient(transparent, oklch(8% 0.03 70 / 0.82)); }
+.dialogue-card {
+    width: min(640px, 100%);
+    margin-bottom: 2rem;
+    padding: 1.1rem 1.3rem;
+    border-radius: var(--radius);
+    border: 1px solid var(--line);
+    background: var(--panel-strong);
+}
+
+.dialogue-speaker {
+    margin: 0 0 0.35rem;
+    font-family: 'Cinzel', Georgia, serif;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    font-size: 0.75rem;
+    color: var(--gold);
+}
+
+.dialogue-text {
+    margin: 0 0 0.8rem;
+    font-size: 1.05rem;
+    line-height: 1.5;
+    color: var(--parchment);
+}
+
+/* loading */
+.loading-overlay { background: var(--ink-deep); }
+.loading-card { text-align: center; }
+
+.loading-card h1 {
+    font-family: 'Cinzel', Georgia, serif;
+    font-size: clamp(1.6rem, 4vw, 2.4rem);
+    margin: 0.8rem 0 0.4rem;
+}
+
+.ring-loader {
+    display: inline-block;
+    width: 54px;
+    height: 54px;
+    border: 4px solid oklch(75% 0.14 82 / 0.25);
+    border-top-color: var(--gold);
+    border-radius: 50%;
+    box-shadow: 0 0 24px oklch(75% 0.16 82 / 0.4);
+    animation: spin 1.1s linear infinite;
+}
+
+@keyframes spin { to { transform: rotate(360deg); } }
+
+.loading-bar {
+    width: min(280px, 70vw);
+    height: 6px;
+    margin: 0.9rem auto 0;
+    border-radius: 99px;
+    background: rgba(255, 255, 255, 0.08);
+    overflow: hidden;
+}
+
+.loading-bar i {
+    display: block;
+    height: 100%;
+    width: 0;
+    background: linear-gradient(90deg, var(--gold-deep), var(--gold));
+    box-shadow: 0 0 12px var(--gold);
+}
+
+/* touch */
+.touch-controls {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+}
+
+.stick {
+    pointer-events: auto;
+    position: absolute;
+    left: calc(1.2rem + var(--safe-left));
+    bottom: calc(1.2rem + var(--safe-bottom));
+    width: 112px;
+    height: 112px;
+    border-radius: 50%;
+    border: 1px solid var(--line);
+    background: var(--panel);
+    display: grid;
+    place-items: center;
+}
+
+.stick i {
+    width: 42px;
+    height: 42px;
+    border-radius: 50%;
+    background: var(--gold);
+    opacity: 0.85;
+}
+
+.stick span {
+    position: absolute;
+    bottom: -1.2rem;
+    font-size: 0.65rem;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--text-dim);
+}
+
+.look-zone {
+    pointer-events: auto;
+    position: absolute;
+    right: 0;
+    top: 20%;
+    width: 48%;
+    height: 55%;
+}
+
+.touch-buttons {
+    pointer-events: auto;
+    position: absolute;
+    right: calc(1rem + var(--safe-right));
+    bottom: calc(1.2rem + var(--safe-bottom));
+    display: flex;
+    flex-direction: column;
+    gap: 0.45rem;
+}
+
+.pad {
+    min-width: 72px;
+    padding: 0.65rem 0.8rem;
+    border-radius: 14px;
+    background: var(--panel-strong);
+    border: 1px solid var(--line);
+    color: var(--parchment);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-size: 0.75rem;
+}
+
+.pad-atk { background: color-mix(in oklab, var(--ember) 35%, var(--panel-strong)); }
+.pad-use { background: color-mix(in oklab, var(--gold) 28%, var(--panel-strong)); color: var(--ink); }
+
+@media (max-width: 860px) {
+    .menu-grid { grid-template-columns: 1fr; }
+    .hud-top { grid-template-columns: 1fr 1fr; }
+    .quest-panel { grid-column: 1 / -1; justify-self: stretch; width: auto; }
+}
+
+@media (max-width: 560px) {
+    .overlay-card { padding: 1.15rem 1rem 1rem; }
+    .menu-head h1 { font-size: 1.7rem; }
+    .hud-actions { bottom: calc(7.5rem + var(--safe-bottom)); }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Homenagem visual ao primeiro filme da trilogia, em third-person no navegador.

## O que entra

Novo lab `labs/jornada-do-anel/` com cinco capítulos jogáveis:

1. **O Condado** — colinas, tocas redondas, árvore da festa e o Anel
2. **A Fuga** — floresta noturna e Cavaleiros com cone de visão
3. **O Vale Élfico** — pavilhão, quedas d’água e o conselho
4. **As Minas** — pilares, goblins, ponte e a Sombra
5. **O Monte da Visão** — ruínas ao entardecer e o desfecho

Stack alinhada aos outros labs 3D: HTML/CSS/JS puro, Three.js 0.185 via CDN, texturas e modelos procedurais (sem GLB), Web Audio original. Card adicionado na galeria de labs.

Textos e música são originais — não há diálogos nem trilha do filme.

## Verificação

Menu, intro e gameplay carregaram no navegador. Ajustes pós-teste: iluminação mais clara no Condado, `THREE.Timer` no lugar do Clock depreciado, e pointer lock só depois de um clique.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ffdb3-c662-7d08-9afc-a76584488dbc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ffdb3-c662-7d08-9afc-a76584488dbc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

