### PR TITLE
📚 README, links dos labs e template de PR

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+## 🎯 Objetivo
+
+<!-- Uma frase: o que esta PR entrega e por quê. Comece o *título* com um emoji que bata com a intenção: ✨ feat · 🐛 fix · 📚 docs · ⚡️ perf · 🎨 UI · 🧪 lab -->
+
+## ✨ O que mudou
+
+-
+
+## 🧪 Como testar
+
+1. Na raiz do repo: `python3 -m http.server 8000`
+2. Abrir [http://localhost:8000/](http://localhost:8000/) (home) e [http://localhost:8000/labs/](http://localhost:8000/labs/) (galeria)
+3. Abrir o lab ou a página alterada e confirmar que CSS, JS e o voltar funcionam
+4. Conferir o link no README (e no `sitemap.xml` se o lab for novo)
+
+## ✅ Checklist
+
+- [ ] Links conferidos: pasta do lab ↔ card da galeria ↔ README ↔ sitemap (e corrigidos se quebravam)
+- [ ] Testado via HTTP na raiz, não via `file://`
+- [ ] Nada fora do escopo foi quebrado

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,6 +4,7 @@
 
 ## ✨ O que mudou
 
+<!-- Lista curta. Um item por mudança visível. -->
 -
 
 ## 🧪 Como testar

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ Este repositório é o portfólio pessoal e *Playground* de laboratórios do Dio
   - Cada laboratório vive em sua própria subpasta em *kebab-case* (ex: `/labs/rock-kombat/`).
   - Cada pasta de laboratório é autocontida (possui seu próprio `index.html`, arquivos `.css`, `.js` e pastas de `assets/`), facilitando a manutenção e a visualização estática.
 - `/AGENTS.md`: regras para agentes (fonte única).
-- `/CLAUDE.md`: ponteiro para o `AGENTS.md` — o Claude Code só lê este nome (maiúsculas).
+- `/CLAUDE.md`: só `@AGENTS.md` — o Claude Code exige este nome (maiúsculas) e importa as regras daqui. Não coloque mais nada nesse arquivo.
 - `/.github/PULL_REQUEST_TEMPLATE.md`: template obrigatório de todo PR.
 
 ## 🛠 Melhores Práticas e Regras de Desenvolvimento

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,9 @@ Este repositório é o portfólio pessoal e *Playground* de laboratórios do Dio
 - `/labs/`: Diretório que contém todos os experimentos e mini-projetos.
   - Cada laboratório vive em sua própria subpasta em *kebab-case* (ex: `/labs/rock-kombat/`).
   - Cada pasta de laboratório é autocontida (possui seu próprio `index.html`, arquivos `.css`, `.js` e pastas de `assets/`), facilitando a manutenção e a visualização estática.
+- `/AGENTS.md`: regras para agentes (fonte única).
+- `/CLAUDE.md`: ponteiro para o `AGENTS.md` — o Claude Code só lê este nome (maiúsculas).
+- `/.github/PULL_REQUEST_TEMPLATE.md`: template obrigatório de todo PR.
 
 ## 🛠 Melhores Práticas e Regras de Desenvolvimento
 
@@ -74,16 +77,10 @@ Também conferir, e corrigir se falhar:
 
 ## Cursor Cloud specific instructions
 
-Site 100% estático (HTML/CSS/JS puro). **Não há build, dependências, lockfiles, nem testes/lint automatizados** — não procure por `package.json`, `npm install`, etc. O código-fonte é o próprio artefato servido no GitHub Pages.
+Site 100% estático (HTML/CSS/JS puro). **Não há build, dependências, lockfiles, nem testes/lint automatizados** — não procure por `package.json` nem `npm install`. O código-fonte é o artefato do GitHub Pages.
 
-- **Rodar em desenvolvimento**: sirva a raiz do repositório por HTTP (abrir os arquivos via `file://` quebra caminhos absolutos como `/favicon.ico` e módulos ES). A partir de `/workspace`:
-  - `python3 -m http.server 8000` → site principal em `http://localhost:8000/`, playground em `http://localhost:8000/labs/`.
-- **Estrutura**: `index.html` (portfólio raiz) + `labs/<nome-do-lab>/index.html` (cada lab é autocontido). `labs/index.html` é a galeria que linka todos os labs.
-- **Caminhos**: o `manifest.json` e alguns assets usam caminhos absolutos (`/favicon.ico`, `/assets/...`), por isso é necessário servir a partir da raiz do repositório, não de uma subpasta.
-- **Verificação/"testes"**: não existe suíte automatizada. Sirva a raiz por HTTP e:
-  - carregue a home (toggle de tema) e a galeria (`/labs/`)
-  - rode a [auditoria de links](#6-auditoria-de-links-obrigatória) e **corrija** 404, cards órfãos e README/sitemap desatualizados
-- **PRs**: todo PR novo usa [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md) (objetivo, o que mudou, como testar, checklist). Sem descrição placeholder.
+- Sirva **a raiz do repo** por HTTP (`python3 -m http.server 8000` → home em `/`, playground em `/labs/`). `file://` quebra `/favicon.ico` e módulos ES.
+- Verificação = [§6 auditoria de links](#6-auditoria-de-links-obrigatória). PRs = [§7](#7-pull-requests).
 
 ---
 *Lembre-se: O objetivo principal do projeto é criatividade, performance e experimentação tecnológica na web sem barreiras.*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ Este repositório é o portfólio pessoal e *Playground* de laboratórios do Dio
 ### 3. Workflow de Modificação (Aja com Precisão)
 - **Não quebre o que está funcionando**: Faça modificações cirúrgicas. Evite reescrever arquivos inteiros ou refatorar códigos e lógicas que estão fora do escopo da solicitação do usuário.
 - **Respeite Comentários e Lógica Existente**: Mantenha as assinaturas de funções antigas ou comentários de explicação a não ser que a tarefa seja especificamente limpar o código.
-- **Caminhos de Arquivos (Paths)**: Como o projeto é servido no GitHub Pages, garanta que os caminhos para imagens e scripts estejam corretos, preferindo caminhos relativos (ex: `./assets/img.png` ou `../style.css`).
+- **Caminhos de Arquivos (Paths)**: Como o projeto é servido no GitHub Pages, garanta que os caminhos para imagens e scripts estejam corretos, preferindo caminhos relativos (ex: `./assets/img.png` ou `../style.css`). Caminhos absolutos da raiz (`/labs/`, `/favicon.ico`, `/assets/...`) também são válidos — testar sempre via HTTP, nunca via `file://`.
 
 ### 4. SEO e Semântica
 - Para novos arquivos HTML, inclua sempre as *tags* fundamentais: `<title>`, `<meta name="viewport">` adequada, meta descrições e utilize HTML semântico (`<main>`, `<section>`, `<article>`, `<header>`, `<footer>`).
@@ -44,6 +44,31 @@ Este repositório é o portfólio pessoal e *Playground* de laboratórios do Dio
 ### 5. Resolução de Problemas e Autonomia
 - Analise, planeje e só então codifique. Se encontrar uma ambiguidade significativa nos requisitos do usuário que impacte a arquitetura, pare e peça esclarecimentos.
 - Sempre documente o código de lógicas complexas (como fórmulas matemáticas para simulações ou regras de jogos).
+
+### 6. Auditoria de links (obrigatória)
+Toda vez que um lab for criado, movido, renomeado ou a galeria/README for tocado — e de preferência ao fechar qualquer PR — **verifique os links e corrija o que estiver quebrado na mesma mudança**. Não deixe 404, card órfão ou README desatualizado para depois.
+
+Checklist mínimo (estas listas devem ter os **mesmos slugs**):
+
+1. Pastas em `/labs/<kebab-case>/` com `index.html`
+2. Card em [`labs/index.html`](labs/index.html) com `href="/labs/<slug>/"`
+3. Linha no playground do [`README.md`](README.md) apontando para `https://diogopaulino.com.br/labs/<slug>/`
+4. Entrada em [`sitemap.xml`](sitemap.xml) com a mesma URL canônica
+
+Também conferir, e corrigir se falhar:
+
+- Link **Labs** da home (`/labs/`) e voltar de cada lab (`/labs/` no header, `/` no footer)
+- Assets, CSS e JS do lab (caminhos relativos ou absolutos a partir da raiz)
+- Canonical / Open Graph `https://diogopaulino.com.br/labs/<slug>/`
+- Servir a **raiz** do repo (`python3 -m http.server 8000`) e abrir home, galeria e o lab alterado — `file://` quebra módulos ES e `/favicon.ico`
+
+### 7. Pull requests
+**Todo PR novo deve nascer do template** [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md). Não envie descrição vazia, genérica ou só com a mensagem do commit.
+
+- Título: emoji + resumo (`✨`, `🐛`, `📚`, `⚡️`, `🎨`, `🧪` conforme o objetivo)
+- Preencha **Objetivo**, **O que mudou** e **Como testar** — apague os comentários placeholder
+- Marque o checklist; se um item não se aplica, diga o porquê em vez de fingir que testou
+- Agentes: ao criar/atualizar o PR, copie a estrutura do template no body (o GitHub só injeta o arquivo automaticamente na UI)
 
 ---
 
@@ -55,7 +80,10 @@ Site 100% estático (HTML/CSS/JS puro). **Não há build, dependências, lockfil
   - `python3 -m http.server 8000` → site principal em `http://localhost:8000/`, playground em `http://localhost:8000/labs/`.
 - **Estrutura**: `index.html` (portfólio raiz) + `labs/<nome-do-lab>/index.html` (cada lab é autocontido). `labs/index.html` é a galeria que linka todos os labs.
 - **Caminhos**: o `manifest.json` e alguns assets usam caminhos absolutos (`/favicon.ico`, `/assets/...`), por isso é necessário servir a partir da raiz do repositório, não de uma subpasta.
-- **Verificação/"testes"**: não existe suíte automatizada. Valide manualmente carregando as páginas no navegador (o toggle de tema na home e abrir um lab da galeria são bons smoke tests).
+- **Verificação/"testes"**: não existe suíte automatizada. Sirva a raiz por HTTP e:
+  - carregue a home (toggle de tema) e a galeria (`/labs/`)
+  - rode a [auditoria de links](#6-auditoria-de-links-obrigatória) e **corrija** 404, cards órfãos e README/sitemap desatualizados
+- **PRs**: todo PR novo usa [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md) (objetivo, o que mudou, como testar, checklist). Sem descrição placeholder.
 
 ---
 *Lembre-se: O objetivo principal do projeto é criatividade, performance e experimentação tecnológica na web sem barreiras.*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,13 +1,1 @@
-# Claude
-
-A fonte única de regras deste repositório é o **[AGENTS.md](./AGENTS.md)**.
-
-Este arquivo precisa se chamar `CLAUDE.md` (maiúsculas) — é o nome que o Claude Code procura na raiz. Não crie `claude.md`.
-
-Leia o `AGENTS.md` por completo antes de criar, alterar ou revisar código. Siga em especial:
-
-- stack vanilla (HTML, CSS e JS puro, sem build na raiz)
-- [auditoria de links](./AGENTS.md#6-auditoria-de-links-obrigatória) dos labs — conferir e **corrigir** galeria, README e sitemap
-- [template de PR](./.github/PULL_REQUEST_TEMPLATE.md) — todo pull request novo se baseia nele
-
-Não duplique diretrizes aqui. Se algo conflitar, o `AGENTS.md` prevalece.
+@AGENTS.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,9 @@
 
 A fonte única de regras deste repositório é o **[AGENTS.md](./AGENTS.md)**.
 
-Leia esse arquivo por completo antes de criar, alterar ou revisar código. Siga em especial:
+Este arquivo precisa se chamar `CLAUDE.md` (maiúsculas) — é o nome que o Claude Code procura na raiz. Não crie `claude.md`.
+
+Leia o `AGENTS.md` por completo antes de criar, alterar ou revisar código. Siga em especial:
 
 - stack vanilla (HTML, CSS e JS puro, sem build na raiz)
 - [auditoria de links](./AGENTS.md#6-auditoria-de-links-obrigatória) dos labs — conferir e **corrigir** galeria, README e sitemap

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="assets/img/diogo-avatar.png" alt="Diogo Paulino" width="150" />
+<img src="assets/img/diogo-avatar.png" alt="Diogo Paulino" width="150" height="150" />
 
 # Diogo Paulino
 
@@ -9,7 +9,7 @@
 Mais de 20 anos em tecnologia, entre liderança, código hands-on e design UI/UX.
 
 [![Website](https://img.shields.io/badge/Website-diogopaulino.com.br-3B82F6?style=flat-square&logo=googlechrome&logoColor=white)](https://diogopaulino.com.br/)
-[![Labs](https://img.shields.io/badge/Labs-Playground-8B5CF6?style=flat-square&logo=stackblitz&logoColor=white)](https://diogopaulino.com.br/labs/)
+[![Labs](https://img.shields.io/badge/Labs-34_experimentos-8B5CF6?style=flat-square&logo=stackblitz&logoColor=white)](https://diogopaulino.com.br/labs/)
 [![GitHub](https://img.shields.io/badge/GitHub-diogopaulino-181717?style=flat-square&logo=github&logoColor=white)](https://github.com/diogopaulino)
 [![LinkedIn](https://img.shields.io/badge/LinkedIn-Diogo_Paulino-0A66C2?style=flat-square)](https://br.linkedin.com/in/diogopaulino)
 [![Spotify](https://img.shields.io/badge/Spotify-Artist-1DB954?style=flat-square&logo=spotify&logoColor=white)](https://open.spotify.com/intl-pt/artist/0ue2WfDQ1P4XR2vXdSIrYQ)
@@ -32,21 +32,32 @@ Gosto de construir coisas — de time e produto até interface e código. Nessa 
 
 > *Abre, experimenta, quebra, reconstrói. Esse é o espírito.*
 
-Um laboratório aberto onde guardo os experimentos e mini-projetos que fui criando ao longo do tempo. Tudo roda direto no navegador, sem instalar nada.
+Um laboratório aberto com **34 experimentos** que rodam direto no navegador — HTML, CSS e JavaScript puro, sem instalar nada. Catálogo completo em [diogopaulino.com.br/labs](https://diogopaulino.com.br/labs/).
+
+### 🪐 Mundos 3D
+
+| Projeto | O que é? |
+| :--- | :--- |
+| 🪐 **[Orbis](https://diogopaulino.com.br/labs/orbis/)** | Observatório de exoplanetas — gere sistemas, aproxime a órbita e forje oceanos, magma e anéis |
+| ✨ **[Aetherion](https://diogopaulino.com.br/labs/aetherion/)** | Observatório estelar em shaders, com mundos vivos e um buraco negro |
+| 🏍️ **[Neon Rider](https://diogopaulino.com.br/labs/neon-rider/)** | Avenida infinita anos 80 — moto, néon, rádio synthwave e fitas VHS |
+| 🍞 **[Torradeira 64](https://diogopaulino.com.br/labs/toaster-64/)** | Kart 3D cômico — disquetes de ouro, Clippy, Pac-Man e o cachorro do Duck Hunt |
+| ⚔️ **[River Knight](https://diogopaulino.com.br/labs/river-knight/)** | Aventura medieval — drakkar, machados e o resgate da princesa no castelo |
+| 💍 **[A Jornada do Anel](https://diogopaulino.com.br/labs/jornada-do-anel/)** | Aventura inspirada no primeiro filme: o Condado, os Cavaleiros, o vale élfico e as minas |
+| 😈 **[Pandemônio](https://diogopaulino.com.br/labs/pandemonium/)** | Platformer no trilho — corra, pule abismos e alcance o portal |
+| 💻 **[Beige Box](https://diogopaulino.com.br/labs/beige-box/)** | Quarto retrô: ligue o 486, insira o disquete SECRET e mexa em cada objeto da mesa |
+| 🏎️ **[F1 Grand Prix](https://diogopaulino.com.br/labs/f1-racing/)** | Simulador WebGPU com circuitos reais, física de pneus, DRS/ERS e IA |
 
 ### 🎮 Games & Retrô
 
 | Projeto | O que é? |
 | :--- | :--- |
-| 🍞 **[Torradeira 64](https://diogopaulino.com.br/labs/toaster-64/)** | Kart 3D cômico em three.js — disquetes de ouro, Clippy, Pac-Man e o cachorro do Duck Hunt |
-| ⚔️ **[River Knight](https://diogopaulino.com.br/labs/river-knight/)** | Aventura medieval 3D em three.js — drakkar, machados e o resgate da princesa no castelo |
-| 🌇 **[Santos Games](https://diogopaulino.com.br/labs/santos-games/)** | Praia de Santos para crianças — toque na tela e jogue surfe, skate, bola, bike, raquete e barco |
+| 🌇 **[Santos Games](https://diogopaulino.com.br/labs/santos-games/)** | Praia de Santos para crianças — surfe, skate, bola, bike, raquete e barco |
 | 🎈 **[Ravi 1·2·3](https://diogopaulino.com.br/labs/ravi-123/)** | Festa surpresa com heróis — conte 1 a 9 estilo Mickey's 123 |
 | 🥊 **[Rock Kombat](https://diogopaulino.com.br/labs/rock-kombat/)** | Luta 2D cinematográfica com lendas do rock |
 | 🕹️ **[Videogame](https://diogopaulino.com.br/labs/videogame/)** | Emulador de Mega Drive com filtro CRT |
 | 🚀 **[Lunar Lander](https://diogopaulino.com.br/labs/lander/)** | Pouso lunar com física realista |
-| 🏎️ **[F1 Grand Prix](https://diogopaulino.com.br/labs/f1-racing/)** | Simulador 3D WebGPU com IA e telemetria |
-| 🏃 **[Jungle Run](https://diogopaulino.com.br/labs/jungle-run/)** | Plataforma retrô |
+| 🏃 **[Jungle Run](https://diogopaulino.com.br/labs/jungle-run/)** | Plataforma retrô pela selva |
 | 🌌 **[Neon Invaders](https://diogopaulino.com.br/labs/space-shooter/)** | Arcade cyberpunk neon |
 | 🧱 **[Tetris 90s](https://diogopaulino.com.br/labs/tetris/)** | Clássico estilo Game Boy |
 | 🐍 **[Retro Snake](https://diogopaulino.com.br/labs/snake/)** | Cobrinha Nokia 3310 |

--- a/claude.md
+++ b/claude.md
@@ -1,5 +1,11 @@
-# Instruções do Claude
+# Claude
 
-Por favor, leia o arquivo [AGENTS.md](./AGENTS.md) para acessar as instruções completas, melhores práticas e diretrizes detalhadas de como atuar neste repositório.
+A fonte única de regras deste repositório é o **[AGENTS.md](./AGENTS.md)**.
 
-Você deve seguir rigorosamente todas as regras estabelecidas nele.
+Leia esse arquivo por completo antes de criar, alterar ou revisar código. Siga em especial:
+
+- stack vanilla (HTML, CSS e JS puro, sem build na raiz)
+- [auditoria de links](./AGENTS.md#6-auditoria-de-links-obrigatória) dos labs — conferir e **corrigir** galeria, README e sitemap
+- [template de PR](./.github/PULL_REQUEST_TEMPLATE.md) — todo pull request novo se baseia nele
+
+Não duplique diretrizes aqui. Se algo conflitar, o `AGENTS.md` prevalece.

--- a/index.html
+++ b/index.html
@@ -9,6 +9,8 @@
     content="Diogo Paulino - Tech Manager especializado em design e código. Construindo experiências digitais simples com design, código, música e IA.">
   <meta name="robots" content="index, follow">
   <link rel="canonical" href="https://diogopaulino.com.br/">
+  <link rel="icon" href="/favicon.ico" sizes="any">
+  <link rel="apple-touch-icon" href="/assets/img/diogo-avatar.png">
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website">
@@ -27,20 +29,12 @@
     content="Construindo experiências digitais simples com design, código, música e um pouco de IA">
   <meta name="twitter:image" content="https://diogopaulino.com.br/assets/img/diogo.jpeg">
 
-  <!-- Preconnect for performance -->
-  <link rel="preconnect" href="https://github.com">
-  <link rel="preconnect" href="https://linkedin.com">
-
-  <!-- DNS prefetch -->
-  <link rel="dns-prefetch" href="https://br.linkedin.com">
-
   <link rel="stylesheet" href="assets/css/tokens.css">
   <link rel="stylesheet" href="assets/css/style.css">
-  <link rel="manifest" href="manifest.json">
+  <link rel="manifest" href="/manifest.json">
 
   <!-- Preload critical scripts -->
   <link rel="preload" href="assets/js/theme.js" as="script">
-  <link rel="preload" href="assets/js/easter-egg.js" as="script">
 
   <!-- Theme Initialization (Prevents FOUC) -->
   <meta name="theme-color" content="#fafbfc">
@@ -94,7 +88,7 @@
         <span class="sr-only">Alternar tema</span>
       </button>
       <img src="assets/img/diogo.jpeg" alt="Foto de perfil de Diogo Paulino" class="profile-pic-minimal"
-        id="profile-pic" itemprop="image" loading="lazy">
+        id="profile-pic" itemprop="image" width="771" height="771" fetchpriority="high" decoding="async">
       <h1 class="main-name" itemprop="name">Diogo Paulino</h1>
       <div class="subtitle" itemprop="jobTitle">Tech Manager</div>
       <div class="subdesc">Design & Code lover</div>
@@ -111,7 +105,7 @@
           itemprop="sameAs" title="Spotify - Diogo Paulino"></a>
       </nav>
       <div class="labs-easter-egg" id="labs-easter-egg">
-        <a href="labs/index.html" class="labs-badge" aria-label="Labs">
+        <a href="/labs/" class="labs-badge" aria-label="Labs">
           <span class="labs-text">labs</span>
           <svg class="labs-sparkles" width="14" height="14" viewBox="0 0 24 24" fill="currentColor" stroke="none">
             <path d="M12 2L14.4 9.6L22 12L14.4 14.4L12 22L9.6 14.4L2 12L9.6 9.6L12 2Z" />

--- a/labs/aetherion/index.html
+++ b/labs/aetherion/index.html
@@ -27,7 +27,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@500;600;700&family=Outfit:wght@300;400;500;600;700&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=6">
+    <link rel="stylesheet" href="/labs/shared.css?v=7">
     <link rel="stylesheet" href="style.css?v=1">
 
     <script type="importmap">
@@ -176,7 +176,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=6" defer></script>
+    <script src="/labs/shared.js?v=7" defer></script>
     <script type="module" src="src/main.js?v=2"></script>
 </body>
 

--- a/labs/aurora-flow/index.html
+++ b/labs/aurora-flow/index.html
@@ -19,7 +19,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Oxanium:wght@400;600;700;800&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=6">
+    <link rel="stylesheet" href="/labs/shared.css?v=7">
     <link rel="stylesheet" href="style.css">
 </head>
 
@@ -162,7 +162,7 @@
 
     <footer data-lab-footer data-home-href="/"></footer>
 
-    <script src="/labs/shared.js?v=6" defer></script>
+    <script src="/labs/shared.js?v=7" defer></script>
     <script src="script.js" defer></script>
 </body>
 

--- a/labs/beige-box/index.html
+++ b/labs/beige-box/index.html
@@ -26,7 +26,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=Outfit:wght@300;400;500;600;700&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=6">
+    <link rel="stylesheet" href="/labs/shared.css?v=7">
     <link rel="stylesheet" href="style.css?v=1">
 
     <script type="importmap">
@@ -93,7 +93,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=6" defer></script>
+    <script src="/labs/shared.js?v=7" defer></script>
     <script type="module" src="src/main.js?v=3"></script>
 </body>
 

--- a/labs/calculator/index.html
+++ b/labs/calculator/index.html
@@ -16,12 +16,13 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Calculator">
     <meta name="twitter:description" content="Calculadora online com modos simples, científico e conversor de moedas em tempo real.">
-    <link rel="stylesheet" href="/labs/shared.css?v=6">
+    <link rel="stylesheet" href="/labs/shared.css?v=7">
     <link rel="stylesheet" href="style.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;500;700&display=swap" rel="stylesheet">
-    <script src="https://unpkg.com/@phosphor-icons/web" defer></script>
+    <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
+    <script src="https://cdn.jsdelivr.net/npm/@phosphor-icons/web@2.1.2" defer></script>
 </head>
 
 <body>
@@ -187,7 +188,7 @@
 
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
-    <script src="/labs/shared.js?v=6" defer></script>
+    <script src="/labs/shared.js?v=7" defer></script>
     <script src="script.js" defer></script>
 </body>
 

--- a/labs/cyberos/index.html
+++ b/labs/cyberos/index.html
@@ -21,7 +21,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=VT323&display=swap"
     rel="stylesheet">
-  <link rel="stylesheet" href="/labs/shared.css?v=6">
+  <link rel="stylesheet" href="/labs/shared.css?v=7">
   <link rel="stylesheet" href="style.css?v=2">
 </head>
 
@@ -192,7 +192,7 @@
 
   <footer data-lab-footer data-home-href="/" class="cyber-lab-footer"></footer>
 
-  <script src="/labs/shared.js?v=6" defer></script>
+  <script src="/labs/shared.js?v=7" defer></script>
   <script src="script.js?v=2" defer></script>
 </body>
 

--- a/labs/english-duo/index.html
+++ b/labs/english-duo/index.html
@@ -15,7 +15,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Talk">
     <meta name="twitter:description" content="Aprenda idiomas de forma divertida e interativa com o Talk.">
-    <link rel="stylesheet" href="/labs/shared.css?v=6">
+    <link rel="stylesheet" href="/labs/shared.css?v=7">
     <link rel="stylesheet" href="style.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -364,7 +364,7 @@
     </div>
 
     <div id="toast-container" class="toast-container"></div>
-    <script src="/labs/shared.js?v=6" defer></script>
+    <script src="/labs/shared.js?v=7" defer></script>
     <script src="script.js" defer></script>
 </body>
 

--- a/labs/f1-racing/index.html
+++ b/labs/f1-racing/index.html
@@ -21,7 +21,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
-    <link rel="stylesheet" href="/labs/shared.css?v=6">
+    <link rel="stylesheet" href="/labs/shared.css?v=7">
     <link rel="stylesheet" href="style.css?v=13">
     <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700&family=Orbitron:wght@500;600;700;800;900&display=swap"
         rel="stylesheet">
@@ -289,7 +289,7 @@
 
     <footer data-lab-footer data-home-href="/"></footer>
 
-    <script src="/labs/shared.js?v=6" defer></script>
+    <script src="/labs/shared.js?v=7" defer></script>
 
     <!--
         Boot watchdog (classic script on purpose): if the ES module never runs — CDN

--- a/labs/gravity/index.html
+++ b/labs/gravity/index.html
@@ -18,7 +18,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=6">
+    <link rel="stylesheet" href="/labs/shared.css?v=7">
     <link rel="stylesheet" href="style.css">
 </head>
 
@@ -287,7 +287,7 @@
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
 
-    <script src="/labs/shared.js?v=6" defer></script>
+    <script src="/labs/shared.js?v=7" defer></script>
     <script src="script.js" defer></script>
 </body>
 

--- a/labs/image-editor/index.html
+++ b/labs/image-editor/index.html
@@ -15,7 +15,9 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Image Editor">
     <meta name="twitter:description" content="Editor de imagens no navegador: recorte, filtros, ajustes de brilho, contraste e saturação, tudo processado localmente sem enviar nada para servidor.">
-    <link rel="stylesheet" href="/labs/shared.css?v=6">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="/labs/shared.css?v=7">
     <link rel="stylesheet" href="style.css">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
 </head>
@@ -163,7 +165,7 @@
 
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
-    <script src="/labs/shared.js?v=6" defer></script>
+    <script src="/labs/shared.js?v=7" defer></script>
     <script src="script.js" defer></script>
 </body>
 

--- a/labs/image-optimizer/index.html
+++ b/labs/image-optimizer/index.html
@@ -15,7 +15,9 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Image Optimizer">
     <meta name="twitter:description" content="Otimize e converta suas imagens para JPG, PNG ou WEBP diretamente no navegador.">
-    <link rel="stylesheet" href="/labs/shared.css?v=6">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="/labs/shared.css?v=7">
     <link rel="stylesheet" href="style.css">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
 </head>
@@ -75,7 +77,7 @@
 
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
-    <script src="/labs/shared.js?v=6" defer></script>
+    <script src="/labs/shared.js?v=7" defer></script>
     <script src="script.js" defer></script>
 </body>
 

--- a/labs/index.html
+++ b/labs/index.html
@@ -5,13 +5,15 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Labs - Diogo Paulino</title>
-  <meta name="description" content="Experimentos e projetos interativos. Design, código e criatividade.">
+  <meta name="description" content="34 experimentos interativos: jogos 3D, ferramentas e música. Design, código e criatividade.">
   <meta name="theme-color" content="#fafbfc">
   <link rel="canonical" href="https://diogopaulino.com.br/labs/">
+  <link rel="icon" href="/favicon.ico" sizes="any">
+  <link rel="apple-touch-icon" href="/assets/img/diogo-avatar.png">
   <meta property="og:type" content="website">
   <meta property="og:title" content="Labs - Diogo Paulino">
   <meta property="og:description"
-    content="Coleção de jogos, ferramentas e experimentos visuais construídos com HTML, CSS e JavaScript puro.">
+    content="34 laboratórios: mundos 3D, jogos, ferramentas e música em HTML, CSS e JavaScript puro.">
   <meta property="og:url" content="https://diogopaulino.com.br/labs/">
   <meta property="og:image" content="https://diogopaulino.com.br/assets/img/diogo.jpeg">
   <meta name="twitter:card" content="summary_large_image">
@@ -20,7 +22,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@100..900&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="/labs/shared.css?v=6">
+  <link rel="stylesheet" href="/labs/shared.css?v=7">
   <link rel="stylesheet" href="/labs/style.css">
   <script type="application/ld+json">
   {
@@ -28,7 +30,7 @@
     "@type": "CollectionPage",
     "name": "Labs - Diogo Paulino",
     "url": "https://diogopaulino.com.br/labs/",
-    "description": "Experimentos interativos com HTML5, CSS e JavaScript.",
+    "description": "34 experimentos interativos com HTML5, CSS e JavaScript.",
     "creator": {
       "@type": "Person",
       "name": "Diogo Paulino"
@@ -39,7 +41,7 @@
 
 <body>
   <div class="container">
-    <header data-lab-header data-title="Labs" data-subtitle="Experimentos interativos" data-back-href="../index.html"
+    <header data-lab-header data-title="Labs" data-subtitle="Experimentos interativos" data-back-href="/"
       data-back-label="Voltar">
       <template data-slot="logo">
         <h1>Labs</h1>
@@ -57,8 +59,8 @@
     <div class="projects-grid">
       <a href="/labs/orbis/" class="project-card" data-groups="creative">
         <div class="project-icon">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
-            stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+            stroke-linecap="round" stroke-linejoin="round">
             <circle cx="12" cy="12" r="3.2" />
             <ellipse cx="12" cy="12" rx="10" ry="4.2" transform="rotate(-18 12 12)" />
             <path d="M12 2.8v2.2M12 19v2.2M4.2 8.5l1.8 1M18 14.5l1.8 1" opacity="0.7" />
@@ -74,10 +76,30 @@
           </div>
         </div>
       </a>
+      <a href="/labs/aetherion/" class="project-card" data-groups="creative,game">
+        <div class="project-icon">
+          <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+            stroke-linecap="round" stroke-linejoin="round">
+            <circle cx="12" cy="12" r="2.2" />
+            <ellipse cx="12" cy="12" rx="9" ry="4.2" />
+            <ellipse cx="12" cy="12" rx="9" ry="4.2" transform="rotate(60 12 12)" opacity="0.7" />
+            <ellipse cx="12" cy="12" rx="9" ry="4.2" transform="rotate(120 12 12)" opacity="0.45" />
+          </svg>
+        </div>
+        <div class="project-content">
+          <h2>Aetherion</h2>
+          <p>Observatório estelar 3D: voe por um sistema gerado em shaders, com mundos vivos e um buraco negro</p>
+          <div class="project-tags">
+            <span class="tag">three.js</span>
+            <span class="tag">Shaders</span>
+            <span class="tag">Espaço</span>
+          </div>
+        </div>
+      </a>
       <a href="/labs/neon-rider/" class="project-card" data-groups="game,creative">
         <div class="project-icon">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
-            stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+            stroke-linecap="round" stroke-linejoin="round">
             <path d="M4 17h3l2-5 3 1 2-4h3" />
             <circle cx="7" cy="18" r="2" />
             <circle cx="17" cy="18" r="2" />
@@ -97,8 +119,8 @@
       </a>
       <a href="/labs/toaster-64/" class="project-card" data-groups="game">
         <div class="project-icon">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
-            stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+            stroke-linecap="round" stroke-linejoin="round">
             <rect x="5" y="8" width="14" height="10" rx="2" />
             <path d="M8 8V6.5a1.5 1.5 0 0 1 3 0V8" />
             <path d="M13 8V6.2a1.5 1.5 0 0 1 3 0V8" />
@@ -118,30 +140,51 @@
           </div>
         </div>
       </a>
-      <a href="/labs/aetherion/" class="project-card" data-groups="creative,game">
+      <a href="/labs/river-knight/" class="project-card" data-groups="game">
         <div class="project-icon">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
-            stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <circle cx="12" cy="12" r="2.2" />
-            <ellipse cx="12" cy="12" rx="9" ry="4.2" />
-            <ellipse cx="12" cy="12" rx="9" ry="4.2" transform="rotate(60 12 12)" opacity="0.7" />
-            <ellipse cx="12" cy="12" rx="9" ry="4.2" transform="rotate(120 12 12)" opacity="0.45" />
+          <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+            stroke-linecap="round" stroke-linejoin="round">
+            <path d="M12 2.5v9" />
+            <path d="M12 4h5.5l-1.8 2.6L17.5 9H12" />
+            <path d="M3.5 12.5h17l-2.6 4.4a3 3 0 0 1-2.6 1.5H8.7a3 3 0 0 1-2.6-1.5l-2.6-4.4z" />
+            <path d="M2 21.5c1.7 0 1.7-1.3 3.3-1.3s1.7 1.3 3.4 1.3 1.7-1.3 3.3-1.3 1.7 1.3 3.4 1.3 1.7-1.3 3.3-1.3 1.7 1.3 3.3 1.3" />
           </svg>
         </div>
         <div class="project-content">
-          <h2>Aetherion</h2>
-          <p>Observatório estelar 3D: voe por um sistema gerado em shaders, com mundos vivos e um buraco negro</p>
+          <h2>River Knight</h2>
+          <p>Aventura medieval 3D em three.js: leve o drakkar rio abaixo, derrube barcos e
+            torres inimigas, vença a Barcaça Negra e resgate a princesa no castelo</p>
           <div class="project-tags">
             <span class="tag">three.js</span>
-            <span class="tag">Shaders</span>
-            <span class="tag">Espaço</span>
+            <span class="tag">3D</span>
+            <span class="tag">Medieval</span>
+          </div>
+        </div>
+      </a>
+      <a href="/labs/jornada-do-anel/" class="project-card" data-groups="game,creative">
+        <div class="project-icon">
+          <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+            stroke-linecap="round" stroke-linejoin="round">
+            <circle cx="12" cy="12" r="7.2" />
+            <circle cx="12" cy="12" r="3.1" />
+            <path d="M12 2v2.4M12 19.6V22M2 12h2.4M19.6 12H22" opacity="0.55" />
+          </svg>
+        </div>
+        <div class="project-content">
+          <h2>A Jornada do Anel</h2>
+          <p>Aventura 3D em three.js inspirada no primeiro filme: o Condado, a fuga dos
+            Cavaleiros, o vale élfico, as minas e o Monte da Visão</p>
+          <div class="project-tags">
+            <span class="tag">three.js</span>
+            <span class="tag">3D</span>
+            <span class="tag">Fantasia</span>
           </div>
         </div>
       </a>
       <a href="/labs/pandemonium/" class="project-card" data-groups="game">
         <div class="project-icon">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
-            stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+            stroke-linecap="round" stroke-linejoin="round">
             <path d="M4 18c3-6 5-10 8-10s5 4 8 10" />
             <path d="M8 10c.5-3 2-5 4-5s3.5 2 4 5" />
             <circle cx="12" cy="7" r="1.6" />
@@ -160,29 +203,10 @@
           </div>
         </div>
       </a>
-      <a href="/labs/ravi-123/" class="project-card" data-groups="game,creative">
-        <div class="project-icon">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
-            stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <path d="M12 2L2 7l10 5 10-5-10-5z" />
-            <path d="M2 17l10 5 10-5" />
-            <path d="M2 12l10 5 10-5" />
-          </svg>
-        </div>
-        <div class="project-content">
-          <h2>Ravi 1·2·3</h2>
-          <p>Toque os números e ajude o Ravi a montar a festa surpresa — feito para crianças pequenas.</p>
-          <div class="project-tags">
-            <span class="tag">Números</span>
-            <span class="tag">Edu</span>
-            <span class="tag">Kids</span>
-          </div>
-        </div>
-      </a>
       <a href="/labs/beige-box/" class="project-card" data-groups="creative">
         <div class="project-icon">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
-            stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+            stroke-linecap="round" stroke-linejoin="round">
             <rect x="3" y="4" width="14" height="12" rx="1.5" />
             <path d="M7 16v3h6v-3" />
             <rect x="6" y="7" width="8" height="6" rx="0.5" />
@@ -200,74 +224,70 @@
           </div>
         </div>
       </a>
-      <a href="/labs/cyberos/" class="project-card" data-groups="creative,game,tools">
+      <a href="/labs/f1-racing/" class="project-card" data-groups="game">
         <div class="project-icon">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
-            stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <rect x="2" y="3" width="20" height="14" rx="2" />
-            <path d="M8 21h8" />
-            <path d="M12 17v4" />
-            <path d="M6 8h.01M9 8h6" />
-            <path d="M6 11h4" opacity="0.6" />
+          <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+            stroke-linecap="round" stroke-linejoin="round">
+            <ellipse cx="12" cy="17" rx="9" ry="4" />
+            <path d="M12 13V3" />
+            <path d="M5 10l7-7 7 7" />
+            <circle cx="12" cy="17" r="1" />
           </svg>
         </div>
         <div class="project-content">
-          <h2>CyberOS Terminal</h2>
-          <p>SO retrô/hacker no browser: terminal explorável, firewall breach, Oracle e cifrador de mensagens</p>
+          <h2>F1 Grand Prix</h2>
+          <p>Simulador 3D WebGPU com circuitos reais, física de pneus, DRS/ERS e IA</p>
           <div class="project-tags">
-            <span class="tag">CRT</span>
-            <span class="tag">Terminal</span>
-            <span class="tag">Cyberpunk</span>
+            <span class="tag">Game</span>
+            <span class="tag">Three.js</span>
+            <span class="tag">WebGPU</span>
           </div>
         </div>
       </a>
-      <a href="/labs/partitura/" class="project-card" data-groups="game,music,creative">
+      <a href="/labs/santos-games/" class="project-card" data-groups="game">
         <div class="project-icon">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
-            stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <path d="M9 18V5l12-2v13" />
-            <circle cx="6" cy="18" r="3" />
-            <circle cx="18" cy="16" r="3" />
-            <path d="M4 10h16M4 14h16M4 6h16" opacity="0.4" />
+          <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+            stroke-linecap="round" stroke-linejoin="round">
+            <circle cx="12" cy="8" r="3.4" />
+            <path d="M3 12h18" />
+            <path d="M6.6 12 9.2 7.6M17.4 12 14.8 7.6" />
+            <path d="M2 17c2 0 2-1.6 4-1.6s2 1.6 4 1.6 2-1.6 4-1.6 2 1.6 4 1.6 2-1.6 4-1.6" />
+            <path d="M2 21c2 0 2-1.6 4-1.6s2 1.6 4 1.6 2-1.6 4-1.6 2 1.6 4 1.6 2-1.6 4-1.6" />
           </svg>
         </div>
         <div class="project-content">
-          <h2>Partitura: Maestro Quest</h2>
-          <p>Aprenda a ler notas, partituras e escalas com gamificação, sintetizador de áudio e troféus interativos</p>
+          <h2>Santos Games</h2>
+          <p>Toque e brinque na praia de Santos: surfe, skate, bola, bike, raquete e barco.</p>
           <div class="project-tags">
-            <span class="tag">Gamification</span>
-            <span class="tag">Music</span>
-            <span class="tag">Web Audio</span>
+            <span class="tag">Kids</span>
+            <span class="tag">Praia</span>
+            <span class="tag">Toque</span>
           </div>
         </div>
       </a>
-      <a href="/labs/matrix/" class="project-card" data-groups="creative">
+      <a href="/labs/ravi-123/" class="project-card" data-groups="game,creative">
         <div class="project-icon">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
-            stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <path d="M4 3v9" />
-            <path d="M9 3v15" />
-            <path d="M14 3v7" />
-            <path d="M19 3v12" />
-            <path d="M4 15v2" opacity="0.5" />
-            <path d="M14 13v2" opacity="0.5" />
-            <path d="M19 18v2" opacity="0.5" />
+          <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+            stroke-linecap="round" stroke-linejoin="round">
+            <path d="M12 2L2 7l10 5 10-5-10-5z" />
+            <path d="M2 17l10 5 10-5" />
+            <path d="M2 12l10 5 10-5" />
           </svg>
         </div>
         <div class="project-content">
-          <h2>Matrix</h2>
-          <p>Chuva digital fiel ao filme, com katakana espelhado, bloom CRT e controles completos</p>
+          <h2>Ravi 1·2·3</h2>
+          <p>Toque os números e ajude o Ravi a montar a festa surpresa — feito para crianças pequenas.</p>
           <div class="project-tags">
-            <span class="tag">Canvas</span>
-            <span class="tag">Cinema</span>
-            <span class="tag">Screensaver</span>
+            <span class="tag">Números</span>
+            <span class="tag">Edu</span>
+            <span class="tag">Kids</span>
           </div>
         </div>
       </a>
       <a href="/labs/rock-kombat/" class="project-card" data-groups="game,music">
         <div class="project-icon">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
-            stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+            stroke-linecap="round" stroke-linejoin="round">
             <path d="M9 18V5l10-2v13" />
             <circle cx="6" cy="18" r="3" />
             <circle cx="16" cy="16" r="3" />
@@ -286,8 +306,8 @@
       </a>
       <a href="/labs/videogame/" class="project-card" data-groups="game">
         <div class="project-icon">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
-            stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+            stroke-linecap="round" stroke-linejoin="round">
             <rect x="2" y="6" width="20" height="12" rx="2" />
             <path d="M6 12h4" />
             <path d="M8 10v4" />
@@ -307,8 +327,8 @@
       </a>
       <a href="/labs/lander/" class="project-card" data-groups="game">
         <div class="project-icon">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
-            stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+            stroke-linecap="round" stroke-linejoin="round">
             <path d="M12 2c0 0-3 6-3 10 0 .5.5 2 3 2s3-1.5 3-2c0-4-3-10-3-10z" />
             <path d="M9 12h6" />
             <path d="M5 21l3-4" />
@@ -325,92 +345,95 @@
           </div>
         </div>
       </a>
-      <a href="/labs/aurora-flow/" class="project-card" data-groups="creative">
+      <a href="/labs/jungle-run/" class="project-card" data-groups="game">
         <div class="project-icon">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
-            stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <path d="M12 3c.132 0 .263 0 .393 0a7.5 7.5 0 0 0 7.92 12.446a9 9 0 1 1 -8.313 -12.454z" />
-            <path d="M17 4a2 2 0 0 0 2 2a2 2 0 0 0 -2 2a2 2 0 0 0 -2 -2a2 2 0 0 0 2 -2" />
-            <path d="M19 11h2m-1 -1v2" />
+          <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+            stroke-linecap="round" stroke-linejoin="round">
+            <path d="M12 22v-7l-2-2" />
+            <path d="M17 8v.8A6 6 0 0 1 13.8 20v0H10v0A6 6 0 0 1 6.8 8.8V8a5 5 0 0 1 10 0Z" />
+            <path d="m14 14-2 2" />
+            <path d="M4 14h1" />
+            <path d="M19 14h1" />
+            <path d="m6 18 1-1" />
+            <path d="m17 17 1 1" />
           </svg>
         </div>
         <div class="project-content">
-          <h2>Aurora Flow</h2>
-          <p>Cortinas, vórtices e tempestades de luz — cenas com física distinta e interação em tempo real</p>
+          <h2>Jungle Run</h2>
+          <p>Aventura estilo Pitfall com gráficos PixiJS, física de plataforma e obstáculos</p>
           <div class="project-tags">
-            <span class="tag">Canvas</span>
-            <span class="tag">Física</span>
-            <span class="tag">Interativo</span>
+            <span class="tag">Game</span>
+            <span class="tag">Arcade</span>
+            <span class="tag">PixiJS</span>
           </div>
         </div>
       </a>
-      <a href="/labs/paint/" class="project-card" data-groups="creative,tools">
+      <a href="/labs/space-shooter/" class="project-card" data-groups="game">
         <div class="project-icon">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
-            stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <path d="M12 19l7-7 3 3-7 7-3-3z"></path>
-            <path d="M18 13l-1.5-7.5L2 2l3.5 14.5L13 18l5-5z"></path>
-            <path d="M2 2l7.586 7.586"></path>
-            <circle cx="11" cy="11" r="2"></circle>
+          <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+            stroke-linecap="round" stroke-linejoin="round">
+            <path d="M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.13-.09-2.91a2.18 2.18 0 0 0-2.91-.09z" />
+            <path
+              d="M12 15l-3-3a22 22 0 0 1 2-3.95A12.88 12.88 0 0 1 22 2c0 2.72-.78 7.5-6 11a22.35 22.35 0 0 1-4 2z" />
+            <path d="M9 12H4s.55-3.03 2-4c1.62-1.08 5 0 5 0" />
+            <path d="M12 15v5s3.03-.55 4-2c1.08-1.62 0-5 0-5" />
           </svg>
         </div>
         <div class="project-content">
-          <h2>Paint Lab</h2>
-          <p>Editor de arte digital completo com pincéis, formas e histórico</p>
+          <h2>Neon Invaders</h2>
+          <p>Arcade clássico com visual cyberpunk, partículas e efeitos neon</p>
           <div class="project-tags">
-            <span class="tag">Canvas</span>
-            <span class="tag">Art</span>
-            <span class="tag">Creative</span>
+            <span class="tag">Game</span>
+            <span class="tag">Arcade</span>
+            <span class="tag">Neon</span>
           </div>
         </div>
       </a>
-      <a href="/labs/piano/" class="project-card" data-groups="music">
+      <a href="/labs/tetris/" class="project-card" data-groups="game">
         <div class="project-icon">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
-            stroke-linejoin="round" aria-hidden="true">
-            <rect x="3" y="5" width="18" height="15" rx="2" />
-            <path d="M7.5 5v9" />
-            <path d="M12 5v9" />
-            <path d="M16.5 5v9" />
-            <path d="M6 5v5" stroke-width="3.5" />
-            <path d="M10 5v5" stroke-width="3.5" />
-            <path d="M14.5 5v5" stroke-width="3.5" />
+          <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+            stroke-linecap="round" stroke-linejoin="round">
+            <path d="M3 10h4v4H3z" />
+            <path d="M7 10h4v4H7z" />
+            <path d="M11 10h4v4h-4z" />
+            <path d="M7 6h4v4H7z" />
           </svg>
         </div>
         <div class="project-content">
-          <h2>Piano</h2>
-          <p>Piano interativo com 4 oitavas, sons ultra realistas e pedal de sustain</p>
+          <h2>Tetris 90s</h2>
+          <p>O clássico jogo de blocos com visual retrô de Game Boy</p>
           <div class="project-tags">
-            <span class="tag">Web Audio API</span>
-            <span class="tag">Síntese</span>
-            <span class="tag">Mobile</span>
+            <span class="tag">Game</span>
+            <span class="tag">Retro</span>
+            <span class="tag">GameBoy</span>
           </div>
         </div>
       </a>
-
-      <a href="/labs/gravity/" class="project-card" data-groups="creative">
+      <a href="/labs/snake/" class="project-card" data-groups="game">
         <div class="project-icon">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <circle cx="12" cy="12" r="10" />
-            <circle cx="12" cy="12" r="4" fill="currentColor" />
-            <path d="M12 2v4M12 18v4M2 12h4M18 12h4" />
+          <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+            stroke-linecap="round" stroke-linejoin="round">
+            <rect x="2" y="2" width="20" height="20" rx="4" ry="4"></rect>
+            <rect x="6" y="6" width="12" height="8" rx="1" ry="1"></rect>
+            <path d="M8 18h.01"></path>
+            <path d="M12 18h.01"></path>
+            <path d="M16 18h.01"></path>
           </svg>
         </div>
         <div class="project-content">
-          <h2>Gravity</h2>
-          <p>Simulação de partículas com física, gravidade e colisões interativas</p>
+          <h2>Retro Snake</h2>
+          <p>Clássico jogo da cobrinha com visual de console portátil dos anos 90</p>
           <div class="project-tags">
-            <span class="tag">Canvas</span>
-            <span class="tag">Física</span>
-            <span class="tag">Interativo</span>
+            <span class="tag">Game</span>
+            <span class="tag">Retro</span>
+            <span class="tag">Nokia</span>
           </div>
         </div>
       </a>
-
       <a href="/labs/minesweeper/" class="project-card" data-groups="game">
         <div class="project-icon">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
-            stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+            stroke-linecap="round" stroke-linejoin="round">
             <circle cx="12" cy="12" r="6" fill="currentColor" fill-opacity="0.2" />
             <path d="M12 6V3" />
             <path d="M16.2 7.8L18.4 5.6" />
@@ -432,10 +455,131 @@
           </div>
         </div>
       </a>
+      <a href="/labs/tamagotchi/" class="project-card" data-groups="game,creative">
+        <div class="project-icon">
+          <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+            stroke-linecap="round" stroke-linejoin="round">
+            <path d="M12 2C8 7 5 11.5 5 15a7 7 0 0 0 14 0c0-3.5-3-8-7-13z" />
+            <circle cx="9.5" cy="15" r="1.2" fill="currentColor" stroke="none" />
+            <circle cx="14.5" cy="15" r="1.2" fill="currentColor" stroke="none" />
+            <path d="M10 18h4" stroke-width="2" />
+          </svg>
+        </div>
+        <div class="project-content">
+          <h2>RakuRaku Dinokun</h2>
+          <p>Réplica do Dinkie Dino de 1997 — mesmo hardware, jan-ken-po e ar-condicionado</p>
+          <div class="project-tags">
+            <span class="tag">Dinkie Dino</span>
+            <span class="tag">1997</span>
+            <span class="tag">Virtual Pet</span>
+          </div>
+        </div>
+      </a>
+      <a href="/labs/cyberos/" class="project-card" data-groups="creative,game,tools">
+        <div class="project-icon">
+          <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+            stroke-linecap="round" stroke-linejoin="round">
+            <rect x="2" y="3" width="20" height="14" rx="2" />
+            <path d="M8 21h8" />
+            <path d="M12 17v4" />
+            <path d="M6 8h.01M9 8h6" />
+            <path d="M6 11h4" opacity="0.6" />
+          </svg>
+        </div>
+        <div class="project-content">
+          <h2>CyberOS Terminal</h2>
+          <p>SO retrô/hacker no browser: terminal explorável, firewall breach, Oracle e cifrador de mensagens</p>
+          <div class="project-tags">
+            <span class="tag">CRT</span>
+            <span class="tag">Terminal</span>
+            <span class="tag">Cyberpunk</span>
+          </div>
+        </div>
+      </a>
+      <a href="/labs/matrix/" class="project-card" data-groups="creative">
+        <div class="project-icon">
+          <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+            stroke-linecap="round" stroke-linejoin="round">
+            <path d="M4 3v9" />
+            <path d="M9 3v15" />
+            <path d="M14 3v7" />
+            <path d="M19 3v12" />
+            <path d="M4 15v2" opacity="0.5" />
+            <path d="M14 13v2" opacity="0.5" />
+            <path d="M19 18v2" opacity="0.5" />
+          </svg>
+        </div>
+        <div class="project-content">
+          <h2>Matrix</h2>
+          <p>Chuva digital fiel ao filme, com katakana espelhado, bloom CRT e controles completos</p>
+          <div class="project-tags">
+            <span class="tag">Canvas</span>
+            <span class="tag">Cinema</span>
+            <span class="tag">Screensaver</span>
+          </div>
+        </div>
+      </a>
+      <a href="/labs/aurora-flow/" class="project-card" data-groups="creative">
+        <div class="project-icon">
+          <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+            stroke-linecap="round" stroke-linejoin="round">
+            <path d="M12 3c.132 0 .263 0 .393 0a7.5 7.5 0 0 0 7.92 12.446a9 9 0 1 1 -8.313 -12.454z" />
+            <path d="M17 4a2 2 0 0 0 2 2a2 2 0 0 0 -2 2a2 2 0 0 0 -2 -2a2 2 0 0 0 2 -2" />
+            <path d="M19 11h2m-1 -1v2" />
+          </svg>
+        </div>
+        <div class="project-content">
+          <h2>Aurora Flow</h2>
+          <p>Cortinas, vórtices e tempestades de luz — cenas com física distinta e interação em tempo real</p>
+          <div class="project-tags">
+            <span class="tag">Canvas</span>
+            <span class="tag">Física</span>
+            <span class="tag">Interativo</span>
+          </div>
+        </div>
+      </a>
+      <a href="/labs/paint/" class="project-card" data-groups="creative,tools">
+        <div class="project-icon">
+          <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+            stroke-linecap="round" stroke-linejoin="round">
+            <path d="M12 19l7-7 3 3-7 7-3-3z"></path>
+            <path d="M18 13l-1.5-7.5L2 2l3.5 14.5L13 18l5-5z"></path>
+            <path d="M2 2l7.586 7.586"></path>
+            <circle cx="11" cy="11" r="2"></circle>
+          </svg>
+        </div>
+        <div class="project-content">
+          <h2>Paint Lab</h2>
+          <p>Editor de arte digital completo com pincéis, formas e histórico</p>
+          <div class="project-tags">
+            <span class="tag">Canvas</span>
+            <span class="tag">Art</span>
+            <span class="tag">Creative</span>
+          </div>
+        </div>
+      </a>
+      <a href="/labs/gravity/" class="project-card" data-groups="creative">
+        <div class="project-icon">
+          <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <circle cx="12" cy="12" r="10" />
+            <circle cx="12" cy="12" r="4" fill="currentColor" />
+            <path d="M12 2v4M12 18v4M2 12h4M18 12h4" />
+          </svg>
+        </div>
+        <div class="project-content">
+          <h2>Gravity</h2>
+          <p>Simulação de partículas com física, gravidade e colisões interativas</p>
+          <div class="project-tags">
+            <span class="tag">Canvas</span>
+            <span class="tag">Física</span>
+            <span class="tag">Interativo</span>
+          </div>
+        </div>
+      </a>
       <a href="/labs/image-optimizer/" class="project-card" data-groups="tools">
         <div class="project-icon">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
-            stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+            stroke-linecap="round" stroke-linejoin="round">
             <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
             <circle cx="8.5" cy="8.5" r="1.5" />
             <polyline points="21 15 16 10 5 21" />
@@ -451,31 +595,63 @@
           </div>
         </div>
       </a>
-      <a href="/labs/space-shooter/" class="project-card" data-groups="game">
+      <a href="/labs/image-editor/" class="project-card" data-groups="tools">
         <div class="project-icon">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
-            stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <path d="M4.5 16.5c-1.5 1.26-2 5-2 5s3.74-.5 5-2c.71-.84.7-2.13-.09-2.91a2.18 2.18 0 0 0-2.91-.09z" />
-            <path
-              d="M12 15l-3-3a22 22 0 0 1 2-3.95A12.88 12.88 0 0 1 22 2c0 2.72-.78 7.5-6 11a22.35 22.35 0 0 1-4 2z" />
-            <path d="M9 12H4s.55-3.03 2-4c1.62-1.08 5 0 5 0" />
-            <path d="M12 15v5s3.03-.55 4-2c1.08-1.62 0-5 0-5" />
+          <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+            stroke-linecap="round" stroke-linejoin="round">
+            <path d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z"></path>
+            <circle cx="12" cy="13" r="4"></circle>
           </svg>
         </div>
         <div class="project-content">
-          <h2>Neon Invaders</h2>
-          <p>Arcade clássico com visual cyberpunk, partículas e efeitos neon</p>
+          <h2>Image Editor</h2>
+          <p>Editor de fotos estilo Instagram com filtros e ajustes profissionais</p>
           <div class="project-tags">
-            <span class="tag">Game</span>
-            <span class="tag">Arcade</span>
-            <span class="tag">Neon</span>
+            <span class="tag">Canvas</span>
+            <span class="tag">Filters</span>
+            <span class="tag">Editor</span>
+          </div>
+        </div>
+      </a>
+      <a href="/labs/pomodoro/" class="project-card" data-groups="tools">
+        <div class="project-icon">
+          <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+            stroke-linecap="round" stroke-linejoin="round">
+            <circle cx="12" cy="12" r="10"></circle>
+            <polyline points="12 6 12 12 16 14"></polyline>
+          </svg>
+        </div>
+        <div class="project-content">
+          <h2>Pomodoro</h2>
+          <p>Timer de foco com tarefas, estatísticas, sons e notificações do navegador</p>
+          <div class="project-tags">
+            <span class="tag">Productivity</span>
+            <span class="tag">Timer</span>
+          </div>
+        </div>
+      </a>
+      <a href="/labs/english-duo/" class="project-card" data-groups="creative,tools">
+        <div class="project-icon">
+          <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+            stroke-linejoin="round">
+            <path d="M14 9a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h7a2 2 0 0 1 2 2z" />
+            <path d="M18 9h1a2 2 0 0 1 2 2v8l-3-3h-6a2 2 0 0 1-2-2v-1" />
+          </svg>
+        </div>
+        <div class="project-content">
+          <h2>Talk</h2>
+          <p>Aprenda idiomas de forma interativa com pronúncia por voz e múltiplas línguas</p>
+          <div class="project-tags">
+            <span class="tag">Education</span>
+            <span class="tag">Speech API</span>
+            <span class="tag">Audio</span>
           </div>
         </div>
       </a>
       <a href="/labs/calculator/" class="project-card" data-groups="tools">
         <div class="project-icon">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
-            stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+            stroke-linecap="round" stroke-linejoin="round">
             <rect x="4" y="2" width="16" height="20" rx="2" />
             <line x1="8" y1="6" x2="16" y2="6" />
             <line x1="16" y1="14" x2="16" y2="14" />
@@ -496,69 +672,53 @@
           </div>
         </div>
       </a>
-      <a href="/labs/english-duo/" class="project-card" data-groups="creative,tools">
+      <a href="/labs/partitura/" class="project-card" data-groups="game,music,creative">
         <div class="project-icon">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
-            stroke-linejoin="round" aria-hidden="true">
-            <path d="M14 9a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h7a2 2 0 0 1 2 2z" />
-            <path d="M18 9h1a2 2 0 0 1 2 2v8l-3-3h-6a2 2 0 0 1-2-2v-1" />
+          <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+            stroke-linecap="round" stroke-linejoin="round">
+            <path d="M9 18V5l12-2v13" />
+            <circle cx="6" cy="18" r="3" />
+            <circle cx="18" cy="16" r="3" />
+            <path d="M4 10h16M4 14h16M4 6h16" opacity="0.4" />
           </svg>
         </div>
         <div class="project-content">
-          <h2>Talk</h2>
-          <p>Aprenda idiomas de forma interativa com pronúncia por voz e múltiplas línguas</p>
+          <h2>Partitura: Maestro Quest</h2>
+          <p>Aprenda a ler notas, partituras e escalas com gamificação, sintetizador de áudio e troféus interativos</p>
           <div class="project-tags">
-            <span class="tag">Education</span>
-            <span class="tag">Speech API</span>
-            <span class="tag">Audio</span>
+            <span class="tag">Gamification</span>
+            <span class="tag">Music</span>
+            <span class="tag">Web Audio</span>
           </div>
         </div>
       </a>
-      <a href="/labs/tetris/" class="project-card" data-groups="game">
+      <a href="/labs/piano/" class="project-card" data-groups="music">
         <div class="project-icon">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
-            stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <path d="M3 10h4v4H3z" />
-            <path d="M7 10h4v4H7z" />
-            <path d="M11 10h4v4h-4z" />
-            <path d="M7 6h4v4H7z" />
+          <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+            stroke-linejoin="round">
+            <rect x="3" y="5" width="18" height="15" rx="2" />
+            <path d="M7.5 5v9" />
+            <path d="M12 5v9" />
+            <path d="M16.5 5v9" />
+            <path d="M6 5v5" stroke-width="3.5" />
+            <path d="M10 5v5" stroke-width="3.5" />
+            <path d="M14.5 5v5" stroke-width="3.5" />
           </svg>
         </div>
         <div class="project-content">
-          <h2>Tetris 90s</h2>
-          <p>O clássico jogo de blocos com visual retrô de Game Boy</p>
+          <h2>Piano</h2>
+          <p>Piano interativo com 4 oitavas, sons ultra realistas e pedal de sustain</p>
           <div class="project-tags">
-            <span class="tag">Game</span>
-            <span class="tag">Retro</span>
-            <span class="tag">GameBoy</span>
-          </div>
-        </div>
-      </a>
-      <a href="/labs/snake/" class="project-card" data-groups="game">
-        <div class="project-icon">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
-            stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <rect x="2" y="2" width="20" height="20" rx="4" ry="4"></rect>
-            <rect x="6" y="6" width="12" height="8" rx="1" ry="1"></rect>
-            <path d="M8 18h.01"></path>
-            <path d="M12 18h.01"></path>
-            <path d="M16 18h.01"></path>
-          </svg>
-        </div>
-        <div class="project-content">
-          <h2>Retro Snake</h2>
-          <p>Clássico jogo da cobrinha com visual de console portátil dos anos 90</p>
-          <div class="project-tags">
-            <span class="tag">Game</span>
-            <span class="tag">Retro</span>
-            <span class="tag">Nokia</span>
+            <span class="tag">Web Audio API</span>
+            <span class="tag">Síntese</span>
+            <span class="tag">Mobile</span>
           </div>
         </div>
       </a>
       <a href="/labs/winamp/" class="project-card" data-groups="music">
         <div class="project-icon">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
-            stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+            stroke-linecap="round" stroke-linejoin="round">
             <path d="M9 18V5l12-2v13"></path>
             <circle cx="6" cy="18" r="3"></circle>
             <circle cx="18" cy="16" r="3"></circle>
@@ -574,107 +734,9 @@
           </div>
         </div>
       </a>
-      <a href="/labs/image-editor/" class="project-card" data-groups="tools">
-        <div class="project-icon">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
-            stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <path d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z"></path>
-            <circle cx="12" cy="13" r="4"></circle>
-          </svg>
-        </div>
-        <div class="project-content">
-          <h2>Image Editor</h2>
-          <p>Editor de fotos estilo Instagram com filtros e ajustes profissionais</p>
-          <div class="project-tags">
-            <span class="tag">Canvas</span>
-            <span class="tag">Filters</span>
-            <span class="tag">Editor</span>
-          </div>
-        </div>
-      </a>
-      <a href="/labs/tamagotchi/" class="project-card" data-groups="game,creative">
-        <div class="project-icon">
-          <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
-            stroke-linecap="round" stroke-linejoin="round">
-            <path d="M12 2C8 7 5 11.5 5 15a7 7 0 0 0 14 0c0-3.5-3-8-7-13z" />
-            <circle cx="9.5" cy="15" r="1.2" fill="currentColor" stroke="none" />
-            <circle cx="14.5" cy="15" r="1.2" fill="currentColor" stroke="none" />
-            <path d="M10 18h4" stroke-width="2" />
-          </svg>
-        </div>
-        <div class="project-content">
-          <h2>RakuRaku Dinokun</h2>
-          <p>Réplica do Dinkie Dino de 1997 — mesmo hardware, jan-ken-po e ar-condicionado</p>
-          <div class="project-tags">
-            <span class="tag">Dinkie Dino</span>
-            <span class="tag">1997</span>
-            <span class="tag">Virtual Pet</span>
-          </div>
-        </div>
-      </a>
-      <a href="/labs/pomodoro/" class="project-card" data-groups="tools">
-        <div class="project-icon">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
-            stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <circle cx="12" cy="12" r="10"></circle>
-            <polyline points="12 6 12 12 16 14"></polyline>
-          </svg>
-        </div>
-        <div class="project-content">
-          <h2>Pomodoro</h2>
-          <p>Timer de foco com tarefas, estatísticas, sons e notificações do navegador</p>
-          <div class="project-tags">
-            <span class="tag">Productivity</span>
-            <span class="tag">AI</span>
-          </div>
-        </div>
-      </a>
-      <a href="/labs/jungle-run/" class="project-card" data-groups="game">
-        <div class="project-icon">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
-            stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <path d="M12 22v-7l-2-2" />
-            <path d="M17 8v.8A6 6 0 0 1 13.8 20v0H10v0A6 6 0 0 1 6.8 8.8V8a5 5 0 0 1 10 0Z" />
-            <path d="m14 14-2 2" />
-            <path d="M4 14h1" />
-            <path d="M19 14h1" />
-            <path d="m6 18 1-1" />
-            <path d="m17 17 1 1" />
-          </svg>
-        </div>
-        <div class="project-content">
-          <h2>Jungle Run</h2>
-          <p>Aventura estilo Pitfall com gráficos PixiJS, física de plataforma e obstáculos</p>
-          <div class="project-tags">
-            <span class="tag">Game</span>
-            <span class="tag">Arcade</span>
-            <span class="tag">PixiJS</span>
-          </div>
-        </div>
-      </a>
-      <a href="/labs/f1-racing/" class="project-card" data-groups="game">
-        <div class="project-icon">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
-            stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <ellipse cx="12" cy="17" rx="9" ry="4" />
-            <path d="M12 13V3" />
-            <path d="M5 10l7-7 7 7" />
-            <circle cx="12" cy="17" r="1" />
-          </svg>
-        </div>
-        <div class="project-content">
-          <h2>F1 Grand Prix</h2>
-          <p>Simulador 3D WebGPU com circuitos reais, física de pneus, DRS/ERS e IA</p>
-          <div class="project-tags">
-            <span class="tag">Game</span>
-            <span class="tag">Three.js</span>
-            <span class="tag">WebGPU</span>
-          </div>
-        </div>
-      </a>
       <a href="/labs/pulsar/" class="project-card" data-groups="music,creative">
         <div class="project-icon">
-          <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+          <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
             stroke-linecap="round" stroke-linejoin="round">
             <circle cx="12" cy="12" r="2.2" />
             <path d="M12 5.5a6.5 6.5 0 0 1 6.5 6.5" opacity="0.85" />
@@ -693,73 +755,10 @@
           </div>
         </div>
       </a>
-      <a href="/labs/river-knight/" class="project-card" data-groups="game">
-        <div class="project-icon">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
-            stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <path d="M12 2.5v9" />
-            <path d="M12 4h5.5l-1.8 2.6L17.5 9H12" />
-            <path d="M3.5 12.5h17l-2.6 4.4a3 3 0 0 1-2.6 1.5H8.7a3 3 0 0 1-2.6-1.5l-2.6-4.4z" />
-            <path d="M2 21.5c1.7 0 1.7-1.3 3.3-1.3s1.7 1.3 3.4 1.3 1.7-1.3 3.3-1.3 1.7 1.3 3.4 1.3 1.7-1.3 3.3-1.3 1.7 1.3 3.3 1.3" />
-          </svg>
-        </div>
-        <div class="project-content">
-          <h2>River Knight</h2>
-          <p>Aventura medieval 3D em three.js: leve o drakkar rio abaixo, derrube barcos e
-            torres inimigas, vença a Barcaça Negra e resgate a princesa no castelo</p>
-          <div class="project-tags">
-            <span class="tag">three.js</span>
-            <span class="tag">3D</span>
-            <span class="tag">Medieval</span>
-          </div>
-        </div>
-      </a>
-      <a href="/labs/jornada-do-anel/" class="project-card" data-groups="game,creative">
-        <div class="project-icon">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
-            stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <circle cx="12" cy="12" r="7.2" />
-            <circle cx="12" cy="12" r="3.1" />
-            <path d="M12 2v2.4M12 19.6V22M2 12h2.4M19.6 12H22" opacity="0.55" />
-          </svg>
-        </div>
-        <div class="project-content">
-          <h2>A Jornada do Anel</h2>
-          <p>Aventura 3D em three.js inspirada no primeiro filme: o Condado, a fuga dos
-            Cavaleiros, o vale élfico, as minas e o Monte da Visão</p>
-          <div class="project-tags">
-            <span class="tag">three.js</span>
-            <span class="tag">3D</span>
-            <span class="tag">Fantasia</span>
-          </div>
-        </div>
-      </a>
-      <a href="/labs/santos-games/" class="project-card" data-groups="game">
-        <div class="project-icon">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
-            stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <circle cx="12" cy="8" r="3.4" />
-            <path d="M3 12h18" />
-            <path d="M6.6 12 9.2 7.6M17.4 12 14.8 7.6" />
-            <path d="M2 17c2 0 2-1.6 4-1.6s2 1.6 4 1.6 2-1.6 4-1.6 2 1.6 4 1.6 2-1.6 4-1.6" />
-            <path d="M2 21c2 0 2-1.6 4-1.6s2 1.6 4 1.6 2-1.6 4-1.6 2 1.6 4 1.6 2-1.6 4-1.6" />
-          </svg>
-        </div>
-        <div class="project-content">
-          <h2>Santos Games</h2>
-          <p>Toque e brinque na praia de Santos: surfe, skate, bola, bike, raquete e barco.</p>
-          <div class="project-tags">
-            <span class="tag">Kids</span>
-            <span class="tag">Praia</span>
-            <span class="tag">Toque</span>
-          </div>
-        </div>
-      </a>
     </div>
+    <footer data-lab-footer data-home-href="/"></footer>
   </div>
-  <footer data-lab-footer data-home-href="/"></footer>
-  </div>
-  <script src="/labs/shared.js?v=6"></script>
+  <script src="/labs/shared.js?v=7"></script>
   <script src="/labs/index.js"></script>
 </body>
 

--- a/labs/jornada-do-anel/index.html
+++ b/labs/jornada-do-anel/index.html
@@ -26,7 +26,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;600;700;800&family=Outfit:wght@300;400;500;600;700&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=6">
+    <link rel="stylesheet" href="/labs/shared.css?v=7">
     <link rel="stylesheet" href="style.css?v=1">
 
     <script type="importmap">
@@ -241,7 +241,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=6" defer></script>
+    <script src="/labs/shared.js?v=7" defer></script>
     <script>
         (function () {
             function hasGpu() {

--- a/labs/jungle-run/index.html
+++ b/labs/jungle-run/index.html
@@ -17,9 +17,10 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@600;900&family=Plus+Jakarta+Sans:wght@400;500;700;800&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=6">
+    <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
+    <link rel="stylesheet" href="/labs/shared.css?v=7">
     <link rel="stylesheet" href="style.css?v=3">
-    <script src="https://pixijs.download/v8.6.6/pixi.min.js" defer></script>
+    <script src="https://cdn.jsdelivr.net/npm/pixi.js@8.6.6/dist/pixi.min.js" defer></script>
 </head>
 
 <body class="jungle-lab">
@@ -238,7 +239,7 @@
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
 
-    <script src="/labs/shared.js?v=6" defer></script>
+    <script src="/labs/shared.js?v=7" defer></script>
     <script src="script.js?v=4" defer></script>
 </body>
 

--- a/labs/lander/index.html
+++ b/labs/lander/index.html
@@ -15,9 +15,10 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Lunar Lander">
     <meta name="twitter:description" content="Pouso lunar com física realista: gravidade, inércia, consumo de combustível e terreno gerado por procedimento. Desça devagar e no ângulo certo.">
-    <link rel="stylesheet" href="/labs/shared.css?v=6">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="/labs/shared.css?v=7">
     <link rel="stylesheet" href="style.css?v=4">
-    <!-- Courier Prime or VT323 for the retro feel -->
     <link href="https://fonts.googleapis.com/css2?family=VT323&display=swap" rel="stylesheet">
 </head>
 
@@ -130,7 +131,7 @@
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
 
-    <script src="/labs/shared.js?v=6" defer></script>
+    <script src="/labs/shared.js?v=7" defer></script>
     <script src="script.js?v=3" defer></script>
 </body>
 

--- a/labs/matrix/index.html
+++ b/labs/matrix/index.html
@@ -20,7 +20,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Share+Tech+Mono&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=6">
+    <link rel="stylesheet" href="/labs/shared.css?v=7">
     <link rel="stylesheet" href="style.css">
 </head>
 
@@ -283,7 +283,7 @@
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
 
-    <script src="/labs/shared.js?v=6" defer></script>
+    <script src="/labs/shared.js?v=7" defer></script>
     <script src="script.js" defer></script>
 </body>
 

--- a/labs/minesweeper/index.html
+++ b/labs/minesweeper/index.html
@@ -15,7 +15,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Campo Minado 95">
     <meta name="twitter:description" content="Clássico jogo de Campo Minado estilo Windows 95.">
-    <link rel="stylesheet" href="/labs/shared.css?v=6">
+    <link rel="stylesheet" href="/labs/shared.css?v=7">
     <link rel="stylesheet" href="style.css">
 </head>
 
@@ -70,7 +70,7 @@
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
 
-    <script src="/labs/shared.js?v=6" defer></script>
+    <script src="/labs/shared.js?v=7" defer></script>
     <script src="script.js" defer></script>
 </body>
 

--- a/labs/neon-rider/index.html
+++ b/labs/neon-rider/index.html
@@ -26,7 +26,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Audiowide&family=Outfit:wght@400;500;600;700&family=Share+Tech+Mono&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=6">
+    <link rel="stylesheet" href="/labs/shared.css?v=7">
     <link rel="stylesheet" href="style.css?v=2">
 
     <script type="importmap">
@@ -215,7 +215,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=6" defer></script>
+    <script src="/labs/shared.js?v=7" defer></script>
     <script type="module" src="src/main.js?v=4"></script>
 </body>
 

--- a/labs/orbis/index.html
+++ b/labs/orbis/index.html
@@ -27,7 +27,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;600;700&family=Syne:wght@400;500;600;700;800&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=6">
+    <link rel="stylesheet" href="/labs/shared.css?v=7">
     <link rel="stylesheet" href="style.css">
 
     <script type="importmap">
@@ -124,7 +124,7 @@
         <p class="fps-badge" aria-hidden="true"><span id="fps">60</span> fps</p>
     </main>
 
-    <script src="/labs/shared.js?v=6" defer></script>
+    <script src="/labs/shared.js?v=7" defer></script>
     <script type="module" src="./src/main.js"></script>
 </body>
 

--- a/labs/paint/index.html
+++ b/labs/paint/index.html
@@ -17,7 +17,7 @@
     <meta property="og:locale" content="pt_BR">
     <meta property="og:image" content="https://diogopaulino.com.br/labs/paint/og-paint.jpg">
     <meta name="twitter:card" content="summary_large_image">
-    <link rel="stylesheet" href="/labs/shared.css?v=6">
+    <link rel="stylesheet" href="/labs/shared.css?v=7">
     <link rel="stylesheet" href="style.css?v=2">
 </head>
 
@@ -250,7 +250,7 @@
 
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
-    <script src="/labs/shared.js?v=6" defer></script>
+    <script src="/labs/shared.js?v=7" defer></script>
     <script src="script.js?v=2" defer></script>
 </body>
 

--- a/labs/pandemonium/index.html
+++ b/labs/pandemonium/index.html
@@ -26,7 +26,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Lilita+One&family=Outfit:wght@300;400;500;600;700;800&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=6">
+    <link rel="stylesheet" href="/labs/shared.css?v=7">
     <link rel="stylesheet" href="style.css?v=1">
 
     <script type="importmap">
@@ -226,7 +226,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=6" defer></script>
+    <script src="/labs/shared.js?v=7" defer></script>
     <script type="module" src="src/main.js?v=1"></script>
 </body>
 

--- a/labs/partitura/index.html
+++ b/labs/partitura/index.html
@@ -20,7 +20,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;500;700;800&family=Space+Mono:wght@400;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="/labs/shared.css?v=6">
+  <link rel="stylesheet" href="/labs/shared.css?v=7">
   <link rel="stylesheet" href="style.css">
 </head>
 
@@ -222,7 +222,7 @@
     <footer data-lab-footer data-home-href="/" class="compact-footer"></footer>
   </div>
 
-  <script src="/labs/shared.js?v=6" defer></script>
+  <script src="/labs/shared.js?v=7" defer></script>
   <script src="script.js" defer></script>
 </body>
 

--- a/labs/piano/index.html
+++ b/labs/piano/index.html
@@ -17,7 +17,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Piano">
     <meta name="twitter:description" content="Piano minimalista com sons ultra realistas. 4 oitavas completas.">
-  <link rel="stylesheet" href="/labs/shared.css?v=6">
+  <link rel="stylesheet" href="/labs/shared.css?v=7">
   <link rel="stylesheet" href="style.css">
 </head>
 
@@ -80,7 +80,7 @@
     <footer data-lab-footer data-home-href="/"></footer>
   </div>
 
-  <script src="/labs/shared.js?v=6" defer></script>
+  <script src="/labs/shared.js?v=7" defer></script>
   <script src="script.js" defer></script>
 </body>
 

--- a/labs/pomodoro/index.html
+++ b/labs/pomodoro/index.html
@@ -19,7 +19,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=6">
+    <link rel="stylesheet" href="/labs/shared.css?v=7">
     <link rel="stylesheet" href="style.css?v=3">
 </head>
 
@@ -304,7 +304,7 @@
     <div class="toast-region" id="toast-region" aria-live="polite" aria-atomic="false"></div>
     <p class="sr-only" id="live-region" role="status" aria-live="polite"></p>
 
-    <script src="/labs/shared.js?v=6" defer></script>
+    <script src="/labs/shared.js?v=7" defer></script>
     <script src="script.js?v=3" defer></script>
 </body>
 

--- a/labs/pulsar/index.html
+++ b/labs/pulsar/index.html
@@ -19,7 +19,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Oxanium:wght@400;600;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=6">
+    <link rel="stylesheet" href="/labs/shared.css?v=7">
     <link rel="stylesheet" href="style.css">
 </head>
 
@@ -110,7 +110,7 @@
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
 
-    <script src="/labs/shared.js?v=6" defer></script>
+    <script src="/labs/shared.js?v=7" defer></script>
     <script src="script.js" defer></script>
 </body>
 

--- a/labs/ravi-123/index.html
+++ b/labs/ravi-123/index.html
@@ -18,7 +18,7 @@
     content="Conte de 1 a 9 e ajude o Ravi a convidar heróis para a maior festa surpresa do reino. Pixel art 320×200, tudo em vanilla.">
   <meta property="og:locale" content="pt_BR">
 
-  <link rel="stylesheet" href="/labs/shared.css?v=6">
+  <link rel="stylesheet" href="/labs/shared.css?v=7">
   <link rel="stylesheet" href="style.css?v=23">
 </head>
 
@@ -49,7 +49,7 @@
   </noscript>
 
   <script type="module" src="main.js?v=23"></script>
-  <script src="/labs/shared.js?v=6" defer></script>
+  <script src="/labs/shared.js?v=7" defer></script>
 </body>
 
 </html>

--- a/labs/river-knight/index.html
+++ b/labs/river-knight/index.html
@@ -26,7 +26,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;600;700;800&family=Outfit:wght@300;400;500;600;700&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=6">
+    <link rel="stylesheet" href="/labs/shared.css?v=7">
     <link rel="stylesheet" href="style.css?v=5">
 
     <script type="importmap">
@@ -247,7 +247,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=6" defer></script>
+    <script src="/labs/shared.js?v=7" defer></script>
     <script type="module" src="src/main.js?v=16"></script>
 </body>
 

--- a/labs/rock-kombat/index.html
+++ b/labs/rock-kombat/index.html
@@ -10,7 +10,7 @@
   <meta property="og:title" content="Rock Kombat — 2D Arcade Fight">
   <meta property="og:description" content="Escolha sua lenda. Leia a distância. Domine o palco.">
   <meta property="og:url" content="https://diogopaulino.com.br/labs/rock-kombat/">
-  <link rel="stylesheet" href="/labs/shared.css?v=6">
+  <link rel="stylesheet" href="/labs/shared.css?v=7">
   <link rel="stylesheet" href="style.css?v=6">
 </head>
 <body data-screen="hero-screen">
@@ -206,7 +206,7 @@
 
   <footer data-lab-footer data-home-href="/"></footer>
 
-  <script src="/labs/shared.js?v=6" defer></script>
+  <script src="/labs/shared.js?v=7" defer></script>
   <script type="module" src="main.js?v=4"></script>
 </body>
 </html>

--- a/labs/santos-games/index.html
+++ b/labs/santos-games/index.html
@@ -18,7 +18,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Fredoka:wght@500;600;700&family=Nunito:wght@700;800;900&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=6">
+    <link rel="stylesheet" href="/labs/shared.css?v=7">
     <link rel="stylesheet" href="style.css?v=9">
 </head>
 
@@ -85,7 +85,7 @@
         <footer data-lab-footer data-home-href="/" class="sg-footer"></footer>
     </div>
 
-    <script src="/labs/shared.js?v=5" defer></script>
+    <script src="/labs/shared.js?v=7" defer></script>
     <script type="module" src="src/main.js?v=9"></script>
 </body>
 

--- a/labs/shared.js
+++ b/labs/shared.js
@@ -57,7 +57,7 @@
     function buildHeader(header) {
         if (header.dataset.labReady === 'true') return;
 
-        const backHref = header.getAttribute('data-back-href') || '../index.html';
+        const backHref = header.getAttribute('data-back-href') || '/labs/';
         const backLabel = header.getAttribute('data-back-label') || 'Labs';
         const title = header.getAttribute('data-title') || document.title || 'Labs';
         const subtitle = header.getAttribute('data-subtitle');
@@ -158,7 +158,17 @@
         document.head.appendChild(script);
     }
 
+    function ensureFavicon() {
+        if (document.querySelector('link[rel="icon"], link[rel="shortcut icon"]')) return;
+        const icon = document.createElement('link');
+        icon.rel = 'icon';
+        icon.href = '/favicon.ico';
+        icon.sizes = 'any';
+        document.head.appendChild(icon);
+    }
+
     function init() {
+        ensureFavicon();
         initChrome();
         ensureThemeCore();
     }

--- a/labs/snake/index.html
+++ b/labs/snake/index.html
@@ -14,7 +14,7 @@
     <meta property="og:description"
         content="Snake retrô em um console portátil 8-bit: colete frutas, ganhe velocidade e bata o seu recorde.">
     <meta property="og:url" content="https://diogopaulino.com.br/labs/snake/">
-    <link rel="stylesheet" href="/labs/shared.css?v=6">
+    <link rel="stylesheet" href="/labs/shared.css?v=7">
     <link rel="stylesheet" href="style.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -115,7 +115,7 @@
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
 
-    <script src="/labs/shared.js?v=6" defer></script>
+    <script src="/labs/shared.js?v=7" defer></script>
     <script src="script.js?v=2" defer></script>
 </body>
 

--- a/labs/space-shooter/index.html
+++ b/labs/space-shooter/index.html
@@ -15,7 +15,9 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Neon Invaders">
     <meta name="twitter:description" content="Jogo de tiro espacial estilo arcade com gráficos neon.">
-    <link rel="stylesheet" href="/labs/shared.css?v=6">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="/labs/shared.css?v=7">
     <link rel="stylesheet" href="style.css?v=3">
     <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
 </head>
@@ -139,7 +141,7 @@
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
 
-    <script src="/labs/shared.js?v=6" defer></script>
+    <script src="/labs/shared.js?v=7" defer></script>
     <script src="script.js?v=3" defer></script>
 </body>
 

--- a/labs/tamagotchi/index.html
+++ b/labs/tamagotchi/index.html
@@ -16,7 +16,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="RakuRaku Dinokun / Dinkie Dino (1997)">
     <meta name="twitter:description" content="Recriação pesquisada do RakuRaku Dinokun / Dinkie Dino: carcaça, LCD, controles e ciclo de cuidado em tempo real.">
-  <link rel="stylesheet" href="/labs/shared.css?v=6">
+  <link rel="stylesheet" href="/labs/shared.css?v=7">
   <link rel="stylesheet" href="style.css?v=12">
 </head>
 
@@ -122,7 +122,7 @@
     <footer data-lab-footer data-home-href="/"></footer>
   </div>
 
-  <script src="/labs/shared.js?v=6" defer></script>
+  <script src="/labs/shared.js?v=7" defer></script>
   <script src="script.js?v=9" defer></script>
 </body>
 

--- a/labs/tetris/index.html
+++ b/labs/tetris/index.html
@@ -15,7 +15,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Tetris 90s">
     <meta name="twitter:description" content="Jogue Tetris clássico estilo anos 90 no seu navegador.">
-    <link rel="stylesheet" href="/labs/shared.css?v=6">
+    <link rel="stylesheet" href="/labs/shared.css?v=7">
     <link rel="stylesheet" href="style.css">
 </head>
 
@@ -93,7 +93,7 @@
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
 
-    <script src="/labs/shared.js?v=6" defer></script>
+    <script src="/labs/shared.js?v=7" defer></script>
     <script src="script.js" defer></script>
 </body>
 

--- a/labs/toaster-64/index.html
+++ b/labs/toaster-64/index.html
@@ -26,7 +26,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Press+Start+2P&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=6">
+    <link rel="stylesheet" href="/labs/shared.css?v=7">
     <link rel="stylesheet" href="style.css?v=1">
 
     <script type="importmap">
@@ -229,7 +229,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=6" defer></script>
+    <script src="/labs/shared.js?v=7" defer></script>
     <script type="module" src="src/main.js?v=2"></script>
 </body>
 

--- a/labs/videogame/index.html
+++ b/labs/videogame/index.html
@@ -18,11 +18,11 @@
 
 
 
-    <link rel="stylesheet" href="/labs/shared.css?v=6">
+    <link rel="stylesheet" href="/labs/shared.css?v=7">
     <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="mobile.css">
     <script src="/labs/videogame/lib/nostalgist.umd.js" defer></script>
-    <script src="/labs/shared.js?v=6" defer></script>
+    <script src="/labs/shared.js?v=7" defer></script>
     <script src="games.js" defer></script>
     <script src="script.js" defer></script>
 </head>

--- a/labs/winamp/index.html
+++ b/labs/winamp/index.html
@@ -18,7 +18,7 @@
     <meta name="twitter:card" content="summary">
     <title>Winamp JS — Diogo Labs</title>
     <link rel="canonical" href="https://diogopaulino.com.br/labs/winamp/">
-    <link rel="stylesheet" href="/labs/shared.css?v=6">
+    <link rel="stylesheet" href="/labs/shared.css?v=7">
     <link rel="stylesheet" href="style.css?v=5">
 </head>
 
@@ -362,7 +362,7 @@
 
     <noscript>Ative o JavaScript para usar o player.</noscript>
     <script type="module" src="script.js?v=5"></script>
-    <script src="/labs/shared.js?v=6" defer></script>
+    <script src="/labs/shared.js?v=7" defer></script>
 </body>
 
 </html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,175 +2,217 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://diogopaulino.com.br/</loc>
-    <lastmod>2026-08-12</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://diogopaulino.com.br/labs/</loc>
-    <lastmod>2026-08-12</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
+    <loc>https://diogopaulino.com.br/labs/aetherion/</loc>
+    <lastmod>2026-08-14</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
     <loc>https://diogopaulino.com.br/labs/aurora-flow/</loc>
-    <lastmod>2026-08-12</lastmod>
+    <lastmod>2026-08-14</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://diogopaulino.com.br/labs/beige-box/</loc>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://diogopaulino.com.br/labs/calculator/</loc>
-    <lastmod>2026-08-12</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://diogopaulino.com.br/labs/cyberos/</loc>
-    <lastmod>2026-08-12</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://diogopaulino.com.br/labs/english-duo/</loc>
-    <lastmod>2026-08-12</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://diogopaulino.com.br/labs/f1-racing/</loc>
-    <lastmod>2026-08-12</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://diogopaulino.com.br/labs/gravity/</loc>
-    <lastmod>2026-08-12</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://diogopaulino.com.br/labs/image-editor/</loc>
-    <lastmod>2026-08-12</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://diogopaulino.com.br/labs/image-optimizer/</loc>
-    <lastmod>2026-08-12</lastmod>
+    <lastmod>2026-08-14</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://diogopaulino.com.br/labs/jornada-do-anel/</loc>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://diogopaulino.com.br/labs/jungle-run/</loc>
-    <lastmod>2026-08-12</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://diogopaulino.com.br/labs/lander/</loc>
-    <lastmod>2026-08-12</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://diogopaulino.com.br/labs/matrix/</loc>
-    <lastmod>2026-08-12</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://diogopaulino.com.br/labs/minesweeper/</loc>
-    <lastmod>2026-08-12</lastmod>
+    <lastmod>2026-08-14</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://diogopaulino.com.br/labs/neon-rider/</loc>
+    <lastmod>2026-08-14</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://diogopaulino.com.br/labs/orbis/</loc>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://diogopaulino.com.br/labs/paint/</loc>
-    <lastmod>2026-08-12</lastmod>
+    <lastmod>2026-08-14</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://diogopaulino.com.br/labs/pandemonium/</loc>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://diogopaulino.com.br/labs/partitura/</loc>
-    <lastmod>2026-08-12</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://diogopaulino.com.br/labs/piano/</loc>
-    <lastmod>2026-08-12</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://diogopaulino.com.br/labs/pomodoro/</loc>
-    <lastmod>2026-08-12</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://diogopaulino.com.br/labs/pulsar/</loc>
-    <lastmod>2026-08-12</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://diogopaulino.com.br/labs/ravi-123/</loc>
-    <lastmod>2026-08-12</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://diogopaulino.com.br/labs/river-knight/</loc>
-    <lastmod>2026-08-13</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://diogopaulino.com.br/labs/rock-kombat/</loc>
-    <lastmod>2026-08-12</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://diogopaulino.com.br/labs/santos-games/</loc>
-    <lastmod>2026-08-12</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://diogopaulino.com.br/labs/snake/</loc>
-    <lastmod>2026-08-12</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://diogopaulino.com.br/labs/space-shooter/</loc>
-    <lastmod>2026-08-12</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://diogopaulino.com.br/labs/tamagotchi/</loc>
-    <lastmod>2026-08-12</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://diogopaulino.com.br/labs/tetris/</loc>
-    <lastmod>2026-08-12</lastmod>
+    <lastmod>2026-08-14</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://diogopaulino.com.br/labs/toaster-64/</loc>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://diogopaulino.com.br/labs/videogame/</loc>
-    <lastmod>2026-08-12</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://diogopaulino.com.br/labs/winamp/</loc>
-    <lastmod>2026-08-12</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 🎯 Objetivo

Alinhar o catálogo dos 34 labs (README, galeria, sitemap) e deixar explícito para os agentes: conferir links, corrigir o que quebrar, e abrir todo PR a partir do template.

## ✨ O que mudou

- README com os 34 labs e a seção **Mundos 3D** (Orbis, Aetherion, Neon Rider, Jornada do Anel, Pandemônio, Beige Box)
- Galeria reordenada, HTML inválido corrigido, voltar para `/`, home com `/labs/`
- `sitemap.xml` com os labs que faltavam
- CDNs mais estáveis (Jungle Run / Calculator), favicon, cache-bust `v=7`
- `AGENTS.md`: auditoria de links obrigatória + PRs baseados no template
- `CLAUDE.md` contém só `@AGENTS.md` (nome em maiúsculas que o Claude Code lê)
- Template em `.github/PULL_REQUEST_TEMPLATE.md`

## 🧪 Como testar

1. Na raiz do repo: `python3 -m http.server 8000`
2. Abrir http://localhost:8000/ (home, badge **labs**) e http://localhost:8000/labs/ (34 cards)
3. Abrir um lab 3D (ex.: `/labs/orbis/`) e um utilitário (ex.: `/labs/calculator/`) — CSS, JS e voltar
4. Conferir o README e o `sitemap.xml` contra as pastas em `/labs/`

## ✅ Checklist

- [x] Links conferidos: pasta do lab ↔ card da galeria ↔ README ↔ sitemap (e corrigidos se quebravam)
- [x] Testado via HTTP na raiz, não via `file://`
- [x] Nada fora do escopo foi quebrado
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ffdd9-510e-77a7-8342-92ce8e17d34f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ffdd9-510e-77a7-8342-92ce8e17d34f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

