### PR TITLE
🧪 Nereida — voo da arraia-manta no recife bioluminescente

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 Mais de 20 anos em tecnologia, entre liderança, código hands-on e design UI/UX.
 
 [![Website](https://img.shields.io/badge/Website-diogopaulino.com.br-3B82F6?style=flat-square&logo=googlechrome&logoColor=white)](https://diogopaulino.com.br/)
-[![Labs](https://img.shields.io/badge/Labs-42_experimentos-8B5CF6?style=flat-square&logo=stackblitz&logoColor=white)](https://diogopaulino.com.br/labs/)
+[![Labs](https://img.shields.io/badge/Labs-44_experimentos-8B5CF6?style=flat-square&logo=stackblitz&logoColor=white)](https://diogopaulino.com.br/labs/)
 [![GitHub](https://img.shields.io/badge/GitHub-diogopaulino-181717?style=flat-square&logo=github&logoColor=white)](https://github.com/diogopaulino)
 [![LinkedIn](https://img.shields.io/badge/LinkedIn-Diogo_Paulino-0A66C2?style=flat-square)](https://br.linkedin.com/in/diogopaulino)
 [![Spotify](https://img.shields.io/badge/Spotify-Artist-1DB954?style=flat-square&logo=spotify&logoColor=white)](https://open.spotify.com/intl-pt/artist/0ue2WfDQ1P4XR2vXdSIrYQ)
@@ -32,12 +32,14 @@ Gosto de construir coisas — de time e produto até interface e código. Nessa 
 
 > *Abre, experimenta, quebra, reconstrói. Esse é o espírito.*
 
-Um laboratório aberto com **42 experimentos** que rodam direto no navegador — HTML, CSS e JavaScript puro, sem instalar nada. Catálogo completo em [diogopaulino.com.br/labs](https://diogopaulino.com.br/labs/).
+Um laboratório aberto com **44 experimentos** que rodam direto no navegador — HTML, CSS e JavaScript puro, sem instalar nada. Catálogo completo em [diogopaulino.com.br/labs](https://diogopaulino.com.br/labs/).
 
 ### 🪐 Mundos 3D
 
 | Projeto | O que é? |
 | :--- | :--- |
+| 🪸 **[Nereida](https://diogopaulino.com.br/labs/nereida/)** | Voo da arraia-manta num recife bioluminescente — anéis de luz, pérolas e o templo náutilo |
+| 🦕 **[Ilha do Âmbar](https://diogopaulino.com.br/labs/ilha-do-ambar/)** | Safari 3D na ilha dos dinossauros — jipe, diário de campo e gigantes entre a névoa |
 | 🕸️ **[Silkline](https://diogopaulino.com.br/labs/silkline/)** | Balanço 3D pelos arranha-céus de Manhattan — teias, chuva, néon e combos no skyline |
 | 🥋 **[Vector Fighter](https://diogopaulino.com.br/labs/vector-fighter/)** | Luta 3D em polígonos no espírito Virtua Fighter — anel octogonal, ring out e K.O. |
 | ✨ **[Lúmina](https://diogopaulino.com.br/labs/lumina/)** | Reino flutuante estilo Disney — voe, colete desejos e acenda as lanternas do castelo |

--- a/index.html
+++ b/index.html
@@ -157,7 +157,7 @@
       </nav>
       <div class="labs-easter-egg" id="labs-easter-egg">
         <a href="/labs/" class="labs-badge"
-          aria-label="Labs de Diogo Paulino: 42 experimentos de jogos, código, música e IA">
+          aria-label="Labs de Diogo Paulino: 44 experimentos de jogos, código, música e IA">
           <span class="labs-text">labs</span>
           <svg class="labs-sparkles" width="14" height="14" viewBox="0 0 24 24" fill="currentColor" stroke="none">
             <path d="M12 2L14.4 9.6L22 12L14.4 14.4L12 22L9.6 14.4L2 12L9.6 9.6L12 2Z" />

--- a/labs/index.html
+++ b/labs/index.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Labs — Diogo Paulino | Jogos 3D, código, música e IA</title>
-  <meta name="description" content="42 experimentos de Diogo Paulino: jogos 3D, ferramentas, música e inteligência artificial em HTML, CSS e JavaScript puro.">
+  <meta name="description" content="44 experimentos de Diogo Paulino: jogos 3D, ferramentas, música e inteligência artificial em HTML, CSS e JavaScript puro.">
   <meta name="author" content="Diogo Paulino">
   <meta name="robots" content="index, follow">
   <meta name="theme-color" content="#fafbfc">
@@ -16,14 +16,14 @@
   <meta property="og:site_name" content="Diogo Paulino · Labs">
   <meta property="og:title" content="Labs — Diogo Paulino | Jogos 3D, código, música e IA">
   <meta property="og:description"
-    content="42 laboratórios de Diogo Paulino: mundos 3D, jogos, ferramentas, música e IA em HTML, CSS e JavaScript puro.">
+    content="44 laboratórios de Diogo Paulino: mundos 3D, jogos, ferramentas, música e IA em HTML, CSS e JavaScript puro.">
   <meta property="og:url" content="https://diogopaulino.com.br/labs/">
   <meta property="og:image" content="https://diogopaulino.com.br/assets/img/diogo.jpeg">
   <meta property="og:image:alt" content="Diogo Paulino">
   <meta property="og:locale" content="pt_BR">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Labs — Diogo Paulino | Jogos 3D, código, música e IA">
-  <meta name="twitter:description" content="42 experimentos de Diogo Paulino: jogos, código, música e inteligência artificial.">
+  <meta name="twitter:description" content="44 experimentos de Diogo Paulino: jogos, código, música e inteligência artificial.">
   <meta name="twitter:image" content="https://diogopaulino.com.br/assets/img/diogo.jpeg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -31,7 +31,7 @@
   <link rel="stylesheet" href="/labs/shared.css?v=7">
   <link rel="stylesheet" href="/labs/style.css">
   <script type="application/ld+json">
-  {
+    {
     "@context": "https://schema.org",
     "@graph": [
       {
@@ -39,7 +39,7 @@
         "@id": "https://diogopaulino.com.br/labs/#page",
         "name": "Labs — Diogo Paulino",
         "url": "https://diogopaulino.com.br/labs/",
-        "description": "42 experimentos de Diogo Paulino: jogos 3D, ferramentas, música e inteligência artificial em HTML, CSS e JavaScript puro.",
+        "description": "44 experimentos de Diogo Paulino: jogos 3D, ferramentas, música e inteligência artificial em HTML, CSS e JavaScript puro.",
         "inLanguage": "pt-BR",
         "isPartOf": {
           "@id": "https://diogopaulino.com.br/#website"
@@ -47,7 +47,7 @@
         "creator": {
           "@id": "https://diogopaulino.com.br/#person"
         },
-        "numberOfItems": 42,
+        "numberOfItems": 44,
         "mainEntity": {
           "@id": "https://diogopaulino.com.br/labs/#list"
         }
@@ -56,257 +56,269 @@
         "@type": "ItemList",
         "@id": "https://diogopaulino.com.br/labs/#list",
         "name": "Labs de Diogo Paulino",
-        "numberOfItems": 42,
+        "numberOfItems": 44,
         "itemListElement": [
           {
             "@type": "ListItem",
             "position": 1,
+            "url": "https://diogopaulino.com.br/labs/nereida/",
+            "name": "Nereida"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "url": "https://diogopaulino.com.br/labs/ilha-do-ambar/",
+            "name": "Ilha do Âmbar"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
             "url": "https://diogopaulino.com.br/labs/silkline/",
             "name": "Silkline"
           },
           {
             "@type": "ListItem",
-            "position": 2,
+            "position": 4,
             "url": "https://diogopaulino.com.br/labs/vector-fighter/",
             "name": "Vector Fighter"
           },
           {
             "@type": "ListItem",
-            "position": 3,
+            "position": 5,
             "url": "https://diogopaulino.com.br/labs/lumina/",
             "name": "Lúmina"
           },
           {
             "@type": "ListItem",
-            "position": 4,
+            "position": 6,
             "url": "https://diogopaulino.com.br/labs/honor-front/",
             "name": "Honor Front"
           },
           {
             "@type": "ListItem",
-            "position": 5,
+            "position": 7,
             "url": "https://diogopaulino.com.br/labs/safari-dourado/",
             "name": "Safari Dourado"
           },
           {
             "@type": "ListItem",
-            "position": 6,
+            "position": 8,
             "url": "https://diogopaulino.com.br/labs/aurelia/",
             "name": "Aurelia Festival"
           },
           {
             "@type": "ListItem",
-            "position": 7,
+            "position": 9,
             "url": "https://diogopaulino.com.br/labs/grao/",
             "name": "Grão"
           },
           {
             "@type": "ListItem",
-            "position": 8,
+            "position": 10,
             "url": "https://diogopaulino.com.br/labs/armilla/",
             "name": "Armilla"
           },
           {
             "@type": "ListItem",
-            "position": 9,
+            "position": 11,
             "url": "https://diogopaulino.com.br/labs/orbis/",
             "name": "Orbis"
           },
           {
             "@type": "ListItem",
-            "position": 10,
+            "position": 12,
             "url": "https://diogopaulino.com.br/labs/aetherion/",
             "name": "Aetherion"
           },
           {
             "@type": "ListItem",
-            "position": 11,
+            "position": 13,
             "url": "https://diogopaulino.com.br/labs/neon-rider/",
             "name": "Neon Rider"
           },
           {
             "@type": "ListItem",
-            "position": 12,
+            "position": 14,
             "url": "https://diogopaulino.com.br/labs/toaster-64/",
             "name": "Torradeira 64"
           },
           {
             "@type": "ListItem",
-            "position": 13,
+            "position": 15,
             "url": "https://diogopaulino.com.br/labs/river-knight/",
             "name": "River Knight"
           },
           {
             "@type": "ListItem",
-            "position": 14,
+            "position": 16,
             "url": "https://diogopaulino.com.br/labs/jornada-do-anel/",
             "name": "A Jornada do Anel"
           },
           {
             "@type": "ListItem",
-            "position": 15,
+            "position": 17,
             "url": "https://diogopaulino.com.br/labs/pandemonium/",
             "name": "Pandemônio"
           },
           {
             "@type": "ListItem",
-            "position": 16,
+            "position": 18,
             "url": "https://diogopaulino.com.br/labs/beige-box/",
             "name": "Beige Box"
           },
           {
             "@type": "ListItem",
-            "position": 17,
+            "position": 19,
             "url": "https://diogopaulino.com.br/labs/f1-racing/",
             "name": "F1 Grand Prix"
           },
           {
             "@type": "ListItem",
-            "position": 18,
+            "position": 20,
             "url": "https://diogopaulino.com.br/labs/santos-games/",
             "name": "Santos Games"
           },
           {
             "@type": "ListItem",
-            "position": 19,
+            "position": 21,
             "url": "https://diogopaulino.com.br/labs/ravi-123/",
             "name": "Ravi 1·2·3"
           },
           {
             "@type": "ListItem",
-            "position": 20,
+            "position": 22,
             "url": "https://diogopaulino.com.br/labs/rock-kombat/",
             "name": "Rock Kombat"
           },
           {
             "@type": "ListItem",
-            "position": 21,
+            "position": 23,
             "url": "https://diogopaulino.com.br/labs/videogame/",
             "name": "Videogame"
           },
           {
             "@type": "ListItem",
-            "position": 22,
+            "position": 24,
             "url": "https://diogopaulino.com.br/labs/lander/",
             "name": "Lunar Lander"
           },
           {
             "@type": "ListItem",
-            "position": 23,
+            "position": 25,
             "url": "https://diogopaulino.com.br/labs/jungle-run/",
             "name": "Jungle Run"
           },
           {
             "@type": "ListItem",
-            "position": 24,
+            "position": 26,
             "url": "https://diogopaulino.com.br/labs/space-shooter/",
             "name": "Neon Invaders"
           },
           {
             "@type": "ListItem",
-            "position": 25,
+            "position": 27,
             "url": "https://diogopaulino.com.br/labs/tetris/",
             "name": "Tetris 90s"
           },
           {
             "@type": "ListItem",
-            "position": 26,
+            "position": 28,
             "url": "https://diogopaulino.com.br/labs/snake/",
             "name": "Retro Snake"
           },
           {
             "@type": "ListItem",
-            "position": 27,
+            "position": 29,
             "url": "https://diogopaulino.com.br/labs/minesweeper/",
             "name": "Campo Minado 95"
           },
           {
             "@type": "ListItem",
-            "position": 28,
+            "position": 30,
             "url": "https://diogopaulino.com.br/labs/tamagotchi/",
             "name": "RakuRaku Dinokun"
           },
           {
             "@type": "ListItem",
-            "position": 29,
+            "position": 31,
             "url": "https://diogopaulino.com.br/labs/cyberos/",
             "name": "CyberOS Terminal"
           },
           {
             "@type": "ListItem",
-            "position": 30,
+            "position": 32,
             "url": "https://diogopaulino.com.br/labs/matrix/",
             "name": "Matrix"
           },
           {
             "@type": "ListItem",
-            "position": 31,
+            "position": 33,
             "url": "https://diogopaulino.com.br/labs/aurora-flow/",
             "name": "Aurora Flow"
           },
           {
             "@type": "ListItem",
-            "position": 32,
+            "position": 34,
             "url": "https://diogopaulino.com.br/labs/paint/",
             "name": "Paint Lab"
           },
           {
             "@type": "ListItem",
-            "position": 33,
+            "position": 35,
             "url": "https://diogopaulino.com.br/labs/gravity/",
             "name": "Gravity"
           },
           {
             "@type": "ListItem",
-            "position": 34,
+            "position": 36,
             "url": "https://diogopaulino.com.br/labs/image-optimizer/",
             "name": "Image Optimizer"
           },
           {
             "@type": "ListItem",
-            "position": 35,
+            "position": 37,
             "url": "https://diogopaulino.com.br/labs/image-editor/",
             "name": "Image Editor"
           },
           {
             "@type": "ListItem",
-            "position": 36,
+            "position": 38,
             "url": "https://diogopaulino.com.br/labs/pomodoro/",
             "name": "Pomodoro"
           },
           {
             "@type": "ListItem",
-            "position": 37,
+            "position": 39,
             "url": "https://diogopaulino.com.br/labs/english-duo/",
             "name": "Talk"
           },
           {
             "@type": "ListItem",
-            "position": 38,
+            "position": 40,
             "url": "https://diogopaulino.com.br/labs/calculator/",
             "name": "Calculator"
           },
           {
             "@type": "ListItem",
-            "position": 39,
+            "position": 41,
             "url": "https://diogopaulino.com.br/labs/partitura/",
             "name": "Partitura: Maestro Quest"
           },
           {
             "@type": "ListItem",
-            "position": 40,
+            "position": 42,
             "url": "https://diogopaulino.com.br/labs/piano/",
             "name": "Piano"
           },
           {
             "@type": "ListItem",
-            "position": 41,
+            "position": 43,
             "url": "https://diogopaulino.com.br/labs/winamp/",
             "name": "Winamp JS"
           },
           {
             "@type": "ListItem",
-            "position": 42,
+            "position": 44,
             "url": "https://diogopaulino.com.br/labs/pulsar/",
             "name": "Pulsar"
           }
@@ -352,6 +364,29 @@
     </div>
 
     <div class="projects-grid">
+      <a href="/labs/nereida/" class="project-card" data-groups="game,creative">
+        <div class="project-icon">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+            stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M4.5 12.5c2.2-1.6 4.2-2.2 7.5-2.2 3.2 0 5.4.6 7.5 2.2" />
+            <path d="M5 12.5c1.8 1.4 3.6 2.2 7 2.2s5.2-.8 7-2.2" opacity="0.7" />
+            <path d="M12 10.3V8.2" opacity="0.55" />
+            <path d="M9.2 11.2c.4-2.4 1.4-3.8 2.8-4.6" opacity="0.7" />
+            <path d="M14.8 11.2c-.4-2.4-1.4-3.8-2.8-4.6" opacity="0.7" />
+            <path d="M3.5 13.2c2.8 3.2 5.2 4.6 8.5 4.6s5.7-1.4 8.5-4.6" opacity="0.4" />
+            <circle cx="12" cy="12.2" r="0.7" fill="currentColor" stroke="none" />
+          </svg>
+        </div>
+        <div class="project-content">
+          <h2>Nereida</h2>
+          <p>Voo 3D de uma arraia-manta no recife bioluminescente: anéis de luz, pérolas e a catedral no abismo</p>
+          <div class="project-tags">
+            <span class="tag">three.js</span>
+            <span class="tag">Recife</span>
+            <span class="tag">Arcade</span>
+          </div>
+        </div>
+      </a>
       <a href="/labs/ilha-do-ambar/" class="project-card" data-groups="game,creative">
         <div class="project-icon">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"

--- a/labs/nereida/index.html
+++ b/labs/nereida/index.html
@@ -1,0 +1,273 @@
+<!DOCTYPE html>
+<html lang="pt-br" data-theme="dark">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport"
+        content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover">
+    <meta name="theme-color" content="#02141c">
+    <title>Nereida — voo da arraia-manta | Diogo Paulino</title>
+    <meta name="description"
+        content="Voe como uma arraia-manta por um recife bioluminescente em three.js: anéis de luz, pérolas, correntes e a catedral no abismo.">
+    <link rel="canonical" href="https://diogopaulino.com.br/labs/nereida/">
+    <meta name="author" content="Diogo Paulino">
+    <meta name="robots" content="index, follow">
+    <link rel="icon" href="/favicon.ico" sizes="any">
+    <meta property="og:image" content="https://diogopaulino.com.br/assets/img/diogo.jpeg">
+    <meta property="og:image:alt" content="Diogo Paulino">
+    <meta property="og:locale" content="pt_BR">
+    <meta name="twitter:image" content="https://diogopaulino.com.br/assets/img/diogo.jpeg">
+
+    <meta property="og:type" content="website">
+    <meta property="og:site_name" content="Diogo Paulino · Labs">
+    <meta property="og:url" content="https://diogopaulino.com.br/labs/nereida/">
+    <meta property="og:title" content="Nereida — voo da arraia-manta | Diogo Paulino">
+    <meta property="og:description"
+        content="Um recife que canta. Encadeie anéis, colete pérolas e deslize com a baleia até o templo náutilo.">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Nereida | Diogo Paulino">
+    <meta name="twitter:description" content="Voo 3D de uma arraia-manta no recife bioluminescente. three.js, anéis e pérolas.">
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,500;0,600;0,700;1,600&family=Outfit:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500&display=swap"
+        rel="stylesheet">
+    <link rel="stylesheet" href="/labs/shared.css?v=7">
+    <link rel="stylesheet" href="style.css">
+
+    <script type="importmap">
+    {
+        "imports": {
+            "three": "https://cdn.jsdelivr.net/npm/three@0.185.1/build/three.module.js",
+            "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.185.1/examples/jsm/"
+        }
+    }
+    </script>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@graph": [
+        {
+          "@type": "WebApplication",
+          "name": "Nereida",
+          "url": "https://diogopaulino.com.br/labs/nereida/",
+          "description": "Voe como uma arraia-manta por um recife bioluminescente em three.js: anéis de luz, pérolas, correntes e a catedral no abismo.",
+          "applicationCategory": "GameApplication",
+          "operatingSystem": "Any",
+          "inLanguage": "pt-BR",
+          "isAccessibleForFree": true,
+          "author": {
+            "@type": "Person",
+            "name": "Diogo Paulino",
+            "url": "https://diogopaulino.com.br/"
+          },
+          "image": "https://diogopaulino.com.br/assets/img/diogo.jpeg"
+        },
+        {
+          "@type": "BreadcrumbList",
+          "itemListElement": [
+            {
+              "@type": "ListItem",
+              "position": 1,
+              "name": "Diogo Paulino",
+              "item": "https://diogopaulino.com.br/"
+            },
+            {
+              "@type": "ListItem",
+              "position": 2,
+              "name": "Labs",
+              "item": "https://diogopaulino.com.br/labs/"
+            },
+            {
+              "@type": "ListItem",
+              "position": 3,
+              "name": "Nereida",
+              "item": "https://diogopaulino.com.br/labs/nereida/"
+            }
+          ]
+        }
+      ]
+    }
+    </script>
+</head>
+
+<body>
+    <main class="game-shell">
+        <header data-lab-header data-title="Nereida" data-back-label="Labs">
+            <template data-slot="logo">
+                <div class="app-logo">
+                    <span class="brand-mark" aria-hidden="true">◈</span>
+                    <span>Nereida</span>
+                </div>
+            </template>
+        </header>
+
+        <canvas id="scene" aria-label="Recife 3D com uma arraia-manta em voo"></canvas>
+        <div class="vignette" aria-hidden="true"></div>
+        <div class="caustic-glass" aria-hidden="true"></div>
+
+        <div id="hud" class="hud" hidden>
+            <div class="hud-top">
+                <div class="panel depth-panel">
+                    <span class="hud-label">Profundidade</span>
+                    <strong id="depthValue" class="mono">024 m</strong>
+                    <span id="zoneValue" class="hud-tag">Jardim de coral</span>
+                </div>
+                <div class="panel race-panel">
+                    <span class="hud-label">Recife</span>
+                    <div class="progress" title="Progresso">
+                        <i id="progressFill"></i>
+                    </div>
+                    <div class="boost-meter" title="Impulso">
+                        <i id="boostFill"></i>
+                    </div>
+                    <span id="speedValue" class="hud-tag mono">00 nós</span>
+                </div>
+                <div class="panel score-panel">
+                    <div class="score-row">
+                        <span class="hud-label">Pérolas</span>
+                        <strong id="pearlValue" class="mono">00</strong>
+                    </div>
+                    <div class="score-row">
+                        <span class="hud-label">Combo</span>
+                        <strong id="comboValue" class="mono">0×</strong>
+                    </div>
+                    <div class="score-row">
+                        <span class="hud-label">Escamas</span>
+                        <strong id="livesValue" class="mono lives">■■■</strong>
+                    </div>
+                </div>
+            </div>
+
+            <p id="message" class="message" data-show="false" role="status" aria-live="polite"></p>
+
+            <div class="hud-actions">
+                <button id="soundButton" class="icon-button" type="button" aria-pressed="true"
+                    title="Som (M)" aria-label="Alternar som">♪</button>
+                <button id="pauseButton" class="icon-button" type="button" title="Pausar (P)"
+                    aria-label="Pausar">II</button>
+                <span id="fpsCounter" class="fps mono">—</span>
+            </div>
+
+            <div id="touchControls" class="touch-controls" hidden>
+                <div class="look-zone" id="lookZone" aria-label="Arraste para guiar">
+                    <span class="steer-hint">guiar</span>
+                </div>
+                <div class="touch-buttons">
+                    <button type="button" class="pad pad-roll" id="touchRoll" aria-label="Pirueta">GIRO</button>
+                    <button type="button" class="pad pad-boost" id="touchBoost" aria-label="Impulso">PULSO</button>
+                </div>
+            </div>
+        </div>
+
+        <div id="loadingOverlay" class="overlay loading-overlay">
+            <div class="loading-card">
+                <span class="loading-mark" aria-hidden="true">◈</span>
+                <h1>NEREIDA</h1>
+                <p id="loadingText">A maré sobe…</p>
+                <div class="loading-bar"><i id="loadingFill"></i></div>
+            </div>
+        </div>
+
+        <div id="menuOverlay" class="overlay menu-overlay" hidden>
+            <div class="overlay-card menu-card">
+                <header class="menu-head">
+                    <p class="eyebrow"><i></i> three.js · recife · bioluminescência</p>
+                    <h1>Nerei<span>da</span></h1>
+                    <p class="lede">Você é a arraia-manta do recife que canta. Deslize pelas
+                        correntes, atravesse os anéis de luz, colete pérolas e acompanhe a baleia
+                        até o templo náutilo. O abismo perdoa pouco — o combo, quase nada.</p>
+                </header>
+
+                <div class="menu-grid">
+                    <section class="menu-section">
+                        <h2>Maré</h2>
+                        <div id="difficultyOptions" class="chip-row" role="radiogroup" aria-label="Dificuldade"></div>
+                        <p id="difficultyBlurb" class="section-note"></p>
+                    </section>
+
+                    <section class="menu-section">
+                        <h2>Comandos</h2>
+                        <div class="keys">
+                            <span><kbd>WASD</kbd> / setas guiar</span>
+                            <span><kbd>Espaço</kbd> impulso · <kbd>Q</kbd> <kbd>E</kbd> pirueta</span>
+                            <span>Mouse: olhar / refinar o voo</span>
+                            <span><kbd>C</kbd> câmera · <kbd>P</kbd> pausa · <kbd>M</kbd> mudo</span>
+                        </div>
+                    </section>
+
+                    <section class="menu-section">
+                        <h2>Ajustes</h2>
+                        <div class="settings-grid">
+                            <label class="field">
+                                <span>Qualidade</span>
+                                <select id="qualitySelect">
+                                    <option value="auto">Automática</option>
+                                    <option value="low">Performance</option>
+                                    <option value="medium">Equilibrada</option>
+                                    <option value="high">Abissal</option>
+                                </select>
+                            </label>
+                            <label class="field">
+                                <span>Volume <b id="volumeValue">70</b></span>
+                                <input id="volumeSlider" type="range" min="0" max="100" step="1" value="70">
+                            </label>
+                        </div>
+                        <p class="section-note">Melhor canto: <b id="bestScore" class="mono">—</b></p>
+                    </section>
+                </div>
+
+                <footer class="menu-foot">
+                    <button id="startButton" class="primary-button" type="button">
+                        <span>Entrar na corrente</span>
+                        <i aria-hidden="true">→</i>
+                    </button>
+                </footer>
+            </div>
+        </div>
+
+        <div id="pauseOverlay" class="overlay" hidden>
+            <div class="overlay-card compact-card">
+                <p class="eyebrow"><i></i> PAUSA</p>
+                <h2>A maré<br>espera.</h2>
+                <div class="card-actions">
+                    <button id="resumeButton" class="primary-button" type="button">
+                        <span>Continuar</span><i aria-hidden="true">→</i>
+                    </button>
+                    <button id="pauseMenuButton" class="ghost-button" type="button">Voltar ao menu</button>
+                </div>
+            </div>
+        </div>
+
+        <div id="gameOverOverlay" class="overlay" hidden>
+            <div class="overlay-card compact-card defeat-card">
+                <p class="eyebrow" id="overEyebrow"><i></i> ABISMO</p>
+                <h2 id="overTitle">A corrente<br>te soltou.</h2>
+                <div id="overStats" class="stats"></div>
+                <div class="card-actions">
+                    <button id="retryButton" class="primary-button" type="button">
+                        <span>Outra maré</span><i aria-hidden="true">↻</i>
+                    </button>
+                    <button id="overMenuButton" class="ghost-button" type="button">Voltar ao menu</button>
+                </div>
+            </div>
+        </div>
+
+        <div id="errorOverlay" class="overlay" hidden>
+            <div class="overlay-card compact-card">
+                <p class="eyebrow eyebrow--danger"><i></i> Falha na maré</p>
+                <h2>O recife não<br>abriu.</h2>
+                <p class="lede" id="errorText">Este laboratório precisa de WebGL. Tente um navegador
+                    atualizado ou reative a aceleração de hardware.</p>
+            </div>
+        </div>
+
+        <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
+    </main>
+
+    <script src="/labs/shared.js?v=7" defer></script>
+    <script type="module" src="src/main.js"></script>
+</body>
+
+</html>

--- a/labs/nereida/src/audio.js
+++ b/labs/nereida/src/audio.js
@@ -1,0 +1,158 @@
+/**
+ * Pad submarino em ré menor, bolhas, impulso e sinos de pérola.
+ * Só Web Audio — nenhum sample externo.
+ */
+
+export class GameAudio {
+    constructor() {
+        this.ctx = null;
+        this.enabled = true;
+        this.volume = 0.7;
+        this.master = null;
+        this.music = null;
+        this.started = false;
+        this.step = 0;
+        this.acc = 0;
+        this.bpm = 72;
+    }
+
+    async resume() {
+        if (!this.enabled) return;
+        if (!this.ctx) this.boot();
+        if (this.ctx.state === 'suspended') await this.ctx.resume();
+        this.started = true;
+    }
+
+    boot() {
+        const AudioCtx = window.AudioContext || window.webkitAudioContext;
+        this.ctx = new AudioCtx();
+        this.master = this.ctx.createGain();
+        this.master.gain.value = this.volume;
+        this.master.connect(this.ctx.destination);
+
+        this.music = this.ctx.createGain();
+        this.music.gain.value = 0.38;
+        this.music.connect(this.master);
+
+        const noiseBuf = this.ctx.createBuffer(1, this.ctx.sampleRate * 2, this.ctx.sampleRate);
+        const data = noiseBuf.getChannelData(0);
+        for (let i = 0; i < data.length; i++) data[i] = Math.random() * 2 - 1;
+        const water = this.ctx.createBufferSource();
+        water.buffer = noiseBuf;
+        water.loop = true;
+        const hp = this.ctx.createBiquadFilter();
+        hp.type = 'bandpass';
+        hp.frequency.value = 420;
+        hp.Q.value = 0.35;
+        this.waterGain = this.ctx.createGain();
+        this.waterGain.gain.value = 0.055;
+        water.connect(hp);
+        hp.connect(this.waterGain);
+        this.waterGain.connect(this.master);
+        water.start();
+
+        this.whoosh = this.ctx.createOscillator();
+        this.whoosh.type = 'sawtooth';
+        this.whoosh.frequency.value = 48;
+        this.whooshGain = this.ctx.createGain();
+        this.whooshGain.gain.value = 0;
+        const lp = this.ctx.createBiquadFilter();
+        lp.type = 'lowpass';
+        lp.frequency.value = 280;
+        this.whoosh.connect(lp);
+        lp.connect(this.whooshGain);
+        this.whooshGain.connect(this.master);
+        this.whoosh.start();
+    }
+
+    setVolume(v) {
+        this.volume = v;
+        if (this.master) this.master.gain.value = this.enabled ? v : 0;
+    }
+
+    setEnabled(on) {
+        this.enabled = on;
+        if (this.master) this.master.gain.value = on ? this.volume : 0;
+    }
+
+    blip(freq, dur, type = 'sine', gain = 0.12) {
+        if (!this.ctx || !this.enabled || !this.started) return;
+        const t = this.ctx.currentTime;
+        const o = this.ctx.createOscillator();
+        const g = this.ctx.createGain();
+        o.type = type;
+        o.frequency.setValueAtTime(freq, t);
+        o.frequency.exponentialRampToValueAtTime(Math.max(40, freq * 0.6), t + dur);
+        g.gain.setValueAtTime(gain, t);
+        g.gain.exponentialRampToValueAtTime(0.001, t + dur);
+        o.connect(g);
+        g.connect(this.master);
+        o.start(t);
+        o.stop(t + dur + 0.02);
+    }
+
+    pearl(combo = 1) {
+        const base = 392 * Math.pow(2, (combo % 8) / 12);
+        this.blip(base, 0.22, 'sine', 0.11);
+        this.blip(base * 1.5, 0.28, 'triangle', 0.06);
+    }
+
+    ring(combo = 1) {
+        this.blip(523 * (1 + combo * 0.03), 0.18, 'sine', 0.1);
+        this.blip(784, 0.32, 'triangle', 0.05);
+    }
+
+    boostOn() {
+        this.blip(180, 0.2, 'sawtooth', 0.06);
+    }
+
+    hit() {
+        this.blip(90, 0.35, 'square', 0.1);
+        this.blip(40, 0.4, 'sawtooth', 0.07);
+    }
+
+    roll() {
+        this.blip(220, 0.16, 'triangle', 0.07);
+        this.blip(440, 0.22, 'sine', 0.05);
+    }
+
+    win() {
+        [523, 659, 784, 1046].forEach((f, i) => {
+            setTimeout(() => this.blip(f, 0.45, 'sine', 0.1), i * 140);
+        });
+    }
+
+    setWhoosh(amount) {
+        if (!this.whooshGain) return;
+        this.whooshGain.gain.value = amount * 0.08;
+        this.whoosh.frequency.value = 40 + amount * 70;
+    }
+
+    update(dt) {
+        if (!this.ctx || !this.enabled || !this.started || !this.music) return;
+        this.acc += dt;
+        const beat = 60 / this.bpm;
+        if (this.acc < beat) return;
+        this.acc -= beat;
+        this.step++;
+
+        const t = this.ctx.currentTime;
+        const scale = [146.83, 174.61, 196, 220, 261.63, 293.66];
+        const note = scale[this.step % scale.length];
+        const o = this.ctx.createOscillator();
+        const g = this.ctx.createGain();
+        const f = this.ctx.createBiquadFilter();
+        o.type = this.step % 4 === 0 ? 'sine' : 'triangle';
+        o.frequency.value = note / (this.step % 8 === 0 ? 1 : 2);
+        f.type = 'lowpass';
+        f.frequency.value = 720;
+        g.gain.setValueAtTime(0.0001, t);
+        g.gain.exponentialRampToValueAtTime(0.045, t + 0.04);
+        g.gain.exponentialRampToValueAtTime(0.0001, t + beat * 2.4);
+        o.connect(f);
+        f.connect(g);
+        g.connect(this.music);
+        o.start(t);
+        o.stop(t + beat * 2.6);
+    }
+}

--- a/labs/nereida/src/config.js
+++ b/labs/nereida/src/config.js
@@ -1,0 +1,163 @@
+/**
+ * Nereida — escala do recife, física do voo e presets.
+ *
+ * Unidades ≈ metros. A arraia segue um spline (a “corrente”) com liberdade
+ * lateral; o impulso é um tanque que recarrega e explode em velocidade.
+ *
+ * Fórmulas (arcade, não Navier–Stokes):
+ *   v'     = v + (vAlvo − v) * (1 − exp(−λ * dt))          // amortecimento exp.
+ *   vAlvo  = cruise * maré + boost * BOOST_MUL + anelBonus
+ *   roll   = damp(roll, −steerX * MAX_BANK, 8, dt)
+ *   pitch  = damp(pitch,  steerY * MAX_PITCH, 7, dt)
+ *   pos   += forward * v * dt
+ *   erro   = pos − path(s);  se |erro| > corredor, puxa com k * (1 − rMax/|erro|)
+ *   combo  = min(12, combo + 1) ao atravessar anel; decai se dtGap > COMBO_WINDOW
+ *   score  += pérola * 40 * combo + anel * 80 * combo + pirueta * 120
+ */
+
+export const STORAGE_KEY = 'nereida-v1';
+
+export const COURSE = {
+    length: 520,
+    /** Raio do corredor mole em torno do spline. */
+    corridor: 16,
+    /** Amostragem do spline para câmera e corrente (m). */
+    sample: 0.85
+};
+
+export const PHYS = {
+    cruise: 18,
+    maxSpeed: 46,
+    boostMul: 1.85,
+    boostCost: 0.38,
+    boostRegen: 0.22,
+    steer: 1.55,
+    maxBank: 0.72,
+    maxPitch: 0.48,
+    railK: 3.4,
+    dragLambda: 2.6,
+    radius: 1.15,
+    invuln: 1.25,
+    comboWindow: 2.4,
+    rollDuration: 0.72,
+    hitSlow: 0.55
+};
+
+export const CAMERA = {
+    chase: { dist: 9.2, height: 3.1, look: 4.8, fov: 62 },
+    shoulder: { dist: 5.4, height: 1.8, look: 5.2, fov: 72 },
+    cinematic: { dist: 16, height: 6.2, look: 3.2, fov: 52 },
+    mouse: 0.0024
+};
+
+export const DIFFICULTY = {
+    lagoon: {
+        id: 'lagoon',
+        label: 'Lagoa',
+        blurb: 'Corrente mansa, corredor largo, pérolas à vontade. Para flanar.',
+        lives: 5,
+        speed: 0.84,
+        corridor: 19,
+        pearls: 1.25,
+        jellies: 0.65
+    },
+    tide: {
+        id: 'tide',
+        label: 'Maré',
+        blurb: 'O ritmo certo: anéis no ponto, a baleia no meio, o templo no fim.',
+        lives: 3,
+        speed: 1,
+        corridor: 16,
+        pearls: 1,
+        jellies: 1
+    },
+    abyss: {
+        id: 'abyss',
+        label: 'Abismo',
+        blurb: 'Corrente cruel, corredor estreito. Encadeie ou a escuridão te come.',
+        lives: 2,
+        speed: 1.22,
+        corridor: 12.5,
+        pearls: 0.85,
+        jellies: 1.35
+    }
+};
+
+export const QUALITY = {
+    low: {
+        antialias: false,
+        pixelRatio: 1,
+        bloom: false,
+        shadows: false,
+        caustics: false,
+        fish: 48,
+        coral: 70,
+        kelp: 40,
+        bubbles: 50,
+        rays: 4
+    },
+    medium: {
+        antialias: true,
+        pixelRatio: 1.35,
+        bloom: true,
+        shadows: true,
+        caustics: true,
+        fish: 110,
+        coral: 130,
+        kelp: 70,
+        bubbles: 90,
+        rays: 8
+    },
+    high: {
+        antialias: true,
+        pixelRatio: 1.7,
+        bloom: true,
+        shadows: true,
+        caustics: true,
+        fish: 180,
+        coral: 190,
+        kelp: 110,
+        bubbles: 140,
+        rays: 12
+    }
+};
+
+export const PALETTE = {
+    abyss: 0x02141c,
+    fog: 0x053445,
+    lumen: 0x5ef0d8,
+    pearl: 0xf4d9a6,
+    coral: 0xff7a8a,
+    sand: 0xc4a574,
+    kelp: 0x1f6b4a
+};
+
+export const ZONES = [
+    { t: 0, name: 'Jardim de coral', fog: 0.016, tint: 0x0a5a62 },
+    { t: 0.28, name: 'Nau partida', fog: 0.02, tint: 0x063048 },
+    { t: 0.58, name: 'Catedral de lúmen', fog: 0.024, tint: 0x1a1848 },
+    { t: 0.88, name: 'Templo náutilo', fog: 0.018, tint: 0x06283a }
+];
+
+export function loadSettings() {
+    try {
+        return {
+            quality: 'auto',
+            volume: 70,
+            muted: false,
+            difficulty: 'tide',
+            best: 0,
+            ...JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}')
+        };
+    } catch {
+        return { quality: 'auto', volume: 70, muted: false, difficulty: 'tide', best: 0 };
+    }
+}
+
+export function saveSettings(s) {
+    try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(s));
+    } catch {
+        /* private mode */
+    }
+}

--- a/labs/nereida/src/effects.js
+++ b/labs/nereida/src/effects.js
@@ -1,0 +1,139 @@
+/**
+ * Bolhas, rastro da arraia e explosões de lúmen ao coletar.
+ */
+
+import * as THREE from 'three';
+
+export class Effects {
+    constructor(scene, quality) {
+        this.scene = scene;
+        this.bubbles = this._bubbles(quality.bubbles);
+        this.trail = [];
+        this.bursts = [];
+        this._trailPool(28);
+        this._burstPool(12);
+        this.time = 0;
+    }
+
+    _bubbles(count) {
+        const geo = new THREE.BufferGeometry();
+        const pos = new Float32Array(count * 3);
+        const phase = new Float32Array(count);
+        for (let i = 0; i < count; i++) {
+            pos[i * 3] = (Math.random() - 0.5) * 80;
+            pos[i * 3 + 1] = Math.random() * 40;
+            pos[i * 3 + 2] = Math.random() * 520;
+            phase[i] = Math.random() * Math.PI * 2;
+        }
+        geo.setAttribute('position', new THREE.BufferAttribute(pos, 3));
+        this.bubblePhase = phase;
+        const pts = new THREE.Points(
+            geo,
+            new THREE.PointsMaterial({
+                color: 0xc8fff8,
+                size: 0.16,
+                transparent: true,
+                opacity: 0.45,
+                depthWrite: false,
+                blending: THREE.AdditiveBlending
+            })
+        );
+        this.scene.add(pts);
+        return pts;
+    }
+
+    _trailPool(n) {
+        const geo = new THREE.SphereGeometry(0.12, 8, 6);
+        const mat = new THREE.MeshBasicMaterial({
+            color: 0x5ef0d8,
+            transparent: true,
+            opacity: 0.7,
+            blending: THREE.AdditiveBlending,
+            depthWrite: false
+        });
+        for (let i = 0; i < n; i++) {
+            const m = new THREE.Mesh(geo, mat.clone());
+            m.visible = false;
+            this.scene.add(m);
+            this.trail.push({ mesh: m, life: 0 });
+        }
+        this.trailIndex = 0;
+    }
+
+    _burstPool(n) {
+        const geo = new THREE.SphereGeometry(0.4, 10, 8);
+        const mat = new THREE.MeshBasicMaterial({
+            color: 0xf4d9a6,
+            transparent: true,
+            opacity: 0.8,
+            blending: THREE.AdditiveBlending,
+            depthWrite: false
+        });
+        for (let i = 0; i < n; i++) {
+            const m = new THREE.Mesh(geo, mat.clone());
+            m.visible = false;
+            this.scene.add(m);
+            this.bursts.push({ mesh: m, life: 0 });
+        }
+        this.burstIndex = 0;
+    }
+
+    spark(pos, color = 0x5ef0d8) {
+        const p = this.trail[this.trailIndex % this.trail.length];
+        this.trailIndex++;
+        p.mesh.position.copy(pos);
+        p.mesh.position.x += (Math.random() - 0.5) * 0.4;
+        p.mesh.position.y += (Math.random() - 0.5) * 0.3;
+        p.mesh.visible = true;
+        p.mesh.material.color.setHex(color);
+        p.mesh.material.opacity = 0.8;
+        p.mesh.scale.setScalar(0.7 + Math.random() * 0.8);
+        p.life = 0.55;
+    }
+
+    burst(pos, color = 0xf4d9a6) {
+        const p = this.bursts[this.burstIndex % this.bursts.length];
+        this.burstIndex++;
+        p.mesh.position.copy(pos);
+        p.mesh.visible = true;
+        p.mesh.material.color.setHex(color);
+        p.mesh.material.opacity = 0.9;
+        p.mesh.scale.setScalar(0.4);
+        p.life = 0.45;
+    }
+
+    update(dt, playerPos, boosting) {
+        this.time += dt;
+        const pos = this.bubbles.geometry.attributes.position;
+        for (let i = 0; i < this.bubblePhase.length; i++) {
+            let y = pos.getY(i) + dt * (0.4 + (i % 5) * 0.08);
+            if (y > 42) y = -4;
+            pos.setY(i, y);
+            pos.setX(i, pos.getX(i) + Math.sin(this.time + this.bubblePhase[i]) * 0.01);
+        }
+        pos.needsUpdate = true;
+
+        if (playerPos) {
+            this.spark(playerPos, boosting ? 0xf4d9a6 : 0x5ef0d8);
+        }
+
+        for (const p of this.trail) {
+            if (p.life <= 0) {
+                p.mesh.visible = false;
+                continue;
+            }
+            p.life -= dt;
+            p.mesh.material.opacity = p.life * 1.4;
+            p.mesh.scale.multiplyScalar(0.96);
+        }
+        for (const p of this.bursts) {
+            if (p.life <= 0) {
+                p.mesh.visible = false;
+                continue;
+            }
+            p.life -= dt;
+            p.mesh.scale.setScalar(0.4 + (0.45 - p.life) * 8);
+            p.mesh.material.opacity = p.life * 2;
+        }
+    }
+}

--- a/labs/nereida/src/hud.js
+++ b/labs/nereida/src/hud.js
@@ -1,0 +1,184 @@
+/**
+ * HUD, menus e overlays. Sem lógica 3D aqui.
+ */
+
+import { DIFFICULTY } from './config.js';
+import { formatTime, formatScore } from './utils.js';
+
+const $ = (id) => document.getElementById(id);
+
+export class Hud {
+    constructor() {
+        this.el = {
+            hud: $('hud'),
+            depth: $('depthValue'),
+            zone: $('zoneValue'),
+            progress: $('progressFill'),
+            boost: $('boostFill'),
+            speed: $('speedValue'),
+            pearls: $('pearlValue'),
+            combo: $('comboValue'),
+            lives: $('livesValue'),
+            fps: $('fpsCounter'),
+            message: $('message'),
+            touch: $('touchControls'),
+            soundButton: $('soundButton'),
+            pauseButton: $('pauseButton'),
+            loading: $('loadingOverlay'),
+            loadingFill: $('loadingFill'),
+            loadingText: $('loadingText'),
+            menu: $('menuOverlay'),
+            pause: $('pauseOverlay'),
+            gameOver: $('gameOverOverlay'),
+            overEyebrow: $('overEyebrow'),
+            overTitle: $('overTitle'),
+            error: $('errorOverlay'),
+            errorText: $('errorText'),
+            difficultyOptions: $('difficultyOptions'),
+            difficultyBlurb: $('difficultyBlurb'),
+            qualitySelect: $('qualitySelect'),
+            volumeSlider: $('volumeSlider'),
+            volumeValue: $('volumeValue'),
+            bestScore: $('bestScore'),
+            overStats: $('overStats'),
+            lookZone: $('lookZone'),
+            touchBoost: $('touchBoost'),
+            touchRoll: $('touchRoll'),
+            startButton: $('startButton'),
+            resumeButton: $('resumeButton'),
+            pauseMenuButton: $('pauseMenuButton'),
+            retryButton: $('retryButton'),
+            overMenuButton: $('overMenuButton')
+        };
+        this.msgTimer = 0;
+        this.buildDifficulties('tide');
+    }
+
+    setState(state) {
+        document.body.dataset.state = state;
+    }
+
+    setLoading(p, text) {
+        if (text) this.el.loadingText.textContent = text;
+        this.el.loadingFill.style.width = `${Math.round(p * 100)}%`;
+    }
+
+    hideLoading() {
+        this.el.loading.hidden = true;
+    }
+
+    showError(msg) {
+        if (msg) this.el.errorText.textContent = msg;
+        this.el.error.hidden = false;
+        this.el.loading.hidden = true;
+    }
+
+    showMenu(on) {
+        this.el.menu.hidden = !on;
+        this.el.hud.hidden = on;
+    }
+
+    showPause(on) {
+        this.el.pause.hidden = !on;
+    }
+
+    showGameOver(on, won = false) {
+        this.el.gameOver.hidden = !on;
+        if (on) {
+            this.el.overEyebrow.classList.toggle('eyebrow--danger', !won);
+            this.el.overEyebrow.innerHTML = won ? '<i></i> NÁUTILO' : '<i></i> ABISMO';
+            this.el.overTitle.innerHTML = won
+                ? 'O templo<br>abriu.'
+                : 'A corrente<br>te soltou.';
+        }
+    }
+
+    showHud(on) {
+        this.el.hud.hidden = !on;
+    }
+
+    setTouchVisible(on) {
+        this.el.touch.hidden = !on;
+    }
+
+    setMuted(on) {
+        this.el.soundButton.setAttribute('aria-pressed', String(!on));
+        this.el.soundButton.textContent = on ? '×♪' : '♪';
+    }
+
+    setFps(fps) {
+        if (!this.el.fps) return;
+        this.el.fps.textContent = `${fps | 0} fps`;
+    }
+
+    message(text, ms = 1600) {
+        this.el.message.textContent = text;
+        this.el.message.dataset.show = 'true';
+        clearTimeout(this.msgTimer);
+        this.msgTimer = setTimeout(() => {
+            this.el.message.dataset.show = 'false';
+        }, ms);
+    }
+
+    update({ depth, zone, progress, boost, speed, pearls, combo, lives }) {
+        this.el.depth.textContent = `${String(Math.max(0, depth | 0)).padStart(3, '0')} m`;
+        this.el.zone.textContent = zone;
+        this.el.progress.style.width = `${Math.round(clamp01(progress) * 100)}%`;
+        this.el.boost.style.width = `${Math.round(clamp01(boost) * 100)}%`;
+        this.el.speed.textContent = `${String(Math.round(speed * 1.94)).padStart(2, '0')} nós`;
+        this.el.pearls.textContent = String(pearls).padStart(2, '0');
+        this.el.combo.textContent = `${Math.floor(combo)}×`;
+        this.el.lives.textContent = '■'.repeat(lives) + '□'.repeat(Math.max(0, 5 - lives));
+    }
+
+    setBest(score) {
+        this.el.bestScore.textContent = score ? formatScore(score) : '—';
+    }
+
+    setOverStats({ pearls, combo, rings, time, score }) {
+        this.el.overStats.innerHTML = `
+            <div><span>Pérolas</span><b>${pearls}</b></div>
+            <div><span>Anéis</span><b>${rings}</b></div>
+            <div><span>Combo máx.</span><b>${combo}×</b></div>
+            <div><span>Tempo</span><b>${formatTime(time)}</b></div>
+            <div><span>Canto</span><b>${formatScore(score)}</b></div>
+        `;
+    }
+
+    buildDifficulties(current, onPick) {
+        const root = this.el.difficultyOptions;
+        root.innerHTML = '';
+        Object.values(DIFFICULTY).forEach((d) => {
+            const btn = document.createElement('button');
+            btn.type = 'button';
+            btn.className = 'chip';
+            btn.textContent = d.label;
+            btn.dataset.id = d.id;
+            btn.setAttribute('aria-pressed', String(d.id === current));
+            btn.addEventListener('click', () => {
+                root.querySelectorAll('.chip').forEach((c) => c.setAttribute('aria-pressed', 'false'));
+                btn.setAttribute('aria-pressed', 'true');
+                this.el.difficultyBlurb.textContent = d.blurb;
+                onPick?.(d.id);
+            });
+            root.appendChild(btn);
+        });
+        this.el.difficultyBlurb.textContent = DIFFICULTY[current].blurb;
+    }
+
+    bindSettings({ quality, volume, onQuality, onVolume }) {
+        this.el.qualitySelect.value = quality;
+        this.el.volumeSlider.value = String(volume);
+        this.el.volumeValue.textContent = String(volume);
+        this.el.qualitySelect.addEventListener('change', () => onQuality(this.el.qualitySelect.value));
+        this.el.volumeSlider.addEventListener('input', () => {
+            const v = Number(this.el.volumeSlider.value);
+            this.el.volumeValue.textContent = String(v);
+            onVolume(v);
+        });
+    }
+}
+
+function clamp01(v) {
+    return v < 0 ? 0 : v > 1 ? 1 : v;
+}

--- a/labs/nereida/src/input.js
+++ b/labs/nereida/src/input.js
@@ -1,0 +1,154 @@
+/**
+ * Teclado, mouse e toque. steerX/steerY ∈ [-1, 1].
+ */
+
+const MOVE_X = { KeyA: -1, ArrowLeft: -1, KeyD: 1, ArrowRight: 1 };
+const MOVE_Y = { KeyW: 1, ArrowUp: 1, KeyS: -1, ArrowDown: -1 };
+
+const ACTIONS = {
+    KeyP: 'pause',
+    Escape: 'pause',
+    KeyM: 'mute',
+    KeyC: 'camera',
+    Enter: 'confirm',
+    KeyQ: 'rollLeft',
+    KeyE: 'rollRight'
+};
+
+export class Input {
+    constructor() {
+        this.steerX = 0;
+        this.steerY = 0;
+        this.lookX = 0;
+        this.lookY = 0;
+        this.boost = false;
+        this.keys = new Set();
+        this.listeners = new Map();
+        this.enabled = true;
+        this.pointerLocked = false;
+        this._lookAccX = 0;
+        this._lookAccY = 0;
+        this.touchLook = { x: 0, y: 0 };
+        this.touchBoost = false;
+        this.touchSteer = { x: 0, y: 0 };
+
+        this._onKeyDown = (e) => {
+            if (ACTIONS[e.code]) {
+                if (ACTIONS[e.code] === 'confirm' && document.activeElement?.tagName === 'BUTTON') return;
+                this.emit(ACTIONS[e.code]);
+                e.preventDefault();
+                return;
+            }
+            if (
+                MOVE_X[e.code] !== undefined ||
+                MOVE_Y[e.code] !== undefined ||
+                e.code === 'Space'
+            ) {
+                this.keys.add(e.code);
+                e.preventDefault();
+            }
+        };
+        this._onKeyUp = (e) => this.keys.delete(e.code);
+        this._onMouseMove = (e) => {
+            if (!this.pointerLocked) return;
+            this._lookAccX += e.movementX || 0;
+            this._lookAccY += e.movementY || 0;
+        };
+        this._onPointerLock = () => {
+            this.pointerLocked = document.pointerLockElement != null;
+        };
+
+        window.addEventListener('keydown', this._onKeyDown);
+        window.addEventListener('keyup', this._onKeyUp);
+        window.addEventListener('mousemove', this._onMouseMove);
+        document.addEventListener('pointerlockchange', this._onPointerLock);
+    }
+
+    bindTouch({ lookZone, boost, roll }) {
+        const steerFrom = (el, e) => {
+            const r = el.getBoundingClientRect();
+            const t = e.touches?.[0] || e;
+            const x = ((t.clientX - r.left) / r.width) * 2 - 1;
+            const y = -(((t.clientY - r.top) / r.height) * 2 - 1);
+            this.touchSteer.x = Math.max(-1, Math.min(1, x * 1.4));
+            this.touchSteer.y = Math.max(-1, Math.min(1, y * 1.4));
+        };
+        lookZone.addEventListener('pointerdown', (e) => {
+            lookZone.setPointerCapture(e.pointerId);
+            steerFrom(lookZone, e);
+        });
+        lookZone.addEventListener('pointermove', (e) => {
+            if (e.buttons || e.pressure) steerFrom(lookZone, e);
+        });
+        const clearSteer = () => {
+            this.touchSteer.x = 0;
+            this.touchSteer.y = 0;
+        };
+        lookZone.addEventListener('pointerup', clearSteer);
+        lookZone.addEventListener('pointercancel', clearSteer);
+        lookZone.addEventListener('pointerleave', clearSteer);
+
+        const hold = (el, flag) => {
+            const on = (e) => {
+                e.preventDefault();
+                this[flag] = true;
+            };
+            const off = () => {
+                this[flag] = false;
+            };
+            el.addEventListener('pointerdown', on);
+            el.addEventListener('pointerup', off);
+            el.addEventListener('pointercancel', off);
+            el.addEventListener('pointerleave', off);
+        };
+        hold(boost, 'touchBoost');
+        roll.addEventListener('pointerdown', (e) => {
+            e.preventDefault();
+            this.emit('rollRight');
+        });
+    }
+
+    on(action, fn) {
+        if (!this.listeners.has(action)) this.listeners.set(action, new Set());
+        this.listeners.get(action).add(fn);
+    }
+
+    emit(action) {
+        this.listeners.get(action)?.forEach((fn) => fn());
+    }
+
+    requestLock(el) {
+        el?.requestPointerLock?.();
+    }
+
+    exitLock() {
+        if (document.pointerLockElement) document.exitPointerLock();
+    }
+
+    sample() {
+        this.lookX = this._lookAccX;
+        this.lookY = this._lookAccY;
+        this._lookAccX = 0;
+        this._lookAccY = 0;
+
+        if (!this.enabled) {
+            this.steerX = 0;
+            this.steerY = 0;
+            this.boost = false;
+            return this;
+        }
+
+        let mx = this.touchSteer.x;
+        let my = this.touchSteer.y;
+        for (const code of this.keys) {
+            if (MOVE_X[code] !== undefined) mx += MOVE_X[code];
+            if (MOVE_Y[code] !== undefined) my += MOVE_Y[code];
+        }
+        mx += this.lookX * 0.04;
+        my -= this.lookY * 0.04;
+        this.steerX = Math.max(-1, Math.min(1, mx));
+        this.steerY = Math.max(-1, Math.min(1, my));
+        this.boost = this.touchBoost || this.keys.has('Space');
+        return this;
+    }
+}

--- a/labs/nereida/src/main.js
+++ b/labs/nereida/src/main.js
@@ -1,0 +1,458 @@
+/**
+ * Nereida — laço principal.
+ * A arraia segue a corrente, os anéis alimentam o combo e o templo
+ * náutilo espera no fim do recife.
+ */
+
+import * as THREE from 'three';
+import { CAMERA, COURSE, DIFFICULTY, PHYS, QUALITY, ZONES, loadSettings, saveSettings } from './config.js';
+import { Effects } from './effects.js';
+import { GameAudio } from './audio.js';
+import { Hud } from './hud.js';
+import { Input } from './input.js';
+import { Manta } from './manta.js';
+import { tickShaders } from './shaders.js';
+import { causticTexture, coralTexture, mantaTexture, sandTexture, skyTexture } from './textures.js';
+import { clamp, detectMobile, detectSoftwareGL, zoneAt } from './utils.js';
+import { Reef } from './world.js';
+
+class Game {
+    constructor() {
+        this.settings = loadSettings();
+        this.state = 'boot';
+        this.hud = new Hud();
+        this.canvas = document.getElementById('scene');
+        this.audio = new GameAudio();
+        this.input = new Input();
+        this.time = 0;
+        this.playTime = 0;
+        this.fpsAccum = 0;
+        this.fpsFrames = 0;
+        this.comboGap = 0;
+        this.bindUi();
+        this.init();
+    }
+
+    resolveQuality() {
+        const choice = this.settings.quality;
+        if (choice !== 'auto' && QUALITY[choice]) return QUALITY[choice];
+        if (detectMobile() || detectSoftwareGL()) return QUALITY.low;
+        const cores = navigator.hardwareConcurrency || 8;
+        if (cores <= 4) return QUALITY.low;
+        const big = Math.min(window.innerWidth, window.innerHeight) >= 900;
+        return big ? QUALITY.high : QUALITY.medium;
+    }
+
+    bindUi() {
+        const h = this.hud.el;
+        this.hud.bindSettings({
+            quality: this.settings.quality,
+            volume: this.settings.volume,
+            onQuality: (v) => {
+                this.settings.quality = v;
+                saveSettings(this.settings);
+            },
+            onVolume: (v) => {
+                this.settings.volume = v;
+                this.audio.setVolume(v / 100);
+                saveSettings(this.settings);
+            }
+        });
+        this.hud.buildDifficulties(this.settings.difficulty, (id) => {
+            this.settings.difficulty = id;
+            saveSettings(this.settings);
+        });
+        this.hud.setBest(this.settings.best);
+        this.audio.setVolume(this.settings.volume / 100);
+        this.audio.setEnabled(!this.settings.muted);
+        this.hud.setMuted(this.settings.muted);
+
+        h.startButton.addEventListener('click', () => this.start());
+        h.resumeButton.addEventListener('click', () => this.resume());
+        h.pauseMenuButton.addEventListener('click', () => this.toMenu());
+        h.retryButton.addEventListener('click', () => this.start());
+        h.overMenuButton.addEventListener('click', () => this.toMenu());
+        h.soundButton.addEventListener('click', () => this.toggleMute());
+        h.pauseButton.addEventListener('click', () => {
+            if (this.state === 'playing') this.pause();
+            else if (this.state === 'paused') this.resume();
+        });
+
+        this.input.on('pause', () => {
+            if (this.state === 'playing') this.pause();
+            else if (this.state === 'paused') this.resume();
+            else if (this.state === 'menu') this.start();
+        });
+        this.input.on('mute', () => this.toggleMute());
+        this.input.on('camera', () => {
+            if (this.state !== 'playing' || !this.manta) return;
+            const name = this.manta.cycleCamera();
+            this.hud.message(name, 900);
+        });
+        this.input.on('confirm', () => {
+            if (this.state === 'menu') this.start();
+        });
+        this.input.on('rollLeft', () => this.tryRoll(-1));
+        this.input.on('rollRight', () => this.tryRoll(1));
+
+        this.input.bindTouch({
+            lookZone: h.lookZone,
+            boost: h.touchBoost,
+            roll: h.touchRoll
+        });
+    }
+
+    async init() {
+        this.hud.setLoading(0.08, 'A maré sobe…');
+        if (document.fonts?.ready) await document.fonts.ready;
+        this.quality = this.resolveQuality();
+
+        try {
+            this.renderer = new THREE.WebGLRenderer({
+                canvas: this.canvas,
+                antialias: this.quality.antialias,
+                powerPreference: 'high-performance',
+                stencil: false
+            });
+        } catch {
+            this.hud.showError('Não foi possível iniciar o WebGL neste navegador.');
+            return;
+        }
+
+        const pr = Math.min(window.devicePixelRatio || 1, this.quality.pixelRatio);
+        this.renderer.setPixelRatio(pr);
+        this.renderer.setSize(window.innerWidth, window.innerHeight, false);
+        this.renderer.toneMapping = THREE.ACESFilmicToneMapping;
+        this.renderer.toneMappingExposure = 1.05;
+        this.renderer.shadowMap.enabled = this.quality.shadows;
+        this.renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+        this.renderer.outputColorSpace = THREE.SRGBColorSpace;
+
+        this.scene = new THREE.Scene();
+        this.scene.background = new THREE.Color(0x02141c);
+        this.scene.fog = new THREE.FogExp2(0x053445, 0.018);
+
+        this.camera = new THREE.PerspectiveCamera(CAMERA.chase.fov, window.innerWidth / window.innerHeight, 0.2, 420);
+        this.camera.position.set(0, 20, -12);
+
+        this.hud.setLoading(0.22, 'Tecendo caústicas…');
+        this.textures = {
+            sand: sandTexture(THREE),
+            coral: coralTexture(THREE),
+            manta: mantaTexture(THREE),
+            sky: skyTexture(THREE),
+            caustic: causticTexture(THREE)
+        };
+
+        const hemi = new THREE.HemisphereLight(0x7ad0d8, 0x0a2430, 0.85);
+        this.scene.add(hemi);
+        const sun = new THREE.DirectionalLight(0xd8fff6, 1.35);
+        sun.position.set(18, 42, 8);
+        sun.castShadow = this.quality.shadows;
+        if (sun.castShadow) {
+            sun.shadow.mapSize.set(1024, 1024);
+            sun.shadow.camera.near = 2;
+            sun.shadow.camera.far = 120;
+            sun.shadow.camera.left = -40;
+            sun.shadow.camera.right = 40;
+            sun.shadow.camera.top = 40;
+            sun.shadow.camera.bottom = -40;
+        }
+        this.sun = sun;
+        this.scene.add(sun);
+        this.scene.add(new THREE.AmbientLight(0x1a3a48, 0.35));
+
+        this.hud.setLoading(0.48, 'Plantando o recife…');
+        const diff = DIFFICULTY[this.settings.difficulty] || DIFFICULTY.tide;
+        this.reef = new Reef(this.scene, this.quality, diff, this.textures);
+        this.manta = new Manta(this.scene, this.camera, this.textures);
+        this.effects = new Effects(this.scene, this.quality);
+
+        this.hud.setLoading(0.78, 'Afinando o canto…');
+        await this.setupPostProcessing();
+
+        this.hud.setTouchVisible(detectMobile());
+        window.addEventListener('resize', () => this.resize());
+        document.addEventListener('visibilitychange', () => {
+            if (document.hidden && this.state === 'playing') this.pause();
+        });
+
+        this.hud.setLoading(1, 'A corrente chama');
+        setTimeout(() => {
+            this.hud.hideLoading();
+            this.toMenu();
+            this.lastFrame = performance.now();
+            this.renderer.setAnimationLoop((now) => this.frame(now));
+        }, 240);
+    }
+
+    async setupPostProcessing() {
+        if (!this.quality.bloom) return;
+        try {
+            const [{ EffectComposer }, { RenderPass }, { UnrealBloomPass }, { OutputPass }] = await Promise.all([
+                import('three/addons/postprocessing/EffectComposer.js'),
+                import('three/addons/postprocessing/RenderPass.js'),
+                import('three/addons/postprocessing/UnrealBloomPass.js'),
+                import('three/addons/postprocessing/OutputPass.js')
+            ]);
+            const composer = new EffectComposer(this.renderer);
+            composer.setPixelRatio(this.renderer.getPixelRatio());
+            composer.setSize(window.innerWidth, window.innerHeight);
+            composer.addPass(new RenderPass(this.scene, this.camera));
+            const bloom = new UnrealBloomPass(
+                new THREE.Vector2(window.innerWidth, window.innerHeight),
+                0.48,
+                0.62,
+                0.38
+            );
+            composer.addPass(bloom);
+            composer.addPass(new OutputPass());
+            this.composer = composer;
+        } catch {
+            this.composer = null;
+        }
+    }
+
+    resize() {
+        const w = window.innerWidth;
+        const h = window.innerHeight;
+        this.camera.aspect = w / h;
+        this.camera.updateProjectionMatrix();
+        this.renderer.setSize(w, h, false);
+        this.composer?.setSize(w, h);
+    }
+
+    diff() {
+        return DIFFICULTY[this.settings.difficulty] || DIFFICULTY.tide;
+    }
+
+    toMenu() {
+        this.state = 'menu';
+        this.input.enabled = false;
+        this.input.exitLock();
+        this.hud.setState('menu');
+        this.hud.showPause(false);
+        this.hud.showGameOver(false);
+        this.hud.showMenu(true);
+        this.hud.showHud(false);
+        this.manta?.reset();
+    }
+
+    async start() {
+        await this.audio.resume();
+        const d = this.diff();
+        this.lives = d.lives;
+        this.pearls = 0;
+        this.rings = 0;
+        this.combo = 1;
+        this.maxCombo = 1;
+        this.score = 0;
+        this.playTime = 0;
+        this.comboGap = 0;
+        this.won = false;
+        this._wreckSaid = false;
+        this._whaleSaid = false;
+        this._boostLatch = false;
+        this.reef.reset();
+        this.manta.reset();
+        this.state = 'playing';
+        this.input.enabled = true;
+        this.hud.setState('playing');
+        this.hud.showMenu(false);
+        this.hud.showPause(false);
+        this.hud.showGameOver(false);
+        this.hud.showHud(true);
+        this.hud.message('A corrente te leva', 1400);
+        this.input.requestLock(this.canvas);
+        this.canvas.addEventListener('click', () => {
+            if (this.state === 'playing') this.input.requestLock(this.canvas);
+        }, { once: true });
+    }
+
+    pause() {
+        if (this.state !== 'playing') return;
+        this.state = 'paused';
+        this.input.enabled = false;
+        this.input.exitLock();
+        this.hud.setState('paused');
+        this.hud.showPause(true);
+    }
+
+    resume() {
+        if (this.state !== 'paused') return;
+        this.state = 'playing';
+        this.input.enabled = true;
+        this.hud.setState('playing');
+        this.hud.showPause(false);
+        this.input.requestLock(this.canvas);
+        this.lastFrame = performance.now();
+    }
+
+    toggleMute() {
+        this.settings.muted = !this.settings.muted;
+        this.audio.setEnabled(!this.settings.muted);
+        this.hud.setMuted(this.settings.muted);
+        saveSettings(this.settings);
+    }
+
+    tryRoll(dir) {
+        if (this.state !== 'playing' || !this.manta) return;
+        if (this.manta.startRoll(dir)) {
+            this.audio.roll();
+            this.combo = Math.min(12, this.combo + 0.5);
+            this.score += 120 * this.combo;
+            this.comboGap = 0;
+            this.hud.message('pirueta', 700);
+            this.effects.burst(this.manta.pos, 0x5ef0d8);
+        }
+    }
+
+    finish(won) {
+        this.won = won;
+        this.state = 'over';
+        this.input.enabled = false;
+        this.input.exitLock();
+        if (won) {
+            this.score += Math.max(0, 4000 - this.playTime * 12);
+            this.audio.win();
+        }
+        if (this.score > (this.settings.best || 0)) {
+            this.settings.best = Math.floor(this.score);
+            saveSettings(this.settings);
+            this.hud.setBest(this.settings.best);
+        }
+        this.hud.setState('over');
+        this.hud.showHud(true);
+        this.hud.setOverStats({
+            pearls: this.pearls,
+            combo: Math.floor(this.maxCombo),
+            rings: this.rings,
+            time: this.playTime,
+            score: this.score
+        });
+        this.hud.showGameOver(true, won);
+        this.hud.message(won ? 'O náutilo canta' : 'Escamas ao vento', 1800);
+    }
+
+    hurt() {
+        if (this.manta.invuln > 0) return;
+        this.manta.hit();
+        this.audio.hit();
+        this.lives -= 1;
+        this.combo = 1;
+        this.effects.burst(this.manta.pos, 0xff7a8a);
+        this.hud.message('choque', 800);
+        if (this.lives <= 0) this.finish(false);
+    }
+
+    frame(now) {
+        const dt = clamp((now - (this.lastFrame || now)) / 1000, 0, 0.05);
+        this.lastFrame = now;
+        this.time += dt;
+        this.fpsAccum += dt;
+        this.fpsFrames++;
+        if (this.fpsAccum >= 0.4) {
+            this.hud.setFps(this.fpsFrames / this.fpsAccum);
+            this.fpsAccum = 0;
+            this.fpsFrames = 0;
+        }
+
+        this.input.sample();
+        const attract = this.state === 'menu' || this.state === 'boot';
+        if (attract && this.manta) {
+            this.manta.s = (this.time * 6) % (COURSE.length * 0.4);
+            this.manta.lat = Math.sin(this.time * 0.35) * 4;
+            this.manta.vert = Math.cos(this.time * 0.28) * 2;
+            this.manta.speed = 10;
+            this.manta.syncPose(dt);
+            this.manta.updateCamera(dt);
+        }
+
+        if (this.state === 'playing') {
+            this.playTime += dt;
+            this.comboGap += dt;
+            if (this.comboGap > PHYS.comboWindow) this.combo = Math.max(1, this.combo - dt * 1.8);
+
+            const boosting = this.input.boost && this.manta.boost > 0.02;
+            if (boosting && !this._boostLatch) {
+                this.audio.boostOn();
+                this._boostLatch = true;
+            }
+            if (!boosting) this._boostLatch = false;
+            const reached = this.manta.update(dt, this.input, this.diff(), boosting);
+            this.audio.setWhoosh(this.manta.speed / PHYS.maxSpeed);
+
+            const events = this.reef.collect(this.manta.pos, PHYS.radius);
+            for (const ev of events) {
+                if (ev.type === 'ring') {
+                    this.rings += 1;
+                    this.combo = Math.min(12, this.combo + 1);
+                    this.maxCombo = Math.max(this.maxCombo, this.combo);
+                    this.comboGap = 0;
+                    this.score += 80 * this.combo;
+                    this.manta.boost = Math.min(1, this.manta.boost + 0.22);
+                    this.manta.speed += 3;
+                    this.audio.ring(this.combo);
+                    this.effects.burst(this.manta.pos, 0x5ef0d8);
+                    if (this.combo >= 4) this.hud.message(`${Math.floor(this.combo)}× corrente`, 900);
+                } else if (ev.type === 'pearl') {
+                    this.pearls += 1;
+                    this.comboGap = 0;
+                    this.combo = Math.min(12, this.combo + 0.35);
+                    this.score += 40 * this.combo;
+                    this.audio.pearl(this.combo);
+                    this.effects.burst(this.manta.pos, 0xf4d9a6);
+                } else if (ev.type === 'jelly') {
+                    this.hurt();
+                }
+            }
+
+            const t = clamp(this.manta.s / COURSE.length, 0, 1);
+            if (t > 0.36 && t < 0.42 && !this._wreckSaid) {
+                this._wreckSaid = true;
+                this.hud.message('A nau partida', 1400);
+            }
+            if (t > 0.54 && t < 0.6 && !this._whaleSaid) {
+                this._whaleSaid = true;
+                this.hud.message('A baleia passa', 1400);
+            }
+            if (reached) this.finish(true);
+        } else {
+            this._wreckSaid = false;
+            this._whaleSaid = false;
+        }
+
+        this.reef.update(dt, this.time);
+        const boosting = this.state === 'playing' && this.input.boost;
+        this.effects.update(dt, this.state === 'playing' ? this.manta.pos : null, boosting);
+        tickShaders(this.scene, this.time);
+        this.audio.update(dt);
+
+        const t = this.manta ? clamp(this.manta.s / COURSE.length, 0, 1) : 0;
+        const zone = zoneAt(t, ZONES);
+        if (this.scene.fog) {
+            this.scene.fog.density = zone.fog;
+            this.scene.fog.color.setHex(zone.tint);
+        }
+        this.scene.background.setHex(zone.tint);
+
+        if (this.state === 'playing' || this.state === 'paused') {
+            const depth = Math.max(4, 42 - this.manta.pos.y);
+            this.hud.update({
+                depth,
+                zone: zone.name,
+                progress: t,
+                boost: this.manta.boost,
+                speed: this.manta.speed,
+                pearls: this.pearls,
+                combo: this.combo,
+                lives: this.lives
+            });
+        }
+
+        if (this.composer) this.composer.render();
+        else this.renderer.render(this.scene, this.camera);
+    }
+}
+
+new Game();

--- a/labs/nereida/src/manta.js
+++ b/labs/nereida/src/manta.js
@@ -1,0 +1,258 @@
+/**
+ * Arraia-manta em geometria nativa. As asas batem com
+ *   flap = sin(t * (1.8 + speed * 0.12)) * 0.48
+ * e a pirueta soma um roll extra de 2π em PHYS.rollDuration segundos.
+ */
+
+import * as THREE from 'three';
+import { CAMERA, COURSE, PHYS } from './config.js';
+import { clamp, damp, pathFrame } from './utils.js';
+
+const CAM_RIGS = [CAMERA.chase, CAMERA.shoulder, CAMERA.cinematic];
+
+export class Manta {
+    constructor(scene, camera, textures) {
+        this.scene = scene;
+        this.camera = camera;
+        this.group = buildManta(textures);
+        scene.add(this.group);
+
+        this.s = 8;
+        this.lat = 0;
+        this.vert = 0;
+        this.speed = PHYS.cruise;
+        this.boost = 1;
+        this.yaw = 0;
+        this.pitch = 0;
+        this.roll = 0;
+        this.spin = 0;
+        this.spinDir = 0;
+        this.invuln = 0;
+        this.lookYaw = 0;
+        this.lookPitch = 0;
+        this.camMode = 0;
+        this.pos = new THREE.Vector3();
+        this.forward = new THREE.Vector3(0, 0, 1);
+        this._q = new THREE.Quaternion();
+        this._extra = new THREE.Quaternion();
+        this._e = new THREE.Euler();
+        this._cam = new THREE.Vector3();
+        this._look = new THREE.Vector3();
+        this._tmp = new THREE.Vector3();
+        this._right = new THREE.Vector3();
+        this._up = new THREE.Vector3();
+        this._basis = new THREE.Matrix4();
+    }
+
+    reset() {
+        this.s = 8;
+        this.lat = 0;
+        this.vert = 0;
+        this.speed = PHYS.cruise * 0.6;
+        this.boost = 1;
+        this.yaw = 0;
+        this.pitch = 0;
+        this.roll = 0;
+        this.spin = 0;
+        this.spinDir = 0;
+        this.invuln = 0;
+        this.lookYaw = 0;
+        this.lookPitch = 0;
+        this.group.visible = true;
+        this.syncPose(0);
+    }
+
+    cycleCamera() {
+        this.camMode = (this.camMode + 1) % CAM_RIGS.length;
+        return ['perseguição', 'ombro', 'cinema'][this.camMode];
+    }
+
+    startRoll(dir) {
+        if (this.spin > 0) return false;
+        this.spin = PHYS.rollDuration;
+        this.spinDir = dir < 0 ? -1 : 1;
+        this.invuln = Math.max(this.invuln, PHYS.rollDuration * 0.85);
+        return true;
+    }
+
+    hit() {
+        this.invuln = PHYS.invuln;
+        this.speed *= PHYS.hitSlow;
+        this.boost = Math.max(0, this.boost - 0.25);
+    }
+
+    update(dt, input, diff, boosting) {
+        const length = COURSE.length;
+        const cruise = PHYS.cruise * diff.speed;
+        const target = cruise * (boosting && this.boost > 0.04 ? PHYS.boostMul : 1);
+        this.speed = damp(this.speed, target, PHYS.dragLambda, dt);
+        this.speed = clamp(this.speed, 6, PHYS.maxSpeed * diff.speed);
+
+        if (boosting && this.boost > 0) {
+            this.boost = Math.max(0, this.boost - PHYS.boostCost * dt);
+        } else {
+            this.boost = Math.min(1, this.boost + PHYS.boostRegen * dt);
+        }
+
+        const steer = PHYS.steer * (0.7 + this.speed / 40);
+        this.lat = clamp(this.lat + input.steerX * steer * 9 * dt, -diff.corridor, diff.corridor);
+        this.vert = clamp(this.vert + input.steerY * steer * 7 * dt, -diff.corridor * 0.72, diff.corridor * 0.72);
+
+        this.s += this.speed * dt;
+        this.lookYaw = damp(this.lookYaw, 0, 3, dt);
+        this.lookPitch = damp(this.lookPitch, 0, 3, dt);
+
+        const bankT = -input.steerX * PHYS.maxBank;
+        const pitchT = input.steerY * PHYS.maxPitch;
+        this.roll = damp(this.roll, bankT, 8, dt);
+        this.pitch = damp(this.pitch, pitchT, 7, dt);
+
+        if (this.spin > 0) {
+            this.spin = Math.max(0, this.spin - dt);
+            const k = 1 - this.spin / PHYS.rollDuration;
+            this.roll += this.spinDir * k * Math.PI * 2 * (dt / PHYS.rollDuration) * 8;
+        }
+
+        this.invuln = Math.max(0, this.invuln - dt);
+        this.syncPose(dt);
+        this.updateCamera(dt);
+        return this.s >= length - 6;
+    }
+
+    syncPose(dt) {
+        const frame = pathFrame(this.s, COURSE.length);
+        const { p, f, r, u } = frame;
+        this.pos.set(
+            p.x + r.x * this.lat + u.x * this.vert,
+            p.y + r.y * this.lat + u.y * this.vert,
+            p.z + r.z * this.lat + u.z * this.vert
+        );
+        this.forward.set(f.x, f.y, f.z);
+        this.group.position.copy(this.pos);
+
+        this._e.set(this.pitch, 0, this.roll, 'YXZ');
+        this._right.set(r.x, r.y, r.z);
+        this._up.set(u.x, u.y, u.z);
+        this._basis.makeBasis(this._right, this._up, this.forward);
+        this._q.setFromRotationMatrix(this._basis);
+        this._extra.setFromEuler(this._e);
+        this.group.quaternion.copy(this._q).multiply(this._extra);
+
+        const flap = Math.sin(performance.now() * 0.001 * (1.8 + this.speed * 0.12)) * 0.48;
+        const wings = this.group.userData.wings;
+        if (wings) {
+            wings.l.rotation.z = 0.18 + flap;
+            wings.r.rotation.z = -0.18 - flap;
+            wings.tail.rotation.x = flap * 0.25;
+        }
+        this.group.userData.glow.intensity = 1.2 + this.boost * 1.8 + (this.spin > 0 ? 2 : 0);
+
+        if (this.invuln > 0) {
+            this.group.visible = Math.sin(this.invuln * 28) > -0.2;
+        } else {
+            this.group.visible = true;
+        }
+        void dt;
+    }
+
+    updateCamera(dt) {
+        const rig = CAM_RIGS[this.camMode];
+        const ahead = pathFrame(this.s + rig.look, COURSE.length);
+        this._look.set(ahead.p.x, ahead.p.y + 0.4, ahead.p.z);
+        this._look.lerp(this.pos, 0.35);
+
+        this._cam.copy(this.pos)
+            .addScaledVector(this.forward, -rig.dist)
+            .add(this._tmp.set(0, rig.height, 0));
+
+        this.camera.position.lerp(this._cam, 1 - Math.exp(-5.5 * dt));
+        this.camera.lookAt(this._look);
+        const fovT = rig.fov + Math.max(0, this.speed - 16) * 0.35;
+        this.camera.fov = damp(this.camera.fov, fovT, 4, dt);
+        this.camera.updateProjectionMatrix();
+    }
+}
+
+function buildManta(textures) {
+    const g = new THREE.Group();
+    const skin = new THREE.MeshPhysicalMaterial({
+        map: textures.manta,
+        roughness: 0.32,
+        metalness: 0.14,
+        emissive: new THREE.Color(0x042028),
+        emissiveIntensity: 0.45,
+        iridescence: 0.9,
+        iridescenceIOR: 1.28,
+        sheen: 0.45,
+        sheenColor: new THREE.Color(0x5ef0d8),
+        clearcoat: 0.28,
+        clearcoatRoughness: 0.4
+    });
+    const belly = new THREE.MeshStandardMaterial({
+        color: 0xe8f2ee,
+        roughness: 0.55,
+        metalness: 0.05
+    });
+
+    const body = new THREE.Mesh(new THREE.SphereGeometry(1, 24, 16), skin);
+    body.scale.set(1.15, 0.28, 1.85);
+    body.castShadow = true;
+    g.add(body);
+
+    const head = new THREE.Mesh(new THREE.SphereGeometry(0.42, 16, 12), skin);
+    head.position.set(0, 0.02, 1.55);
+    head.scale.set(1.1, 0.7, 1.2);
+    g.add(head);
+
+    const wingGeo = new THREE.BoxGeometry(2.6, 0.08, 1.35);
+    wingGeo.translate(1.3, 0, 0);
+    const wingL = new THREE.Mesh(wingGeo, skin);
+    const wingR = new THREE.Mesh(wingGeo, skin);
+    wingR.scale.x = -1;
+    g.add(wingL, wingR);
+
+    const tipL = new THREE.Mesh(new THREE.ConeGeometry(0.12, 0.7, 8), skin);
+    tipL.rotation.z = -Math.PI / 2;
+    tipL.position.set(2.7, 0, -0.15);
+    const tipR = tipL.clone();
+    tipR.position.x = -2.7;
+    tipR.rotation.z = Math.PI / 2;
+    g.add(tipL, tipR);
+
+    const horn = new THREE.Mesh(new THREE.BoxGeometry(0.12, 0.08, 0.55), belly);
+    const hL = horn.clone();
+    hL.position.set(0.28, -0.05, 1.95);
+    hL.rotation.y = 0.35;
+    const hR = horn.clone();
+    hR.position.set(-0.28, -0.05, 1.95);
+    hR.rotation.y = -0.35;
+    g.add(hL, hR);
+
+    const tail = new THREE.Mesh(new THREE.CylinderGeometry(0.04, 0.02, 1.8, 8), skin);
+    tail.rotation.x = Math.PI / 2;
+    tail.position.set(0, 0.02, -2.1);
+    g.add(tail);
+
+    const eyeM = new THREE.MeshStandardMaterial({
+        color: 0x0a1014,
+        roughness: 0.2,
+        emissive: 0x5ef0d8,
+        emissiveIntensity: 0.35
+    });
+    const eye = new THREE.Mesh(new THREE.SphereGeometry(0.07, 10, 8), eyeM);
+    const eL = eye.clone();
+    eL.position.set(0.32, 0.08, 1.72);
+    const eR = eye.clone();
+    eR.position.set(-0.32, 0.08, 1.72);
+    g.add(eL, eR);
+
+    const glow = new THREE.PointLight(0x5ef0d8, 1.4, 18, 2);
+    glow.position.set(0, 0.4, 0.2);
+    g.add(glow);
+
+    g.userData.wings = { l: wingL, r: wingR, tail };
+    g.userData.glow = glow;
+    wingL.castShadow = true;
+    wingR.castShadow = true;
+    return g;
+}

--- a/labs/nereida/src/shaders.js
+++ b/labs/nereida/src/shaders.js
@@ -1,0 +1,85 @@
+/**
+ * Caústicas projetadas no fundo e pele iridescente da arraia.
+ * Injetadas em MeshStandardMaterial via onBeforeCompile.
+ */
+
+const CAUSTIC_KEY = 'nereida-caustics-v1';
+const SKIN_KEY = 'nereida-skin-v1';
+
+export function applyCaustics(material, strength = 0.42) {
+    material.onBeforeCompile = (shader) => {
+        shader.uniforms.uTime = { value: 0 };
+        shader.uniforms.uCaustic = { value: strength };
+        shader.vertexShader = shader.vertexShader
+            .replace(
+                '#include <common>',
+                `#include <common>\nvarying vec3 vWorldPos;`
+            )
+            .replace(
+                '#include <worldpos_vertex>',
+                `#include <worldpos_vertex>\nvWorldPos = (modelMatrix * vec4(transformed, 1.0)).xyz;`
+            );
+        shader.fragmentShader = shader.fragmentShader
+            .replace(
+                '#include <common>',
+                `#include <common>
+                uniform float uTime;
+                uniform float uCaustic;
+                varying vec3 vWorldPos;
+                float caustic(vec2 p, float t) {
+                    vec2 q = p;
+                    float c = 0.0;
+                    c += sin(q.x * 3.1 + t * 1.25) * sin(q.y * 2.7 - t * 0.9);
+                    c += sin(q.x * 5.4 - t * 0.7) * sin(q.y * 4.2 + t * 1.05);
+                    c += sin((q.x + q.y) * 2.15 + t * 0.6);
+                    return pow(max(c * 0.28 + 0.18, 0.0), 2.15);
+                }`
+            )
+            .replace(
+                '#include <emissivemap_fragment>',
+                `#include <emissivemap_fragment>
+                float cau = caustic(vWorldPos.xz * 0.11, uTime);
+                float depthFade = smoothstep(2.0, 28.0, vWorldPos.y);
+                totalEmissiveRadiance += vec3(0.22, 0.85, 0.92) * cau * uCaustic * depthFade;`
+            );
+        material.userData.shader = shader;
+    };
+    material.customProgramCacheKey = () => CAUSTIC_KEY;
+    return material;
+}
+
+export function applyMantaSkin(material) {
+    material.onBeforeCompile = (shader) => {
+        shader.uniforms.uTime = { value: 0 };
+        shader.fragmentShader = shader.fragmentShader
+            .replace(
+                '#include <common>',
+                `#include <common>
+                uniform float uTime;`
+            )
+            .replace(
+                '#include <emissivemap_fragment>',
+                `#include <emissivemap_fragment>
+                float fres = pow(1.0 - max(dot(normalize(vNormal), normalize(vViewPosition)), 0.0), 2.4);
+                vec3 irid = vec3(0.25, 0.95, 0.85) * fres + vec3(0.55, 0.35, 1.0) * fres * fres;
+                totalEmissiveRadiance += irid * (0.35 + 0.15 * sin(uTime * 2.2));`
+            );
+        material.userData.shader = shader;
+    };
+    material.customProgramCacheKey = () => SKIN_KEY;
+    return material;
+}
+
+export function tickShaders(root, time) {
+    root.traverse((obj) => {
+        const sh = obj.material?.userData?.shader;
+        if (sh?.uniforms?.uTime) sh.uniforms.uTime.value = time;
+        if (Array.isArray(obj.material)) {
+            for (const m of obj.material) {
+                if (m.userData?.shader?.uniforms?.uTime) {
+                    m.userData.shader.uniforms.uTime.value = time;
+                }
+            }
+        }
+    });
+}

--- a/labs/nereida/src/textures.js
+++ b/labs/nereida/src/textures.js
@@ -1,0 +1,117 @@
+/**
+ * Texturas geradas em canvas: areia, coral, pele da arraia e caústicas.
+ */
+
+export function makeCanvas(size, draw, h = size) {
+    const canvas = document.createElement('canvas');
+    canvas.width = size;
+    canvas.height = h;
+    const ctx = canvas.getContext('2d');
+    draw(ctx, size, h);
+    return canvas;
+}
+
+export function canvasTexture(THREE, canvas, { repeatX = 1, repeatY = 1 } = {}) {
+    const tex = new THREE.CanvasTexture(canvas);
+    tex.wrapS = THREE.RepeatWrapping;
+    tex.wrapT = THREE.RepeatWrapping;
+    tex.repeat.set(repeatX, repeatY);
+    tex.anisotropy = 4;
+    tex.needsUpdate = true;
+    if (THREE.SRGBColorSpace) tex.colorSpace = THREE.SRGBColorSpace;
+    return tex;
+}
+
+export function sandTexture(THREE) {
+    const canvas = makeCanvas(256, (ctx, s) => {
+        ctx.fillStyle = '#c4a574';
+        ctx.fillRect(0, 0, s, s);
+        for (let i = 0; i < 1400; i++) {
+            const n = Math.random();
+            ctx.fillStyle = `rgba(${160 + n * 70 | 0},${120 + n * 50 | 0},${70 + n * 40 | 0},${0.35})`;
+            ctx.fillRect(Math.random() * s, Math.random() * s, 2 + n * 3, 1 + n * 2);
+        }
+        ctx.fillStyle = 'rgba(80, 50, 30, 0.12)';
+        for (let i = 0; i < 12; i++) {
+            ctx.beginPath();
+            ctx.ellipse(Math.random() * s, Math.random() * s, 8 + Math.random() * 18, 3, Math.random(), 0, Math.PI * 2);
+            ctx.fill();
+        }
+    });
+    return canvasTexture(THREE, canvas, { repeatX: 8, repeatY: 8 });
+}
+
+export function coralTexture(THREE, hue = 12) {
+    const canvas = makeCanvas(128, (ctx, s) => {
+        ctx.fillStyle = `hsl(${hue} 55% 48%)`;
+        ctx.fillRect(0, 0, s, s);
+        for (let i = 0; i < 80; i++) {
+            ctx.fillStyle = `hsla(${hue + Math.random() * 20} 60% ${40 + Math.random() * 30}% / 0.5)`;
+            ctx.beginPath();
+            ctx.arc(Math.random() * s, Math.random() * s, 2 + Math.random() * 6, 0, Math.PI * 2);
+            ctx.fill();
+        }
+    });
+    return canvasTexture(THREE, canvas, { repeatX: 2, repeatY: 2 });
+}
+
+export function mantaTexture(THREE) {
+    const canvas = makeCanvas(256, (ctx, s) => {
+        const g = ctx.createLinearGradient(0, 0, 0, s);
+        g.addColorStop(0, '#0a2a3a');
+        g.addColorStop(0.45, '#12384c');
+        g.addColorStop(0.72, '#cfd8d4');
+        g.addColorStop(1, '#eef4f0');
+        ctx.fillStyle = g;
+        ctx.fillRect(0, 0, s, s);
+        ctx.fillStyle = 'rgba(240, 248, 255, 0.85)';
+        for (let i = 0; i < 28; i++) {
+            const x = 30 + Math.random() * 196;
+            const y = 20 + Math.random() * 110;
+            ctx.beginPath();
+            ctx.ellipse(x, y, 3 + Math.random() * 7, 2 + Math.random() * 4, 0.3, 0, Math.PI * 2);
+            ctx.fill();
+        }
+        ctx.fillStyle = 'rgba(20, 80, 90, 0.35)';
+        ctx.fillRect(0, 0, s, 8);
+    });
+    const tex = canvasTexture(THREE, canvas);
+    tex.wrapS = THREE.ClampToEdgeWrapping;
+    tex.wrapT = THREE.ClampToEdgeWrapping;
+    return tex;
+}
+
+export function causticTexture(THREE) {
+    const canvas = makeCanvas(256, (ctx, s) => {
+        ctx.fillStyle = '#000';
+        ctx.fillRect(0, 0, s, s);
+        ctx.globalCompositeOperation = 'lighter';
+        for (let i = 0; i < 40; i++) {
+            ctx.strokeStyle = `rgba(140, 255, 240, ${0.08 + Math.random() * 0.12})`;
+            ctx.lineWidth = 1 + Math.random() * 2;
+            ctx.beginPath();
+            const x = Math.random() * s;
+            const y = Math.random() * s;
+            ctx.moveTo(x, y);
+            ctx.quadraticCurveTo(x + 40, y - 20, x + 80, y + 10);
+            ctx.stroke();
+        }
+    });
+    return canvasTexture(THREE, canvas, { repeatX: 4, repeatY: 4 });
+}
+
+export function skyTexture(THREE) {
+    const canvas = makeCanvas(4, (ctx, s, h) => {
+        const g = ctx.createLinearGradient(0, 0, 0, h);
+        g.addColorStop(0, '#7ec8d4');
+        g.addColorStop(0.22, '#1a6a78');
+        g.addColorStop(0.5, '#063044');
+        g.addColorStop(1, '#010b12');
+        ctx.fillStyle = g;
+        ctx.fillRect(0, 0, s, h);
+    }, 64);
+    const tex = canvasTexture(THREE, canvas);
+    tex.magFilter = THREE.LinearFilter;
+    tex.minFilter = THREE.LinearFilter;
+    return tex;
+}

--- a/labs/nereida/src/utils.js
+++ b/labs/nereida/src/utils.js
@@ -1,0 +1,106 @@
+/** Utilitários numéricos, spline do recife e detecção de dispositivo. */
+
+export const clamp = (v, min, max) => (v < min ? min : v > max ? max : v);
+export const lerp = (a, b, t) => a + (b - a) * t;
+export const damp = (current, target, lambda, dt) =>
+    lerp(current, target, 1 - Math.exp(-lambda * dt));
+
+export const randRange = (min, max) => min + Math.random() * (max - min);
+export const pick = (arr) => arr[Math.floor(Math.random() * arr.length)];
+
+export function hash(n) {
+    n = (n | 0) * 374761393 + 668265263;
+    n = (n ^ (n >>> 13)) * 1274126177;
+    return ((n ^ (n >>> 16)) >>> 0) / 4294967296;
+}
+
+export function mulberry32(seed) {
+    let a = seed | 0;
+    return () => {
+        a |= 0;
+        a = (a + 0x6d2b79f5) | 0;
+        let t = Math.imul(a ^ (a >>> 15), 1 | a);
+        t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+        return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+    };
+}
+
+export function formatTime(seconds) {
+    const s = Math.max(0, Math.floor(seconds));
+    const m = Math.floor(s / 60);
+    const r = s % 60;
+    return `${m}:${r.toString().padStart(2, '0')}`;
+}
+
+export function formatScore(n) {
+    return Math.floor(n).toLocaleString('pt-BR');
+}
+
+export function detectMobile() {
+    if (typeof navigator === 'undefined') return false;
+    const coarse = window.matchMedia?.('(pointer: coarse)')?.matches;
+    const narrow = Math.min(window.innerWidth, window.innerHeight) < 760;
+    return Boolean(coarse && narrow) || /Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
+}
+
+export function detectSoftwareGL() {
+    try {
+        const canvas = document.createElement('canvas');
+        const gl = canvas.getContext('webgl2') || canvas.getContext('webgl');
+        if (!gl) return true;
+        const info = gl.getExtension('WEBGL_debug_renderer_info');
+        const name = info ? String(gl.getParameter(info.UNMASKED_RENDERER_WEBGL) || '') : '';
+        return /swiftshader|llvmpipe|softpipe|microsoft basic render|\bcpu\b/i.test(name);
+    } catch {
+        return true;
+    }
+}
+
+/**
+ * Spline da corrente. s em metros ao longo de z, com meandros em x/y.
+ * x = 34 sin(2.15π t) + 11 sin(5.4π t)
+ * y = 16 + 9 sin(1.7π t) + 4 cos(3.6π t)
+ */
+export function pathAt(s, length) {
+    const t = clamp(s / length, 0, 1);
+    const x = Math.sin(t * Math.PI * 2.15) * 34 + Math.sin(t * Math.PI * 5.4) * 11;
+    const y = 16 + Math.sin(t * Math.PI * 1.7) * 9 + Math.cos(t * Math.PI * 3.6) * 4;
+    return { x, y, z: s, t };
+}
+
+export function pathTangent(s, length) {
+    const a = pathAt(s, length);
+    const b = pathAt(s + 0.9, length);
+    const dx = b.x - a.x;
+    const dy = b.y - a.y;
+    const dz = b.z - a.z;
+    const len = Math.hypot(dx, dy, dz) || 1;
+    return { x: dx / len, y: dy / len, z: dz / len };
+}
+
+export function pathFrame(s, length) {
+    const p = pathAt(s, length);
+    const f = pathTangent(s, length);
+    const upx = 0;
+    const upy = 1;
+    const upz = 0;
+    let rx = f.y * upz - f.z * upy;
+    let ry = f.z * upx - f.x * upz;
+    let rz = f.x * upy - f.y * upx;
+    const rl = Math.hypot(rx, ry, rz) || 1;
+    rx /= rl;
+    ry /= rl;
+    rz /= rl;
+    const ux = ry * f.z - rz * f.y;
+    const uy = rz * f.x - rx * f.z;
+    const uz = rx * f.y - ry * f.x;
+    return { p, f, r: { x: rx, y: ry, z: rz }, u: { x: ux, y: uy, z: uz } };
+}
+
+export function zoneAt(t, zones) {
+    let z = zones[0];
+    for (let i = 0; i < zones.length; i++) {
+        if (t >= zones[i].t) z = zones[i];
+    }
+    return z;
+}

--- a/labs/nereida/src/world.js
+++ b/labs/nereida/src/world.js
@@ -1,0 +1,520 @@
+/**
+ * Recife procedural ao longo do spline: coral instanciado, anéis, pérolas,
+ * águas-vivas, a baleia e o templo náutilo.
+ */
+
+import * as THREE from 'three';
+import { COURSE, PALETTE } from './config.js';
+import { applyCaustics } from './shaders.js';
+import { coralTexture, sandTexture, skyTexture } from './textures.js';
+import { hash, mulberry32, pathAt, pathFrame } from './utils.js';
+
+const _m = new THREE.Matrix4();
+const _q = new THREE.Quaternion();
+const _p = new THREE.Vector3();
+const _s = new THREE.Vector3();
+const _e = new THREE.Euler();
+
+export class Reef {
+    constructor(scene, quality, difficulty, textures) {
+        this.scene = scene;
+        this.quality = quality;
+        this.diff = difficulty;
+        this.textures = textures;
+        this.rings = [];
+        this.pearls = [];
+        this.jellies = [];
+        this.causticMats = [];
+        this.group = new THREE.Group();
+        scene.add(this.group);
+        this._buildSky();
+        this._buildVolume();
+        this._buildSand();
+        this._buildCoral();
+        this._buildKelp();
+        this._buildFish();
+        this._buildPickups();
+        this._buildWhale();
+        this._buildWreck();
+        this._buildTemple();
+        this._buildRays();
+    }
+
+    _mat(color, { rough = 0.72, metal = 0.08, em = 0, emc = 0x000000, map = null, trans = false, op = 1, cau = false } = {}) {
+        const m = new THREE.MeshStandardMaterial({
+            color,
+            map,
+            roughness: rough,
+            metalness: metal,
+            emissive: emc,
+            emissiveIntensity: em,
+            transparent: trans,
+            opacity: op,
+            depthWrite: !trans
+        });
+        if (cau && this.quality.caustics) {
+            applyCaustics(m, 0.5);
+            this.causticMats.push(m);
+        }
+        return m;
+    }
+
+    _buildSky() {
+        const sky = new THREE.Mesh(
+            new THREE.SphereGeometry(280, 24, 16),
+            new THREE.MeshBasicMaterial({ map: this.textures.sky, side: THREE.BackSide, fog: false })
+        );
+        this.group.add(sky);
+
+        const sun = new THREE.Mesh(
+            new THREE.CircleGeometry(18, 24),
+            new THREE.MeshBasicMaterial({ color: 0xc8fff4, fog: false, transparent: true, opacity: 0.55 })
+        );
+        sun.position.set(20, 90, -40);
+        sun.lookAt(0, 0, 0);
+        this.group.add(sun);
+    }
+
+    _buildVolume() {
+        const water = new THREE.Mesh(
+            new THREE.PlaneGeometry(420, 640, 1, 1),
+            new THREE.MeshPhysicalMaterial({
+                color: 0x3ec6d4,
+                roughness: 0.15,
+                metalness: 0,
+                transmission: 0.55,
+                thickness: 2,
+                transparent: true,
+                opacity: 0.35,
+                side: THREE.DoubleSide,
+                depthWrite: false
+            })
+        );
+        water.rotation.x = -Math.PI / 2;
+        water.position.set(0, 38, COURSE.length * 0.5);
+        this.water = water;
+        if (!this.quality.caustics) water.material.transmission = 0;
+        this.group.add(water);
+    }
+
+    _buildSand() {
+        const geo = new THREE.PlaneGeometry(220, COURSE.length + 80, 40, 80);
+        const pos = geo.attributes.position;
+        for (let i = 0; i < pos.count; i++) {
+            const x = pos.getX(i);
+            const y = pos.getY(i);
+            const n = Math.sin(x * 0.09) * 1.8 + Math.cos(y * 0.05) * 2.2 + hash(i * 13) * 1.4;
+            pos.setZ(i, n);
+        }
+        geo.computeVertexNormals();
+        const mesh = new THREE.Mesh(geo, this._mat(PALETTE.sand, { map: this.textures.sand, cau: true, rough: 0.95 }));
+        mesh.rotation.x = -Math.PI / 2;
+        mesh.position.set(0, -6, COURSE.length * 0.5);
+        mesh.receiveShadow = true;
+        this.group.add(mesh);
+    }
+
+    _buildCoral() {
+        const kinds = [
+            new THREE.ConeGeometry(0.7, 2.2, 7),
+            new THREE.SphereGeometry(0.7, 8, 6),
+            new THREE.CylinderGeometry(0.15, 0.35, 2.4, 6)
+        ];
+        const colors = [0xe15b64, 0xff8a6a, 0xf2c14e, 0xd94f8a, 0x5ec8c8];
+        const count = this.quality.coral;
+        const mesh = new THREE.InstancedMesh(
+            kinds[0],
+            this._mat(0xe15b64, { map: this.textures.coral, cau: true, em: 0.12, emc: 0xff6a7a }),
+            count
+        );
+        mesh.instanceMatrix.setUsage(THREE.DynamicDrawUsage);
+        mesh.castShadow = this.quality.shadows;
+        const rng = mulberry32(42);
+        for (let i = 0; i < count; i++) {
+            const s = 12 + rng() * (COURSE.length - 24);
+            const frame = pathFrame(s, COURSE.length);
+            const side = rng() > 0.5 ? 1 : -1;
+            const dist = this.diff.corridor + 3 + rng() * 10;
+            const along = (rng() - 0.5) * 4;
+            _p.set(
+                frame.p.x + frame.r.x * side * dist + frame.f.x * along,
+                -4 + rng() * 6,
+                frame.p.z + frame.r.z * side * dist + frame.f.z * along
+            );
+            _e.set(rng() * 0.3, rng() * Math.PI * 2, rng() * 0.2);
+            _q.setFromEuler(_e);
+            const sc = 0.7 + rng() * 1.8;
+            _s.set(sc, sc * (0.8 + rng() * 1.4), sc);
+            _m.compose(_p, _q, _s);
+            mesh.setMatrixAt(i, _m);
+            mesh.setColorAt?.(i, new THREE.Color(colors[i % colors.length]));
+        }
+        if (mesh.instanceColor) mesh.instanceColor.needsUpdate = true;
+        this.group.add(mesh);
+
+        const fans = new THREE.InstancedMesh(
+            new THREE.ConeGeometry(1.1, 0.35, 10),
+            this._mat(0xff9bb0, { trans: true, op: 0.78, em: 0.2, emc: 0xff7a8a }),
+            Math.floor(count * 0.45)
+        );
+        for (let i = 0; i < fans.count; i++) {
+            const s = 20 + hash(i + 9) * (COURSE.length - 40);
+            const frame = pathFrame(s, COURSE.length);
+            const ang = hash(i * 3) * Math.PI * 2;
+            const dist = 6 + hash(i * 7) * 14;
+            _p.set(frame.p.x + Math.cos(ang) * dist, -3.5 + hash(i) * 2, frame.p.z + Math.sin(ang) * dist);
+            _q.setFromEuler(_e.set(-Math.PI / 2, 0, ang));
+            _s.set(1, 1, 1);
+            _m.compose(_p, _q, _s);
+            fans.setMatrixAt(i, _m);
+        }
+        this.group.add(fans);
+        void kinds;
+    }
+
+    _buildKelp() {
+        const count = this.quality.kelp;
+        const kelp = new THREE.InstancedMesh(
+            new THREE.CylinderGeometry(0.08, 0.16, 1, 5),
+            this._mat(PALETTE.kelp, { em: 0.18, emc: 0x2cff9a, cau: true }),
+            count
+        );
+        this.kelp = [];
+        for (let i = 0; i < count; i++) {
+            const s = 8 + hash(i + 21) * (COURSE.length - 16);
+            const frame = pathFrame(s, COURSE.length);
+            const side = hash(i) > 0.5 ? 1 : -1;
+            const dist = 5 + hash(i * 2) * 12;
+            const h = 4 + hash(i * 5) * 10;
+            _p.set(
+                frame.p.x + frame.r.x * side * dist,
+                h * 0.5 - 5,
+                frame.p.z + frame.r.z * side * dist
+            );
+            _s.set(1, h, 1);
+            _q.identity();
+            _m.compose(_p, _q, _s);
+            kelp.setMatrixAt(i, _m);
+            this.kelp.push({ s, side, dist, h, phase: hash(i * 11) * 6 });
+        }
+        this.kelpMesh = kelp;
+        this.group.add(kelp);
+    }
+
+    _buildFish() {
+        const count = this.quality.fish;
+        const fish = new THREE.InstancedMesh(
+            new THREE.ConeGeometry(0.12, 0.45, 5),
+            this._mat(0x7ad7ff, { em: 0.35, emc: 0x5ef0d8, rough: 0.3 }),
+            count
+        );
+        this.fish = [];
+        for (let i = 0; i < count; i++) {
+            this.fish.push({
+                s: hash(i + 3) * COURSE.length,
+                orbit: 2 + hash(i * 4) * 8,
+                phase: hash(i * 8) * 6.2,
+                speed: 0.3 + hash(i * 2) * 0.7,
+                y: (hash(i * 5) - 0.5) * 8
+            });
+        }
+        this.fishMesh = fish;
+        this.group.add(fish);
+    }
+
+    _buildPickups() {
+        const ringGeo = new THREE.TorusGeometry(3.4, 0.12, 8, 32);
+        const ringMat = new THREE.MeshBasicMaterial({
+            color: PALETTE.lumen,
+            transparent: true,
+            opacity: 0.85,
+            blending: THREE.AdditiveBlending,
+            depthWrite: false
+        });
+        const pearlGeo = new THREE.SphereGeometry(0.32, 12, 10);
+        const pearlMat = new THREE.MeshStandardMaterial({
+            color: PALETTE.pearl,
+            emissive: PALETTE.pearl,
+            emissiveIntensity: 0.85,
+            roughness: 0.2,
+            metalness: 0.4
+        });
+        const jellyGeo = new THREE.SphereGeometry(0.85, 12, 10, 0, Math.PI * 2, 0, Math.PI * 0.55);
+        const jellyMat = new THREE.MeshPhysicalMaterial({
+            color: 0xc77dff,
+            transparent: true,
+            opacity: 0.45,
+            roughness: 0.15,
+            transmission: this.quality.caustics ? 0.4 : 0,
+            emissive: 0xaa66ff,
+            emissiveIntensity: 0.55,
+            depthWrite: false
+        });
+
+        const rng = mulberry32(99);
+        const ringCount = 22;
+        for (let i = 0; i < ringCount; i++) {
+            const s = 28 + (i / (ringCount - 1)) * (COURSE.length - 70);
+            const frame = pathFrame(s, COURSE.length);
+            const lat = (rng() - 0.5) * this.diff.corridor * 0.7;
+            const vert = (rng() - 0.5) * this.diff.corridor * 0.45;
+            const mesh = new THREE.Mesh(ringGeo, ringMat.clone());
+            mesh.position.set(
+                frame.p.x + frame.r.x * lat + frame.u.x * vert,
+                frame.p.y + frame.r.y * lat + frame.u.y * vert,
+                frame.p.z + frame.r.z * lat + frame.u.z * vert
+            );
+            mesh.lookAt(
+                mesh.position.x + frame.f.x,
+                mesh.position.y + frame.f.y,
+                mesh.position.z + frame.f.z
+            );
+            const glow = new THREE.PointLight(PALETTE.lumen, 1.1, 12, 2);
+            mesh.add(glow);
+            this.group.add(mesh);
+            this.rings.push({ mesh, taken: false, s, lat, vert });
+        }
+
+        const pearlCount = Math.round(36 * this.diff.pearls);
+        for (let i = 0; i < pearlCount; i++) {
+            const s = 18 + rng() * (COURSE.length - 50);
+            const frame = pathFrame(s, COURSE.length);
+            const lat = (rng() - 0.5) * this.diff.corridor * 0.85;
+            const vert = (rng() - 0.5) * this.diff.corridor * 0.55;
+            const mesh = new THREE.Mesh(pearlGeo, pearlMat);
+            mesh.position.set(
+                frame.p.x + frame.r.x * lat + frame.u.x * vert,
+                frame.p.y + frame.u.y * vert,
+                frame.p.z + frame.r.z * lat + frame.u.z * vert
+            );
+            this.group.add(mesh);
+            this.pearls.push({ mesh, taken: false, phase: rng() * 6 });
+        }
+
+        const jellyCount = Math.round(16 * this.diff.jellies);
+        for (let i = 0; i < jellyCount; i++) {
+            const s = 90 + rng() * (COURSE.length - 140);
+            const frame = pathFrame(s, COURSE.length);
+            const lat = (rng() - 0.5) * this.diff.corridor * 0.9;
+            const vert = (rng() - 0.4) * this.diff.corridor * 0.5;
+            const mesh = new THREE.Mesh(jellyGeo, jellyMat.clone());
+            mesh.position.set(
+                frame.p.x + frame.r.x * lat,
+                frame.p.y + vert,
+                frame.p.z + frame.r.z * lat
+            );
+            const tent = new THREE.Mesh(
+                new THREE.CylinderGeometry(0.04, 0.02, 1.6, 5),
+                jellyMat
+            );
+            tent.position.y = -1.1;
+            mesh.add(tent, tent.clone(), tent.clone());
+            mesh.children[1].position.x = 0.25;
+            mesh.children[2].position.x = -0.22;
+            this.group.add(mesh);
+            this.jellies.push({ mesh, s, lat, phase: rng() * 6, hit: 0 });
+        }
+    }
+
+    _buildWhale() {
+        const w = new THREE.Group();
+        const skin = this._mat(0x4a6a78, { rough: 0.6, em: 0.08, emc: 0x88c8d8 });
+        const body = new THREE.Mesh(new THREE.SphereGeometry(1, 16, 12), skin);
+        body.scale.set(2.4, 1.3, 5.2);
+        const head = new THREE.Mesh(new THREE.SphereGeometry(0.9, 12, 10), skin);
+        head.position.z = 4.2;
+        head.scale.set(1.1, 0.95, 1.4);
+        const fin = new THREE.Mesh(new THREE.BoxGeometry(3.4, 0.12, 1.1), skin);
+        fin.position.set(0, 0.1, 0.2);
+        const tail = new THREE.Mesh(new THREE.BoxGeometry(2.6, 0.1, 1.2), skin);
+        tail.position.set(0, 0.2, -5.1);
+        w.add(body, head, fin, tail);
+        this.whale = w;
+        this.whaleTail = tail;
+        this.group.add(w);
+    }
+
+    _buildWreck() {
+        const wood = this._mat(0x5a3a28, { rough: 0.9, cau: true });
+        const hull = new THREE.Mesh(new THREE.BoxGeometry(18, 6, 42), wood);
+        const mid = pathAt(COURSE.length * 0.38, COURSE.length);
+        hull.position.set(mid.x + 18, -1, mid.z);
+        hull.rotation.y = 0.5;
+        hull.rotation.z = 0.18;
+        this.group.add(hull);
+        const mast = new THREE.Mesh(new THREE.CylinderGeometry(0.35, 0.45, 22, 8), wood);
+        mast.position.set(mid.x + 16, 10, mid.z + 4);
+        mast.rotation.z = 0.4;
+        this.group.add(mast);
+        const sail = new THREE.Mesh(
+            new THREE.PlaneGeometry(10, 14),
+            this._mat(0xd8c4a0, { trans: true, op: 0.35 })
+        );
+        sail.position.copy(mast.position).add(new THREE.Vector3(2, -1, 0));
+        this.group.add(sail);
+    }
+
+    _buildTemple() {
+        const end = pathAt(COURSE.length - 8, COURSE.length);
+        const gold = this._mat(PALETTE.pearl, { rough: 0.25, metal: 0.55, em: 0.6, emc: PALETTE.lumen });
+        const nautilus = new THREE.Group();
+        for (let i = 0; i < 10; i++) {
+            const t = i / 10;
+            const rad = 2 + i * 1.15;
+            const ring = new THREE.Mesh(new THREE.TorusGeometry(rad, 0.18, 8, 28), gold);
+            ring.position.y = i * 0.55;
+            ring.rotation.x = Math.PI / 2;
+            ring.rotation.z = t * 0.8;
+            nautilus.add(ring);
+        }
+        const core = new THREE.Mesh(new THREE.SphereGeometry(2.2, 24, 18), gold);
+        core.position.y = 3.2;
+        nautilus.add(core);
+        const light = new THREE.PointLight(PALETTE.pearl, 4, 40, 2);
+        light.position.y = 4;
+        nautilus.add(light);
+        nautilus.position.set(end.x, end.y - 2, end.z + 6);
+        this.temple = nautilus;
+        this.group.add(nautilus);
+
+        const columns = this._mat(0x8ab8c4, { cau: true, rough: 0.5 });
+        for (let i = 0; i < 6; i++) {
+            const a = (i / 6) * Math.PI * 2;
+            const col = new THREE.Mesh(new THREE.CylinderGeometry(0.45, 0.55, 9, 8), columns);
+            col.position.set(end.x + Math.cos(a) * 9, end.y - 4, end.z + 6 + Math.sin(a) * 9);
+            this.group.add(col);
+        }
+    }
+
+    _buildRays() {
+        const mat = new THREE.MeshBasicMaterial({
+            color: 0xb8fff4,
+            transparent: true,
+            opacity: 0.06,
+            blending: THREE.AdditiveBlending,
+            depthWrite: false,
+            side: THREE.DoubleSide
+        });
+        this.rays = [];
+        for (let i = 0; i < this.quality.rays; i++) {
+            const ray = new THREE.Mesh(new THREE.ConeGeometry(3.5, 42, 8, 1, true), mat.clone());
+            ray.rotation.x = Math.PI;
+            const s = 40 + hash(i + 4) * (COURSE.length - 80);
+            const p = pathAt(s, COURSE.length);
+            ray.position.set(p.x + (hash(i) - 0.5) * 16, 22, p.z);
+            this.group.add(ray);
+            this.rays.push(ray);
+        }
+    }
+
+    collect(playerPos, radius) {
+        const events = [];
+        for (const ring of this.rings) {
+            if (ring.taken) continue;
+            const d = ring.mesh.position.distanceTo(playerPos);
+            if (d < 3.6 + radius) {
+                ring.taken = true;
+                ring.mesh.visible = false;
+                events.push({ type: 'ring' });
+            }
+        }
+        for (const pearl of this.pearls) {
+            if (pearl.taken) continue;
+            if (pearl.mesh.position.distanceTo(playerPos) < 1.4 + radius) {
+                pearl.taken = true;
+                pearl.mesh.visible = false;
+                events.push({ type: 'pearl' });
+            }
+        }
+        for (const j of this.jellies) {
+            if (j.hit > 0) continue;
+            if (j.mesh.position.distanceTo(playerPos) < 1.5 + radius) {
+                j.hit = 1.2;
+                events.push({ type: 'jelly' });
+            }
+        }
+        return events;
+    }
+
+    reset() {
+        for (const ring of this.rings) {
+            ring.taken = false;
+            ring.mesh.visible = true;
+        }
+        for (const pearl of this.pearls) {
+            pearl.taken = false;
+            pearl.mesh.visible = true;
+        }
+        for (const j of this.jellies) j.hit = 0;
+    }
+
+    update(dt, time) {
+        if (this.water) this.water.position.y = 38 + Math.sin(time * 0.4) * 0.35;
+
+        for (const pearl of this.pearls) {
+            if (pearl.taken) continue;
+            pearl.mesh.position.y += Math.sin(time * 2.2 + pearl.phase) * 0.01;
+            pearl.mesh.rotation.y += dt * 1.4;
+        }
+        for (const ring of this.rings) {
+            if (ring.taken) continue;
+            ring.mesh.rotation.z += dt * 0.8;
+        }
+        for (const j of this.jellies) {
+            j.mesh.position.y += Math.sin(time * 1.3 + j.phase) * 0.02;
+            j.mesh.rotation.y += dt * 0.4;
+            j.hit = Math.max(0, j.hit - dt);
+            j.mesh.material.opacity = j.hit > 0 ? 0.2 : 0.45;
+        }
+
+        if (this.fishMesh) {
+            for (let i = 0; i < this.fish.length; i++) {
+                const f = this.fish[i];
+                f.s = (f.s + f.speed * 6 * dt) % COURSE.length;
+                const frame = pathFrame(f.s, COURSE.length);
+                const a = time * f.speed + f.phase;
+                _p.set(
+                    frame.p.x + Math.cos(a) * f.orbit,
+                    frame.p.y + f.y + Math.sin(a * 1.3) * 0.6,
+                    frame.p.z + Math.sin(a) * f.orbit
+                );
+                _e.set(0, -a, 0.2);
+                _q.setFromEuler(_e);
+                _s.set(1, 1, 1);
+                _m.compose(_p, _q, _s);
+                this.fishMesh.setMatrixAt(i, _m);
+            }
+            this.fishMesh.instanceMatrix.needsUpdate = true;
+        }
+
+        if (this.kelpMesh) {
+            for (let i = 0; i < this.kelp.length; i++) {
+                const k = this.kelp[i];
+                const frame = pathFrame(k.s, COURSE.length);
+                _p.set(
+                    frame.p.x + frame.r.x * k.side * k.dist,
+                    k.h * 0.5 - 5,
+                    frame.p.z + frame.r.z * k.side * k.dist
+                );
+                _e.set(Math.sin(time * 1.2 + k.phase) * 0.18, 0, Math.cos(time * 0.9 + k.phase) * 0.12);
+                _q.setFromEuler(_e);
+                _s.set(1, k.h, 1);
+                _m.compose(_p, _q, _s);
+                this.kelpMesh.setMatrixAt(i, _m);
+            }
+            this.kelpMesh.instanceMatrix.needsUpdate = true;
+        }
+
+        if (this.whale) {
+            const s = 220 + Math.sin(time * 0.12) * 40;
+            const frame = pathFrame(s, COURSE.length);
+            this.whale.position.set(frame.p.x + 10, frame.p.y + 2, frame.p.z);
+            this.whale.lookAt(frame.p.x + frame.f.x * 10, frame.p.y, frame.p.z + frame.f.z * 10);
+            this.whaleTail.rotation.y = Math.sin(time * 1.6) * 0.4;
+        }
+        if (this.temple) this.temple.rotation.y += dt * 0.15;
+        for (const ray of this.rays) {
+            ray.material.opacity = 0.04 + Math.sin(time * 0.7 + ray.position.z) * 0.025;
+        }
+    }
+}

--- a/labs/nereida/style.css
+++ b/labs/nereida/style.css
@@ -1,0 +1,697 @@
+/* ================================================================
+   Nereida — recife bioluminescente
+   Paleta: abismo teal, pérola, coral e ciano-lúmen.
+   ================================================================ */
+
+:root {
+    --lumen: #5ef0d8;
+    --pearl: #f4d9a6;
+    --coral: #ff7a8a;
+    --ink: #02141c;
+    --ink-deep: #010b12;
+    --text: #e8f7f4;
+    --text-soft: #b7d4ce;
+    --text-dim: #6e908a;
+
+    --panel: color-mix(in oklab, #062430 64%, transparent);
+    --panel-strong: color-mix(in oklab, #031820 84%, transparent);
+    --line: color-mix(in oklab, var(--lumen) 38%, transparent);
+    --line-soft: color-mix(in oklab, #ffffff 10%, transparent);
+
+    --radius: 14px;
+    --radius-lg: 22px;
+    --blur: 18px;
+
+    --safe-top: env(safe-area-inset-top, 0px);
+    --safe-bottom: env(safe-area-inset-bottom, 0px);
+    --safe-left: env(safe-area-inset-left, 0px);
+    --safe-right: env(safe-area-inset-right, 0px);
+
+    --ease: cubic-bezier(0.22, 1, 0.36, 1);
+    --font-display: 'Cormorant Garamond', Georgia, serif;
+    --font-mono: 'IBM Plex Mono', ui-monospace, monospace;
+}
+
+*, *::before, *::after {
+    box-sizing: border-box;
+    -webkit-tap-highlight-color: transparent;
+}
+
+html, body {
+    margin: 0;
+    width: 100%;
+    height: 100%;
+    overflow: clip;
+    overscroll-behavior: none;
+    background: var(--ink-deep);
+}
+
+body {
+    min-height: 100dvh;
+    padding: 0;
+    color: var(--text);
+    font-family: 'Outfit', system-ui, sans-serif;
+    user-select: none;
+    -webkit-user-select: none;
+    touch-action: none;
+}
+
+button, input, select {
+    font: inherit;
+    color: inherit;
+}
+
+button {
+    background: none;
+    border: 0;
+    cursor: pointer;
+}
+
+.mono {
+    font-family: var(--font-mono);
+    font-variant-numeric: tabular-nums;
+}
+
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip-path: inset(50%);
+}
+
+:focus-visible {
+    outline: 2px solid var(--lumen);
+    outline-offset: 3px;
+}
+
+.game-shell {
+    position: fixed;
+    inset: 0;
+    overflow: hidden;
+    background: var(--ink-deep);
+}
+
+#scene {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    display: block;
+    touch-action: none;
+}
+
+.vignette {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    z-index: 15;
+    background:
+        radial-gradient(110% 85% at 50% 42%, transparent 48%, rgba(0, 12, 18, 0.62) 100%);
+    box-shadow: inset 0 0 90px rgba(0, 20, 28, 0.5);
+}
+
+.caustic-glass {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    z-index: 16;
+    opacity: 0.22;
+    mix-blend-mode: screen;
+    background:
+        radial-gradient(ellipse 50% 18% at 50% -4%, rgba(180, 255, 240, 0.55), transparent 70%),
+        repeating-linear-gradient(
+            118deg,
+            transparent 0 28px,
+            rgba(94, 240, 216, 0.06) 28px 30px
+        );
+    animation: causticDrift 9s linear infinite;
+}
+
+@keyframes causticDrift {
+    to { background-position: 120px 40px, 80px 0; }
+}
+
+.game-shell > header {
+    position: absolute;
+    top: calc(0.9rem + var(--safe-top));
+    left: calc(1rem + var(--safe-left));
+    right: calc(1rem + var(--safe-right));
+    z-index: 40;
+    margin: 0;
+    padding: 0;
+    max-width: none;
+    width: auto;
+    pointer-events: none;
+    gap: 0.6rem;
+}
+
+.game-shell > header > * {
+    pointer-events: auto;
+}
+
+.game-shell > header .back-link {
+    background: var(--panel-strong);
+    backdrop-filter: blur(var(--blur));
+    -webkit-backdrop-filter: blur(var(--blur));
+    border-color: var(--line);
+    color: var(--text-soft);
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.45);
+}
+
+.game-shell > header .back-link:hover {
+    color: var(--lumen);
+    border-color: var(--lumen);
+}
+
+.game-shell > header .app-logo {
+    font-family: var(--font-display);
+    font-weight: 600;
+    font-style: italic;
+    letter-spacing: 0.08em;
+    font-size: 1.35rem;
+    color: var(--text);
+    text-shadow: 0 0 18px color-mix(in oklab, var(--lumen) 70%, transparent);
+}
+
+.game-shell > header .brand-mark {
+    color: var(--lumen);
+    filter: drop-shadow(0 0 10px var(--lumen));
+    font-style: normal;
+}
+
+.lab-foot {
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: calc(0.4rem + var(--safe-bottom));
+    z-index: 30;
+    margin: 0;
+    padding: 0.4rem;
+    border: 0;
+    font-size: 0.72rem;
+    color: var(--text-dim);
+    opacity: 0.55;
+    pointer-events: none;
+}
+
+.lab-foot a {
+    color: var(--text-soft);
+    pointer-events: auto;
+}
+
+body[data-state="playing"] .lab-foot,
+body[data-state="playing"] .game-shell > header .app-logo {
+    opacity: 0.28;
+}
+
+.hud {
+    position: absolute;
+    inset: 0;
+    z-index: 20;
+    pointer-events: none;
+}
+
+.hud[hidden] { display: none; }
+
+.hud-top {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    gap: 0.7rem;
+    align-items: start;
+    padding: calc(4.2rem + var(--safe-top)) calc(1.1rem + var(--safe-right)) 0 calc(1.1rem + var(--safe-left));
+}
+
+.panel {
+    background: var(--panel);
+    border: 1px solid var(--line-soft);
+    border-radius: var(--radius);
+    padding: 0.55rem 0.75rem;
+    backdrop-filter: blur(var(--blur));
+    -webkit-backdrop-filter: blur(var(--blur));
+    box-shadow: 0 10px 28px rgba(0, 0, 0, 0.28);
+}
+
+.hud-label {
+    display: block;
+    font-size: 0.62rem;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--text-dim);
+}
+
+.depth-panel strong {
+    font-family: var(--font-display);
+    font-size: 1.7rem;
+    font-weight: 600;
+    line-height: 1.1;
+    color: var(--lumen);
+}
+
+.hud-tag {
+    display: inline-block;
+    margin-top: 0.15rem;
+    font-size: 0.72rem;
+    color: var(--pearl);
+}
+
+.race-panel {
+    justify-self: center;
+    min-width: min(280px, 46vw);
+}
+
+.progress,
+.boost-meter {
+    height: 6px;
+    margin-top: 0.45rem;
+    border-radius: 99px;
+    background: rgba(255, 255, 255, 0.08);
+    overflow: hidden;
+}
+
+.progress i,
+.boost-meter i {
+    display: block;
+    height: 100%;
+    width: 0;
+    border-radius: inherit;
+}
+
+.progress i {
+    background: linear-gradient(90deg, var(--lumen), var(--pearl));
+}
+
+.boost-meter i {
+    background: linear-gradient(90deg, #3ecfc0, var(--lumen));
+    box-shadow: 0 0 12px var(--lumen);
+}
+
+.score-panel .score-row {
+    display: flex;
+    justify-content: space-between;
+    gap: 1.2rem;
+    align-items: baseline;
+}
+
+.score-panel strong {
+    color: var(--pearl);
+}
+
+.lives {
+    letter-spacing: 0.12em;
+    color: var(--lumen);
+}
+
+.message {
+    position: absolute;
+    left: 50%;
+    top: 38%;
+    translate: -50% -50%;
+    margin: 0;
+    font-family: var(--font-display);
+    font-style: italic;
+    font-size: clamp(1.4rem, 4vw, 2.4rem);
+    text-align: center;
+    color: var(--text);
+    text-shadow: 0 0 24px var(--lumen);
+    opacity: 0;
+    transform: translateY(8px);
+    transition: opacity 0.35s var(--ease), transform 0.35s var(--ease);
+}
+
+.message[data-show="true"] {
+    opacity: 1;
+    transform: none;
+}
+
+.hud-actions {
+    position: absolute;
+    top: calc(4.2rem + var(--safe-top));
+    right: calc(1.1rem + var(--safe-right));
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 0.4rem;
+    pointer-events: auto;
+    margin-top: 6.6rem;
+}
+
+.icon-button {
+    width: 38px;
+    height: 38px;
+    border-radius: 50%;
+    border: 1px solid var(--line);
+    background: var(--panel-strong);
+    color: var(--text-soft);
+}
+
+.icon-button:hover {
+    color: var(--lumen);
+    border-color: var(--lumen);
+}
+
+.icon-button[aria-pressed="false"] { opacity: 0.45; }
+
+.fps {
+    font-size: 0.7rem;
+    color: var(--text-dim);
+}
+
+.touch-controls {
+    position: absolute;
+    inset: auto 0 0 0;
+    height: 42%;
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between;
+    padding: 0 calc(1rem + var(--safe-left)) calc(1.2rem + var(--safe-bottom)) calc(1rem + var(--safe-right));
+    pointer-events: none;
+}
+
+.touch-controls[hidden] { display: none; }
+
+.look-zone {
+    pointer-events: auto;
+    width: 46%;
+    height: 100%;
+    display: grid;
+    place-items: end start;
+    padding: 1rem;
+}
+
+.steer-hint {
+    font-size: 0.68rem;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: var(--text-dim);
+    opacity: 0.5;
+}
+
+.touch-buttons {
+    display: flex;
+    gap: 0.7rem;
+    pointer-events: auto;
+}
+
+.pad {
+    width: 78px;
+    height: 78px;
+    border-radius: 50%;
+    background: var(--panel-strong);
+    border: 1px solid var(--line);
+    font-family: var(--font-display);
+    font-style: italic;
+    font-size: 0.85rem;
+    letter-spacing: 0.08em;
+}
+
+.pad-boost {
+    width: 96px;
+    height: 96px;
+    color: var(--lumen);
+    box-shadow: 0 0 24px color-mix(in oklab, var(--lumen) 40%, transparent);
+}
+
+.pad-roll { color: var(--pearl); }
+
+.pad:active { transform: scale(0.92); }
+
+.overlay {
+    position: absolute;
+    inset: 0;
+    z-index: 50;
+    display: grid;
+    place-items: center;
+    padding: calc(1.2rem + var(--safe-top)) 1.2rem calc(1.2rem + var(--safe-bottom));
+    background:
+        radial-gradient(80% 60% at 50% 0%, color-mix(in oklab, var(--lumen) 16%, transparent), transparent 55%),
+        rgba(1, 10, 16, 0.52);
+    backdrop-filter: blur(6px);
+}
+
+.overlay[hidden] { display: none; }
+
+.overlay-card {
+    width: min(760px, 100%);
+    background: color-mix(in oklab, #062430 78%, transparent);
+    border: 1px solid var(--line);
+    border-radius: var(--radius-lg);
+    box-shadow: 0 30px 80px rgba(0, 0, 0, 0.55), 0 0 40px color-mix(in oklab, var(--lumen) 20%, transparent);
+    padding: 1.4rem 1.5rem 1.2rem;
+    backdrop-filter: blur(18px);
+}
+
+.compact-card {
+    width: min(440px, 100%);
+    text-align: center;
+}
+
+.menu-head h1,
+.compact-card h2 {
+    font-family: var(--font-display);
+    font-weight: 600;
+    font-style: italic;
+    letter-spacing: 0.04em;
+    margin: 0.2rem 0 0.6rem;
+    font-size: clamp(2.4rem, 6vw, 3.8rem);
+    line-height: 0.95;
+}
+
+.menu-head h1 span,
+.compact-card h2 {
+    color: var(--lumen);
+    text-shadow: 0 0 24px var(--lumen);
+}
+
+.eyebrow {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin: 0;
+    font-family: var(--font-mono);
+    font-size: 0.78rem;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--pearl);
+}
+
+.eyebrow i {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--lumen);
+    box-shadow: 0 0 10px var(--lumen);
+    animation: pulse 1.4s ease-in-out infinite;
+}
+
+@keyframes pulse {
+    50% { opacity: 0.35; }
+}
+
+.eyebrow--danger { color: var(--coral); }
+.eyebrow--danger i { background: var(--coral); box-shadow: 0 0 10px var(--coral); }
+
+.lede {
+    margin: 0;
+    color: var(--text-soft);
+    line-height: 1.55;
+    max-width: 52ch;
+}
+
+.menu-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 1rem;
+    margin: 1.2rem 0 1rem;
+}
+
+.menu-section h2 {
+    font-family: var(--font-display);
+    font-style: italic;
+    font-size: 1.05rem;
+    letter-spacing: 0.04em;
+    color: var(--pearl);
+    margin: 0 0 0.55rem;
+}
+
+.chip-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+}
+
+.chip {
+    padding: 0.4rem 0.7rem;
+    border-radius: 99px;
+    border: 1px solid var(--line-soft);
+    background: rgba(255, 255, 255, 0.04);
+    font-size: 0.82rem;
+}
+
+.chip[aria-pressed="true"] {
+    border-color: var(--lumen);
+    color: var(--ink);
+    background: linear-gradient(120deg, var(--lumen), var(--pearl));
+    box-shadow: 0 0 16px color-mix(in oklab, var(--lumen) 45%, transparent);
+}
+
+.section-note {
+    margin: 0.55rem 0 0;
+    font-size: 0.82rem;
+    color: var(--text-dim);
+    line-height: 1.45;
+}
+
+.keys {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    font-size: 0.8rem;
+    color: var(--text-soft);
+}
+
+kbd {
+    display: inline-block;
+    min-width: 1.4em;
+    padding: 0.08rem 0.32rem;
+    margin-right: 0.15rem;
+    border-radius: 6px;
+    border: 1px solid var(--line);
+    background: rgba(0, 0, 0, 0.35);
+    font-family: var(--font-mono);
+    font-size: 0.75rem;
+}
+
+.settings-grid {
+    display: grid;
+    gap: 0.7rem;
+}
+
+.field {
+    display: grid;
+    gap: 0.3rem;
+    font-size: 0.82rem;
+    color: var(--text-soft);
+}
+
+.field select,
+.field input[type="range"] {
+    width: 100%;
+    accent-color: var(--lumen);
+}
+
+.field select {
+    background: rgba(0, 0, 0, 0.35);
+    border: 1px solid var(--line-soft);
+    border-radius: 10px;
+    padding: 0.4rem 0.55rem;
+}
+
+.menu-foot {
+    display: flex;
+    justify-content: flex-end;
+}
+
+.primary-button,
+.ghost-button {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.55rem;
+    padding: 0.75rem 1.15rem;
+    border-radius: 999px;
+    font-family: var(--font-display);
+    font-style: italic;
+    letter-spacing: 0.04em;
+    font-size: 1.15rem;
+}
+
+.primary-button {
+    background: linear-gradient(120deg, var(--lumen), var(--pearl));
+    color: #041218;
+    box-shadow: 0 10px 30px color-mix(in oklab, var(--lumen) 40%, transparent);
+}
+
+.primary-button:hover { transform: translateY(-2px); }
+
+.ghost-button {
+    border: 1px solid var(--line-soft);
+    color: var(--text-soft);
+}
+
+.card-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.6rem;
+    justify-content: center;
+    margin-top: 1rem;
+}
+
+.stats {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.55rem 1rem;
+    margin: 1rem 0 0.2rem;
+    text-align: left;
+}
+
+.stats span {
+    display: block;
+    font-size: 0.68rem;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--text-dim);
+}
+
+.stats b {
+    font-family: var(--font-mono);
+    font-size: 1.15rem;
+}
+
+.loading-card {
+    text-align: center;
+}
+
+.loading-card h1 {
+    font-family: var(--font-display);
+    font-style: italic;
+    letter-spacing: 0.18em;
+    font-size: 2.4rem;
+    margin: 0.4rem 0;
+    text-shadow: 0 0 22px var(--lumen);
+}
+
+.loading-mark {
+    font-size: 2rem;
+    color: var(--lumen);
+    filter: drop-shadow(0 0 12px var(--lumen));
+}
+
+.loading-bar {
+    width: min(280px, 70vw);
+    height: 6px;
+    margin: 1rem auto 0;
+    border-radius: 99px;
+    background: rgba(255, 255, 255, 0.08);
+    overflow: hidden;
+}
+
+.loading-bar i {
+    display: block;
+    height: 100%;
+    width: 0;
+    background: linear-gradient(90deg, var(--lumen), var(--pearl));
+}
+
+@media (max-width: 860px) {
+    .menu-grid { grid-template-columns: 1fr; }
+    .hud-top { grid-template-columns: 1fr 1fr; }
+    .race-panel { grid-column: 1 / -1; justify-self: stretch; width: auto; }
+    .hud-actions { margin-top: 0; top: auto; bottom: calc(42% + 0.4rem); }
+}
+
+@media (max-width: 560px) {
+    .overlay-card { padding: 1rem; }
+    .menu-head h1 { font-size: 2.1rem; }
+    .hud-top { gap: 0.45rem; }
+    .panel { padding: 0.45rem 0.6rem; }
+}

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -145,6 +145,12 @@
     <priority>0.7</priority>
   </url>
   <url>
+    <loc>https://diogopaulino.com.br/labs/nereida/</loc>
+    <lastmod>2026-08-14</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
     <loc>https://diogopaulino.com.br/labs/orbis/</loc>
     <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 🎯 Objetivo

Novo lab 3D em three.js: um voo arcade de arraia-manta por um recife bioluminescente, com anéis de luz, pérolas, correntes e o templo náutilo.

## ✨ O que mudou

- Lab `labs/nereida/` — mundo submarino procedural, física de voo documentada, caústicas, bloom e Web Audio
- Galeria, README e `sitemap.xml` atualizados (**46 experimentos**, após merge com `master`: Nereida + Riftball + Noctiluca)
- SEO do lab (title, description, canonical, OG, Twitter, JSON-LD) e da galeria (contagem)

## 🧪 Como testar

1. Na raiz do repo: `python3 -m http.server 8000`
2. Abrir [http://localhost:8000/](http://localhost:8000/) (home) e [http://localhost:8000/labs/](http://localhost:8000/labs/) (galeria)
3. Abrir [http://localhost:8000/labs/nereida/](http://localhost:8000/labs/nereida/) — **Entrar na corrente**
4. WASD guia, Espaço impulso, Q/E pirueta; atravessar anéis e coletar pérolas até o templo
5. Conferir pasta ↔ card da galeria ↔ README ↔ `sitemap.xml` ↔ canonical/OG (Nereida, Riftball e Noctiluca todos presentes)

## ✅ Checklist

- [x] Links conferidos: pasta do lab ↔ card da galeria ↔ README ↔ sitemap (e corrigidos se quebravam)
- [x] README atualizado (linha na tabela + URL + contagem no badge/texto) — obrigatório em lab novo, renomeado ou removido
- [x] SEO consistente: title, description, canonical, author, robots, OG, Twitter, JSON-LD (e contagem nos metas da galeria)
- [x] Testado via HTTP na raiz, não via `file://`
- [x] Nada fora do escopo foi quebrado
- [x] Merge com `master` resolvido (conflitos só de catálogo, todos simples)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ffe05-9202-775c-a3d5-61a0389b2d68?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ffe05-9202-775c-a3d5-61a0389b2d68&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

