### PR TITLE
🧪 Riftball — duelo 1v1 no rift com three.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 Mais de 20 anos em tecnologia, entre liderança, código hands-on e design UI/UX.
 
 [![Website](https://img.shields.io/badge/Website-diogopaulino.com.br-3B82F6?style=flat-square&logo=googlechrome&logoColor=white)](https://diogopaulino.com.br/)
-[![Labs](https://img.shields.io/badge/Labs-42_experimentos-8B5CF6?style=flat-square&logo=stackblitz&logoColor=white)](https://diogopaulino.com.br/labs/)
+[![Labs](https://img.shields.io/badge/Labs-43_experimentos-8B5CF6?style=flat-square&logo=stackblitz&logoColor=white)](https://diogopaulino.com.br/labs/)
 [![GitHub](https://img.shields.io/badge/GitHub-diogopaulino-181717?style=flat-square&logo=github&logoColor=white)](https://github.com/diogopaulino)
 [![LinkedIn](https://img.shields.io/badge/LinkedIn-Diogo_Paulino-0A66C2?style=flat-square)](https://br.linkedin.com/in/diogopaulino)
 [![Spotify](https://img.shields.io/badge/Spotify-Artist-1DB954?style=flat-square&logo=spotify&logoColor=white)](https://open.spotify.com/intl-pt/artist/0ue2WfDQ1P4XR2vXdSIrYQ)
@@ -32,12 +32,13 @@ Gosto de construir coisas — de time e produto até interface e código. Nessa 
 
 > *Abre, experimenta, quebra, reconstrói. Esse é o espírito.*
 
-Um laboratório aberto com **42 experimentos** que rodam direto no navegador — HTML, CSS e JavaScript puro, sem instalar nada. Catálogo completo em [diogopaulino.com.br/labs](https://diogopaulino.com.br/labs/).
+Um laboratório aberto com **43 experimentos** que rodam direto no navegador — HTML, CSS e JavaScript puro, sem instalar nada. Catálogo completo em [diogopaulino.com.br/labs](https://diogopaulino.com.br/labs/).
 
 ### 🪐 Mundos 3D
 
 | Projeto | O que é? |
 | :--- | :--- |
+| ◎ **[Riftball](https://diogopaulino.com.br/labs/riftball/)** | Duelo 1v1 no rift — hovers, bola de éter e gol online com código de sala |
 | 🕸️ **[Silkline](https://diogopaulino.com.br/labs/silkline/)** | Balanço 3D pelos arranha-céus de Manhattan — teias, chuva, néon e combos no skyline |
 | 🥋 **[Vector Fighter](https://diogopaulino.com.br/labs/vector-fighter/)** | Luta 3D em polígonos no espírito Virtua Fighter — anel octogonal, ring out e K.O. |
 | ✨ **[Lúmina](https://diogopaulino.com.br/labs/lumina/)** | Reino flutuante estilo Disney — voe, colete desejos e acenda as lanternas do castelo |

--- a/index.html
+++ b/index.html
@@ -157,7 +157,7 @@
       </nav>
       <div class="labs-easter-egg" id="labs-easter-egg">
         <a href="/labs/" class="labs-badge"
-          aria-label="Labs de Diogo Paulino: 42 experimentos de jogos, código, música e IA">
+          aria-label="Labs de Diogo Paulino: 43 experimentos de jogos, código, música e IA">
           <span class="labs-text">labs</span>
           <svg class="labs-sparkles" width="14" height="14" viewBox="0 0 24 24" fill="currentColor" stroke="none">
             <path d="M12 2L14.4 9.6L22 12L14.4 14.4L12 22L9.6 14.4L2 12L9.6 9.6L12 2Z" />

--- a/labs/index.html
+++ b/labs/index.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Labs — Diogo Paulino | Jogos 3D, código, música e IA</title>
-  <meta name="description" content="42 experimentos de Diogo Paulino: jogos 3D, ferramentas, música e inteligência artificial em HTML, CSS e JavaScript puro.">
+  <meta name="description" content="43 experimentos de Diogo Paulino: jogos 3D, ferramentas, música e inteligência artificial em HTML, CSS e JavaScript puro.">
   <meta name="author" content="Diogo Paulino">
   <meta name="robots" content="index, follow">
   <meta name="theme-color" content="#fafbfc">
@@ -16,321 +16,327 @@
   <meta property="og:site_name" content="Diogo Paulino · Labs">
   <meta property="og:title" content="Labs — Diogo Paulino | Jogos 3D, código, música e IA">
   <meta property="og:description"
-    content="42 laboratórios de Diogo Paulino: mundos 3D, jogos, ferramentas, música e IA em HTML, CSS e JavaScript puro.">
+    content="43 laboratórios de Diogo Paulino: mundos 3D, jogos, ferramentas, música e IA em HTML, CSS e JavaScript puro.">
   <meta property="og:url" content="https://diogopaulino.com.br/labs/">
   <meta property="og:image" content="https://diogopaulino.com.br/assets/img/diogo.jpeg">
   <meta property="og:image:alt" content="Diogo Paulino">
   <meta property="og:locale" content="pt_BR">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Labs — Diogo Paulino | Jogos 3D, código, música e IA">
-  <meta name="twitter:description" content="42 experimentos de Diogo Paulino: jogos, código, música e inteligência artificial.">
+  <meta name="twitter:description" content="43 experimentos de Diogo Paulino: jogos, código, música e inteligência artificial.">
   <meta name="twitter:image" content="https://diogopaulino.com.br/assets/img/diogo.jpeg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@100..900&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/labs/shared.css?v=7">
   <link rel="stylesheet" href="/labs/style.css">
-  <script type="application/ld+json">
-  {
-    "@context": "https://schema.org",
-    "@graph": [
-      {
-        "@type": "CollectionPage",
-        "@id": "https://diogopaulino.com.br/labs/#page",
-        "name": "Labs — Diogo Paulino",
-        "url": "https://diogopaulino.com.br/labs/",
-        "description": "42 experimentos de Diogo Paulino: jogos 3D, ferramentas, música e inteligência artificial em HTML, CSS e JavaScript puro.",
-        "inLanguage": "pt-BR",
-        "isPartOf": {
-          "@id": "https://diogopaulino.com.br/#website"
-        },
-        "creator": {
-          "@id": "https://diogopaulino.com.br/#person"
-        },
-        "numberOfItems": 42,
-        "mainEntity": {
-          "@id": "https://diogopaulino.com.br/labs/#list"
-        }
+    <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "CollectionPage",
+      "@id": "https://diogopaulino.com.br/labs/#page",
+      "name": "Labs — Diogo Paulino",
+      "url": "https://diogopaulino.com.br/labs/",
+      "description": "43 experimentos de Diogo Paulino: jogos 3D, ferramentas, música e inteligência artificial em HTML, CSS e JavaScript puro.",
+      "inLanguage": "pt-BR",
+      "isPartOf": {
+        "@id": "https://diogopaulino.com.br/#website"
       },
-      {
-        "@type": "ItemList",
-        "@id": "https://diogopaulino.com.br/labs/#list",
-        "name": "Labs de Diogo Paulino",
-        "numberOfItems": 42,
-        "itemListElement": [
-          {
-            "@type": "ListItem",
-            "position": 1,
-            "url": "https://diogopaulino.com.br/labs/silkline/",
-            "name": "Silkline"
-          },
-          {
-            "@type": "ListItem",
-            "position": 2,
-            "url": "https://diogopaulino.com.br/labs/vector-fighter/",
-            "name": "Vector Fighter"
-          },
-          {
-            "@type": "ListItem",
-            "position": 3,
-            "url": "https://diogopaulino.com.br/labs/lumina/",
-            "name": "Lúmina"
-          },
-          {
-            "@type": "ListItem",
-            "position": 4,
-            "url": "https://diogopaulino.com.br/labs/honor-front/",
-            "name": "Honor Front"
-          },
-          {
-            "@type": "ListItem",
-            "position": 5,
-            "url": "https://diogopaulino.com.br/labs/safari-dourado/",
-            "name": "Safari Dourado"
-          },
-          {
-            "@type": "ListItem",
-            "position": 6,
-            "url": "https://diogopaulino.com.br/labs/aurelia/",
-            "name": "Aurelia Festival"
-          },
-          {
-            "@type": "ListItem",
-            "position": 7,
-            "url": "https://diogopaulino.com.br/labs/grao/",
-            "name": "Grão"
-          },
-          {
-            "@type": "ListItem",
-            "position": 8,
-            "url": "https://diogopaulino.com.br/labs/armilla/",
-            "name": "Armilla"
-          },
-          {
-            "@type": "ListItem",
-            "position": 9,
-            "url": "https://diogopaulino.com.br/labs/orbis/",
-            "name": "Orbis"
-          },
-          {
-            "@type": "ListItem",
-            "position": 10,
-            "url": "https://diogopaulino.com.br/labs/aetherion/",
-            "name": "Aetherion"
-          },
-          {
-            "@type": "ListItem",
-            "position": 11,
-            "url": "https://diogopaulino.com.br/labs/neon-rider/",
-            "name": "Neon Rider"
-          },
-          {
-            "@type": "ListItem",
-            "position": 12,
-            "url": "https://diogopaulino.com.br/labs/toaster-64/",
-            "name": "Torradeira 64"
-          },
-          {
-            "@type": "ListItem",
-            "position": 13,
-            "url": "https://diogopaulino.com.br/labs/river-knight/",
-            "name": "River Knight"
-          },
-          {
-            "@type": "ListItem",
-            "position": 14,
-            "url": "https://diogopaulino.com.br/labs/jornada-do-anel/",
-            "name": "A Jornada do Anel"
-          },
-          {
-            "@type": "ListItem",
-            "position": 15,
-            "url": "https://diogopaulino.com.br/labs/pandemonium/",
-            "name": "Pandemônio"
-          },
-          {
-            "@type": "ListItem",
-            "position": 16,
-            "url": "https://diogopaulino.com.br/labs/beige-box/",
-            "name": "Beige Box"
-          },
-          {
-            "@type": "ListItem",
-            "position": 17,
-            "url": "https://diogopaulino.com.br/labs/f1-racing/",
-            "name": "F1 Grand Prix"
-          },
-          {
-            "@type": "ListItem",
-            "position": 18,
-            "url": "https://diogopaulino.com.br/labs/santos-games/",
-            "name": "Santos Games"
-          },
-          {
-            "@type": "ListItem",
-            "position": 19,
-            "url": "https://diogopaulino.com.br/labs/ravi-123/",
-            "name": "Ravi 1·2·3"
-          },
-          {
-            "@type": "ListItem",
-            "position": 20,
-            "url": "https://diogopaulino.com.br/labs/rock-kombat/",
-            "name": "Rock Kombat"
-          },
-          {
-            "@type": "ListItem",
-            "position": 21,
-            "url": "https://diogopaulino.com.br/labs/videogame/",
-            "name": "Videogame"
-          },
-          {
-            "@type": "ListItem",
-            "position": 22,
-            "url": "https://diogopaulino.com.br/labs/lander/",
-            "name": "Lunar Lander"
-          },
-          {
-            "@type": "ListItem",
-            "position": 23,
-            "url": "https://diogopaulino.com.br/labs/jungle-run/",
-            "name": "Jungle Run"
-          },
-          {
-            "@type": "ListItem",
-            "position": 24,
-            "url": "https://diogopaulino.com.br/labs/space-shooter/",
-            "name": "Neon Invaders"
-          },
-          {
-            "@type": "ListItem",
-            "position": 25,
-            "url": "https://diogopaulino.com.br/labs/tetris/",
-            "name": "Tetris 90s"
-          },
-          {
-            "@type": "ListItem",
-            "position": 26,
-            "url": "https://diogopaulino.com.br/labs/snake/",
-            "name": "Retro Snake"
-          },
-          {
-            "@type": "ListItem",
-            "position": 27,
-            "url": "https://diogopaulino.com.br/labs/minesweeper/",
-            "name": "Campo Minado 95"
-          },
-          {
-            "@type": "ListItem",
-            "position": 28,
-            "url": "https://diogopaulino.com.br/labs/tamagotchi/",
-            "name": "RakuRaku Dinokun"
-          },
-          {
-            "@type": "ListItem",
-            "position": 29,
-            "url": "https://diogopaulino.com.br/labs/cyberos/",
-            "name": "CyberOS Terminal"
-          },
-          {
-            "@type": "ListItem",
-            "position": 30,
-            "url": "https://diogopaulino.com.br/labs/matrix/",
-            "name": "Matrix"
-          },
-          {
-            "@type": "ListItem",
-            "position": 31,
-            "url": "https://diogopaulino.com.br/labs/aurora-flow/",
-            "name": "Aurora Flow"
-          },
-          {
-            "@type": "ListItem",
-            "position": 32,
-            "url": "https://diogopaulino.com.br/labs/paint/",
-            "name": "Paint Lab"
-          },
-          {
-            "@type": "ListItem",
-            "position": 33,
-            "url": "https://diogopaulino.com.br/labs/gravity/",
-            "name": "Gravity"
-          },
-          {
-            "@type": "ListItem",
-            "position": 34,
-            "url": "https://diogopaulino.com.br/labs/image-optimizer/",
-            "name": "Image Optimizer"
-          },
-          {
-            "@type": "ListItem",
-            "position": 35,
-            "url": "https://diogopaulino.com.br/labs/image-editor/",
-            "name": "Image Editor"
-          },
-          {
-            "@type": "ListItem",
-            "position": 36,
-            "url": "https://diogopaulino.com.br/labs/pomodoro/",
-            "name": "Pomodoro"
-          },
-          {
-            "@type": "ListItem",
-            "position": 37,
-            "url": "https://diogopaulino.com.br/labs/english-duo/",
-            "name": "Talk"
-          },
-          {
-            "@type": "ListItem",
-            "position": 38,
-            "url": "https://diogopaulino.com.br/labs/calculator/",
-            "name": "Calculator"
-          },
-          {
-            "@type": "ListItem",
-            "position": 39,
-            "url": "https://diogopaulino.com.br/labs/partitura/",
-            "name": "Partitura: Maestro Quest"
-          },
-          {
-            "@type": "ListItem",
-            "position": 40,
-            "url": "https://diogopaulino.com.br/labs/piano/",
-            "name": "Piano"
-          },
-          {
-            "@type": "ListItem",
-            "position": 41,
-            "url": "https://diogopaulino.com.br/labs/winamp/",
-            "name": "Winamp JS"
-          },
-          {
-            "@type": "ListItem",
-            "position": 42,
-            "url": "https://diogopaulino.com.br/labs/pulsar/",
-            "name": "Pulsar"
-          }
-        ]
+      "creator": {
+        "@id": "https://diogopaulino.com.br/#person"
       },
-      {
-        "@type": "BreadcrumbList",
-        "itemListElement": [
-          {
-            "@type": "ListItem",
-            "position": 1,
-            "name": "Diogo Paulino",
-            "item": "https://diogopaulino.com.br/"
-          },
-          {
-            "@type": "ListItem",
-            "position": 2,
-            "name": "Labs",
-            "item": "https://diogopaulino.com.br/labs/"
-          }
-        ]
+      "numberOfItems": 43,
+      "mainEntity": {
+        "@id": "https://diogopaulino.com.br/labs/#list"
       }
-    ]
-  }
+    },
+    {
+      "@type": "ItemList",
+      "@id": "https://diogopaulino.com.br/labs/#list",
+      "name": "Labs de Diogo Paulino",
+      "numberOfItems": 43,
+      "itemListElement": [
+        {
+          "@type": "ListItem",
+          "position": 1,
+          "url": "https://diogopaulino.com.br/labs/riftball/",
+          "name": "Riftball"
+        },
+        {
+          "@type": "ListItem",
+          "position": 2,
+          "url": "https://diogopaulino.com.br/labs/silkline/",
+          "name": "Silkline"
+        },
+        {
+          "@type": "ListItem",
+          "position": 3,
+          "url": "https://diogopaulino.com.br/labs/vector-fighter/",
+          "name": "Vector Fighter"
+        },
+        {
+          "@type": "ListItem",
+          "position": 4,
+          "url": "https://diogopaulino.com.br/labs/lumina/",
+          "name": "Lúmina"
+        },
+        {
+          "@type": "ListItem",
+          "position": 5,
+          "url": "https://diogopaulino.com.br/labs/honor-front/",
+          "name": "Honor Front"
+        },
+        {
+          "@type": "ListItem",
+          "position": 6,
+          "url": "https://diogopaulino.com.br/labs/safari-dourado/",
+          "name": "Safari Dourado"
+        },
+        {
+          "@type": "ListItem",
+          "position": 7,
+          "url": "https://diogopaulino.com.br/labs/aurelia/",
+          "name": "Aurelia Festival"
+        },
+        {
+          "@type": "ListItem",
+          "position": 8,
+          "url": "https://diogopaulino.com.br/labs/grao/",
+          "name": "Grão"
+        },
+        {
+          "@type": "ListItem",
+          "position": 9,
+          "url": "https://diogopaulino.com.br/labs/armilla/",
+          "name": "Armilla"
+        },
+        {
+          "@type": "ListItem",
+          "position": 10,
+          "url": "https://diogopaulino.com.br/labs/orbis/",
+          "name": "Orbis"
+        },
+        {
+          "@type": "ListItem",
+          "position": 11,
+          "url": "https://diogopaulino.com.br/labs/aetherion/",
+          "name": "Aetherion"
+        },
+        {
+          "@type": "ListItem",
+          "position": 12,
+          "url": "https://diogopaulino.com.br/labs/neon-rider/",
+          "name": "Neon Rider"
+        },
+        {
+          "@type": "ListItem",
+          "position": 13,
+          "url": "https://diogopaulino.com.br/labs/toaster-64/",
+          "name": "Torradeira 64"
+        },
+        {
+          "@type": "ListItem",
+          "position": 14,
+          "url": "https://diogopaulino.com.br/labs/river-knight/",
+          "name": "River Knight"
+        },
+        {
+          "@type": "ListItem",
+          "position": 15,
+          "url": "https://diogopaulino.com.br/labs/jornada-do-anel/",
+          "name": "A Jornada do Anel"
+        },
+        {
+          "@type": "ListItem",
+          "position": 16,
+          "url": "https://diogopaulino.com.br/labs/pandemonium/",
+          "name": "Pandemônio"
+        },
+        {
+          "@type": "ListItem",
+          "position": 17,
+          "url": "https://diogopaulino.com.br/labs/beige-box/",
+          "name": "Beige Box"
+        },
+        {
+          "@type": "ListItem",
+          "position": 18,
+          "url": "https://diogopaulino.com.br/labs/f1-racing/",
+          "name": "F1 Grand Prix"
+        },
+        {
+          "@type": "ListItem",
+          "position": 19,
+          "url": "https://diogopaulino.com.br/labs/santos-games/",
+          "name": "Santos Games"
+        },
+        {
+          "@type": "ListItem",
+          "position": 20,
+          "url": "https://diogopaulino.com.br/labs/ravi-123/",
+          "name": "Ravi 1·2·3"
+        },
+        {
+          "@type": "ListItem",
+          "position": 21,
+          "url": "https://diogopaulino.com.br/labs/rock-kombat/",
+          "name": "Rock Kombat"
+        },
+        {
+          "@type": "ListItem",
+          "position": 22,
+          "url": "https://diogopaulino.com.br/labs/videogame/",
+          "name": "Videogame"
+        },
+        {
+          "@type": "ListItem",
+          "position": 23,
+          "url": "https://diogopaulino.com.br/labs/lander/",
+          "name": "Lunar Lander"
+        },
+        {
+          "@type": "ListItem",
+          "position": 24,
+          "url": "https://diogopaulino.com.br/labs/jungle-run/",
+          "name": "Jungle Run"
+        },
+        {
+          "@type": "ListItem",
+          "position": 25,
+          "url": "https://diogopaulino.com.br/labs/space-shooter/",
+          "name": "Neon Invaders"
+        },
+        {
+          "@type": "ListItem",
+          "position": 26,
+          "url": "https://diogopaulino.com.br/labs/tetris/",
+          "name": "Tetris 90s"
+        },
+        {
+          "@type": "ListItem",
+          "position": 27,
+          "url": "https://diogopaulino.com.br/labs/snake/",
+          "name": "Retro Snake"
+        },
+        {
+          "@type": "ListItem",
+          "position": 28,
+          "url": "https://diogopaulino.com.br/labs/minesweeper/",
+          "name": "Campo Minado 95"
+        },
+        {
+          "@type": "ListItem",
+          "position": 29,
+          "url": "https://diogopaulino.com.br/labs/tamagotchi/",
+          "name": "RakuRaku Dinokun"
+        },
+        {
+          "@type": "ListItem",
+          "position": 30,
+          "url": "https://diogopaulino.com.br/labs/cyberos/",
+          "name": "CyberOS Terminal"
+        },
+        {
+          "@type": "ListItem",
+          "position": 31,
+          "url": "https://diogopaulino.com.br/labs/matrix/",
+          "name": "Matrix"
+        },
+        {
+          "@type": "ListItem",
+          "position": 32,
+          "url": "https://diogopaulino.com.br/labs/aurora-flow/",
+          "name": "Aurora Flow"
+        },
+        {
+          "@type": "ListItem",
+          "position": 33,
+          "url": "https://diogopaulino.com.br/labs/paint/",
+          "name": "Paint Lab"
+        },
+        {
+          "@type": "ListItem",
+          "position": 34,
+          "url": "https://diogopaulino.com.br/labs/gravity/",
+          "name": "Gravity"
+        },
+        {
+          "@type": "ListItem",
+          "position": 35,
+          "url": "https://diogopaulino.com.br/labs/image-optimizer/",
+          "name": "Image Optimizer"
+        },
+        {
+          "@type": "ListItem",
+          "position": 36,
+          "url": "https://diogopaulino.com.br/labs/image-editor/",
+          "name": "Image Editor"
+        },
+        {
+          "@type": "ListItem",
+          "position": 37,
+          "url": "https://diogopaulino.com.br/labs/pomodoro/",
+          "name": "Pomodoro"
+        },
+        {
+          "@type": "ListItem",
+          "position": 38,
+          "url": "https://diogopaulino.com.br/labs/english-duo/",
+          "name": "Talk"
+        },
+        {
+          "@type": "ListItem",
+          "position": 39,
+          "url": "https://diogopaulino.com.br/labs/calculator/",
+          "name": "Calculator"
+        },
+        {
+          "@type": "ListItem",
+          "position": 40,
+          "url": "https://diogopaulino.com.br/labs/partitura/",
+          "name": "Partitura: Maestro Quest"
+        },
+        {
+          "@type": "ListItem",
+          "position": 41,
+          "url": "https://diogopaulino.com.br/labs/piano/",
+          "name": "Piano"
+        },
+        {
+          "@type": "ListItem",
+          "position": 42,
+          "url": "https://diogopaulino.com.br/labs/winamp/",
+          "name": "Winamp JS"
+        },
+        {
+          "@type": "ListItem",
+          "position": 43,
+          "url": "https://diogopaulino.com.br/labs/pulsar/",
+          "name": "Pulsar"
+        }
+      ]
+    },
+    {
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        {
+          "@type": "ListItem",
+          "position": 1,
+          "name": "Diogo Paulino",
+          "item": "https://diogopaulino.com.br/"
+        },
+        {
+          "@type": "ListItem",
+          "position": 2,
+          "name": "Labs",
+          "item": "https://diogopaulino.com.br/labs/"
+        }
+      ]
+    }
+  ]
+}
   </script>
 </head>
 
@@ -352,6 +358,27 @@
     </div>
 
     <div class="projects-grid">
+      <a href="/labs/riftball/" class="project-card" data-groups="game,creative">
+        <div class="project-icon">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+            stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <ellipse cx="12" cy="12" rx="9.2" ry="5.4" />
+            <path d="M3 12h18" opacity="0.45" />
+            <circle cx="12" cy="12" r="1.7" fill="currentColor" stroke="none" />
+            <path d="M6.2 10.2 4 8.4M17.8 10.2 20 8.4" opacity="0.8" />
+            <path d="M7 16.5v2.2M17 16.5v2.2" opacity="0.55" />
+          </svg>
+        </div>
+        <div class="project-content">
+          <h2>Riftball</h2>
+          <p>Duelo 1v1 no rift: dois hovers, uma bola de éter e um gol — crie uma sala e jogue online</p>
+          <div class="project-tags">
+            <span class="tag">three.js</span>
+            <span class="tag">1v1</span>
+            <span class="tag">Online</span>
+          </div>
+        </div>
+      </a>
       <a href="/labs/ilha-do-ambar/" class="project-card" data-groups="game,creative">
         <div class="project-icon">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"

--- a/labs/riftball/index.html
+++ b/labs/riftball/index.html
@@ -1,0 +1,291 @@
+<!DOCTYPE html>
+<html lang="pt-br" data-theme="dark">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport"
+        content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover">
+    <meta name="theme-color" content="#070b18">
+    <title>Riftball — gol 1v1 no rift | Diogo Paulino</title>
+    <meta name="description"
+        content="Duelo 1v1 em three.js: dois hovers, uma bola de éter e um gol no rift. Crie uma sala, mande o código e jogue online com outra pessoa.">
+    <link rel="canonical" href="https://diogopaulino.com.br/labs/riftball/">
+    <meta name="author" content="Diogo Paulino">
+    <meta name="robots" content="index, follow">
+    <link rel="icon" href="/favicon.ico" sizes="any">
+    <meta property="og:image" content="https://diogopaulino.com.br/assets/img/diogo.jpeg">
+    <meta property="og:image:alt" content="Diogo Paulino">
+    <meta property="og:locale" content="pt_BR">
+    <meta name="twitter:image" content="https://diogopaulino.com.br/assets/img/diogo.jpeg">
+
+    <meta property="og:type" content="website">
+    <meta property="og:site_name" content="Diogo Paulino · Labs">
+    <meta property="og:url" content="https://diogopaulino.com.br/labs/riftball/">
+    <meta property="og:title" content="Riftball — gol 1v1 no rift | Diogo Paulino">
+    <meta property="og:description"
+        content="Arena flutuante, hovers de néon e uma bola de éter. three.js, WebRTC e um código de sala.">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Riftball | Diogo Paulino">
+    <meta name="twitter:description" content="Duelo 1v1 no rift. Crie uma sala e jogue online com outra pessoa.">
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600;700;800&family=Syne:wght@700;800&display=swap"
+        rel="stylesheet">
+    <link rel="stylesheet" href="/labs/shared.css?v=7">
+    <link rel="stylesheet" href="style.css">
+
+    <script type="importmap">
+    {
+        "imports": {
+            "three": "https://cdn.jsdelivr.net/npm/three@0.185.1/build/three.module.js",
+            "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.185.1/examples/jsm/"
+        }
+    }
+    </script>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@graph": [
+        {
+          "@type": "WebApplication",
+          "name": "Riftball",
+          "url": "https://diogopaulino.com.br/labs/riftball/",
+          "description": "Duelo 1v1 em three.js: dois hovers, uma bola de éter e um gol no rift. Crie uma sala, mande o código e jogue online com outra pessoa.",
+          "applicationCategory": "GameApplication",
+          "operatingSystem": "Any",
+          "inLanguage": "pt-BR",
+          "isAccessibleForFree": true,
+          "author": {
+            "@type": "Person",
+            "name": "Diogo Paulino",
+            "url": "https://diogopaulino.com.br/"
+          },
+          "image": "https://diogopaulino.com.br/assets/img/diogo.jpeg"
+        },
+        {
+          "@type": "BreadcrumbList",
+          "itemListElement": [
+            {
+              "@type": "ListItem",
+              "position": 1,
+              "name": "Diogo Paulino",
+              "item": "https://diogopaulino.com.br/"
+            },
+            {
+              "@type": "ListItem",
+              "position": 2,
+              "name": "Labs",
+              "item": "https://diogopaulino.com.br/labs/"
+            },
+            {
+              "@type": "ListItem",
+              "position": 3,
+              "name": "Riftball",
+              "item": "https://diogopaulino.com.br/labs/riftball/"
+            }
+          ]
+        }
+      ]
+    }
+    </script>
+</head>
+
+<body>
+    <main class="game-shell">
+        <header data-lab-header data-title="Riftball" data-back-label="Labs">
+            <template data-slot="logo">
+                <div class="app-logo">
+                    <span class="brand-mark" aria-hidden="true">◎</span>
+                    <span>Riftball</span>
+                </div>
+            </template>
+        </header>
+
+        <canvas id="scene" aria-label="Arena 3D do Riftball"></canvas>
+        <div class="vignette" aria-hidden="true"></div>
+        <div class="scan" aria-hidden="true"></div>
+
+        <div id="hud" class="hud" hidden>
+            <div class="scoreboard">
+                <div class="score-side score-side--p1">
+                    <span class="score-name" id="p1Name">Ciano</span>
+                    <strong class="score-num mono" id="p1Score">0</strong>
+                </div>
+                <div class="score-mid">
+                    <span class="score-clock mono" id="matchClock">3:00</span>
+                    <span class="score-best" id="scoreTo">primeiro a 5</span>
+                </div>
+                <div class="score-side score-side--p2">
+                    <strong class="score-num mono" id="p2Score">0</strong>
+                    <span class="score-name" id="p2Name">Magenta</span>
+                </div>
+            </div>
+
+            <div class="boost-wrap boost-wrap--self">
+                <span class="boost-label">Boost</span>
+                <div class="boost-rail"><i id="boostFill"></i></div>
+            </div>
+
+            <p id="announce" class="announce" data-show="false" role="status" aria-live="polite"></p>
+            <p id="netBadge" class="net-badge" hidden>P2P</p>
+
+            <div class="hud-actions">
+                <button id="soundButton" class="icon-button" type="button" aria-pressed="true"
+                    title="Som (M)" aria-label="Alternar som">♪</button>
+                <button id="pauseButton" class="icon-button" type="button" title="Pausar (P)"
+                    aria-label="Pausar">II</button>
+                <span id="fpsCounter" class="fps mono" hidden>—</span>
+            </div>
+
+            <div id="touchControls" class="touch-controls" hidden>
+                <div class="steer-zone" id="steerZone" aria-label="Arraste para dirigir">
+                    <span id="steerKnob" class="steer-knob"></span>
+                    <span class="steer-hint">dirigir</span>
+                </div>
+                <div class="touch-buttons">
+                    <button type="button" class="pad pad-jump" id="jumpPad" aria-label="Pular">PULO</button>
+                    <button type="button" class="pad pad-boost" id="boostPad" aria-label="Boost">BOOST</button>
+                </div>
+            </div>
+        </div>
+
+        <div id="loadingOverlay" class="overlay loading-overlay">
+            <div class="loading-card">
+                <span class="loading-mark" aria-hidden="true">◎</span>
+                <h1>Riftball</h1>
+                <p id="loadingText">Abrindo o rift…</p>
+                <div class="loading-bar"><i id="loadingFill"></i></div>
+            </div>
+        </div>
+
+        <div id="menuOverlay" class="overlay menu-overlay" hidden>
+            <div class="overlay-card menu-card">
+                <header class="menu-head">
+                    <p class="eyebrow"><i></i> three.js · WebRTC · 1v1</p>
+                    <h1>Rift<span>ball</span></h1>
+                    <p class="lede">Dois hovers, uma bola de éter, um gol. A arena flutua no rift —
+                        crie uma sala, mande o código e dispute online. Ou sente alguém do seu lado
+                        no teclado.</p>
+                </header>
+
+                <div class="menu-grid">
+                    <section class="menu-section">
+                        <h2>Como jogar</h2>
+                        <div class="keys">
+                            <span><kbd>WASD</kbd> acelerar e virar · P2 usa <kbd>↑←↓→</kbd></span>
+                            <span><kbd>Shift</kbd> / <kbd>Ctrl</kbd> boost · <kbd>Espaço</kbd> / <kbd>.</kbd> pulo</span>
+                            <span>Empurre a bola para o portal do rival. Primeiro a 5 gols.</span>
+                            <span><kbd>C</kbd> câmera · <kbd>P</kbd> pausa · <kbd>M</kbd> som</span>
+                        </div>
+                    </section>
+                    <section class="menu-section">
+                        <h2>Online</h2>
+                        <p class="section-note">Ponto a ponto no navegador — sem servidor de jogo.
+                            A física fica com quem cria a sala. Se o NAT for teimoso, use duas abas
+                            neste mesmo computador ou o modo teclado.</p>
+                    </section>
+                    <section class="menu-section">
+                        <h2>Ajustes</h2>
+                        <div class="settings-grid">
+                            <label class="field">
+                                <span>Qualidade</span>
+                                <select id="qualitySelect">
+                                    <option value="auto">Automática</option>
+                                    <option value="low">Performance</option>
+                                    <option value="medium">Equilibrada</option>
+                                    <option value="high">Cinemática</option>
+                                </select>
+                            </label>
+                            <label class="field">
+                                <span>Volume <b id="volumeValue">70</b></span>
+                                <input id="volumeSlider" type="range" min="0" max="100" step="1" value="70">
+                            </label>
+                        </div>
+                    </section>
+                </div>
+
+                <div class="play-grid">
+                    <button id="hostButton" class="primary-button" type="button">
+                        <span>Criar sala online</span><i aria-hidden="true">◎</i>
+                    </button>
+                    <button id="joinToggle" class="ghost-button" type="button">Entrar com código</button>
+                    <button id="localButton" class="ghost-button" type="button">Dois no teclado</button>
+                    <button id="cpuButton" class="ghost-button" type="button">Contra a CPU</button>
+                </div>
+
+                <form id="joinForm" class="join-form" hidden>
+                    <label class="field">
+                        <span>Código da sala</span>
+                        <input id="joinCode" type="text" maxlength="6" autocomplete="off" spellcheck="false"
+                            placeholder="A7KX" aria-label="Código da sala">
+                    </label>
+                    <button id="joinButton" class="primary-button" type="submit">
+                        <span>Entrar no rift</span><i aria-hidden="true">→</i>
+                    </button>
+                </form>
+            </div>
+        </div>
+
+        <div id="lobbyOverlay" class="overlay" hidden>
+            <div class="overlay-card compact-card lobby-card">
+                <p class="eyebrow"><i></i> sala aberta</p>
+                <h2>Manda o código</h2>
+                <p class="lede">Quem abrir o link entra como Magenta. Você é Ciano, no portal oeste.</p>
+                <div class="room-code-row">
+                    <strong id="roomCode" class="room-code mono">————</strong>
+                    <button id="copyLinkButton" class="ghost-button" type="button">Copiar link</button>
+                </div>
+                <p id="lobbyStatus" class="section-note">Esperando o segundo hover atravessar o rift…</p>
+                <div class="card-actions">
+                    <button id="cancelLobbyButton" class="ghost-button" type="button">Cancelar</button>
+                </div>
+            </div>
+        </div>
+
+        <div id="pauseOverlay" class="overlay" hidden>
+            <div class="overlay-card compact-card">
+                <p class="eyebrow"><i></i> pausa</p>
+                <h2>O rift espera.</h2>
+                <div class="card-actions">
+                    <button id="resumeButton" class="primary-button" type="button">
+                        <span>Continuar</span><i aria-hidden="true">→</i>
+                    </button>
+                    <button id="pauseMenuButton" class="ghost-button" type="button">Menu</button>
+                </div>
+            </div>
+        </div>
+
+        <div id="resultOverlay" class="overlay" hidden>
+            <div class="overlay-card compact-card result-card">
+                <p class="eyebrow" id="resultEyebrow"><i></i> fim de jogo</p>
+                <h2 id="resultTitle">Gol de ouro.</h2>
+                <p id="resultStats" class="lede"></p>
+                <div class="card-actions">
+                    <button id="replayButton" class="primary-button" type="button">
+                        <span>Revide</span><i aria-hidden="true">↻</i>
+                    </button>
+                    <button id="resultMenuButton" class="ghost-button" type="button">Menu</button>
+                </div>
+            </div>
+        </div>
+
+        <div id="errorOverlay" class="overlay" hidden>
+            <div class="overlay-card compact-card">
+                <p class="eyebrow eyebrow--danger"><i></i> falha no rift</p>
+                <h2>Não abriu.</h2>
+                <p class="lede" id="errorText">Este laboratório precisa de WebGL. Ative a aceleração
+                    de hardware ou tente um navegador atualizado.</p>
+            </div>
+        </div>
+
+        <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
+    </main>
+
+    <script src="https://cdn.jsdelivr.net/npm/peerjs@1.5.4/dist/peerjs.min.js" defer></script>
+    <script src="/labs/shared.js?v=7" defer></script>
+    <script type="module" src="src/main.js"></script>
+</body>
+
+</html>

--- a/labs/riftball/src/ai.js
+++ b/labs/riftball/src/ai.js
@@ -1,0 +1,40 @@
+/**
+ * CPU arcade: ataca se está mais perto da bola; senão cobre o próprio gol.
+ * Mira um ponto atrás da bola, na direção do portal rival.
+ */
+
+import { ARENA } from './config.js';
+import { clamp, wrapPi } from './utils.js';
+
+export function aiInput(me, opp, ball, team) {
+    const attackX = team === 0 ? ARENA.halfX : -ARENA.halfX;
+    const defendX = -attackX;
+    const myDist = Math.hypot(me.x - ball.x, me.z - ball.z);
+    const oppDist = Math.hypot(opp.x - ball.x, opp.z - ball.z);
+    const ownHalf = Math.sign(ball.x || 1) === Math.sign(defendX);
+
+    let tx;
+    let tz;
+    if (myDist < oppDist + 1.8 || !ownHalf) {
+        const gx = attackX - ball.x;
+        const gz = -ball.z;
+        const glen = Math.hypot(gx, gz) || 1;
+        tx = ball.x - (gx / glen) * 3.1;
+        tz = ball.z - (gz / glen) * 3.1;
+    } else {
+        tx = ball.x * 0.45 + defendX * 0.4;
+        tz = ball.z * 0.65;
+    }
+
+    const dx = tx - me.x;
+    const dz = tz - me.z;
+    const desired = Math.atan2(dx, dz);
+    const err = wrapPi(desired - me.yaw);
+    const steer = clamp(err / 0.55, -1, 1);
+    const ahead = Math.hypot(dx, dz);
+    const facing = Math.cos(err);
+    const throttle = ahead > 1.2 ? (facing > 0.15 ? 1 : 0.35) : 0.15;
+    const boost = ahead > 9 && facing > 0.55 && me.boost > 0.2;
+    const jump = ball.y > 2.3 && myDist < 3.6 && facing > 0.2;
+    return { throttle, steer, boost, jump };
+}

--- a/labs/riftball/src/audio.js
+++ b/labs/riftball/src/audio.js
@@ -1,0 +1,176 @@
+/**
+ * Trilha synth no rift — baixo em pulso, lead pentatônico, SFX de chute/gol.
+ * Tudo sintetizado na Web Audio API.
+ */
+
+const PENT = [0, 2, 4, 7, 9];
+const ROOT = 110;
+
+function deg(step, oct = 0) {
+    const i = ((step % PENT.length) + PENT.length) % PENT.length;
+    const o = oct + Math.floor(step / PENT.length);
+    return ROOT * Math.pow(2, o + PENT[i] / 12);
+}
+
+export class GameAudio {
+    constructor() {
+        this.ctx = null;
+        this.enabled = true;
+        this.volume = 0.7;
+        this.mode = 'menu';
+        this.step = 0;
+        this.next = 0;
+        this.timer = null;
+        this.bpm = 118;
+    }
+
+    init() {
+        if (this.ctx) {
+            if (this.ctx.state === 'suspended') this.ctx.resume();
+            return;
+        }
+        const Ctx = window.AudioContext || window.webkitAudioContext;
+        if (!Ctx) return;
+        const ctx = new Ctx();
+        this.ctx = ctx;
+        this.master = ctx.createGain();
+        this.master.gain.value = this.enabled ? this.volume : 0;
+        this.comp = ctx.createDynamicsCompressor();
+        this.comp.threshold.value = -18;
+        this.comp.ratio.value = 3.5;
+        this.music = ctx.createGain();
+        this.music.gain.value = 0.32;
+        this.sfx = ctx.createGain();
+        this.sfx.gain.value = 0.9;
+        this.music.connect(this.comp);
+        this.sfx.connect(this.comp);
+        this.comp.connect(this.master);
+        this.master.connect(ctx.destination);
+        this.next = ctx.currentTime + 0.05;
+        this.loop();
+    }
+
+    setVolume(v) {
+        this.volume = v;
+        if (this.master) this.master.gain.value = this.enabled ? v : 0;
+    }
+
+    setEnabled(on) {
+        this.enabled = on;
+        if (this.master) this.master.gain.value = on ? this.volume : 0;
+    }
+
+    setMode(mode) {
+        this.mode = mode;
+        this.bpm = mode === 'play' ? 132 : mode === 'goal' ? 108 : 118;
+    }
+
+    loop() {
+        if (!this.ctx) return;
+        const ctx = this.ctx;
+        const stepDur = 60 / this.bpm / 4;
+        const horizon = ctx.currentTime + 0.18;
+        while (this.next < horizon) {
+            this.tick(this.next, this.step);
+            this.next += stepDur;
+            this.step = (this.step + 1) % 16;
+        }
+        this.timer = window.setTimeout(() => this.loop(), 40);
+    }
+
+    tick(t, step) {
+        const bass = [0, 0, 3, 0, 4, 4, 3, 0, 0, 2, 3, 0, 4, 3, 2, 0][step];
+        this.tone(deg(bass, 0), t, 0.18, 'sawtooth', 0.09, this.music);
+        if (step % 4 === 0) this.kick(t);
+        if (step % 4 === 2) this.hat(t, 0.03);
+        if (this.mode === 'play' && (step === 4 || step === 12)) {
+            this.tone(deg(step === 4 ? 4 : 6, 2), t, 0.22, 'triangle', 0.05, this.music);
+        }
+        if (this.mode === 'menu' && step % 8 === 6) {
+            this.tone(deg(7, 2), t, 0.4, 'sine', 0.04, this.music);
+        }
+    }
+
+    tone(freq, t, dur, type, gain, dest) {
+        const ctx = this.ctx;
+        if (!ctx) return;
+        const o = ctx.createOscillator();
+        const g = ctx.createGain();
+        o.type = type;
+        o.frequency.setValueAtTime(freq, t);
+        g.gain.setValueAtTime(0.0001, t);
+        g.gain.exponentialRampToValueAtTime(gain, t + 0.02);
+        g.gain.exponentialRampToValueAtTime(0.0001, t + dur);
+        o.connect(g);
+        g.connect(dest);
+        o.start(t);
+        o.stop(t + dur + 0.02);
+    }
+
+    kick(t) {
+        const ctx = this.ctx;
+        if (!ctx) return;
+        const o = ctx.createOscillator();
+        const g = ctx.createGain();
+        o.type = 'sine';
+        o.frequency.setValueAtTime(140, t);
+        o.frequency.exponentialRampToValueAtTime(42, t + 0.12);
+        g.gain.setValueAtTime(0.22, t);
+        g.gain.exponentialRampToValueAtTime(0.0001, t + 0.16);
+        o.connect(g);
+        g.connect(this.music);
+        o.start(t);
+        o.stop(t + 0.18);
+    }
+
+    hat(t, gain) {
+        const ctx = this.ctx;
+        if (!ctx) return;
+        const buf = ctx.createBuffer(1, 2200, ctx.sampleRate);
+        const data = buf.getChannelData(0);
+        for (let i = 0; i < data.length; i++) data[i] = Math.random() * 2 - 1;
+        const src = ctx.createBufferSource();
+        src.buffer = buf;
+        const f = ctx.createBiquadFilter();
+        f.type = 'highpass';
+        f.frequency.value = 6000;
+        const g = ctx.createGain();
+        g.gain.setValueAtTime(gain, t);
+        g.gain.exponentialRampToValueAtTime(0.0001, t + 0.05);
+        src.connect(f);
+        f.connect(g);
+        g.connect(this.music);
+        src.start(t);
+        src.stop(t + 0.06);
+    }
+
+    blip() {
+        if (!this.ctx) return;
+        this.tone(880, this.ctx.currentTime, 0.08, 'square', 0.05, this.sfx);
+    }
+
+    kickHit(impact = 1) {
+        if (!this.ctx) return;
+        const t = this.ctx.currentTime;
+        this.tone(220 + impact * 40, t, 0.1, 'triangle', 0.08 * Math.min(1.4, impact), this.sfx);
+        this.hat(t, 0.04);
+    }
+
+    bump() {
+        if (!this.ctx) return;
+        this.tone(90, this.ctx.currentTime, 0.12, 'sawtooth', 0.07, this.sfx);
+    }
+
+    goal() {
+        if (!this.ctx) return;
+        const t = this.ctx.currentTime;
+        this.tone(deg(4, 3), t, 0.35, 'triangle', 0.1, this.sfx);
+        this.tone(deg(6, 3), t + 0.08, 0.4, 'triangle', 0.09, this.sfx);
+        this.tone(deg(8, 3), t + 0.16, 0.55, 'sine', 0.08, this.sfx);
+    }
+
+    whistle() {
+        if (!this.ctx) return;
+        this.tone(1480, this.ctx.currentTime, 0.22, 'sine', 0.07, this.sfx);
+    }
+}

--- a/labs/riftball/src/config.js
+++ b/labs/riftball/src/config.js
@@ -1,0 +1,104 @@
+/**
+ * Riftball — constantes, regras e fórmulas da simulação.
+ *
+ * Partida: primeiro a SCORE_LIMIT gols, ou quem liderar quando o relógio
+ * zerar. Empate vai a gol de ouro (phase 'overtime').
+ *
+ * Física em passo fixo DT = 1/60. Host (sala) é autoridade; o convidado
+ * só envia input e interpola snapshots.
+ */
+
+export const STORAGE_KEY = 'riftball:v1';
+
+export const DT = 1 / 60;
+export const MAX_STEPS = 5;
+export const SCORE_LIMIT = 5;
+export const MATCH_TIME = 180;
+export const KICKOFF_T = 1.35;
+export const GOAL_FREEZE = 2.15;
+
+export const ARENA = {
+    halfX: 26,
+    halfZ: 16,
+    wall: 0.55,
+    floorY: 0,
+    ceiling: 12,
+    goalHalfZ: 4.2,
+    goalHeight: 4.4,
+    goalDepth: 1.8
+};
+
+/** Hover arcade, sempre em pé. Impulso no eixo do yaw; deriva lateral morre rápido. */
+export const CRAFT = {
+    radius: 1.12,
+    hover: 0.62,
+    thrust: 38,
+    boostThrust: 28,
+    maxSpeed: 22,
+    boostMax: 30,
+    drag: 1.15,
+    grip: 7.2,
+    steer: 2.85,
+    reverseSteer: 0.72,
+    jump: 10.4,
+    gravity: 28,
+    mass: 2.4,
+    boostMaxMeter: 1,
+    boostDrain: 0.55,
+    boostRegen: 0.28,
+    padRegen: 1.35,
+    wallRest: 0.35
+};
+
+/** Bola de éter: mais leve, quica, pouco arrasto no ar. */
+export const BALL = {
+    radius: 0.92,
+    mass: 0.85,
+    gravity: 22,
+    restitution: 0.74,
+    floorFriction: 0.82,
+    airDrag: 0.18,
+    maxSpeed: 34,
+    wallRest: 0.68
+};
+
+/**
+ * Colisão esfera-esfera (impulso ao longo da normal):
+ *   j = -(1 + e) * rel · n / (1/mA + 1/mB)
+ * Chute extra se o hover está em boost: + KICK * heading.
+ */
+export const HIT = {
+    craftBallE: 0.62,
+    craftCraftE: 0.45,
+    kick: 6.5,
+    boostKick: 4.8,
+    minSep: 0.02
+};
+
+export const PADS = [
+    { x: 0, z: -9.5 },
+    { x: 0, z: 9.5 },
+    { x: -12, z: 0 },
+    { x: 12, z: 0 }
+];
+
+export const PAD_RADIUS = 2.1;
+
+export const TEAMS = [
+    { id: 'cyan', name: 'Ciano', color: 0x3cf0ff, accent: 0x1494c8, spawnX: -12, yaw: Math.PI / 2 },
+    { id: 'magenta', name: 'Magenta', color: 0xff4ad8, accent: 0xc4249a, spawnX: 12, yaw: -Math.PI / 2 }
+];
+
+export const QUALITY = {
+    low: { antialias: false, pixelRatio: 1, bloom: false, shadows: false, particles: 80, shards: 10 },
+    medium: { antialias: true, pixelRatio: 1.35, bloom: true, shadows: true, particles: 160, shards: 16 },
+    high: { antialias: true, pixelRatio: 1.75, bloom: true, shadows: true, particles: 260, shards: 22 }
+};
+
+export const NET = {
+    prefix: 'dp-riftball-v1-',
+    tick: 1 / 20,
+    inputTick: 1 / 30,
+    delay: 0.08,
+    alphabet: 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789'
+};

--- a/labs/riftball/src/crafts.js
+++ b/labs/riftball/src/crafts.js
@@ -1,0 +1,193 @@
+/**
+ * Hovers low-poly com glow e a bola de éter (icosaedro interno + casca).
+ */
+
+import * as THREE from 'three';
+import { BALL, TEAMS } from './config.js';
+
+function bodyMat(color, emissive, extra = {}) {
+    return new THREE.MeshStandardMaterial({
+        color,
+        metalness: 0.55,
+        roughness: 0.32,
+        emissive,
+        emissiveIntensity: 0.35,
+        ...extra
+    });
+}
+
+export function createCraft(team) {
+    const def = TEAMS[team];
+    const root = new THREE.Group();
+    const dark = bodyMat(0x12161f, 0x000000);
+    const paint = bodyMat(def.accent, def.color, { emissiveIntensity: 0.22 });
+    const glow = new THREE.MeshBasicMaterial({
+        color: def.color,
+        transparent: true,
+        opacity: 0.85,
+        blending: THREE.AdditiveBlending,
+        depthWrite: false
+    });
+
+    const hull = new THREE.Mesh(new THREE.BoxGeometry(2.15, 0.38, 1.15), paint);
+    hull.position.y = 0.18;
+    hull.castShadow = true;
+    root.add(hull);
+
+    const nose = new THREE.Mesh(new THREE.BoxGeometry(0.85, 0.28, 0.72), paint);
+    nose.position.set(0.95, 0.16, 0);
+    nose.castShadow = true;
+    root.add(nose);
+
+    const cabin = new THREE.Mesh(
+        new THREE.BoxGeometry(0.7, 0.32, 0.7),
+        new THREE.MeshStandardMaterial({
+            color: 0x071018,
+            metalness: 0.2,
+            roughness: 0.15,
+            emissive: def.color,
+            emissiveIntensity: 0.55,
+            transparent: true,
+            opacity: 0.85
+        })
+    );
+    cabin.position.set(0.15, 0.42, 0);
+    root.add(cabin);
+
+    const wingGeo = new THREE.BoxGeometry(0.9, 0.08, 1.55);
+    const wingL = new THREE.Mesh(wingGeo, dark);
+    const wingR = wingL.clone();
+    wingL.position.set(-0.15, 0.12, 0.72);
+    wingR.position.set(-0.15, 0.12, -0.72);
+    wingL.rotation.z = 0.12;
+    wingR.rotation.z = 0.12;
+    root.add(wingL, wingR);
+
+    const stripe = new THREE.Mesh(new THREE.BoxGeometry(2.0, 0.06, 0.18), glow);
+    stripe.position.set(0.05, 0.38, 0);
+    root.add(stripe);
+
+    const engineGeo = new THREE.CylinderGeometry(0.16, 0.22, 0.35, 10);
+    const engL = new THREE.Mesh(engineGeo, dark);
+    const engR = engL.clone();
+    engL.rotation.z = Math.PI / 2;
+    engR.rotation.z = Math.PI / 2;
+    engL.position.set(-1.15, 0.16, 0.28);
+    engR.position.set(-1.15, 0.16, -0.28);
+    root.add(engL, engR);
+
+    const flameGeo = new THREE.ConeGeometry(0.16, 0.7, 8);
+    const flameMat = new THREE.MeshBasicMaterial({
+        color: 0xffe08a,
+        transparent: true,
+        opacity: 0.0,
+        blending: THREE.AdditiveBlending,
+        depthWrite: false
+    });
+    const flameL = new THREE.Mesh(flameGeo, flameMat);
+    const flameR = new THREE.Mesh(flameGeo, flameMat.clone());
+    flameL.rotation.z = Math.PI / 2;
+    flameR.rotation.z = Math.PI / 2;
+    flameL.position.set(-1.45, 0.16, 0.28);
+    flameR.position.set(-1.45, 0.16, -0.28);
+    root.add(flameL, flameR);
+
+    const under = new THREE.PointLight(def.color, 4.5, 9, 2);
+    under.position.set(0, -0.15, 0);
+    root.add(under);
+
+    const disc = new THREE.Mesh(
+        new THREE.CircleGeometry(0.85, 20),
+        new THREE.MeshBasicMaterial({
+            color: def.color,
+            transparent: true,
+            opacity: 0.35,
+            blending: THREE.AdditiveBlending,
+            depthWrite: false,
+            side: THREE.DoubleSide
+        })
+    );
+    disc.rotation.x = -Math.PI / 2;
+    disc.position.y = -0.42;
+    root.add(disc);
+
+    root.userData = { flames: [flameL, flameR], under, disc, team };
+    root.rotation.order = 'YXZ';
+    return root;
+}
+
+export function createBall() {
+    const root = new THREE.Group();
+    const shell = new THREE.Mesh(
+        new THREE.IcosahedronGeometry(BALL.radius, 1),
+        new THREE.MeshStandardMaterial({
+            color: 0xf4f0ff,
+            metalness: 0.15,
+            roughness: 0.18,
+            emissive: 0xfff4c8,
+            emissiveIntensity: 0.85,
+            transparent: true,
+            opacity: 0.92
+        })
+    );
+    shell.castShadow = true;
+    root.add(shell);
+
+    const core = new THREE.Mesh(
+        new THREE.IcosahedronGeometry(BALL.radius * 0.45, 0),
+        new THREE.MeshBasicMaterial({
+            color: 0xffffff,
+            transparent: true,
+            opacity: 0.9,
+            blending: THREE.AdditiveBlending,
+            depthWrite: false
+        })
+    );
+    root.add(core);
+
+    const halo = new THREE.Mesh(
+        new THREE.SphereGeometry(BALL.radius * 1.18, 16, 12),
+        new THREE.MeshBasicMaterial({
+            color: 0xffe08a,
+            transparent: true,
+            opacity: 0.18,
+            blending: THREE.AdditiveBlending,
+            depthWrite: false
+        })
+    );
+    root.add(halo);
+
+    const light = new THREE.PointLight(0xffe8a8, 16, 16, 2);
+    root.add(light);
+    root.userData = { shell, core, halo, light };
+    return root;
+}
+
+export function syncCraft(mesh, craft, dt) {
+    mesh.position.set(craft.x, craft.y, craft.z);
+    // Modelo com nariz em +X; o yaw da física aponta (sin, cos) = +Z em 0.
+    mesh.rotation.y = craft.yaw - Math.PI / 2;
+    const hx = Math.sin(craft.yaw);
+    const hz = Math.cos(craft.yaw);
+    const fwd = craft.vx * hx + craft.vz * hz;
+    const lat = craft.vx * hz - craft.vz * hx;
+    const tilt = THREE.MathUtils.clamp(-lat * 0.045, -0.32, 0.32);
+    const pitch = THREE.MathUtils.clamp(-fwd * 0.012, -0.22, 0.22);
+    mesh.rotation.z = THREE.MathUtils.damp(mesh.rotation.z, tilt, 8, dt);
+    mesh.rotation.x = THREE.MathUtils.damp(mesh.rotation.x, pitch, 8, dt);
+    const boost = craft.boosting ? 1 : 0.12;
+    for (const f of mesh.userData.flames) {
+        f.material.opacity = THREE.MathUtils.damp(f.material.opacity, boost, 12, dt);
+        f.scale.y = 0.7 + boost * 1.4 + Math.random() * 0.2;
+    }
+    mesh.userData.under.intensity = 3.2 + (craft.boosting ? 6 : 0);
+    mesh.userData.disc.material.opacity = 0.22 + (craft.boosting ? 0.35 : 0);
+}
+
+export function syncBall(mesh, ball, t) {
+    mesh.position.set(ball.x, ball.y, ball.z);
+    mesh.userData.shell.rotation.y = t * 1.6;
+    mesh.userData.core.rotation.x = -t * 2.4;
+    const pulse = 1 + Math.sin(t * 6) * 0.04;
+    mesh.userData.halo.scale.setScalar(pulse);
+}

--- a/labs/riftball/src/crafts.js
+++ b/labs/riftball/src/crafts.js
@@ -97,11 +97,11 @@ export function createCraft(team) {
     root.add(under);
 
     const disc = new THREE.Mesh(
-        new THREE.CircleGeometry(0.85, 20),
+        new THREE.CircleGeometry(0.62, 20),
         new THREE.MeshBasicMaterial({
             color: def.color,
             transparent: true,
-            opacity: 0.35,
+            opacity: 0.22,
             blending: THREE.AdditiveBlending,
             depthWrite: false,
             side: THREE.DoubleSide

--- a/labs/riftball/src/effects.js
+++ b/labs/riftball/src/effects.js
@@ -1,0 +1,162 @@
+/**
+ * Faíscas, rastros e onda de gol. Pools, sem alloc no laço quente.
+ */
+
+import * as THREE from 'three';
+import { TEAMS } from './config.js';
+
+const MATRIX = new THREE.Matrix4();
+const POS = new THREE.Vector3();
+const QUAT = new THREE.Quaternion();
+const SCALE = new THREE.Vector3();
+export class Effects {
+    constructor(scene, count) {
+        this.scene = scene;
+        this.max = count;
+        this.cursor = 0;
+        this.life = new Float32Array(count);
+        this.maxLife = new Float32Array(count);
+        this.vel = new Float32Array(count * 3);
+
+        const geo = new THREE.SphereGeometry(0.12, 6, 6);
+        const mat = new THREE.MeshBasicMaterial({
+            color: 0xffffff,
+            transparent: true,
+            opacity: 0.9,
+            blending: THREE.AdditiveBlending,
+            depthWrite: false
+        });
+        this.mesh = new THREE.InstancedMesh(geo, mat, count);
+        this.mesh.frustumCulled = false;
+        this.mesh.instanceMatrix.setUsage(THREE.DynamicDrawUsage);
+        this.tint = new THREE.Color(0xffffff);
+        for (let i = 0; i < count; i++) this.mesh.setColorAt(i, this.tint);
+        scene.add(this.mesh);
+        this.hideAll();
+
+        this.shock = new THREE.Mesh(
+            new THREE.RingGeometry(0.4, 0.55, 32),
+            new THREE.MeshBasicMaterial({
+                color: 0xffffff,
+                transparent: true,
+                opacity: 0,
+                side: THREE.DoubleSide,
+                blending: THREE.AdditiveBlending,
+                depthWrite: false
+            })
+        );
+        this.shock.rotation.x = -Math.PI / 2;
+        this.shockLife = 0;
+        scene.add(this.shock);
+
+        this.trails = [makeTrail(TEAMS[0].color), makeTrail(TEAMS[1].color)];
+        this.trails.forEach((t) => scene.add(t.mesh));
+    }
+
+    hideAll() {
+        SCALE.set(0, 0, 0);
+        for (let i = 0; i < this.max; i++) {
+            this.life[i] = 0;
+            MATRIX.compose(POS, QUAT, SCALE);
+            this.mesh.setMatrixAt(i, MATRIX);
+        }
+        this.mesh.instanceMatrix.needsUpdate = true;
+    }
+
+    burst(x, y, z, color, n = 18, speed = 8) {
+        const c = new THREE.Color(color);
+        for (let k = 0; k < n; k++) {
+            const i = this.cursor++ % this.max;
+            this.life[i] = 1;
+            this.maxLife[i] = 0.35 + Math.random() * 0.45;
+            this.vel[i * 3] = (Math.random() - 0.5) * speed;
+            this.vel[i * 3 + 1] = Math.random() * speed;
+            this.vel[i * 3 + 2] = (Math.random() - 0.5) * speed;
+            POS.set(x, y, z);
+            SCALE.setScalar(0.6 + Math.random() * 1.1);
+            MATRIX.compose(POS, QUAT, SCALE);
+            this.mesh.setMatrixAt(i, MATRIX);
+            this.mesh.setColorAt(i, c);
+        }
+        this.mesh.instanceMatrix.needsUpdate = true;
+        if (this.mesh.instanceColor) this.mesh.instanceColor.needsUpdate = true;
+    }
+
+    shockwave(x, z, color) {
+        this.shock.position.set(x, 0.12, z);
+        this.shock.material.color.setHex(color);
+        this.shock.material.opacity = 0.9;
+        this.shock.scale.setScalar(1);
+        this.shockLife = 1;
+    }
+
+    trail(slot, x, y, z, on) {
+        this.trails[slot].push(x, y, z, on);
+    }
+
+    update(dt) {
+        for (let i = 0; i < this.max; i++) {
+            if (this.life[i] <= 0) continue;
+            this.life[i] -= dt / this.maxLife[i];
+            this.mesh.getMatrixAt(i, MATRIX);
+            MATRIX.decompose(POS, QUAT, SCALE);
+            POS.x += this.vel[i * 3] * dt;
+            POS.y += this.vel[i * 3 + 1] * dt;
+            POS.z += this.vel[i * 3 + 2] * dt;
+            this.vel[i * 3 + 1] -= 12 * dt;
+            const s = Math.max(0, this.life[i]) * 1.2;
+            SCALE.setScalar(s);
+            MATRIX.compose(POS, QUAT, SCALE);
+            this.mesh.setMatrixAt(i, MATRIX);
+            if (this.life[i] <= 0) {
+                SCALE.set(0, 0, 0);
+                MATRIX.compose(POS, QUAT, SCALE);
+                this.mesh.setMatrixAt(i, MATRIX);
+            }
+        }
+        this.mesh.instanceMatrix.needsUpdate = true;
+
+        if (this.shockLife > 0) {
+            this.shockLife -= dt * 1.6;
+            this.shock.scale.setScalar(1 + (1 - this.shockLife) * 14);
+            this.shock.material.opacity = Math.max(0, this.shockLife);
+        }
+
+        this.trails.forEach((t) => t.update());
+    }
+}
+
+function makeTrail(color) {
+    const max = 28;
+    const positions = new Float32Array(max * 3);
+    const geo = new THREE.BufferGeometry();
+    geo.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+    geo.setDrawRange(0, 0);
+    const mat = new THREE.LineBasicMaterial({
+        color,
+        transparent: true,
+        opacity: 0.55,
+        blending: THREE.AdditiveBlending,
+        depthWrite: false
+    });
+    const mesh = new THREE.Line(geo, mat);
+    mesh.frustumCulled = false;
+    const pts = [];
+    return {
+        mesh,
+        push(x, y, z, on) {
+            if (!on) {
+                pts.length = 0;
+                geo.setDrawRange(0, 0);
+                return;
+            }
+            pts.push(x, y * 0.4 + 0.15, z);
+            if (pts.length > max * 3) pts.splice(0, 3);
+            positions.set(pts);
+            geo.attributes.position.needsUpdate = true;
+            geo.setDrawRange(0, pts.length / 3);
+            geo.computeBoundingSphere();
+        },
+        update() { /* positions already written */ }
+    };
+}

--- a/labs/riftball/src/hud.js
+++ b/labs/riftball/src/hud.js
@@ -1,0 +1,163 @@
+/**
+ * HUD: overlays, placar, anúncios de gol e sala.
+ */
+
+import { SCORE_LIMIT } from './config.js';
+import { formatTime } from './utils.js';
+
+export class Hud {
+    constructor() {
+        this.els = {
+            loading: document.getElementById('loadingOverlay'),
+            loadingFill: document.getElementById('loadingFill'),
+            loadingText: document.getElementById('loadingText'),
+            menu: document.getElementById('menuOverlay'),
+            lobby: document.getElementById('lobbyOverlay'),
+            hud: document.getElementById('hud'),
+            pause: document.getElementById('pauseOverlay'),
+            result: document.getElementById('resultOverlay'),
+            error: document.getElementById('errorOverlay'),
+            errorText: document.getElementById('errorText'),
+            p1Score: document.getElementById('p1Score'),
+            p2Score: document.getElementById('p2Score'),
+            p1Name: document.getElementById('p1Name'),
+            p2Name: document.getElementById('p2Name'),
+            clock: document.getElementById('matchClock'),
+            scoreTo: document.getElementById('scoreTo'),
+            boostFill: document.getElementById('boostFill'),
+            announce: document.getElementById('announce'),
+            netBadge: document.getElementById('netBadge'),
+            roomCode: document.getElementById('roomCode'),
+            lobbyStatus: document.getElementById('lobbyStatus'),
+            joinForm: document.getElementById('joinForm'),
+            joinCode: document.getElementById('joinCode'),
+            resultTitle: document.getElementById('resultTitle'),
+            resultStats: document.getElementById('resultStats'),
+            resultEyebrow: document.getElementById('resultEyebrow'),
+            volume: document.getElementById('volumeSlider'),
+            volumeValue: document.getElementById('volumeValue'),
+            quality: document.getElementById('qualitySelect'),
+            touch: document.getElementById('touchControls'),
+            fps: document.getElementById('fpsCounter'),
+            sound: document.getElementById('soundButton')
+        };
+        this.announceUntil = 0;
+    }
+
+    setLoading(p, text) {
+        if (this.els.loadingFill) this.els.loadingFill.style.width = `${Math.round(p * 100)}%`;
+        if (text && this.els.loadingText) this.els.loadingText.textContent = text;
+    }
+
+    hideLoading() {
+        if (this.els.loading) this.els.loading.hidden = true;
+    }
+
+    showMenu() {
+        this.hideAll();
+        if (this.els.menu) this.els.menu.hidden = false;
+    }
+
+    showLobby(code) {
+        this.hideAll();
+        if (this.els.lobby) this.els.lobby.hidden = false;
+        if (this.els.roomCode) this.els.roomCode.textContent = code;
+        if (this.els.lobbyStatus) {
+            this.els.lobbyStatus.textContent = 'Esperando o segundo hover atravessar o rift…';
+        }
+    }
+
+    setLobbyStatus(text) {
+        if (this.els.lobbyStatus) this.els.lobbyStatus.textContent = text;
+    }
+
+    showHud() {
+        this.hideAll();
+        if (this.els.hud) this.els.hud.hidden = false;
+    }
+
+    showPause(on) {
+        if (this.els.pause) this.els.pause.hidden = !on;
+    }
+
+    showResult(winnerName, score, overtime) {
+        this.hideAll();
+        if (this.els.hud) this.els.hud.hidden = false;
+        if (this.els.result) this.els.result.hidden = false;
+        if (this.els.resultEyebrow) {
+            this.els.resultEyebrow.innerHTML = overtime
+                ? '<i></i> gol de ouro'
+                : '<i></i> fim de jogo';
+        }
+        if (this.els.resultTitle) this.els.resultTitle.textContent = `${winnerName} vence`;
+        if (this.els.resultStats) {
+            this.els.resultStats.textContent = `Placar ${score[0]} — ${score[1]}. Primeiro a ${SCORE_LIMIT}, ou o relógio.`;
+        }
+    }
+
+    showError(text) {
+        if (this.els.error) this.els.error.hidden = false;
+        if (this.els.errorText) this.els.errorText.textContent = text;
+    }
+
+    hideAll() {
+        for (const key of ['menu', 'lobby', 'pause', 'result', 'error']) {
+            if (this.els[key]) this.els[key].hidden = true;
+        }
+    }
+
+    setNames(a, b) {
+        if (this.els.p1Name) this.els.p1Name.textContent = a;
+        if (this.els.p2Name) this.els.p2Name.textContent = b;
+    }
+
+    setScore(score, clock, overtime) {
+        if (this.els.p1Score) this.els.p1Score.textContent = String(score[0]);
+        if (this.els.p2Score) this.els.p2Score.textContent = String(score[1]);
+        if (this.els.clock) this.els.clock.textContent = overtime ? 'OURO' : formatTime(clock);
+        if (this.els.scoreTo) {
+            this.els.scoreTo.textContent = overtime ? 'próximo gol ganha' : `primeiro a ${SCORE_LIMIT}`;
+        }
+    }
+
+    setBoost(v) {
+        if (this.els.boostFill) this.els.boostFill.style.width = `${Math.round(v * 100)}%`;
+    }
+
+    setNet(text) {
+        if (!this.els.netBadge) return;
+        if (!text) {
+            this.els.netBadge.hidden = true;
+            return;
+        }
+        this.els.netBadge.hidden = false;
+        this.els.netBadge.textContent = text;
+    }
+
+    announce(text, dur = 1.4) {
+        if (!this.els.announce) return;
+        this.els.announce.textContent = text;
+        this.els.announce.dataset.show = 'true';
+        this.announceUntil = performance.now() / 1000 + dur;
+    }
+
+    tick(now) {
+        if (this.els.announce && now > this.announceUntil) {
+            this.els.announce.dataset.show = 'false';
+        }
+    }
+
+    setMuted(on) {
+        if (this.els.sound) this.els.sound.setAttribute('aria-pressed', on ? 'false' : 'true');
+    }
+
+    setFps(n, show) {
+        if (!this.els.fps) return;
+        this.els.fps.hidden = !show;
+        this.els.fps.textContent = `${n} fps`;
+    }
+
+    setTouch(on) {
+        if (this.els.touch) this.els.touch.hidden = !on;
+    }
+}

--- a/labs/riftball/src/input.js
+++ b/labs/riftball/src/input.js
@@ -1,0 +1,168 @@
+/**
+ * Teclado (P1 WASD, P2 setas), toque e atalhos de HUD.
+ * sample(slot) devolve { throttle, steer, boost, jump }.
+ */
+
+const P1 = {
+    KeyW: 'up', KeyS: 'down', KeyA: 'left', KeyD: 'right'
+};
+const P2 = {
+    ArrowUp: 'up', ArrowDown: 'down', ArrowLeft: 'left', ArrowRight: 'right'
+};
+
+export class Input {
+    constructor() {
+        this.keys = new Set();
+        this.touchX = 0;
+        this.touchY = 0;
+        this.touchBoost = false;
+        this.jumpQueued = [false, false];
+        this.listeners = new Map();
+        this.enabled = true;
+        this.stickId = null;
+        this._bind();
+    }
+
+    on(action, handler) {
+        if (!this.listeners.has(action)) this.listeners.set(action, new Set());
+        this.listeners.get(action).add(handler);
+        return () => this.listeners.get(action).delete(handler);
+    }
+
+    emit(action, payload) {
+        this.listeners.get(action)?.forEach((fn) => fn(payload));
+    }
+
+    consumeJump(slot) {
+        const v = this.jumpQueued[slot];
+        this.jumpQueued[slot] = false;
+        return v;
+    }
+
+    sample(slot) {
+        let x = slot === 0 ? this.touchX : 0;
+        let y = slot === 0 ? this.touchY : 0;
+        const map = slot === 0 ? P1 : P2;
+        if (this.keys.has(slot === 0 ? 'p1-left' : 'p2-left')) x -= 1;
+        if (this.keys.has(slot === 0 ? 'p1-right' : 'p2-right')) x += 1;
+        if (this.keys.has(slot === 0 ? 'p1-up' : 'p2-up')) y += 1;
+        if (this.keys.has(slot === 0 ? 'p1-down' : 'p2-down')) y -= 1;
+        const mag = Math.hypot(x, y);
+        if (mag > 1) {
+            x /= mag;
+            y /= mag;
+        }
+        const boost = slot === 0
+            ? this.keys.has('p1-boost') || this.touchBoost
+            : this.keys.has('p2-boost');
+        const jump = this.consumeJump(slot);
+        return { throttle: y, steer: x, boost, jump };
+    }
+
+    _bind() {
+        this._onKeyDown = (e) => {
+            if (e.repeat) {
+                if (['Space', 'ShiftLeft', 'ShiftRight'].includes(e.code)) e.preventDefault();
+                return;
+            }
+            if (e.code === 'KeyP' || e.code === 'Escape') {
+                this.emit('pause');
+                return;
+            }
+            if (e.code === 'KeyM') {
+                this.emit('mute');
+                return;
+            }
+            if (e.code === 'KeyC') {
+                this.emit('camera');
+                return;
+            }
+            if (!this.enabled) return;
+
+            if (P1[e.code]) this.keys.add(`p1-${P1[e.code]}`);
+            if (P2[e.code]) {
+                e.preventDefault();
+                this.keys.add(`p2-${P2[e.code]}`);
+            }
+            if (e.code === 'ShiftLeft' || e.code === 'ShiftRight') this.keys.add('p1-boost');
+            if (e.code === 'ControlLeft' || e.code === 'ControlRight') {
+                e.preventDefault();
+                this.keys.add('p2-boost');
+            }
+            if (e.code === 'Space') {
+                e.preventDefault();
+                this.jumpQueued[0] = true;
+            }
+            if (e.code === 'Period' || e.code === 'NumpadDecimal') this.jumpQueued[1] = true;
+        };
+
+        this._onKeyUp = (e) => {
+            if (P1[e.code]) this.keys.delete(`p1-${P1[e.code]}`);
+            if (P2[e.code]) this.keys.delete(`p2-${P2[e.code]}`);
+            if (e.code === 'ShiftLeft' || e.code === 'ShiftRight') this.keys.delete('p1-boost');
+            if (e.code === 'ControlLeft' || e.code === 'ControlRight') this.keys.delete('p2-boost');
+        };
+
+        window.addEventListener('keydown', this._onKeyDown);
+        window.addEventListener('keyup', this._onKeyUp);
+        window.addEventListener('blur', () => this.keys.clear());
+    }
+
+    bindTouch({ zone, knob, boost, jump }) {
+        if (!zone) return;
+        const setKnob = (x, y) => {
+            const max = 42;
+            const px = x * max;
+            const py = -y * max;
+            if (knob) knob.style.transform = `translate(calc(-50% + ${px}px), calc(-50% + ${py}px))`;
+        };
+        const sampleStick = (ev) => {
+            const rect = zone.getBoundingClientRect();
+            const cx = rect.left + rect.width / 2;
+            const cy = rect.top + rect.height / 2;
+            let dx = (ev.clientX - cx) / (rect.width * 0.42);
+            let dy = (cy - ev.clientY) / (rect.height * 0.42);
+            const mag = Math.hypot(dx, dy);
+            if (mag > 1) {
+                dx /= mag;
+                dy /= mag;
+            }
+            this.touchX = dx;
+            this.touchY = dy;
+            setKnob(dx, dy);
+        };
+        const endStick = () => {
+            this.touchX = 0;
+            this.touchY = 0;
+            this.stickId = null;
+            setKnob(0, 0);
+        };
+
+        zone.addEventListener('pointerdown', (ev) => {
+            this.stickId = ev.pointerId;
+            zone.setPointerCapture?.(ev.pointerId);
+            sampleStick(ev);
+        });
+        zone.addEventListener('pointermove', (ev) => {
+            if (this.stickId !== ev.pointerId) return;
+            sampleStick(ev);
+        });
+        zone.addEventListener('pointerup', endStick);
+        zone.addEventListener('pointercancel', endStick);
+
+        const hold = (el, on, off) => {
+            if (!el) return;
+            const down = (ev) => {
+                ev.preventDefault();
+                on();
+            };
+            const up = () => off();
+            el.addEventListener('pointerdown', down);
+            el.addEventListener('pointerup', up);
+            el.addEventListener('pointercancel', up);
+            el.addEventListener('pointerleave', up);
+        };
+        hold(boost, () => { this.touchBoost = true; }, () => { this.touchBoost = false; });
+        hold(jump, () => { this.jumpQueued[0] = true; }, () => {});
+    }
+}

--- a/labs/riftball/src/main.js
+++ b/labs/riftball/src/main.js
@@ -1,0 +1,576 @@
+/**
+ * Riftball — laço principal, câmera, modos (online / local / CPU) e attract.
+ */
+
+import * as THREE from 'three';
+import { EffectComposer } from 'three/addons/postprocessing/EffectComposer.js';
+import { RenderPass } from 'three/addons/postprocessing/RenderPass.js';
+import { UnrealBloomPass } from 'three/addons/postprocessing/UnrealBloomPass.js';
+import { OutputPass } from 'three/addons/postprocessing/OutputPass.js';
+
+import {
+    STORAGE_KEY, QUALITY, DT, MAX_STEPS, NET, TEAMS
+} from './config.js';
+import { clamp, lerp, wrapPi, detectMobile, detectSoftwareGL } from './utils.js';
+import { Input } from './input.js';
+import { GameAudio } from './audio.js';
+import { Hud } from './hud.js';
+import { World } from './world.js';
+import { createCraft, createBall, syncCraft, syncBall } from './crafts.js';
+import { Effects } from './effects.js';
+import { createMatch, step, snapshot, applySnapshot, blankInput } from './physics.js';
+import { aiInput } from './ai.js';
+import { Net, randomCode, roomUrl } from './net.js';
+
+const CAMERAS = ['chase', 'broadcast', 'orbit'];
+
+class Game {
+    constructor() {
+        this.hud = new Hud();
+        this.input = new Input();
+        this.audio = new GameAudio();
+        this.net = new Net();
+        this.canvas = document.getElementById('scene');
+        this.settings = this.loadSettings();
+        this.state = 'boot';
+        this.mode = 'attract';
+        this.match = createMatch();
+        this.inputs = [blankInput(), blankInput()];
+        this.guestInput = blankInput();
+        this.localSlot = 0;
+        this.accum = 0;
+        this.time = 0;
+        this.last = performance.now();
+        this.paused = false;
+        this.cameraMode = 0;
+        this.fps = 60;
+        this.fpsAccum = 0;
+        this.fpsFrames = 0;
+        this.netAccum = 0;
+        this.inputAccum = 0;
+        this.snaps = [];
+        this.pendingEvents = [];
+        this.mobile = detectMobile();
+        this._camPos = new THREE.Vector3();
+        this._look = new THREE.Vector3();
+        this._wanted = new THREE.Vector3();
+        this._dir = new THREE.Vector3();
+        this._lookFrom = new THREE.Vector3();
+    }
+
+    loadSettings() {
+        try {
+            const raw = localStorage.getItem(STORAGE_KEY);
+            if (raw) return { quality: 'auto', volume: 70, muted: false, ...JSON.parse(raw) };
+        } catch { /* ignore */ }
+        return { quality: 'auto', volume: 70, muted: false };
+    }
+
+    saveSettings() {
+        try {
+            localStorage.setItem(STORAGE_KEY, JSON.stringify(this.settings));
+        } catch { /* ignore */ }
+    }
+
+    qualityPreset() {
+        let key = this.settings.quality;
+        if (key === 'auto') key = (this.mobile || detectSoftwareGL()) ? 'low' : 'high';
+        return QUALITY[key] || QUALITY.medium;
+    }
+
+    async boot() {
+        this.hud.setLoading(0.12, 'Abrindo o rift…');
+        const quality = this.qualityPreset();
+        this.quality = quality;
+
+        try {
+            this.renderer = new THREE.WebGLRenderer({
+                canvas: this.canvas,
+                antialias: quality.antialias,
+                powerPreference: 'high-performance',
+                stencil: false
+            });
+        } catch {
+            this.hud.showError('Este laboratório precisa de WebGL. Ative a aceleração de hardware.');
+            return;
+        }
+
+        this.renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, quality.pixelRatio));
+        this.renderer.setSize(window.innerWidth, window.innerHeight, false);
+        this.renderer.outputColorSpace = THREE.SRGBColorSpace;
+        this.renderer.toneMapping = THREE.ACESFilmicToneMapping;
+        this.renderer.toneMappingExposure = 1.05;
+        this.renderer.shadowMap.enabled = quality.shadows;
+        this.renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+
+        this.scene = new THREE.Scene();
+        this.camera = new THREE.PerspectiveCamera(58, window.innerWidth / window.innerHeight, 0.15, 420);
+        this.camera.position.set(0, 18, 28);
+
+        this.hud.setLoading(0.4, 'Montando a arena…');
+        this.world = new World(this.scene, quality);
+        this.crafts = [createCraft(0), createCraft(1)];
+        this.crafts.forEach((c) => this.scene.add(c));
+        this.ball = createBall();
+        this.scene.add(this.ball);
+        this.effects = new Effects(this.scene, quality.particles);
+
+        this.composer = new EffectComposer(this.renderer);
+        this.composer.addPass(new RenderPass(this.scene, this.camera));
+        if (quality.bloom) {
+            this.bloom = new UnrealBloomPass(
+                new THREE.Vector2(window.innerWidth, window.innerHeight),
+                0.48,
+                0.62,
+                0.78
+            );
+            this.composer.addPass(this.bloom);
+        }
+        this.composer.addPass(new OutputPass());
+
+        this.hud.setLoading(0.78, 'Sintonizando o éter…');
+        this.bindUi();
+        this.bindNet();
+        window.addEventListener('resize', () => this.resize());
+        this.resize();
+
+        this.hud.hideLoading();
+        this.enterAttract();
+        this.loop();
+
+        const sala = new URLSearchParams(window.location.search).get('sala');
+        if (sala) {
+            this.hud.els.joinForm.hidden = false;
+            this.hud.els.joinCode.value = sala.trim().toUpperCase();
+        }
+    }
+
+    bindUi() {
+        if (this.hud.els.quality) {
+            this.hud.els.quality.value = this.settings.quality;
+            this.hud.els.quality.addEventListener('change', () => {
+                this.settings.quality = this.hud.els.quality.value;
+                this.saveSettings();
+            });
+        }
+        if (this.hud.els.volume) {
+            this.hud.els.volume.value = this.settings.volume;
+            this.hud.els.volumeValue.textContent = String(this.settings.volume);
+            this.hud.els.volume.addEventListener('input', () => {
+                this.settings.volume = Number(this.hud.els.volume.value);
+                this.hud.els.volumeValue.textContent = this.hud.els.volume.value;
+                this.audio.setVolume(this.settings.volume / 100);
+                this.saveSettings();
+            });
+        }
+
+        document.getElementById('hostButton')?.addEventListener('click', () => this.startHost());
+        document.getElementById('joinToggle')?.addEventListener('click', () => {
+            const form = this.hud.els.joinForm;
+            form.hidden = !form.hidden;
+        });
+        document.getElementById('joinForm')?.addEventListener('submit', (e) => {
+            e.preventDefault();
+            this.startJoin(this.hud.els.joinCode.value);
+        });
+        document.getElementById('localButton')?.addEventListener('click', () => this.startMatch('local'));
+        document.getElementById('cpuButton')?.addEventListener('click', () => this.startMatch('cpu'));
+        document.getElementById('copyLinkButton')?.addEventListener('click', () => this.copyRoom());
+        document.getElementById('cancelLobbyButton')?.addEventListener('click', () => this.backToMenu());
+        document.getElementById('resumeButton')?.addEventListener('click', () => this.togglePause(false));
+        document.getElementById('pauseMenuButton')?.addEventListener('click', () => this.backToMenu());
+        document.getElementById('replayButton')?.addEventListener('click', () => this.replay());
+        document.getElementById('resultMenuButton')?.addEventListener('click', () => this.backToMenu());
+        document.getElementById('pauseButton')?.addEventListener('click', () => this.togglePause());
+        document.getElementById('soundButton')?.addEventListener('click', () => this.toggleMute());
+
+        this.input.on('pause', () => this.togglePause());
+        this.input.on('mute', () => this.toggleMute());
+        this.input.on('camera', () => {
+            this.cameraMode = (this.cameraMode + 1) % CAMERAS.length;
+        });
+        this.input.bindTouch({
+            zone: document.getElementById('steerZone'),
+            knob: document.getElementById('steerKnob'),
+            boost: document.getElementById('boostPad'),
+            jump: document.getElementById('jumpPad')
+        });
+        this.hud.setMuted(this.settings.muted);
+        this.audio.setVolume(this.settings.volume / 100);
+        this.audio.setEnabled(!this.settings.muted);
+
+        const unlock = () => this.audio.init();
+        window.addEventListener('pointerdown', unlock, { once: true });
+        window.addEventListener('keydown', unlock, { once: true });
+    }
+
+    bindNet() {
+        this.net.on('connected', () => {
+            this.hud.setLobbyStatus('Hover no rift. Vai começar.');
+            if (this.net.role === 'host') {
+                this.startMatch('online-host');
+            } else {
+                this.startMatch('online-guest');
+            }
+        });
+        this.net.on('disconnected', () => {
+            this.hud.announce('conexão caiu', 2);
+            this.hud.setNet('offline');
+        });
+        this.net.on('error', (msg) => {
+            this.hud.setLobbyStatus(msg);
+        });
+        this.net.on('warn', (msg) => this.hud.setLobbyStatus(msg));
+        this.net.on('message', (msg) => this.onNet(msg));
+    }
+
+    onNet(msg) {
+        if (!msg || !msg.type) return;
+        if (this.mode === 'online-host' && msg.type === 'input') {
+            this.guestInput = {
+                throttle: clamp(msg.throttle || 0, -1, 1),
+                steer: clamp(msg.steer || 0, -1, 1),
+                boost: Boolean(msg.boost),
+                jump: Boolean(msg.jump)
+            };
+        }
+        if (this.mode === 'online-guest' && msg.type === 'state') {
+            this.snaps.push({ t: performance.now() / 1000, snap: msg.snap, events: msg.events || [] });
+            if (this.snaps.length > 24) this.snaps.shift();
+            if (msg.events) this.handleEvents(msg.events, false);
+        }
+    }
+
+    enterAttract() {
+        this.mode = 'attract';
+        this.state = 'menu';
+        this.match = createMatch();
+        this.paused = false;
+        this.hud.showMenu();
+        this.hud.setTouch(false);
+        this.audio.setMode('menu');
+        this.net.destroy();
+    }
+
+    async startHost() {
+        this.audio.init();
+        this.audio.blip();
+        const code = randomCode();
+        this.hud.showLobby(code);
+        this.state = 'lobby';
+        this.mode = 'lobby';
+        await this.net.host(code);
+    }
+
+    async startJoin(raw) {
+        this.audio.init();
+        const code = String(raw || '').trim().toUpperCase().replace(/[^A-Z0-9]/g, '').slice(0, 4);
+        if (code.length < 4) {
+            this.hud.els.joinForm.hidden = false;
+            this.hud.els.joinCode.focus();
+            return;
+        }
+        this.audio.blip();
+        this.hud.showLobby(code);
+        this.hud.setLobbyStatus('Procurando o host no rift…');
+        this.state = 'lobby';
+        this.mode = 'lobby';
+        await this.net.join(code);
+    }
+
+    async copyRoom() {
+        if (!this.net.code) return;
+        const url = roomUrl(this.net.code);
+        try {
+            await navigator.clipboard.writeText(url);
+            this.hud.setLobbyStatus('Link copiado. Manda para a outra pessoa.');
+        } catch {
+            this.hud.setLobbyStatus(url);
+        }
+        this.audio.blip();
+    }
+
+    startMatch(mode) {
+        this.audio.init();
+        this.audio.blip();
+        this.mode = mode;
+        this.state = 'play';
+        this.paused = false;
+        this.match = createMatch();
+        this.snaps.length = 0;
+        this.pendingEvents = [];
+        this.guestInput = blankInput();
+        this.localSlot = mode === 'online-guest' ? 1 : 0;
+        this.hud.showHud();
+        this.hud.setTouch(this.mobile && mode !== 'local');
+        this.hud.setNames(TEAMS[0].name, TEAMS[1].name);
+        this.hud.setScore(this.match.score, this.match.clock, false);
+        this.hud.announce('Riftball', 1.1);
+        this.audio.setMode('play');
+        this.audio.whistle();
+        if (mode === 'online-host') this.hud.setNet(this.net.transport === 'broadcast' ? 'abas' : 'P2P host');
+        else if (mode === 'online-guest') this.hud.setNet('P2P');
+        else this.hud.setNet(mode === 'local' ? '2P local' : mode === 'cpu' ? 'CPU' : '');
+        this.input.enabled = true;
+    }
+
+    replay() {
+        if (this.mode === 'online-guest') return;
+        if (this.mode === 'online-host' || this.mode === 'local' || this.mode === 'cpu') {
+            this.startMatch(this.mode);
+        } else {
+            this.startMatch('cpu');
+        }
+    }
+
+    backToMenu() {
+        this.net.destroy();
+        this.hud.showPause(false);
+        this.enterAttract();
+        const url = new URL(window.location.href);
+        url.searchParams.delete('sala');
+        history.replaceState({}, '', url);
+    }
+
+    togglePause(force) {
+        if (this.state !== 'play') return;
+        if (this.mode.startsWith('online')) return;
+        this.paused = typeof force === 'boolean' ? force : !this.paused;
+        this.hud.showPause(this.paused);
+        this.input.enabled = !this.paused;
+    }
+
+    toggleMute() {
+        this.settings.muted = !this.settings.muted;
+        this.audio.setEnabled(!this.settings.muted);
+        this.hud.setMuted(this.settings.muted);
+        this.saveSettings();
+    }
+
+    handleEvents(events, localSim) {
+        const attract = this.mode === 'attract';
+        for (const ev of events) {
+            if (ev.type === 'kick') {
+                this.effects.burst(ev.x, ev.y, ev.z, TEAMS[ev.team].color, 10 + ev.impact * 2, 7);
+                if (localSim && !attract) this.audio.kickHit(ev.impact);
+            }
+            if (ev.type === 'bump') {
+                this.effects.burst(ev.x, ev.y, ev.z, 0xffffff, 8, 5);
+                if (localSim && !attract) this.audio.bump();
+            }
+            if (ev.type === 'goal') {
+                this.effects.burst(ev.x, ev.y, ev.z, TEAMS[ev.team].color, 48, 14);
+                this.effects.shockwave(ev.x, ev.z, TEAMS[ev.team].color);
+                if (!attract) {
+                    this.hud.announce(`GOL · ${TEAMS[ev.team].name}`, 1.8);
+                    this.audio.setMode('goal');
+                    this.audio.goal();
+                    window.setTimeout(() => this.audio.setMode('play'), 1600);
+                }
+            }
+            if (attract) continue;
+            if (ev.type === 'play') this.hud.announce('vai', 0.7);
+            if (ev.type === 'overtime') this.hud.announce('gol de ouro', 1.6);
+            if (ev.type === 'over') {
+                const w = TEAMS[ev.winner];
+                this.hud.showResult(w.name, ev.score || this.match.score, ev.overtime);
+                this.audio.setMode('menu');
+                this.state = 'result';
+            }
+        }
+    }
+
+    sim(dt) {
+        if (this.mode === 'online-guest') return;
+
+        this.inputs[0] = blankInput();
+        this.inputs[1] = blankInput();
+
+        if (this.mode === 'attract') {
+            this.inputs[0] = aiInput(this.match.crafts[0], this.match.crafts[1], this.match.ball, 0);
+            this.inputs[1] = aiInput(this.match.crafts[1], this.match.crafts[0], this.match.ball, 1);
+        } else if (this.mode === 'cpu') {
+            this.inputs[0] = this.input.sample(0);
+            this.inputs[1] = aiInput(this.match.crafts[1], this.match.crafts[0], this.match.ball, 1);
+        } else if (this.mode === 'local') {
+            this.inputs[0] = this.input.sample(0);
+            this.inputs[1] = this.input.sample(1);
+        } else if (this.mode === 'online-host') {
+            this.inputs[0] = this.input.sample(0);
+            this.inputs[1] = this.guestInput;
+            this.guestInput = { ...this.guestInput, jump: false };
+        }
+
+        step(this.match, this.inputs, dt);
+        this.handleEvents(this.match.events, true);
+        if (this.mode === 'online-host' && this.match.events.length) {
+            this.pendingEvents.push(...this.match.events);
+        }
+
+        if (this.mode === 'attract' && this.match.phase === 'over') {
+            this.match = createMatch();
+        }
+    }
+
+    sendNet(dt) {
+        if (this.mode === 'online-host') {
+            this.netAccum += dt;
+            if (this.netAccum >= NET.tick) {
+                this.netAccum = 0;
+                this.net.send({
+                    type: 'state',
+                    snap: snapshot(this.match),
+                    events: this.pendingEvents.splice(0, this.pendingEvents.length)
+                });
+            }
+        }
+        if (this.mode === 'online-guest') {
+            this.inputAccum += dt;
+            if (this.inputAccum >= NET.inputTick) {
+                this.inputAccum = 0;
+                const inp = this.input.sample(0);
+                this.net.send({ type: 'input', ...inp });
+            }
+        }
+    }
+
+    applyGuestView() {
+        if (this.snaps.length < 2) {
+            if (this.snaps[0]) applySnapshot(this.match, this.snaps[0].snap);
+            return;
+        }
+        const now = performance.now() / 1000 - NET.delay;
+        let a = this.snaps[0];
+        let b = this.snaps[this.snaps.length - 1];
+        for (let i = 0; i < this.snaps.length - 1; i++) {
+            if (this.snaps[i].t <= now && this.snaps[i + 1].t >= now) {
+                a = this.snaps[i];
+                b = this.snaps[i + 1];
+                break;
+            }
+        }
+        const span = Math.max(1e-4, b.t - a.t);
+        const t = clamp((now - a.t) / span, 0, 1);
+        const sa = a.snap;
+        const sb = b.snap;
+        for (let i = 0; i < 2; i++) {
+            const ca = sa.crafts[i];
+            const cb = sb.crafts[i];
+            const c = this.match.crafts[i];
+            c.x = lerp(ca.x, cb.x, t);
+            c.y = lerp(ca.y, cb.y, t);
+            c.z = lerp(ca.z, cb.z, t);
+            c.yaw = ca.yaw + wrapPi(cb.yaw - ca.yaw) * t;
+            c.boost = lerp(ca.boost, cb.boost, t);
+            c.boosting = cb.boosting;
+        }
+        const ba = sa.ball;
+        const bb = sb.ball;
+        this.match.ball.x = lerp(ba.x, bb.x, t);
+        this.match.ball.y = lerp(ba.y, bb.y, t);
+        this.match.ball.z = lerp(ba.z, bb.z, t);
+        this.match.score[0] = sb.score[0];
+        this.match.score[1] = sb.score[1];
+        this.match.phase = sb.phase;
+        this.match.clock = sb.clock;
+        this.match.overtime = sb.overtime;
+    }
+
+    updateCamera(dt) {
+        const mode = CAMERAS[this.cameraMode];
+        const p1 = this.match.crafts[0];
+        const p2 = this.match.crafts[1];
+        const ball = this.match.ball;
+        const me = this.match.crafts[this.localSlot];
+
+        if (this.mode === 'attract' || mode === 'orbit') {
+            const ang = this.time * 0.12;
+            this._wanted.set(Math.sin(ang) * 34, 16, Math.cos(ang) * 34);
+            this._look.set(0, 1.2, 0);
+        } else if (mode === 'broadcast' || this.mode === 'local') {
+            const cx = (p1.x + p2.x + ball.x) / 3;
+            const cz = (p1.z + p2.z + ball.z) / 3;
+            const spread = Math.max(
+                Math.hypot(p1.x - p2.x, p1.z - p2.z),
+                Math.hypot(p1.x - ball.x, p1.z - ball.z),
+                14
+            );
+            this._wanted.set(cx, 9 + spread * 0.38, cz + 16 + spread * 0.2);
+            this._look.set(cx, 1, cz);
+        } else {
+            const hx = Math.sin(me.yaw);
+            const hz = Math.cos(me.yaw);
+            this._wanted.set(me.x - hx * 9.5, me.y + 4.2, me.z - hz * 9.5);
+            this._look.set(me.x + hx * 4 + ball.x * 0.08, 1.1, me.z + hz * 4 + ball.z * 0.08);
+        }
+
+        this._camPos.lerp(this._wanted, 1 - Math.exp(-3.2 * dt));
+        this.camera.position.copy(this._camPos);
+        this.camera.getWorldDirection(this._dir);
+        this._lookFrom.copy(this._look).sub(this.camera.position).normalize();
+        this._dir.lerp(this._lookFrom, 1 - Math.exp(-4 * dt));
+        this._lookFrom.copy(this.camera.position).add(this._dir);
+        this.camera.lookAt(this._lookFrom);
+    }
+
+    resize() {
+        const w = window.innerWidth;
+        const h = window.innerHeight;
+        this.camera.aspect = w / h;
+        this.camera.updateProjectionMatrix();
+        this.renderer.setSize(w, h, false);
+        this.composer.setSize(w, h);
+        this.bloom?.setSize(w, h);
+    }
+
+    loop = () => {
+        requestAnimationFrame(this.loop);
+        const now = performance.now();
+        let dt = (now - this.last) / 1000;
+        this.last = now;
+        if (dt > 0.08) dt = 0.08;
+        this.time += dt;
+
+        this.fpsAccum += dt;
+        this.fpsFrames += 1;
+        if (this.fpsAccum >= 0.4) {
+            this.fps = Math.round(this.fpsFrames / this.fpsAccum);
+            this.fpsAccum = 0;
+            this.fpsFrames = 0;
+            this.hud.setFps(this.fps, this.settings.quality === 'low');
+        }
+
+        if (!this.paused) {
+            this.accum += dt;
+            let steps = 0;
+            while (this.accum >= DT && steps < MAX_STEPS) {
+                this.sim(DT);
+                this.accum -= DT;
+                steps += 1;
+            }
+            this.sendNet(dt);
+            if (this.mode === 'online-guest') this.applyGuestView();
+        }
+
+        syncCraft(this.crafts[0], this.match.crafts[0], dt);
+        syncCraft(this.crafts[1], this.match.crafts[1], dt);
+        syncBall(this.ball, this.match.ball, this.time);
+        this.effects.trail(0, this.match.crafts[0].x, this.match.crafts[0].y, this.match.crafts[0].z, this.match.crafts[0].boosting);
+        this.effects.trail(1, this.match.crafts[1].x, this.match.crafts[1].y, this.match.crafts[1].z, this.match.crafts[1].boosting);
+        this.effects.update(dt);
+        this.world.update(dt, this.time);
+        this.updateCamera(dt);
+
+        if (this.state === 'play' || this.state === 'result') {
+            this.hud.setScore(this.match.score, this.match.clock, this.match.overtime);
+            const me = this.match.crafts[this.localSlot];
+            this.hud.setBoost(me.boost);
+        }
+        this.hud.tick(this.time);
+
+        this.composer.render();
+    };
+}
+
+const game = new Game();
+game.boot();

--- a/labs/riftball/src/net.js
+++ b/labs/riftball/src/net.js
@@ -1,0 +1,186 @@
+/**
+ * Rede 1v1: BroadcastChannel (mesma origem / duas abas) + WebRTC via PeerJS
+ * (máquinas diferentes, sinalização na nuvem pública do PeerJS).
+ *
+ * O host é autoridade da física. O convidado manda input; o host devolve
+ * snapshots. Sem servidor de jogo — GitHub Pages só entrega o estático.
+ */
+
+import { NET } from './config.js';
+
+export function randomCode() {
+    let s = '';
+    for (let i = 0; i < 4; i++) {
+        s += NET.alphabet[Math.floor(Math.random() * NET.alphabet.length)];
+    }
+    return s;
+}
+
+export function roomUrl(code) {
+    const url = new URL(window.location.href);
+    url.searchParams.set('sala', code);
+    url.hash = '';
+    return url.toString();
+}
+
+function waitPeerCtor(timeout = 6000) {
+    if (window.Peer) return Promise.resolve(window.Peer);
+    return new Promise((resolve, reject) => {
+        const t0 = performance.now();
+        const tick = () => {
+            if (window.Peer) return resolve(window.Peer);
+            if (performance.now() - t0 > timeout) {
+                reject(new Error('PeerJS não carregou. Verifique a rede.'));
+                return;
+            }
+            requestAnimationFrame(tick);
+        };
+        tick();
+    });
+}
+
+export class Net {
+    constructor() {
+        this.role = null;
+        this.code = null;
+        this.connected = false;
+        this.transport = null;
+        this.peer = null;
+        this.conn = null;
+        this.channel = null;
+        this.handlers = {};
+        this._bcBound = false;
+    }
+
+    on(ev, fn) {
+        this.handlers[ev] = fn;
+    }
+
+    emit(ev, data) {
+        this.handlers[ev]?.(data);
+    }
+
+    send(msg) {
+        if (!this.connected) return;
+        try {
+            if (this.conn?.open) this.conn.send(msg);
+        } catch { /* ignore */ }
+        try {
+            this.channel?.postMessage({ from: this.role, msg });
+        } catch { /* ignore */ }
+    }
+
+    destroy() {
+        this.connected = false;
+        try { this.conn?.close(); } catch { /* ignore */ }
+        try { this.peer?.destroy(); } catch { /* ignore */ }
+        try { this.channel?.close(); } catch { /* ignore */ }
+        this.conn = null;
+        this.peer = null;
+        this.channel = null;
+        this._bcBound = false;
+    }
+
+    _bindBroadcast(code) {
+        if (typeof BroadcastChannel === 'undefined') return;
+        this.channel = new BroadcastChannel(`riftball:${code}`);
+        this.channel.onmessage = (ev) => {
+            const data = ev.data;
+            if (!data || data.from === this.role) return;
+            if (data.msg?.type === 'hello' && this.role === 'host' && !this.connected) {
+                this.transport = 'broadcast';
+                this.connected = true;
+                this.channel.postMessage({ from: 'host', msg: { type: 'welcome' } });
+                this.emit('connected');
+                return;
+            }
+            if (data.msg?.type === 'welcome' && this.role === 'guest' && !this.connected) {
+                this.transport = 'broadcast';
+                this.connected = true;
+                this.emit('connected');
+                return;
+            }
+            if (this.connected) this.emit('message', data.msg);
+        };
+        this._bcBound = true;
+    }
+
+    async host(code) {
+        this.destroy();
+        this.role = 'host';
+        this.code = code;
+        this._bindBroadcast(code);
+        this._startPeerHost(code).catch((err) => this.emit('warn', err.message));
+    }
+
+    async join(code) {
+        this.destroy();
+        this.role = 'guest';
+        this.code = code;
+        this._bindBroadcast(code);
+        this.channel?.postMessage({ from: 'guest', msg: { type: 'hello' } });
+        this._startPeerGuest(code).catch((err) => this.emit('error', err.message));
+    }
+
+    async _startPeerHost(code) {
+        const Peer = await waitPeerCtor();
+        const peer = new Peer(`${NET.prefix}${code}`, { debug: 0 });
+        this.peer = peer;
+        peer.on('error', (err) => {
+            if (String(err?.type) === 'unavailable-id') {
+                this.emit('error', 'Esse código já está em uso. Crie outra sala.');
+            } else {
+                this.emit('warn', err.message || 'PeerJS avisou um erro.');
+            }
+        });
+        peer.on('connection', (conn) => {
+            if (this.connected && this.transport === 'broadcast') {
+                conn.close();
+                return;
+            }
+            this.conn = conn;
+            conn.on('data', (msg) => this.emit('message', msg));
+            conn.on('close', () => {
+                if (this.transport === 'webrtc') {
+                    this.connected = false;
+                    this.emit('disconnected');
+                }
+            });
+            conn.on('open', () => {
+                if (this.connected) return;
+                this.transport = 'webrtc';
+                this.connected = true;
+                this.emit('connected');
+            });
+        });
+    }
+
+    async _startPeerGuest(code) {
+        const Peer = await waitPeerCtor();
+        const peer = new Peer({ debug: 0 });
+        this.peer = peer;
+        peer.on('error', (err) => {
+            this.emit('error', err.message || 'Não deu para achar a sala.');
+        });
+        await new Promise((resolve, reject) => {
+            peer.on('open', resolve);
+            peer.on('error', reject);
+        });
+        if (this.connected) return;
+        const conn = peer.connect(`${NET.prefix}${code}`, { reliable: true });
+        this.conn = conn;
+        conn.on('data', (msg) => this.emit('message', msg));
+        conn.on('close', () => {
+            if (this.transport === 'webrtc') {
+                this.connected = false;
+                this.emit('disconnected');
+            }
+        });
+        conn.on('open', () => {
+            if (this.connected) return;
+            this.transport = 'webrtc';
+            this.connected = true;
+            this.emit('connected');
+        });
+    }
+}

--- a/labs/riftball/src/physics.js
+++ b/labs/riftball/src/physics.js
@@ -1,0 +1,362 @@
+/**
+ * Simulação pura — sem three.js. O host (ou o modo local) avança o estado.
+ *
+ * Hover: a = heading * (thrust + boostThrust * boosting)
+ *        v_lat *= exp(-grip * dt)   // deriva morre
+ *        |v| limitado; yaw' = steer * STEER * (0.28 + 0.72 * speedNorm)
+ *
+ * Bola: gravidade, quique com restituição, arrasto leve.
+ * Gol: |x| > halfX - 0.15, |z| < goalHalfZ, y < goalHeight.
+ */
+
+import {
+    ARENA, BALL, CRAFT, HIT, PADS, PAD_RADIUS, TEAMS,
+    SCORE_LIMIT, MATCH_TIME, KICKOFF_T, GOAL_FREEZE
+} from './config.js';
+import { clamp, wrapPi } from './utils.js';
+
+function emptyInput() {
+    return { throttle: 0, steer: 0, boost: false, jump: false };
+}
+
+export function blankInput() {
+    return emptyInput();
+}
+
+function makeCraft(team) {
+    const def = TEAMS[team];
+    return {
+        team,
+        x: def.spawnX,
+        y: CRAFT.hover,
+        z: 0,
+        yaw: def.yaw,
+        vx: 0,
+        vy: 0,
+        vz: 0,
+        boost: 1,
+        air: false,
+        boosting: false
+    };
+}
+
+function makeBall() {
+    return { x: 0, y: BALL.radius + 0.15, z: 0, vx: 0, vy: 0, vz: 0 };
+}
+
+export function createMatch() {
+    return {
+        crafts: [makeCraft(0), makeCraft(1)],
+        ball: makeBall(),
+        score: [0, 0],
+        phase: 'kickoff',
+        phaseT: KICKOFF_T,
+        clock: MATCH_TIME,
+        overtime: false,
+        events: []
+    };
+}
+
+export function resetKickoff(state, scorer = -1) {
+    state.crafts[0] = makeCraft(0);
+    state.crafts[1] = makeCraft(1);
+    state.ball = makeBall();
+    if (scorer === 0) state.ball.vx = 2.2;
+    else if (scorer === 1) state.ball.vx = -2.2;
+    state.phase = 'kickoff';
+    state.phaseT = KICKOFF_T;
+}
+
+function speedLimit(vx, vz, max) {
+    const s = Math.hypot(vx, vz);
+    if (s <= max || s < 1e-6) return [vx, vz];
+    const k = max / s;
+    return [vx * k, vz * k];
+}
+
+function bounceWalls(body, r, rest) {
+    const maxX = ARENA.halfX - r;
+    const maxZ = ARENA.halfZ - r;
+    let hit = false;
+    if (body.x > maxX) {
+        body.x = maxX;
+        if (body.vx > 0) body.vx *= -rest;
+        hit = true;
+    } else if (body.x < -maxX) {
+        body.x = -maxX;
+        if (body.vx < 0) body.vx *= -rest;
+        hit = true;
+    }
+    if (body.z > maxZ) {
+        body.z = maxZ;
+        if (body.vz > 0) body.vz *= -rest;
+        hit = true;
+    } else if (body.z < -maxZ) {
+        body.z = -maxZ;
+        if (body.vz < 0) body.vz *= -rest;
+        hit = true;
+    }
+    return hit;
+}
+
+function collideSpheres(a, ra, ma, b, rb, mb, e) {
+    const dx = b.x - a.x;
+    const dy = b.y - a.y;
+    const dz = b.z - a.z;
+    const dist = Math.hypot(dx, dy, dz);
+    const min = ra + rb;
+    if (dist < 1e-6 || dist >= min) return false;
+    const nx = dx / dist;
+    const ny = dy / dist;
+    const nz = dz / dist;
+    const overlap = min - dist + HIT.minSep;
+    const inv = 1 / ma + 1 / mb;
+    a.x -= nx * overlap * (1 / ma) / inv;
+    a.y -= ny * overlap * (1 / ma) / inv;
+    a.z -= nz * overlap * (1 / ma) / inv;
+    b.x += nx * overlap * (1 / mb) / inv;
+    b.y += ny * overlap * (1 / mb) / inv;
+    b.z += nz * overlap * (1 / mb) / inv;
+    const rel = (b.vx - a.vx) * nx + (b.vy - a.vy) * ny + (b.vz - a.vz) * nz;
+    if (rel < 0) {
+        const j = -(1 + e) * rel / inv;
+        a.vx -= (j / ma) * nx;
+        a.vy -= (j / ma) * ny;
+        a.vz -= (j / ma) * nz;
+        b.vx += (j / mb) * nx;
+        b.vy += (j / mb) * ny;
+        b.vz += (j / mb) * nz;
+    }
+    return true;
+}
+
+function inGoal(ball) {
+    if (ball.y > ARENA.goalHeight) return -1;
+    if (Math.abs(ball.z) > ARENA.goalHalfZ) return -1;
+    if (ball.x > ARENA.halfX - 0.2) return 0;
+    if (ball.x < -ARENA.halfX + 0.2) return 1;
+    return -1;
+}
+
+function stepCraft(c, input, dt) {
+    const throttle = clamp(input.throttle, -1, 1);
+    const steer = clamp(input.steer, -1, 1);
+    const headingX = Math.sin(c.yaw);
+    const headingZ = Math.cos(c.yaw);
+    const boosting = Boolean(input.boost) && c.boost > 0.04 && throttle >= 0;
+    c.boosting = boosting;
+
+    const thrust = CRAFT.thrust * throttle + (boosting ? CRAFT.boostThrust : 0);
+    c.vx += headingX * thrust * dt;
+    c.vz += headingZ * thrust * dt;
+
+    const fwd = c.vx * headingX + c.vz * headingZ;
+    let latX = c.vx - headingX * fwd;
+    let latZ = c.vz - headingZ * fwd;
+    const grip = Math.exp(-CRAFT.grip * dt);
+    latX *= grip;
+    latZ *= grip;
+    c.vx = headingX * fwd + latX;
+    c.vz = headingZ * fwd + latZ;
+
+    const max = boosting ? CRAFT.boostMax : CRAFT.maxSpeed;
+    [c.vx, c.vz] = speedLimit(c.vx, c.vz, max);
+    const drag = Math.exp(-CRAFT.drag * dt);
+    c.vx *= drag;
+    c.vz *= drag;
+
+    const spd = Math.hypot(c.vx, c.vz);
+    const speedNorm = clamp(spd / CRAFT.maxSpeed, 0, 1);
+    const reverse = fwd < -0.4 ? -CRAFT.reverseSteer : 1;
+    c.yaw += steer * CRAFT.steer * (0.28 + 0.72 * speedNorm) * reverse * dt;
+    c.yaw = wrapPi(c.yaw);
+
+    if (input.jump && !c.air && c.y <= CRAFT.hover + 0.08) {
+        c.vy = CRAFT.jump;
+        c.air = true;
+    }
+    c.vy -= CRAFT.gravity * dt;
+    c.y += c.vy * dt;
+    if (c.y <= CRAFT.hover) {
+        c.y = CRAFT.hover;
+        if (c.vy < 0) c.vy = 0;
+        c.air = false;
+    }
+
+    c.x += c.vx * dt;
+    c.z += c.vz * dt;
+    if (bounceWalls(c, CRAFT.radius, CRAFT.wallRest)) {
+        /* wall tap */
+    }
+
+    if (boosting) c.boost = Math.max(0, c.boost - CRAFT.boostDrain * dt);
+    else c.boost = Math.min(CRAFT.boostMaxMeter, c.boost + CRAFT.boostRegen * dt);
+
+    for (const pad of PADS) {
+        if (Math.hypot(c.x - pad.x, c.z - pad.z) < PAD_RADIUS) {
+            c.boost = Math.min(CRAFT.boostMaxMeter, c.boost + CRAFT.padRegen * dt);
+        }
+    }
+}
+
+function stepBall(b, dt) {
+    b.vy -= BALL.gravity * dt;
+    const ad = Math.exp(-BALL.airDrag * dt);
+    b.vx *= ad;
+    b.vz *= ad;
+    b.x += b.vx * dt;
+    b.y += b.vy * dt;
+    b.z += b.vz * dt;
+
+    const floor = ARENA.floorY + BALL.radius;
+    if (b.y < floor) {
+        b.y = floor;
+        if (b.vy < 0) b.vy = -b.vy * BALL.restitution;
+        b.vx *= BALL.floorFriction;
+        b.vz *= BALL.floorFriction;
+        if (Math.abs(b.vy) < 0.8) b.vy = 0;
+    }
+    if (b.y > ARENA.ceiling - BALL.radius) {
+        b.y = ARENA.ceiling - BALL.radius;
+        if (b.vy > 0) b.vy *= -0.4;
+    }
+    const inMouth = Math.abs(b.z) < ARENA.goalHalfZ && b.y < ARENA.goalHeight;
+    if (inMouth) {
+        const maxZ = ARENA.halfZ - BALL.radius;
+        if (b.z > maxZ) {
+            b.z = maxZ;
+            if (b.vz > 0) b.vz *= -BALL.wallRest;
+        } else if (b.z < -maxZ) {
+            b.z = -maxZ;
+            if (b.vz < 0) b.vz *= -BALL.wallRest;
+        }
+    } else {
+        bounceWalls(b, BALL.radius, BALL.wallRest);
+    }
+    [b.vx, b.vz] = speedLimit(b.vx, b.vz, BALL.maxSpeed);
+}
+
+export function step(state, inputs, dt) {
+    state.events.length = 0;
+    if (state.phase === 'over') return state;
+
+    if (state.phase === 'kickoff' || state.phase === 'goal') {
+        state.phaseT -= dt;
+        if (state.phase === 'kickoff' && state.phaseT <= 0) {
+            state.phase = 'play';
+            state.events.push({ type: 'play' });
+        }
+        if (state.phase === 'goal' && state.phaseT <= 0) {
+            const last = state.events;
+            resetKickoff(state, state._lastScorer ?? -1);
+            state.events = last;
+        }
+        return state;
+    }
+
+    if (!state.overtime) {
+        state.clock = Math.max(0, state.clock - dt);
+    }
+
+    const ins = [inputs[0] || emptyInput(), inputs[1] || emptyInput()];
+    stepCraft(state.crafts[0], ins[0], dt);
+    stepCraft(state.crafts[1], ins[1], dt);
+    stepBall(state.ball, dt);
+
+    const a = state.crafts[0];
+    const b = state.crafts[1];
+    const ball = state.ball;
+
+    if (collideSpheres(a, CRAFT.radius, CRAFT.mass, b, CRAFT.radius, CRAFT.mass, HIT.craftCraftE)) {
+        state.events.push({ type: 'bump', x: (a.x + b.x) * 0.5, y: (a.y + b.y) * 0.5, z: (a.z + b.z) * 0.5 });
+    }
+
+    for (const c of state.crafts) {
+        const before = { vx: ball.vx, vy: ball.vy, vz: ball.vz };
+        if (collideSpheres(c, CRAFT.radius, CRAFT.mass, ball, BALL.radius, BALL.mass, HIT.craftBallE)) {
+            const hx = Math.sin(c.yaw);
+            const hz = Math.cos(c.yaw);
+            const extra = HIT.kick + (c.boosting ? HIT.boostKick : 0);
+            ball.vx += hx * extra * 0.35;
+            ball.vz += hz * extra * 0.35;
+            const impact = Math.hypot(ball.vx - before.vx, ball.vy - before.vy, ball.vz - before.vz);
+            state.events.push({
+                type: 'kick',
+                x: ball.x,
+                y: ball.y,
+                z: ball.z,
+                team: c.team,
+                impact
+            });
+        }
+    }
+
+    const scorer = inGoal(ball);
+    if (scorer >= 0) {
+        state.score[scorer] += 1;
+        state._lastScorer = scorer;
+        state.events.push({ type: 'goal', team: scorer, x: ball.x, y: ball.y, z: ball.z });
+        const lead = state.score[0] !== state.score[1];
+        const hitLimit = state.score[scorer] >= SCORE_LIMIT;
+        const timeUp = state.clock <= 0;
+        if (hitLimit || (timeUp && lead) || (state.overtime && lead)) {
+            state.phase = 'over';
+            state.events.push({
+                type: 'over',
+                winner: state.score[0] > state.score[1] ? 0 : 1,
+                score: [state.score[0], state.score[1]],
+                overtime: state.overtime
+            });
+        } else {
+            state.phase = 'goal';
+            state.phaseT = GOAL_FREEZE;
+        }
+        return state;
+    }
+
+    if (state.clock <= 0 && !state.overtime && state.phase === 'play') {
+        if (state.score[0] !== state.score[1]) {
+            state.phase = 'over';
+            state.events.push({
+                type: 'over',
+                winner: state.score[0] > state.score[1] ? 0 : 1,
+                score: [state.score[0], state.score[1]],
+                overtime: false
+            });
+        } else {
+            state.overtime = true;
+            state.events.push({ type: 'overtime' });
+        }
+    }
+
+    return state;
+}
+
+export function snapshot(state) {
+    const c = (p) => ({
+        x: p.x, y: p.y, z: p.z, yaw: p.yaw,
+        vx: p.vx, vy: p.vy, vz: p.vz,
+        boost: p.boost, air: p.air, boosting: p.boosting
+    });
+    return {
+        crafts: [c(state.crafts[0]), c(state.crafts[1])],
+        ball: { ...state.ball },
+        score: [state.score[0], state.score[1]],
+        phase: state.phase,
+        phaseT: state.phaseT,
+        clock: state.clock,
+        overtime: state.overtime
+    };
+}
+
+export function applySnapshot(state, snap) {
+    Object.assign(state.crafts[0], snap.crafts[0]);
+    Object.assign(state.crafts[1], snap.crafts[1]);
+    Object.assign(state.ball, snap.ball);
+    state.score[0] = snap.score[0];
+    state.score[1] = snap.score[1];
+    state.phase = snap.phase;
+    state.phaseT = snap.phaseT;
+    state.clock = snap.clock;
+    state.overtime = snap.overtime;
+}

--- a/labs/riftball/src/utils.js
+++ b/labs/riftball/src/utils.js
@@ -1,0 +1,45 @@
+/** Utilitários numéricos e detecção de dispositivo. */
+
+export const clamp = (v, min, max) => (v < min ? min : v > max ? max : v);
+export const lerp = (a, b, t) => a + (b - a) * t;
+export const damp = (current, target, lambda, dt) =>
+    lerp(current, target, 1 - Math.exp(-lambda * dt));
+
+export const TAU = Math.PI * 2;
+
+export function wrapPi(a) {
+    while (a > Math.PI) a -= TAU;
+    while (a < -Math.PI) a += TAU;
+    return a;
+}
+
+export function formatTime(seconds) {
+    const s = Math.max(0, Math.floor(seconds));
+    const m = Math.floor(s / 60);
+    const r = s % 60;
+    return `${m}:${r.toString().padStart(2, '0')}`;
+}
+
+export function detectMobile() {
+    if (typeof navigator === 'undefined') return false;
+    const coarse = window.matchMedia?.('(pointer: coarse)')?.matches;
+    const narrow = Math.min(window.innerWidth, window.innerHeight) < 760;
+    return Boolean(coarse && narrow) || /Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
+}
+
+export function detectSoftwareGL() {
+    try {
+        const canvas = document.createElement('canvas');
+        const gl = canvas.getContext('webgl2') || canvas.getContext('webgl');
+        if (!gl) return true;
+        const info = gl.getExtension('WEBGL_debug_renderer_info');
+        const name = info ? String(gl.getParameter(info.UNMASKED_RENDERER_WEBGL) || '') : '';
+        return /swiftshader|llvmpipe|softpipe|microsoft basic render|\bcpu\b/i.test(name);
+    } catch {
+        return true;
+    }
+}
+
+export function hexColor(n) {
+    return `#${n.toString(16).padStart(6, '0')}`;
+}

--- a/labs/riftball/src/world.js
+++ b/labs/riftball/src/world.js
@@ -1,0 +1,327 @@
+/**
+ * Arena flutuante no rift: céu em shader, piso de energia, portais-gol,
+ * boost pads e fragmentos de cristal.
+ */
+
+import * as THREE from 'three';
+import { ARENA, PADS, PAD_RADIUS, TEAMS } from './config.js';
+
+function skyMaterial() {
+    return new THREE.ShaderMaterial({
+        side: THREE.BackSide,
+        depthWrite: false,
+        fog: false,
+        uniforms: {
+            uTime: { value: 0 }
+        },
+        vertexShader: /* glsl */ `
+            varying vec3 vPos;
+            void main() {
+                vPos = position;
+                gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+            }
+        `,
+        fragmentShader: /* glsl */ `
+            varying vec3 vPos;
+            uniform float uTime;
+            float hash(vec2 p) {
+                return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453);
+            }
+            float noise(vec2 p) {
+                vec2 i = floor(p);
+                vec2 f = fract(p);
+                float a = hash(i);
+                float b = hash(i + vec2(1.0, 0.0));
+                float c = hash(i + vec2(0.0, 1.0));
+                float d = hash(i + vec2(1.0, 1.0));
+                vec2 u = f * f * (3.0 - 2.0 * f);
+                return mix(mix(a, b, u.x), mix(c, d, u.x), u.y);
+            }
+            void main() {
+                vec3 n = normalize(vPos);
+                float h = n.y;
+                vec3 zenith = vec3(0.02, 0.03, 0.08);
+                vec3 horizon = vec3(0.08, 0.18, 0.38);
+                vec3 ground = vec3(0.04, 0.02, 0.08);
+                vec3 col = mix(horizon, zenith, smoothstep(0.0, 0.55, h));
+                col = mix(ground, col, smoothstep(-0.25, 0.04, h));
+
+                float aurora = noise(vec2(n.x * 3.0 + uTime * 0.04, n.z * 2.2));
+                aurora *= smoothstep(0.05, 0.45, h) * smoothstep(0.85, 0.35, h);
+                col += vec3(0.15, 0.85, 0.9) * aurora * 0.28;
+                col += vec3(0.9, 0.2, 0.75) * (1.0 - aurora) * aurora * 0.22;
+
+                float glow = exp(-pow((h - 0.02) * 6.0, 2.0));
+                col += vec3(0.25, 0.45, 0.9) * glow * 0.35;
+
+                float stars = step(0.993, hash(floor(n.xz * 90.0 + n.y * 40.0))) * smoothstep(0.12, 0.5, h);
+                col += vec3(0.85, 0.92, 1.0) * stars;
+
+                vec3 moonDir = normalize(vec3(-0.42, 0.55, 0.35));
+                float moon = exp(-pow(length(n - moonDir) * 26.0, 2.0));
+                col += vec3(0.85, 0.9, 1.0) * moon * 1.5;
+                col += vec3(0.4, 0.55, 0.95) * exp(-pow(length(n - moonDir) * 7.0, 2.0)) * 0.28;
+
+                gl_FragColor = vec4(col, 1.0);
+            }
+        `
+    });
+}
+
+function floorMaterial() {
+    return new THREE.ShaderMaterial({
+        transparent: true,
+        side: THREE.DoubleSide,
+        uniforms: {
+            uTime: { value: 0 },
+            uHalfX: { value: ARENA.halfX },
+            uHalfZ: { value: ARENA.halfZ }
+        },
+        vertexShader: /* glsl */ `
+            varying vec3 vWorld;
+            void main() {
+                vec4 w = modelMatrix * vec4(position, 1.0);
+                vWorld = w.xyz;
+                gl_Position = projectionMatrix * viewMatrix * w;
+            }
+        `,
+        fragmentShader: /* glsl */ `
+            varying vec3 vWorld;
+            uniform float uTime;
+            uniform float uHalfX;
+            uniform float uHalfZ;
+            void main() {
+                vec2 p = vWorld.xz;
+                float gx = 1.0 - smoothstep(0.04, 0.08, abs(mod(p.x + 1.5, 3.0) - 1.5));
+                float gz = 1.0 - smoothstep(0.04, 0.08, abs(mod(p.y + 1.5, 3.0) - 1.5));
+                float grid = max(gx, gz);
+                float circle = 1.0 - smoothstep(0.06, 0.14, abs(length(p) - 5.5));
+                float mid = 1.0 - smoothstep(0.04, 0.1, abs(p.x));
+                float edgeX = 1.0 - smoothstep(uHalfX - 0.35, uHalfX, abs(p.x));
+                float edgeZ = 1.0 - smoothstep(uHalfZ - 0.35, uHalfZ, abs(p.y));
+                float rim = 1.0 - min(edgeX, edgeZ);
+
+                vec3 cyan = vec3(0.24, 0.94, 1.0);
+                vec3 mag = vec3(1.0, 0.29, 0.85);
+                float side = smoothstep(-8.0, 8.0, p.x);
+                vec3 neon = mix(cyan, mag, side);
+                vec3 base = vec3(0.04, 0.07, 0.14);
+                vec3 col = mix(base, neon, grid * 0.55 + circle * 0.8 + mid * 0.2);
+                col += neon * rim * 0.85;
+                float pulse = 0.55 + 0.45 * sin(uTime * 2.0 + p.x * 0.15);
+                float alpha = 0.42 + grid * 0.28 + rim * 0.35 + circle * 0.2;
+                gl_FragColor = vec4(col * pulse, alpha);
+            }
+        `
+    });
+}
+
+function makeGoal(team) {
+    const def = TEAMS[team];
+    const g = new THREE.Group();
+    const x = team === 0 ? -ARENA.halfX : ARENA.halfX;
+    g.position.x = x;
+    const frameMat = new THREE.MeshStandardMaterial({
+        color: 0x10141c,
+        metalness: 0.7,
+        roughness: 0.28,
+        emissive: def.color,
+        emissiveIntensity: 0.35
+    });
+    const bar = (w, h, d, px, py, pz) => {
+        const m = new THREE.Mesh(new THREE.BoxGeometry(w, h, d), frameMat);
+        m.position.set(px, py, pz);
+        m.castShadow = true;
+        g.add(m);
+    };
+    const w = ARENA.goalHalfZ * 2;
+    bar(0.35, ARENA.goalHeight + 0.35, 0.35, 0, ARENA.goalHeight * 0.5, w * 0.5);
+    bar(0.35, ARENA.goalHeight + 0.35, 0.35, 0, ARENA.goalHeight * 0.5, -w * 0.5);
+    bar(0.35, 0.35, w + 0.35, 0, ARENA.goalHeight, 0);
+    bar(0.35, 0.22, w + 0.35, 0, 0.12, 0);
+
+    const veil = new THREE.Mesh(
+        new THREE.PlaneGeometry(w * 0.96, ARENA.goalHeight * 0.92),
+        new THREE.MeshBasicMaterial({
+            color: def.color,
+            transparent: true,
+            opacity: 0.22,
+            side: THREE.DoubleSide,
+            blending: THREE.AdditiveBlending,
+            depthWrite: false
+        })
+    );
+    veil.position.set(team === 0 ? -0.2 : 0.2, ARENA.goalHeight * 0.48, 0);
+    veil.rotation.y = Math.PI / 2;
+    g.add(veil);
+
+    const ring = new THREE.Mesh(
+        new THREE.TorusGeometry(2.2, 0.08, 10, 48),
+        new THREE.MeshBasicMaterial({
+            color: def.color,
+            transparent: true,
+            opacity: 0.85,
+            blending: THREE.AdditiveBlending,
+            depthWrite: false
+        })
+    );
+    ring.rotation.y = Math.PI / 2;
+    ring.position.y = 2.1;
+    ring.position.x = team === 0 ? -0.8 : 0.8;
+    g.add(ring);
+
+    const light = new THREE.PointLight(def.color, 18, 28, 2);
+    light.position.set(team === 0 ? 2.5 : -2.5, 3.2, 0);
+    g.add(light);
+    g.userData.veil = veil;
+    g.userData.ring = ring;
+    return g;
+}
+
+export class World {
+    constructor(scene, quality) {
+        this.scene = scene;
+        this.quality = quality;
+        this.time = 0;
+        this.group = new THREE.Group();
+        scene.add(this.group);
+
+        this.skyMat = skyMaterial();
+        const sky = new THREE.Mesh(new THREE.SphereGeometry(220, 32, 24), this.skyMat);
+        this.group.add(sky);
+
+        const hemi = new THREE.HemisphereLight(0x6aa0ff, 0x1a1028, 0.55);
+        this.group.add(hemi);
+        const sun = new THREE.DirectionalLight(0xc8d8ff, 1.15);
+        sun.position.set(-30, 48, 18);
+        sun.castShadow = quality.shadows;
+        if (quality.shadows) {
+            sun.shadow.mapSize.set(1024, 1024);
+            sun.shadow.camera.near = 4;
+            sun.shadow.camera.far = 120;
+            sun.shadow.camera.left = -40;
+            sun.shadow.camera.right = 40;
+            sun.shadow.camera.top = 30;
+            sun.shadow.camera.bottom = -30;
+        }
+        this.group.add(sun);
+
+        this.floorMat = floorMaterial();
+        const floor = new THREE.Mesh(
+            new THREE.PlaneGeometry(ARENA.halfX * 2 + 1.2, ARENA.halfZ * 2 + 1.2, 1, 1),
+            this.floorMat
+        );
+        floor.rotation.x = -Math.PI / 2;
+        floor.receiveShadow = true;
+        this.group.add(floor);
+
+        const deck = new THREE.Mesh(
+            new THREE.BoxGeometry(ARENA.halfX * 2 + 4, 0.7, ARENA.halfZ * 2 + 4),
+            new THREE.MeshStandardMaterial({
+                color: 0x0b1020,
+                metalness: 0.4,
+                roughness: 0.55,
+                emissive: 0x0a1830,
+                emissiveIntensity: 0.2
+            })
+        );
+        deck.position.y = -0.42;
+        deck.receiveShadow = true;
+        this.group.add(deck);
+
+        const railMat = new THREE.MeshStandardMaterial({
+            color: 0x101828,
+            metalness: 0.65,
+            roughness: 0.3,
+            emissive: 0x1a3a66,
+            emissiveIntensity: 0.4
+        });
+        const mkRail = (w, d, x, z) => {
+            const m = new THREE.Mesh(new THREE.BoxGeometry(w, 0.85, d), railMat);
+            m.position.set(x, 0.35, z);
+            m.castShadow = true;
+            this.group.add(m);
+        };
+        mkRail(ARENA.halfX * 2 + 2.2, 0.42, 0, ARENA.halfZ + 0.4);
+        mkRail(ARENA.halfX * 2 + 2.2, 0.42, 0, -ARENA.halfZ - 0.4);
+        mkRail(0.42, ARENA.halfZ * 2 - ARENA.goalHalfZ * 2 + 0.4, ARENA.halfX + 0.4, ARENA.halfZ * 0.55);
+        mkRail(0.42, ARENA.halfZ * 2 - ARENA.goalHalfZ * 2 + 0.4, ARENA.halfX + 0.4, -ARENA.halfZ * 0.55);
+        mkRail(0.42, ARENA.halfZ * 2 - ARENA.goalHalfZ * 2 + 0.4, -ARENA.halfX - 0.4, ARENA.halfZ * 0.55);
+        mkRail(0.42, ARENA.halfZ * 2 - ARENA.goalHalfZ * 2 + 0.4, -ARENA.halfX - 0.4, -ARENA.halfZ * 0.55);
+
+        this.goals = [makeGoal(0), makeGoal(1)];
+        this.goals.forEach((g) => this.group.add(g));
+
+        this.pads = PADS.map((p) => {
+            const mesh = new THREE.Mesh(
+                new THREE.CylinderGeometry(PAD_RADIUS * 0.92, PAD_RADIUS, 0.12, 24),
+                new THREE.MeshStandardMaterial({
+                    color: 0x241806,
+                    emissive: 0xffe08a,
+                    emissiveIntensity: 0.8,
+                    metalness: 0.2,
+                    roughness: 0.4
+                })
+            );
+            mesh.position.set(p.x, 0.04, p.z);
+            this.group.add(mesh);
+            const ring = new THREE.Mesh(
+                new THREE.TorusGeometry(PAD_RADIUS * 0.72, 0.05, 8, 32),
+                new THREE.MeshBasicMaterial({
+                    color: 0xffe08a,
+                    transparent: true,
+                    opacity: 0.7,
+                    blending: THREE.AdditiveBlending,
+                    depthWrite: false
+                })
+            );
+            ring.rotation.x = Math.PI / 2;
+            ring.position.set(p.x, 0.18, p.z);
+            this.group.add(ring);
+            return { mesh, ring };
+        });
+
+        this.shards = [];
+        const shardGeo = new THREE.OctahedronGeometry(1, 0);
+        const shardMat = new THREE.MeshStandardMaterial({
+            color: 0x8ecbff,
+            metalness: 0.3,
+            roughness: 0.25,
+            emissive: 0x3cf0ff,
+            emissiveIntensity: 0.15,
+            transparent: true,
+            opacity: 0.85
+        });
+        for (let i = 0; i < quality.shards; i++) {
+            const m = new THREE.Mesh(shardGeo, shardMat.clone());
+            const ang = (i / quality.shards) * Math.PI * 2;
+            const r = 34 + (i % 5) * 4;
+            m.position.set(Math.cos(ang) * r, 4 + (i % 7) * 1.6, Math.sin(ang) * r * 0.7);
+            m.scale.setScalar(0.6 + (i % 4) * 0.45);
+            m.rotation.set(i, i * 0.4, i * 0.2);
+            this.group.add(m);
+            this.shards.push(m);
+        }
+
+        scene.fog = new THREE.FogExp2(0x070b18, 0.012);
+    }
+
+    update(dt, t) {
+        this.time = t;
+        this.skyMat.uniforms.uTime.value = t;
+        this.floorMat.uniforms.uTime.value = t;
+        for (const s of this.shards) {
+            s.rotation.y += dt * 0.12;
+            s.rotation.x += dt * 0.05;
+            s.position.y += Math.sin(t * 0.6 + s.position.x) * 0.01;
+        }
+        for (const pad of this.pads) {
+            pad.ring.rotation.z += dt * 0.8;
+            pad.mesh.material.emissiveIntensity = 0.55 + Math.sin(t * 3) * 0.25;
+        }
+        for (const g of this.goals) {
+            g.userData.ring.rotation.z += dt * 0.7;
+            g.userData.veil.material.opacity = 0.16 + Math.sin(t * 2.4) * 0.06;
+        }
+    }
+}

--- a/labs/riftball/style.css
+++ b/labs/riftball/style.css
@@ -666,6 +666,10 @@ kbd {
     align-items: end;
 }
 
+.join-form[hidden] {
+    display: none;
+}
+
 .join-form .field input {
     font-family: var(--display);
     letter-spacing: 0.28em;

--- a/labs/riftball/style.css
+++ b/labs/riftball/style.css
@@ -1,0 +1,794 @@
+/* ================================================================
+   Riftball — néon ciano/magenta sobre o vazio. Arena flutuante.
+   ================================================================ */
+
+:root {
+    --ink: #070b18;
+    --ink-deep: #04060e;
+    --cyan: #3cf0ff;
+    --cyan-deep: #1494c8;
+    --magenta: #ff4ad8;
+    --magenta-deep: #c4249a;
+    --gold: #ffe08a;
+    --paper: #eef6ff;
+
+    --text: #f4f7ff;
+    --text-soft: #c5d0e8;
+    --text-dim: #7e8aa8;
+
+    --panel: color-mix(in oklab, #0c1224 58%, transparent);
+    --panel-strong: color-mix(in oklab, #080d1c 86%, transparent);
+    --line: color-mix(in oklab, var(--cyan) 28%, transparent);
+
+    --radius: 16px;
+    --radius-lg: 24px;
+    --blur: 18px;
+    --display: "Syne", "Outfit", system-ui, sans-serif;
+    --sans: "Outfit", system-ui, sans-serif;
+
+    --safe-top: env(safe-area-inset-top, 0px);
+    --safe-bottom: env(safe-area-inset-bottom, 0px);
+    --safe-left: env(safe-area-inset-left, 0px);
+    --safe-right: env(safe-area-inset-right, 0px);
+    --ease: cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+*, *::before, *::after {
+    box-sizing: border-box;
+    -webkit-tap-highlight-color: transparent;
+}
+
+html, body {
+    margin: 0;
+    width: 100%;
+    height: 100%;
+    overflow: clip;
+    overscroll-behavior: none;
+    background: var(--ink-deep);
+}
+
+body {
+    min-height: 100dvh;
+    padding: 0;
+    color: var(--text);
+    font-family: var(--sans);
+    user-select: none;
+    -webkit-user-select: none;
+    touch-action: none;
+}
+
+button, input, select {
+    font: inherit;
+    color: inherit;
+}
+
+button {
+    background: none;
+    border: 0;
+    cursor: pointer;
+}
+
+.mono {
+    font-variant-numeric: tabular-nums;
+    font-feature-settings: "tnum" 1;
+}
+
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip-path: inset(50%);
+}
+
+:focus-visible {
+    outline: 2px solid var(--cyan);
+    outline-offset: 3px;
+}
+
+.game-shell {
+    position: fixed;
+    inset: 0;
+    overflow: hidden;
+    background: var(--ink-deep);
+}
+
+#scene {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    display: block;
+    touch-action: none;
+}
+
+.vignette {
+    pointer-events: none;
+    position: absolute;
+    inset: 0;
+    z-index: 2;
+    background:
+        radial-gradient(ellipse at 50% 40%, transparent 42%, rgb(4 6 14 / 0.55) 100%),
+        linear-gradient(to bottom, rgb(4 6 14 / 0.35), transparent 18%, transparent 78%, rgb(4 6 14 / 0.5));
+}
+
+.scan {
+    pointer-events: none;
+    position: absolute;
+    inset: 0;
+    z-index: 3;
+    opacity: 0.07;
+    background: repeating-linear-gradient(
+        to bottom,
+        transparent 0,
+        transparent 2px,
+        rgb(0 0 0 / 0.35) 3px
+    );
+    mix-blend-mode: overlay;
+}
+
+.game-shell > header {
+    position: absolute;
+    top: calc(0.9rem + var(--safe-top));
+    left: calc(1rem + var(--safe-left));
+    right: calc(1rem + var(--safe-right));
+    z-index: 40;
+    margin: 0;
+    padding: 0;
+    max-width: none;
+    width: auto;
+    pointer-events: none;
+    gap: 0.6rem;
+}
+
+.game-shell > header > * {
+    pointer-events: auto;
+}
+
+.game-shell > header .back-link {
+    background: var(--panel-strong);
+    backdrop-filter: blur(var(--blur));
+    border-color: var(--line);
+    color: var(--text-soft);
+    box-shadow: 0 10px 30px rgb(0 0 0 / 0.4);
+}
+
+.game-shell > header .back-link:hover {
+    color: var(--cyan);
+    border-color: var(--cyan);
+}
+
+.game-shell > header .app-logo {
+    background: var(--panel-strong);
+    backdrop-filter: blur(var(--blur));
+    border: 1px solid var(--line);
+    color: var(--text);
+    box-shadow: 0 10px 30px rgb(0 0 0 / 0.35);
+}
+
+.brand-mark {
+    color: var(--cyan);
+    text-shadow: 0 0 18px var(--cyan);
+}
+
+.lab-foot {
+    position: absolute;
+    bottom: calc(0.7rem + var(--safe-bottom));
+    left: calc(1rem + var(--safe-left));
+    z-index: 40;
+    pointer-events: none;
+}
+
+.lab-foot a {
+    pointer-events: auto;
+    color: var(--text-dim);
+    font-size: 0.78rem;
+}
+
+.lab-foot a:hover {
+    color: var(--cyan);
+}
+
+/* ---------- HUD ---------- */
+
+.hud {
+    position: absolute;
+    inset: 0;
+    z-index: 12;
+    pointer-events: none;
+}
+
+.hud > * {
+    pointer-events: none;
+}
+
+.hud-actions,
+.touch-controls {
+    pointer-events: auto;
+}
+
+.scoreboard {
+    position: absolute;
+    top: calc(4.4rem + var(--safe-top));
+    left: 50%;
+    transform: translateX(-50%);
+    display: flex;
+    align-items: stretch;
+    gap: 0;
+    min-width: min(520px, calc(100vw - 2rem));
+    background: var(--panel-strong);
+    backdrop-filter: blur(var(--blur));
+    border: 1px solid var(--line);
+    border-radius: 999px;
+    overflow: hidden;
+    box-shadow: 0 16px 40px rgb(0 0 0 / 0.45);
+}
+
+.score-side {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    gap: 0.7rem;
+    padding: 0.55rem 1.1rem;
+}
+
+.score-side--p1 {
+    justify-content: flex-start;
+    background: linear-gradient(90deg, color-mix(in oklab, var(--cyan) 18%, transparent), transparent);
+}
+
+.score-side--p2 {
+    justify-content: flex-end;
+    background: linear-gradient(270deg, color-mix(in oklab, var(--magenta) 18%, transparent), transparent);
+}
+
+.score-name {
+    font-size: 0.72rem;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--text-soft);
+}
+
+.score-num {
+    font-family: var(--display);
+    font-size: 1.7rem;
+    line-height: 1;
+}
+
+.score-side--p1 .score-num { color: var(--cyan); text-shadow: 0 0 18px var(--cyan); }
+.score-side--p2 .score-num { color: var(--magenta); text-shadow: 0 0 18px var(--magenta); }
+
+.score-mid {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 0.4rem 0.9rem;
+    border-left: 1px solid var(--line);
+    border-right: 1px solid var(--line);
+    min-width: 7.2rem;
+}
+
+.score-clock {
+    font-size: 1.05rem;
+    letter-spacing: 0.08em;
+}
+
+.score-best {
+    font-size: 0.62rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--text-dim);
+}
+
+.boost-wrap {
+    position: absolute;
+    left: 50%;
+    bottom: calc(1.4rem + var(--safe-bottom));
+    transform: translateX(-50%);
+    width: min(280px, 70vw);
+    display: flex;
+    flex-direction: column;
+    gap: 0.28rem;
+    align-items: stretch;
+}
+
+.boost-label {
+    font-size: 0.62rem;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: var(--gold);
+    text-align: center;
+}
+
+.boost-rail {
+    height: 8px;
+    border-radius: 99px;
+    background: rgb(255 255 255 / 0.08);
+    border: 1px solid rgb(255 255 255 / 0.12);
+    overflow: hidden;
+}
+
+.boost-rail i {
+    display: block;
+    height: 100%;
+    width: 0%;
+    background: linear-gradient(90deg, var(--gold), #fff6c8);
+    box-shadow: 0 0 12px var(--gold);
+    transition: width 80ms linear;
+}
+
+.announce {
+    position: absolute;
+    left: 50%;
+    top: 42%;
+    transform: translate(-50%, -50%) scale(0.92);
+    margin: 0;
+    font-family: var(--display);
+    font-size: clamp(2.2rem, 7vw, 4.4rem);
+    font-weight: 800;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: #fff;
+    text-shadow:
+        0 0 24px color-mix(in oklab, var(--cyan) 70%, var(--magenta)),
+        0 8px 40px rgb(0 0 0 / 0.6);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 180ms var(--ease), transform 180ms var(--ease);
+}
+
+.announce[data-show="true"] {
+    opacity: 1;
+    transform: translate(-50%, -50%) scale(1);
+}
+
+.net-badge {
+    position: absolute;
+    top: calc(4.6rem + var(--safe-top));
+    right: calc(1.1rem + var(--safe-right));
+    font-size: 0.62rem;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    padding: 0.35rem 0.6rem;
+    border-radius: 99px;
+    border: 1px solid var(--line);
+    background: var(--panel-strong);
+    color: var(--cyan);
+}
+
+.hud-actions {
+    position: absolute;
+    top: calc(4.5rem + var(--safe-top));
+    left: calc(1.1rem + var(--safe-left));
+    display: flex;
+    gap: 0.45rem;
+    align-items: center;
+}
+
+.icon-button {
+    width: 40px;
+    height: 40px;
+    border-radius: 12px;
+    border: 1px solid var(--line);
+    background: var(--panel-strong);
+    backdrop-filter: blur(var(--blur));
+    color: var(--text-soft);
+    pointer-events: auto;
+}
+
+.icon-button:hover {
+    color: var(--cyan);
+    border-color: var(--cyan);
+}
+
+.fps {
+    font-size: 0.7rem;
+    color: var(--text-dim);
+}
+
+.touch-controls {
+    position: absolute;
+    inset: auto 0 0 0;
+    padding: 0 1rem calc(5.4rem + var(--safe-bottom));
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-end;
+    gap: 1rem;
+}
+
+.steer-zone {
+    width: 132px;
+    height: 132px;
+    border-radius: 50%;
+    border: 1px solid var(--line);
+    background: rgb(8 12 28 / 0.45);
+    position: relative;
+    touch-action: none;
+}
+
+.steer-knob {
+    position: absolute;
+    width: 48px;
+    height: 48px;
+    border-radius: 50%;
+    background: color-mix(in oklab, var(--cyan) 70%, white);
+    box-shadow: 0 0 18px var(--cyan);
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
+}
+
+.steer-hint {
+    position: absolute;
+    bottom: -1.3rem;
+    left: 0;
+    right: 0;
+    text-align: center;
+    font-size: 0.62rem;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--text-dim);
+}
+
+.touch-buttons {
+    display: flex;
+    gap: 0.7rem;
+}
+
+.pad {
+    width: 78px;
+    height: 78px;
+    border-radius: 50%;
+    border: 1px solid var(--line);
+    background: var(--panel-strong);
+    font-size: 0.62rem;
+    letter-spacing: 0.12em;
+    font-weight: 700;
+    color: var(--text);
+}
+
+.pad-boost {
+    border-color: color-mix(in oklab, var(--gold) 50%, transparent);
+    color: var(--gold);
+}
+
+.pad-jump {
+    border-color: color-mix(in oklab, var(--cyan) 50%, transparent);
+}
+
+/* ---------- Overlays ---------- */
+
+.overlay {
+    position: absolute;
+    inset: 0;
+    z-index: 30;
+    display: grid;
+    place-items: center;
+    padding: 5.5rem 1rem 2rem;
+    background: rgb(4 6 14 / 0.42);
+    backdrop-filter: blur(8px);
+}
+
+.overlay[hidden] {
+    display: none;
+}
+
+.overlay-card {
+    width: min(720px, 100%);
+    background: var(--panel-strong);
+    border: 1px solid var(--line);
+    border-radius: var(--radius-lg);
+    box-shadow:
+        0 30px 80px rgb(0 0 0 / 0.5),
+        0 0 80px color-mix(in oklab, var(--cyan) 12%, transparent);
+    padding: 1.6rem 1.6rem 1.4rem;
+}
+
+.compact-card {
+    width: min(440px, 100%);
+    text-align: center;
+}
+
+.menu-head h1,
+.overlay-card h2,
+.loading-card h1 {
+    font-family: var(--display);
+    font-weight: 800;
+    letter-spacing: -0.03em;
+    margin: 0.15rem 0 0.5rem;
+}
+
+.menu-head h1 {
+    font-size: clamp(2.6rem, 8vw, 4.2rem);
+    line-height: 0.92;
+}
+
+.menu-head h1 span {
+    color: var(--cyan);
+    text-shadow: 0 0 28px var(--cyan);
+}
+
+.overlay-card h2 {
+    font-size: clamp(1.8rem, 5vw, 2.4rem);
+    line-height: 1.05;
+}
+
+.lede,
+.section-note {
+    color: var(--text-soft);
+    font-size: 0.95rem;
+    line-height: 1.45;
+    margin: 0;
+}
+
+.section-note {
+    font-size: 0.86rem;
+    color: var(--text-dim);
+}
+
+.eyebrow {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    margin: 0;
+    font-size: 0.68rem;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--cyan);
+}
+
+.eyebrow i {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--cyan);
+    box-shadow: 0 0 12px var(--cyan);
+}
+
+.eyebrow--danger {
+    color: #ff8aa8;
+}
+
+.eyebrow--danger i {
+    background: #ff8aa8;
+    box-shadow: 0 0 12px #ff8aa8;
+}
+
+.menu-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 0.9rem;
+    margin: 1.2rem 0 1.3rem;
+}
+
+.menu-section {
+    background: rgb(255 255 255 / 0.03);
+    border: 1px solid rgb(255 255 255 / 0.06);
+    border-radius: var(--radius);
+    padding: 0.9rem;
+}
+
+.menu-section h2 {
+    font-size: 0.72rem;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--gold);
+    margin: 0 0 0.55rem;
+    font-family: var(--sans);
+    font-weight: 700;
+}
+
+.keys {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    font-size: 0.82rem;
+    color: var(--text-soft);
+}
+
+kbd {
+    display: inline-block;
+    padding: 0.08rem 0.35rem;
+    border-radius: 6px;
+    border: 1px solid rgb(255 255 255 / 0.14);
+    background: rgb(255 255 255 / 0.06);
+    font-size: 0.75em;
+}
+
+.settings-grid {
+    display: grid;
+    gap: 0.7rem;
+}
+
+.field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+    font-size: 0.78rem;
+    color: var(--text-dim);
+}
+
+.field input,
+.field select {
+    background: rgb(255 255 255 / 0.05);
+    border: 1px solid rgb(255 255 255 / 0.1);
+    border-radius: 10px;
+    padding: 0.5rem 0.65rem;
+}
+
+.play-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.6rem;
+}
+
+.primary-button,
+.ghost-button {
+    pointer-events: auto;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    min-height: 48px;
+    padding: 0.7rem 1rem;
+    border-radius: 14px;
+    font-weight: 700;
+    letter-spacing: 0.02em;
+}
+
+.primary-button {
+    background: linear-gradient(90deg, var(--cyan), #7af6ff);
+    color: #041018;
+    box-shadow: 0 8px 28px color-mix(in oklab, var(--cyan) 40%, transparent);
+}
+
+.primary-button:hover {
+    filter: brightness(1.06);
+}
+
+.ghost-button {
+    border: 1px solid var(--line);
+    background: rgb(255 255 255 / 0.04);
+    color: var(--text);
+}
+
+.ghost-button:hover {
+    border-color: var(--cyan);
+    color: var(--cyan);
+}
+
+.join-form {
+    margin-top: 0.9rem;
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: 0.6rem;
+    align-items: end;
+}
+
+.join-form .field input {
+    font-family: var(--display);
+    letter-spacing: 0.28em;
+    text-transform: uppercase;
+    font-size: 1.2rem;
+    text-align: center;
+}
+
+.room-code {
+    display: block;
+    font-family: var(--display);
+    font-size: 2.4rem;
+    letter-spacing: 0.28em;
+    color: var(--cyan);
+    text-shadow: 0 0 24px var(--cyan);
+    margin: 0.4rem 0;
+}
+
+.room-code-row {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.6rem;
+    margin: 0.8rem 0;
+}
+
+.card-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    justify-content: center;
+    margin-top: 1.1rem;
+}
+
+.loading-card {
+    text-align: center;
+}
+
+.loading-mark {
+    font-size: 2.4rem;
+    color: var(--cyan);
+    text-shadow: 0 0 24px var(--cyan);
+}
+
+.loading-bar {
+    margin: 1rem auto 0;
+    width: min(240px, 70vw);
+    height: 6px;
+    border-radius: 99px;
+    background: rgb(255 255 255 / 0.08);
+    overflow: hidden;
+}
+
+.loading-bar i {
+    display: block;
+    height: 100%;
+    width: 8%;
+    background: linear-gradient(90deg, var(--cyan), var(--magenta));
+}
+
+.result-card h2 {
+    background: linear-gradient(90deg, var(--cyan), var(--magenta));
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+}
+
+/* ---------- Responsive ---------- */
+
+@media (max-width: 820px) {
+    .menu-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .play-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .join-form {
+        grid-template-columns: 1fr;
+    }
+
+    .scoreboard {
+        top: calc(4.1rem + var(--safe-top));
+        min-width: calc(100vw - 1.4rem);
+        border-radius: 18px;
+    }
+
+    .score-name {
+        display: none;
+    }
+
+    .hud-actions {
+        top: auto;
+        bottom: calc(1.2rem + var(--safe-bottom));
+        left: auto;
+        right: calc(1rem + var(--safe-right));
+    }
+
+    .net-badge {
+        top: auto;
+        bottom: calc(1.35rem + var(--safe-bottom));
+        right: auto;
+        left: calc(1rem + var(--safe-left));
+    }
+
+    .lab-foot {
+        display: none;
+    }
+}
+
+@media (max-width: 560px) {
+    .overlay {
+        padding: 4.6rem 0.7rem 1rem;
+        align-items: end;
+    }
+
+    .overlay-card {
+        padding: 1.15rem 1rem 1.05rem;
+        border-radius: 18px;
+    }
+
+    .boost-wrap {
+        bottom: calc(7.2rem + var(--safe-bottom));
+    }
+}

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -193,6 +193,12 @@
     <priority>0.7</priority>
   </url>
   <url>
+    <loc>https://diogopaulino.com.br/labs/riftball/</loc>
+    <lastmod>2026-08-14</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
     <loc>https://diogopaulino.com.br/labs/river-knight/</loc>
     <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 🎯 Objetivo

Novo lab **Riftball**: um 1v1 de hovers numa arena flutuante em three.js, feito para jogar online com outra pessoa (código de sala) — e também no sofá, no mesmo teclado.

## ✨ O que mudou

- Lab `/labs/riftball/` — arena 3D com bloom, céu em shader, portais-gol, boost pads e bola de éter
- Online P2P (PeerJS + WebRTC) ou duas abas no mesmo computador (BroadcastChannel); host é autoridade da física
- Modos extra: dois no teclado (WASD vs setas) e contra a CPU
- Attract mode no menu (CPU vs CPU) para o rift já estar vivo
- Catálogo: galeria, README, `sitemap.xml` e contagem **44 experimentos** (Riftball + Noctiluca do `master`)
- Merge com `master`: conflitos só de catálogo (ambos os ramos subiram 42→43); resolução mantém os dois labs

[Menu do Riftball](https://cursor.com/agents/bc-019ffe05-77fe-7271-b3d3-e9e64fc3d436/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Friftball-menu.webp)
[Partida contra a CPU](https://cursor.com/agents/bc-019ffe05-77fe-7271-b3d3-e9e64fc3d436/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Friftball-play.webp)

## 🧪 Como testar

1. Na raiz do repo: `python3 -m http.server 8000`
2. Abrir [http://localhost:8000/](http://localhost:8000/) (home) e [http://localhost:8000/labs/](http://localhost:8000/labs/) (galeria — Riftball no topo, Noctiluca em seguida)
3. Abrir [http://localhost:8000/labs/riftball/](http://localhost:8000/labs/riftball/)
   - **Contra a CPU** — WASD, Shift boost, Espaço pulo; primeiro a 5 gols
   - **Dois no teclado** — P2 usa setas, Ctrl boost, ponto (.) pulo
   - **Criar sala online** — copiar o link; em outra aba/dispositivo entrar com o código (ou `?sala=XXXX`)
4. Conferir pasta ↔ card da galeria ↔ README ↔ `sitemap.xml` ↔ canonical/OG
5. Header volta para `/labs/`, footer para `/`

## ✅ Checklist

- [x] Links conferidos: pasta do lab ↔ card da galeria ↔ README ↔ sitemap (e corrigidos se quebravam)
- [x] README atualizado (linha na tabela + URL + contagem no badge/texto) — obrigatório em lab novo, renomeado ou removido
- [x] SEO consistente: title, description, canonical, author, robots, OG, Twitter, JSON-LD (e contagem nos metas da galeria)
- [x] Testado via HTTP na raiz, não via `file://`
- [x] Nada fora do escopo foi quebrado


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ffe05-77fe-7271-b3d3-e9e64fc3d436?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ffe05-77fe-7271-b3d3-e9e64fc3d436&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

