### PR TITLE
🧪 O Guerreiro e o Castelo — aventura 3D cinematográfica

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 Mais de 20 anos em tecnologia, entre liderança, código hands-on e design UI/UX.
 
 [![Website](https://img.shields.io/badge/Website-diogopaulino.com.br-3B82F6?style=flat-square&logo=googlechrome&logoColor=white)](https://diogopaulino.com.br/)
-[![Labs](https://img.shields.io/badge/Labs-43_experimentos-8B5CF6?style=flat-square&logo=stackblitz&logoColor=white)](https://diogopaulino.com.br/labs/)
+[![Labs](https://img.shields.io/badge/Labs-44_experimentos-8B5CF6?style=flat-square&logo=stackblitz&logoColor=white)](https://diogopaulino.com.br/labs/)
 [![GitHub](https://img.shields.io/badge/GitHub-diogopaulino-181717?style=flat-square&logo=github&logoColor=white)](https://github.com/diogopaulino)
 [![LinkedIn](https://img.shields.io/badge/LinkedIn-Diogo_Paulino-0A66C2?style=flat-square)](https://br.linkedin.com/in/diogopaulino)
 [![Spotify](https://img.shields.io/badge/Spotify-Artist-1DB954?style=flat-square&logo=spotify&logoColor=white)](https://open.spotify.com/intl-pt/artist/0ue2WfDQ1P4XR2vXdSIrYQ)
@@ -32,7 +32,7 @@ Gosto de construir coisas — de time e produto até interface e código. Nessa 
 
 > *Abre, experimenta, quebra, reconstrói. Esse é o espírito.*
 
-Um laboratório aberto com **43 experimentos** que rodam direto no navegador — HTML, CSS e JavaScript puro, sem instalar nada. Catálogo completo em [diogopaulino.com.br/labs](https://diogopaulino.com.br/labs/).
+Um laboratório aberto com **44 experimentos** que rodam direto no navegador — HTML, CSS e JavaScript puro, sem instalar nada. Catálogo completo em [diogopaulino.com.br/labs](https://diogopaulino.com.br/labs/).
 
 ### 🪐 Mundos 3D
 
@@ -49,6 +49,7 @@ Um laboratório aberto com **43 experimentos** que rodam direto no navegador —
 | ✨ **[Aetherion](https://diogopaulino.com.br/labs/aetherion/)** | Observatório estelar em shaders, com mundos vivos e um buraco negro |
 | 🏍️ **[Neon Rider](https://diogopaulino.com.br/labs/neon-rider/)** | Avenida infinita anos 80 — moto, néon, rádio synthwave e fitas VHS |
 | 🍞 **[Torradeira 64](https://diogopaulino.com.br/labs/toaster-64/)** | Kart 3D cômico — disquetes de ouro, Clippy, Pac-Man e o cachorro do Duck Hunt |
+| ⚔️ **[O Guerreiro e o Castelo](https://diogopaulino.com.br/labs/guerreiro-castelo/)** | Aventura 3D — Dico e Teco atravessam o mar e resgatam Camila no castelo |
 | ⚔️ **[River Knight](https://diogopaulino.com.br/labs/river-knight/)** | Aventura medieval — drakkar, machados e o resgate da princesa no castelo |
 | 💍 **[A Jornada do Anel](https://diogopaulino.com.br/labs/jornada-do-anel/)** | Aventura inspirada no primeiro filme: o Condado, os Cavaleiros, o vale élfico e as minas |
 | 😈 **[Pandemônio](https://diogopaulino.com.br/labs/pandemonium/)** | Platformer no trilho — corra, pule abismos e alcance o portal |

--- a/labs/guerreiro-castelo/css/style.css
+++ b/labs/guerreiro-castelo/css/style.css
@@ -1,0 +1,422 @@
+:root {
+    --ink: #e8dcc4;
+    --muted: #b8a88a;
+    --gold: #d4b45a;
+    --ember: #e07a3a;
+    --bg: #08090d;
+}
+
+html, body {
+    margin: 0;
+    height: 100%;
+    background: var(--bg);
+    color: var(--ink);
+    font-family: Outfit, sans-serif;
+    overflow: hidden;
+}
+
+.game-shell {
+    position: relative;
+    width: 100%;
+    height: 100dvh;
+    min-height: 100vh;
+}
+
+#scene {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    display: block;
+    cursor: crosshair;
+}
+
+.fade {
+    position: absolute;
+    inset: 0;
+    background: #05060a;
+    opacity: 1;
+    pointer-events: none;
+    transition: none;
+    z-index: 20;
+}
+
+.vignette {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    z-index: 8;
+    background: radial-gradient(ellipse at center, transparent 48%, rgba(0, 0, 0, 0.45) 100%);
+}
+
+.app-logo {
+    display: flex;
+    align-items: center;
+    gap: 0.55rem;
+    font-family: Cinzel, serif;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+}
+
+.brand-mark {
+    opacity: 0.85;
+}
+
+.hud {
+    position: absolute;
+    inset: 0;
+    z-index: 12;
+    pointer-events: none;
+}
+
+.hud-top {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 5.5rem 1.4rem 0;
+}
+
+.panel {
+    background: linear-gradient(180deg, rgba(8, 10, 16, 0.55), rgba(8, 10, 16, 0.2));
+    border: 1px solid rgba(212, 180, 90, 0.18);
+    backdrop-filter: blur(8px);
+    padding: 0.7rem 0.95rem;
+    min-width: 10rem;
+}
+
+.hud-label {
+    display: block;
+    font-size: 0.68rem;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--gold);
+    margin-bottom: 0.25rem;
+}
+
+.hearts {
+    display: flex;
+    gap: 0.25rem;
+    color: #c94a3a;
+    font-size: 1.05rem;
+}
+
+.heart.is-empty {
+    opacity: 0.22;
+}
+
+.objective {
+    margin: 0;
+    font-size: 1.02rem;
+    font-weight: 500;
+    max-width: 28rem;
+}
+
+.quest-panel.is-flash .objective {
+    animation: pulse 1.4s ease;
+}
+
+.objective[data-urgent="true"] {
+    color: #ffd27a;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    font-family: Cinzel, serif;
+}
+
+.stealth {
+    position: absolute;
+    top: 8.5rem;
+    left: 50%;
+    transform: translateX(-50%);
+    width: min(16rem, 70vw);
+    text-align: center;
+    font-size: 0.75rem;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--muted);
+}
+
+.stealth i {
+    display: block;
+    height: 4px;
+    margin-top: 0.4rem;
+    background: rgba(255, 255, 255, 0.12);
+    border-radius: 99px;
+    overflow: hidden;
+}
+
+.stealth b {
+    display: block;
+    height: 100%;
+    width: 0;
+    background: #7ad0a0;
+}
+
+.stealth[data-danger="true"] b {
+    background: #d45a3a;
+}
+
+.prompt, .toast {
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
+    margin: 0;
+}
+
+.prompt {
+    bottom: 7.5rem;
+    padding: 0.45rem 0.8rem;
+    background: rgba(8, 10, 16, 0.62);
+    border: 1px solid rgba(232, 220, 196, 0.2);
+    font-size: 0.95rem;
+}
+
+.toast {
+    top: 42%;
+    font-family: Cinzel, serif;
+    letter-spacing: 0.12em;
+    font-size: 1.15rem;
+    text-shadow: 0 2px 16px #000;
+}
+
+kbd {
+    display: inline-block;
+    min-width: 1.2rem;
+    padding: 0.1rem 0.35rem;
+    margin-right: 0.15rem;
+    border: 1px solid rgba(232, 220, 196, 0.35);
+    font-family: Outfit, sans-serif;
+    font-size: 0.78rem;
+}
+
+.dialogue {
+    position: absolute;
+    left: 50%;
+    bottom: 2.2rem;
+    transform: translateX(-50%);
+    width: min(40rem, 90vw);
+    text-align: center;
+    pointer-events: none;
+}
+
+.speaker {
+    display: block;
+    font-family: Cinzel, serif;
+    font-size: 0.78rem;
+    letter-spacing: 0.22em;
+    color: var(--gold);
+    margin-bottom: 0.35rem;
+}
+
+.line {
+    margin: 0;
+    font-size: 1.2rem;
+    line-height: 1.45;
+    text-shadow: 0 2px 18px #000;
+}
+
+.hud-actions {
+    position: absolute;
+    right: 1.2rem;
+    bottom: 1rem;
+}
+
+.fps {
+    font-size: 0.7rem;
+    opacity: 0.4;
+}
+
+.chapter-card {
+    position: absolute;
+    inset: 0;
+    z-index: 15;
+    display: grid;
+    place-content: center;
+    text-align: center;
+    pointer-events: none;
+}
+
+.chapter-card h2 {
+    font-family: Cinzel, serif;
+    font-weight: 600;
+    letter-spacing: 0.18em;
+    font-size: clamp(1.4rem, 4vw, 2.4rem);
+    margin: 0;
+}
+
+.overlay {
+    position: absolute;
+    inset: 0;
+    z-index: 30;
+    display: grid;
+    place-items: center;
+    background: linear-gradient(180deg, rgba(6, 8, 12, 0.72), rgba(6, 8, 12, 0.88));
+    padding: 1.5rem;
+}
+
+.overlay[hidden],
+.hud[hidden],
+.chapter-card[hidden],
+.prompt[hidden],
+.toast[hidden],
+.dialogue[hidden],
+.stealth[hidden] {
+    display: none !important;
+}
+
+.overlay-card {
+    width: min(40rem, 100%);
+    background: rgba(12, 14, 20, 0.82);
+    border: 1px solid rgba(212, 180, 90, 0.22);
+    padding: 2rem 1.8rem;
+    box-shadow: 0 24px 80px rgba(0, 0, 0, 0.45);
+}
+
+.menu-head h1,
+.end-card h1 {
+    font-family: Cinzel, serif;
+    font-weight: 700;
+    line-height: 1.25;
+    margin: 0.4rem 0 0.8rem;
+    font-size: clamp(1.6rem, 4vw, 2.5rem);
+}
+
+.menu-head h1 span,
+.end-card h1 span {
+    font-weight: 500;
+    color: var(--gold);
+}
+
+.eyebrow {
+    letter-spacing: 0.28em;
+    text-transform: uppercase;
+    font-size: 0.72rem;
+    color: var(--gold);
+    margin: 0;
+}
+
+.lede {
+    color: var(--muted);
+    line-height: 1.5;
+    margin: 0 0 1.4rem;
+}
+
+.menu-actions {
+    display: grid;
+    gap: 0.55rem;
+}
+
+.primary-button,
+.ghost-button {
+    font-family: Outfit, sans-serif;
+    font-size: 1rem;
+    padding: 0.75rem 1rem;
+    cursor: pointer;
+    border-radius: 0;
+}
+
+.primary-button {
+    background: linear-gradient(180deg, #d4b45a, #b08a32);
+    color: #1a140c;
+    border: 0;
+    font-weight: 650;
+}
+
+.ghost-button {
+    background: transparent;
+    color: var(--ink);
+    border: 1px solid rgba(232, 220, 196, 0.28);
+}
+
+.primary-button:disabled {
+    opacity: 0.35;
+    cursor: not-allowed;
+}
+
+.keys {
+    display: grid;
+    gap: 0.45rem;
+    margin: 1rem 0 1.4rem;
+    color: var(--muted);
+}
+
+.field {
+    display: grid;
+    gap: 0.35rem;
+    margin-bottom: 1rem;
+}
+
+.field select,
+.field input {
+    font: inherit;
+    padding: 0.45rem;
+    background: #12141c;
+    color: var(--ink);
+    border: 1px solid rgba(232, 220, 196, 0.2);
+}
+
+.loading-card {
+    text-align: center;
+}
+
+.loading-card h1 {
+    font-family: Cinzel, serif;
+    margin: 0.4rem 0 0;
+}
+
+.loading-card .sub {
+    color: var(--gold);
+    letter-spacing: 0.16em;
+    text-transform: lowercase;
+    margin: 0.2rem 0 1.4rem;
+}
+
+.loading-bar {
+    width: min(18rem, 70vw);
+    height: 4px;
+    margin: 0.8rem auto;
+    background: rgba(255, 255, 255, 0.1);
+}
+
+.loading-bar i {
+    display: block;
+    height: 100%;
+    width: 0;
+    background: var(--gold);
+}
+
+.pct {
+    opacity: 0.6;
+    font-size: 0.85rem;
+}
+
+.ember {
+    display: block;
+    width: 10px;
+    height: 10px;
+    margin: 0 auto 1rem;
+    border-radius: 50%;
+    background: var(--ember);
+    box-shadow: 0 0 18px var(--ember);
+    animation: glow 1.4s ease-in-out infinite;
+}
+
+@keyframes glow {
+    50% { transform: scale(1.25); opacity: 0.7; }
+}
+
+@keyframes pulse {
+    0%, 100% { opacity: 1; }
+    40% { opacity: 0.35; }
+}
+
+.end-overlay {
+    background: #05060a;
+}
+
+@media (max-width: 720px) {
+    .hud-top {
+        flex-direction: column;
+        padding-top: 4.6rem;
+    }
+    .line { font-size: 1.02rem; }
+}

--- a/labs/guerreiro-castelo/index.html
+++ b/labs/guerreiro-castelo/index.html
@@ -1,0 +1,235 @@
+<!DOCTYPE html>
+<html lang="pt-br" data-theme="dark">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport"
+        content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover">
+    <meta name="theme-color" content="#0a0c12">
+    <title>O Guerreiro e o Castelo — aventura 3D | Diogo Paulino</title>
+    <meta name="description"
+        content="Aventura 3D em three.js de Diogo Paulino: Dico, Teco e a travessia do mar até o castelo para resgatar Camila. Terceira pessoa, stealth, puzzles e fuga cinematográfica.">
+    <meta name="author" content="Diogo Paulino">
+    <meta name="robots" content="index, follow">
+    <link rel="canonical" href="https://diogopaulino.com.br/labs/guerreiro-castelo/">
+    <link rel="icon" href="/favicon.ico" sizes="any">
+    <meta property="og:type" content="website">
+    <meta property="og:site_name" content="Diogo Paulino · Labs">
+    <meta property="og:url" content="https://diogopaulino.com.br/labs/guerreiro-castelo/">
+    <meta property="og:title" content="O Guerreiro e o Castelo do Outro Lado do Mar | Diogo Paulino">
+    <meta property="og:description"
+        content="Uma história antes de dormir vira travessia, tempestade, stealth e fuga. Jogo 3D em terceira pessoa no navegador.">
+    <meta property="og:image" content="https://diogopaulino.com.br/assets/img/diogo.jpeg">
+    <meta property="og:image:alt" content="Diogo Paulino">
+    <meta property="og:locale" content="pt_BR">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="O Guerreiro e o Castelo do Outro Lado do Mar | Diogo Paulino">
+    <meta name="twitter:description"
+        content="Aventura 3D cinematográfica: navio, castelo, Teco e o resgate de Camila. three.js no navegador.">
+    <meta name="twitter:image" content="https://diogopaulino.com.br/assets/img/diogo.jpeg">
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;600;700;800&family=Outfit:wght@300;400;500;600;700&display=swap"
+        rel="stylesheet">
+    <link rel="stylesheet" href="/labs/shared.css?v=7">
+    <link rel="stylesheet" href="css/style.css">
+
+    <script type="importmap">
+    {
+        "imports": {
+            "three": "https://cdn.jsdelivr.net/npm/three@0.185.1/build/three.module.js",
+            "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.185.1/examples/jsm/"
+        }
+    }
+    </script>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@graph": [
+        {
+          "@type": "WebApplication",
+          "name": "O Guerreiro e o Castelo do Outro Lado do Mar",
+          "url": "https://diogopaulino.com.br/labs/guerreiro-castelo/",
+          "description": "Aventura 3D em three.js: Dico, Teco e a travessia do mar até o castelo para resgatar Camila.",
+          "applicationCategory": "GameApplication",
+          "operatingSystem": "Any",
+          "inLanguage": "pt-BR",
+          "isAccessibleForFree": true,
+          "author": {
+            "@type": "Person",
+            "name": "Diogo Paulino",
+            "url": "https://diogopaulino.com.br/"
+          },
+          "image": "https://diogopaulino.com.br/assets/img/diogo.jpeg"
+        },
+        {
+          "@type": "BreadcrumbList",
+          "itemListElement": [
+            {
+              "@type": "ListItem",
+              "position": 1,
+              "name": "Diogo Paulino",
+              "item": "https://diogopaulino.com.br/"
+            },
+            {
+              "@type": "ListItem",
+              "position": 2,
+              "name": "Labs",
+              "item": "https://diogopaulino.com.br/labs/"
+            },
+            {
+              "@type": "ListItem",
+              "position": 3,
+              "name": "O Guerreiro e o Castelo",
+              "item": "https://diogopaulino.com.br/labs/guerreiro-castelo/"
+            }
+          ]
+        }
+      ]
+    }
+    </script>
+</head>
+
+<body>
+    <main class="game-shell">
+        <header data-lab-header data-title="O Guerreiro e o Castelo" data-back-href="/labs/" data-back-label="Labs">
+            <template data-slot="logo">
+                <div class="app-logo">
+                    <span class="brand-mark" aria-hidden="true">⚔</span>
+                    <span>O Guerreiro e o Castelo</span>
+                </div>
+            </template>
+        </header>
+
+        <canvas id="scene" aria-label="Mundo 3D da aventura"></canvas>
+        <div id="fade" class="fade" aria-hidden="true"></div>
+        <div class="vignette" aria-hidden="true"></div>
+
+        <div id="chapterCard" class="chapter-card" hidden>
+            <h2 id="chapterTitle"></h2>
+            <p id="chapterSub"></p>
+        </div>
+
+        <div id="hud" class="hud" hidden>
+            <div class="hud-top">
+                <div class="panel heart-panel">
+                    <span class="hud-label">Dico</span>
+                    <div id="hearts" class="hearts" aria-label="Vida"></div>
+                </div>
+                <div class="panel quest-panel">
+                    <span class="hud-label">Objetivo</span>
+                    <p id="objective" class="objective">Explore o navio</p>
+                </div>
+            </div>
+
+            <div id="stealth" class="stealth" hidden data-danger="false">
+                <span>Silêncio</span>
+                <i><b id="stealthFill"></b></i>
+            </div>
+
+            <p id="toast" class="toast" hidden></p>
+            <p id="prompt" class="prompt" hidden></p>
+
+            <div id="dialogue" class="dialogue" hidden>
+                <span id="speaker" class="speaker"></span>
+                <p id="line" class="line"></p>
+            </div>
+
+            <div class="hud-actions">
+                <span id="fpsCounter" class="fps">—</span>
+            </div>
+        </div>
+
+        <div id="loadingOverlay" class="overlay loading-overlay">
+            <div class="loading-card">
+                <span class="ember" aria-hidden="true"></span>
+                <h1>O Guerreiro e o Castelo</h1>
+                <p class="sub">do outro lado do mar</p>
+                <p id="loadingText">Carregando...</p>
+                <div class="loading-bar"><i id="loadingFill"></i></div>
+                <p id="loadingPct" class="pct">0%</p>
+            </div>
+        </div>
+
+        <div id="menuOverlay" class="overlay menu-overlay">
+            <div class="overlay-card menu-card">
+                <header class="menu-head">
+                    <p class="eyebrow">uma história antes de dormir</p>
+                    <h1>O Guerreiro e o Castelo<br><span>do Outro Lado do Mar</span></h1>
+                    <p class="lede">Dico atravessa o mar com Teco para resgatar Camila. Tempestade, stealth, um tigre e a fuga sob flechas.</p>
+                </header>
+                <div class="menu-actions">
+                    <button id="btnContinue" class="primary-button" type="button" disabled>Continuar</button>
+                    <button id="btnNewGame" class="primary-button" type="button">Novo jogo</button>
+                    <button id="btnControls" class="ghost-button" type="button">Controles</button>
+                    <button id="btnSettings" class="ghost-button" type="button">Configurações</button>
+                </div>
+            </div>
+        </div>
+
+        <div id="controlsOverlay" class="overlay" hidden>
+            <div class="overlay-card">
+                <h2>Controles</h2>
+                <div class="keys">
+                    <span><kbd>W</kbd><kbd>A</kbd><kbd>S</kbd><kbd>D</kbd> mover</span>
+                    <span><kbd>Mouse</kbd> câmera · clique para capturar</span>
+                    <span><kbd>Shift</kbd> correr · <kbd>C</kbd> agachar · <kbd>Espaço</kbd> pular</span>
+                    <span><kbd>E</kbd> interagir · <kbd>F</kbd> atacar · <kbd>Q</kbd> defender</span>
+                    <span><kbd>Tab</kbd> objetivo · <kbd>Esc</kbd> pausa</span>
+                </div>
+                <button id="btnCloseControls" class="primary-button" type="button">Fechar</button>
+            </div>
+        </div>
+
+        <div id="settingsOverlay" class="overlay" hidden>
+            <div class="overlay-card">
+                <h2>Configurações</h2>
+                <label class="field">
+                    <span>Qualidade</span>
+                    <select id="qualitySelect">
+                        <option value="low">Baixo</option>
+                        <option value="medium">Médio</option>
+                        <option value="high">Alto</option>
+                        <option value="ultra">Ultra</option>
+                    </select>
+                </label>
+                <label class="field">
+                    <span>Volume <b id="volumeValue">75</b></span>
+                    <input id="volumeSlider" type="range" min="0" max="100" step="1" value="75">
+                </label>
+                <button id="btnCloseSettings" class="primary-button" type="button">Fechar</button>
+            </div>
+        </div>
+
+        <div id="pauseOverlay" class="overlay" hidden>
+            <div class="overlay-card">
+                <h2>Pausa</h2>
+                <div class="menu-actions">
+                    <button id="btnResume" class="primary-button" type="button">Continuar</button>
+                    <button id="btnRestartCp" class="ghost-button" type="button">Reiniciar checkpoint</button>
+                    <button id="btnPauseSettings" class="ghost-button" type="button">Configurações</button>
+                    <button id="btnQuitMenu" class="ghost-button" type="button">Sair para o menu</button>
+                </div>
+            </div>
+        </div>
+
+        <div id="endOverlay" class="overlay end-overlay" hidden>
+            <div class="overlay-card end-card">
+                <p class="eyebrow">fim</p>
+                <h1>O Guerreiro e o Castelo<br><span>do Outro Lado do Mar</span></h1>
+                <p class="lede">Fim</p>
+                <div class="menu-actions">
+                    <button id="btnPlayAgain" class="primary-button" type="button">Jogar novamente</button>
+                    <button id="btnEndMenu" class="ghost-button" type="button">Menu</button>
+                </div>
+            </div>
+        </div>
+    </main>
+
+    <script src="/labs/shared.js" defer></script>
+    <script type="module" src="js/main.js"></script>
+</body>
+
+</html>

--- a/labs/guerreiro-castelo/js/ai/FollowerAI.js
+++ b/labs/guerreiro-castelo/js/ai/FollowerAI.js
@@ -1,0 +1,31 @@
+/** Follower genérico para amigos do navio. */
+
+import { damp } from '../utils/math.js';
+
+export class FollowerAI {
+    constructor(root, offset) {
+        this.root = root;
+        this.offset = offset;
+        this.active = false;
+        this.facing = 0;
+        this.speed = 0;
+    }
+
+    update(dt, player) {
+        if (!this.active) return;
+        const tx = player.position.x + this.offset.x;
+        const tz = player.position.z + this.offset.z;
+        const dx = tx - this.root.position.x;
+        const dz = tz - this.root.position.z;
+        const dist = Math.hypot(dx, dz);
+        const spd = dist > 4 ? 6 : 3.6;
+        if (dist > 1.2) {
+            this.root.position.x += (dx / dist) * spd * dt;
+            this.root.position.z += (dz / dist) * spd * dt;
+            this.root.position.y = damp(this.root.position.y, player.position.y, 8, dt);
+            this.facing = Math.atan2(dx, dz);
+            this.root.rotation.y = this.facing;
+            this.speed = spd;
+        } else this.speed = 0;
+    }
+}

--- a/labs/guerreiro-castelo/js/ai/GuardAI.js
+++ b/labs/guerreiro-castelo/js/ai/GuardAI.js
@@ -1,0 +1,149 @@
+/**
+ * Percepção de guarda: cone de visão, raycast, audição e estados.
+ */
+
+import * as THREE from 'three';
+import { damp } from '../utils/math.js';
+
+export class GuardAI {
+    constructor(guard, opts = {}) {
+        this.guard = guard;
+        this.state = opts.sleep ? 'SLEEP' : 'IDLE';
+        this.home = new THREE.Vector3();
+        this.facing = 0;
+        this.viewDist = opts.viewDist ?? 9;
+        this.viewAngle = opts.viewAngle ?? 0.7;
+        this.hearRadius = opts.hearRadius ?? 4.2;
+        this.patrol = opts.patrol || [];
+        this.patrolI = 0;
+        this.timer = 0;
+        this.suspicion = 0;
+        this.attackCd = 0;
+        this.sleep = Boolean(opts.sleep);
+        this.ray = new THREE.Raycaster();
+        this._dir = new THREE.Vector3();
+        this.snoreT = 0;
+    }
+
+    canSee(game) {
+        const g = this.guard;
+        const p = game.player.position;
+        const dx = p.x - g.position.x;
+        const dz = p.z - g.position.z;
+        const dist = Math.hypot(dx, dz);
+        if (dist > this.viewDist) return false;
+        const ang = Math.atan2(dx, dz);
+        let d = Math.abs(((ang - this.facing + Math.PI) % (Math.PI * 2)) - Math.PI);
+        if (d > this.viewAngle) return false;
+        this.ray.set(
+            new THREE.Vector3(g.position.x, g.position.y + 1.4, g.position.z),
+            this._dir.set(dx, 0, dz).normalize()
+        );
+        this.ray.far = dist;
+        const hits = this.ray.intersectObjects(game.cameraRig?._obstacles || [], true);
+        if (hits.length && hits[0].distance < dist - 0.4) return false;
+        return true;
+    }
+
+    hear(game) {
+        const g = this.guard;
+        const p = game.player.position;
+        const dist = Math.hypot(p.x - g.position.x, p.z - g.position.z);
+        const noise = game.player.noise;
+        let hear = noise * this.hearRadius;
+        if (game.player.crouching) hear *= 0.55;
+        if (dist < hear) return true;
+        for (const n of game.collision.noiseSources) {
+            if (Math.hypot(n.x - g.position.x, n.z - g.position.z) < n.amount * 5) return true;
+        }
+        return false;
+    }
+
+    update(dt, game) {
+        const g = this.guard;
+        this.timer += dt;
+        this.attackCd = Math.max(0, this.attackCd - dt);
+
+        if (this.state === 'SLEEP') {
+            g.root.rotation.x = 0.15;
+            this.snoreT += dt;
+            if (this.snoreT > 2.4) {
+                this.snoreT = 0;
+                game.audio.play('snore');
+                game.hud?.flashStealth?.('Ronc… ronc…');
+            }
+            if (this.hear(game) && game.player.noise > 0.9) {
+                this.suspicion += dt * 0.8;
+            }
+            if (this.suspicion > 1.2) {
+                this.state = 'SUSPICIOUS';
+                this.timer = 0;
+            }
+            g.speed = 0;
+            return;
+        }
+
+        g.root.rotation.x = damp(g.root.rotation.x, 0, 8, dt);
+
+        const p = game.player.position;
+        const dx = p.x - g.position.x;
+        const dz = p.z - g.position.z;
+        const dist = Math.hypot(dx, dz);
+
+        if (this.canSee(game) || (this.hear(game) && game.player.noise > 0.7)) {
+            this.state = dist < 1.8 ? 'ATTACK' : 'CHASE';
+        }
+
+        if (this.state === 'CHASE') {
+            this.facing = Math.atan2(dx, dz);
+            const spd = 3.4;
+            g.position.x += Math.sin(this.facing) * spd * dt;
+            g.position.z += Math.cos(this.facing) * spd * dt;
+            g.speed = spd;
+            if (dist < 1.7) this.state = 'ATTACK';
+            return;
+        }
+
+        if (this.state === 'ATTACK') {
+            this.facing = Math.atan2(dx, dz);
+            g.speed = 0;
+            if (this.attackCd <= 0 && dist < 2.1) {
+                this.attackCd = 1.1;
+                if (!game.player.blockT) game.player.hurt(1);
+                game.audio.play('hit');
+                game.cameraRig.addShake(0.1, 0.2);
+            }
+            return;
+        }
+
+        if (this.state === 'SUSPICIOUS' || this.state === 'SEARCH') {
+            this.facing += dt * 0.8;
+            g.speed = 0;
+            if (this.timer > 3) {
+                this.state = this.sleep ? 'SLEEP' : 'RETURN';
+                this.suspicion = 0;
+            }
+            return;
+        }
+
+        if (this.state === 'RETURN' || this.state === 'IDLE' || this.state === 'PATROL') {
+            if (this.patrol.length) {
+                this.state = 'PATROL';
+                const goal = this.patrol[this.patrolI];
+                const gx = goal.x - g.position.x;
+                const gz = goal.z - g.position.z;
+                const gd = Math.hypot(gx, gz);
+                if (gd < 0.3) this.patrolI = (this.patrolI + 1) % this.patrol.length;
+                else {
+                    this.facing = Math.atan2(gx, gz);
+                    g.position.x += Math.sin(this.facing) * 1.6 * dt;
+                    g.position.z += Math.cos(this.facing) * 1.6 * dt;
+                    g.speed = 1.6;
+                }
+            } else {
+                this.state = 'IDLE';
+                g.speed = 0;
+            }
+        }
+    }
+}

--- a/labs/guerreiro-castelo/js/ai/MonkeyAI.js
+++ b/labs/guerreiro-castelo/js/ai/MonkeyAI.js
@@ -1,0 +1,170 @@
+/**
+ * Companion Teco — estados reutilizáveis para seguir, pousar no ombro,
+ * ir a um alvo, escalar, interagir e voltar.
+ */
+
+import * as THREE from 'three';
+import { damp } from '../utils/math.js';
+
+export const MonkeyState = {
+    IDLE: 'IDLE',
+    FOLLOW: 'FOLLOW',
+    PERCHED: 'PERCHED',
+    MOVE_TO: 'MOVE_TO',
+    CLIMB: 'CLIMB',
+    INTERACT: 'INTERACT',
+    RETURN: 'RETURN',
+    SCARED: 'SCARED',
+    CELEBRATE: 'CELEBRATE'
+};
+
+const _tmp = new THREE.Vector3();
+
+export class MonkeyAI {
+    constructor(teco) {
+        this.teco = teco;
+        this.state = MonkeyState.FOLLOW;
+        this.facing = 0;
+        this.target = null;
+        this.path = [];
+        this.pathI = 0;
+        this.timer = 0;
+        this.perchTimer = 0;
+        this.onComplete = null;
+        this.speed = 4.2;
+    }
+
+    reset() {
+        this.state = MonkeyState.FOLLOW;
+        this.path = [];
+        this.pathI = 0;
+        this.target = null;
+        this.teco.onShoulder = false;
+    }
+
+    /**
+     * Tarefa especial: waypoints em espaço local do parent do Teco.
+     * onArrive é chamado no INTERACT.
+     */
+    command(path, { climb = false, scared = false, celebrate = false, onComplete = null } = {}) {
+        this.path = path.map((p) => p.clone());
+        this.pathI = 0;
+        this.onComplete = onComplete;
+        this.state = climb ? MonkeyState.CLIMB : MonkeyState.MOVE_TO;
+        this.teco.onShoulder = false;
+        this.teco.play(climb ? 'Climb' : 'Run');
+        this._celebrate = celebrate;
+        this._scared = scared;
+    }
+
+    update(dt, game) {
+        const teco = this.teco;
+        const player = game.player;
+        this.timer += dt;
+
+        if (this.state === MonkeyState.PERCHED) {
+            const shoulder = _tmp.set(0.22, 1.52, 0.05);
+            shoulder.applyAxisAngle(new THREE.Vector3(0, 1, 0), player.facing);
+            teco.position.set(
+                player.position.x + shoulder.x,
+                player.position.y + shoulder.y,
+                player.position.z + shoulder.z
+            );
+            this.facing = player.facing;
+            teco.play('Shoulder');
+            teco.onShoulder = true;
+            this.perchTimer -= dt;
+            if (this.perchTimer < -8 && Math.random() < 0.002) {
+                this.state = MonkeyState.FOLLOW;
+                teco.onShoulder = false;
+            }
+            return;
+        }
+
+        if (this.state === MonkeyState.MOVE_TO || this.state === MonkeyState.CLIMB || this.state === MonkeyState.RETURN) {
+            const goal = this.path[this.pathI];
+            if (!goal) {
+                this.state = MonkeyState.INTERACT;
+                this.timer = 0;
+                return;
+            }
+            const dx = goal.x - teco.position.x;
+            const dy = goal.y - teco.position.y;
+            const dz = goal.z - teco.position.z;
+            const dist = Math.hypot(dx, dy, dz);
+            const spd = this.state === MonkeyState.CLIMB ? 3.4 : this.speed;
+            if (dist < 0.18) {
+                this.pathI++;
+                if (this.pathI >= this.path.length) {
+                    this.state = this.state === MonkeyState.RETURN ? MonkeyState.FOLLOW : MonkeyState.INTERACT;
+                    this.timer = 0;
+                }
+            } else {
+                teco.position.x += (dx / dist) * spd * dt;
+                teco.position.y += (dy / dist) * spd * dt;
+                teco.position.z += (dz / dist) * spd * dt;
+                this.facing = Math.atan2(dx, dz);
+            }
+            teco.play(this.state === MonkeyState.CLIMB ? 'Climb' : 'Run');
+            return;
+        }
+
+        if (this.state === MonkeyState.INTERACT) {
+            teco.play('Grab');
+            if (this.timer > 0.7) {
+                const cb = this.onComplete;
+                this.onComplete = null;
+                cb?.(game);
+                if (this._scared) {
+                    this.state = MonkeyState.SCARED;
+                    this.timer = 0;
+                    teco.play('Scared');
+                } else if (this._celebrate) {
+                    this.state = MonkeyState.CELEBRATE;
+                    this.timer = 0;
+                    teco.play('Celebrate');
+                } else {
+                    this.state = MonkeyState.FOLLOW;
+                }
+            }
+            return;
+        }
+
+        if (this.state === MonkeyState.SCARED) {
+            teco.play('Scared');
+            if (this.timer > 1.2) this.state = MonkeyState.FOLLOW;
+            return;
+        }
+
+        if (this.state === MonkeyState.CELEBRATE) {
+            teco.play('Celebrate');
+            if (this.timer > 1.4) this.state = MonkeyState.FOLLOW;
+            return;
+        }
+
+        const dx = player.position.x - teco.position.x;
+        const dz = player.position.z - teco.position.z;
+        const dist = Math.hypot(dx, dz);
+        const targetY = player.position.y + 0.05;
+
+        if (dist > 1.4) {
+            this.state = MonkeyState.FOLLOW;
+            const spd = dist > 6 ? 7 : 4.2;
+            teco.position.x += (dx / (dist || 1)) * spd * dt;
+            teco.position.z += (dz / (dist || 1)) * spd * dt;
+            teco.position.y = damp(teco.position.y, targetY, 8, dt);
+            this.facing = Math.atan2(dx, dz);
+            teco.play(dist > 5 ? 'Run' : 'Walk');
+            teco.onShoulder = false;
+        } else {
+            teco.position.y = damp(teco.position.y, targetY, 8, dt);
+            this.facing = player.facing;
+            teco.play('Idle');
+            this.perchTimer += dt;
+            if (this.perchTimer > 7 && dist < 1.1) {
+                this.state = MonkeyState.PERCHED;
+                this.perchTimer = 0;
+            }
+        }
+    }
+}

--- a/labs/guerreiro-castelo/js/ai/PrincessAI.js
+++ b/labs/guerreiro-castelo/js/ai/PrincessAI.js
@@ -1,0 +1,75 @@
+/**
+ * Camila segue Dico com offset, sem bloquear portas.
+ */
+
+import * as THREE from 'three';
+import { damp } from '../utils/math.js';
+
+export class PrincessAI {
+    constructor(camila) {
+        this.camila = camila;
+        this.state = 'WAIT';
+        this.facing = 0;
+        this.offset = new THREE.Vector3(-0.7, 0, -0.9);
+        this.stuck = 0;
+        this.last = new THREE.Vector3();
+    }
+
+    reset() {
+        this.state = 'WAIT';
+        this.stuck = 0;
+    }
+
+    follow() {
+        this.state = 'FOLLOW';
+    }
+
+    run() {
+        this.state = 'RUN';
+    }
+
+    update(dt, game) {
+        const c = this.camila;
+        if (this.state === 'WAIT') {
+            c.speed = 0;
+            const dx = game.player.position.x - c.position.x;
+            const dz = game.player.position.z - c.position.z;
+            this.facing = Math.atan2(dx, dz);
+            return;
+        }
+
+        const p = game.player;
+        const ox = Math.sin(p.facing + Math.PI) * 0.85 + Math.cos(p.facing) * -0.55;
+        const oz = Math.cos(p.facing + Math.PI) * 0.85 + Math.sin(p.facing) * -0.55;
+        const tx = p.position.x + ox;
+        const tz = p.position.z + oz;
+        const ty = p.position.y;
+        const dx = tx - c.position.x;
+        const dz = tz - c.position.z;
+        const dist = Math.hypot(dx, dz);
+        const run = this.state === 'RUN' || this.state === 'ESCAPE';
+        const spd = run ? 5.6 : 3.4;
+
+        if (dist > 1.15) {
+            c.position.x += (dx / dist) * spd * dt;
+            c.position.z += (dz / dist) * spd * dt;
+            c.position.y = damp(c.position.y, ty, 8, dt);
+            this.facing = Math.atan2(dx, dz);
+            c.speed = spd;
+        } else {
+            c.speed = 0;
+            c.position.y = damp(c.position.y, ty, 8, dt);
+            this.facing = p.facing;
+        }
+
+        if (Math.hypot(c.position.x - this.last.x, c.position.z - this.last.z) < 0.01 && dist > 2) {
+            this.stuck += dt;
+            if (this.stuck > 1.2) {
+                c.position.x = tx;
+                c.position.z = tz;
+                this.stuck = 0;
+            }
+        } else this.stuck = 0;
+        this.last.copy(c.position);
+    }
+}

--- a/labs/guerreiro-castelo/js/ai/TigerAI.js
+++ b/labs/guerreiro-castelo/js/ai/TigerAI.js
@@ -1,0 +1,93 @@
+/**
+ * Tigre da sala — tensão e puzzle, não boss fight.
+ * Reage a Teco na rota superior; permanece na sala.
+ */
+
+import * as THREE from 'three';
+import { damp } from '../utils/math.js';
+
+export class TigerAI {
+    constructor(tiger) {
+        this.tiger = tiger;
+        this.state = 'REST';
+        this.home = new THREE.Vector3();
+        this.timer = 0;
+        this.bounds = { minX: -6, maxX: 6, minZ: -6, maxZ: 6 };
+    }
+
+    reset() {
+        this.state = 'REST';
+        this.timer = 0;
+        this.home.copy(this.tiger.position);
+    }
+
+    setBounds(minX, maxX, minZ, maxZ) {
+        this.bounds = { minX, maxX, minZ, maxZ };
+    }
+
+    update(dt, game) {
+        const t = this.tiger;
+        this.timer += dt;
+        const teco = game.teco;
+        const tecoBusy = teco.ai.state === 'CLIMB' || teco.ai.state === 'MOVE_TO' || teco.ai.state === 'INTERACT';
+
+        if (this.state === 'REST') {
+            t.animator.play('Idle');
+            if (this.timer > 0.4) {
+                this.state = 'WATCH';
+                t.animator.play('Growl');
+                game.audio.play('growl');
+            }
+            return;
+        }
+
+        if (this.state === 'WATCH' || this.state === 'THREATEN') {
+            const dx = game.player.position.x - t.position.x;
+            const dz = game.player.position.z - t.position.z;
+            t.facing = Math.atan2(dx, dz);
+            t.animator.play(this.state === 'THREATEN' ? 'Growl' : 'Idle');
+            if (tecoBusy) {
+                this.state = 'TRACK_TECO';
+                this.timer = 0;
+            }
+            return;
+        }
+
+        if (this.state === 'TRACK_TECO') {
+            const dx = teco.position.x - t.position.x;
+            const dz = teco.position.z - t.position.z;
+            t.facing = Math.atan2(dx, dz);
+            const nx = t.position.x + Math.sin(t.facing) * 2.2 * dt;
+            const nz = t.position.z + Math.cos(t.facing) * 2.2 * dt;
+            t.position.x = Math.min(this.bounds.maxX, Math.max(this.bounds.minX, nx));
+            t.position.z = Math.min(this.bounds.maxZ, Math.max(this.bounds.minZ, nz));
+            t.animator.play('Walk');
+            if (teco.position.y > t.position.y + 1.4 && this.timer > 0.5) {
+                this.state = 'JUMP';
+                this.timer = 0;
+                t.animator.play('Jump');
+            }
+            if (!tecoBusy && this.timer > 0.8) this.state = 'RETURN';
+            return;
+        }
+
+        if (this.state === 'JUMP') {
+            t.position.y = this.home.y + Math.sin(Math.min(1, this.timer / 0.45) * Math.PI) * 1.1;
+            if (this.timer > 0.5) {
+                t.position.y = this.home.y;
+                this.state = 'TRACK_TECO';
+                this.timer = 0;
+            }
+            return;
+        }
+
+        if (this.state === 'RETURN') {
+            t.position.x = damp(t.position.x, this.home.x, 3, dt);
+            t.position.z = damp(t.position.z, this.home.z, 3, dt);
+            t.animator.play('Walk');
+            if (Math.hypot(t.position.x - this.home.x, t.position.z - this.home.z) < 0.2) {
+                this.state = 'WATCH';
+            }
+        }
+    }
+}

--- a/labs/guerreiro-castelo/js/audio/AudioManager.js
+++ b/labs/guerreiro-castelo/js/audio/AudioManager.js
@@ -1,0 +1,1 @@
+export { AudioManager } from '../core/AudioManager.js';

--- a/labs/guerreiro-castelo/js/characters/Camila.js
+++ b/labs/guerreiro-castelo/js/characters/Camila.js
@@ -10,6 +10,7 @@ export class Camila {
         this.parts = built.parts;
         this.animator = new CharacterAnimator(built.group, built.clips);
         scene.add(this.root);
+        this.root.traverse((c) => { if (c.isMesh) c.userData.ignoreCamera = true; });
         this.position = new THREE.Vector3();
         this.facing = 0;
         this.ai = new PrincessAI(this);

--- a/labs/guerreiro-castelo/js/characters/Camila.js
+++ b/labs/guerreiro-castelo/js/characters/Camila.js
@@ -1,0 +1,51 @@
+import * as THREE from 'three';
+import { buildCamila, CharacterAnimator, applyLocomotion } from './builders.js';
+import { PrincessAI } from '../ai/PrincessAI.js';
+import { angleDamp } from '../utils/math.js';
+
+export class Camila {
+    constructor(scene) {
+        const built = buildCamila();
+        this.root = built.group;
+        this.parts = built.parts;
+        this.animator = new CharacterAnimator(built.group, built.clips);
+        scene.add(this.root);
+        this.position = new THREE.Vector3();
+        this.facing = 0;
+        this.ai = new PrincessAI(this);
+        this.freed = false;
+        this.shackled = true;
+        this.active = false;
+        this.root.visible = false;
+        this.speed = 0;
+    }
+
+    spawn(x, y, z) {
+        this.position.set(x, y, z);
+        this.root.position.copy(this.position);
+        this.root.visible = true;
+        this.active = true;
+        this.ai.reset();
+    }
+
+    setShackles(on) {
+        this.shackled = on;
+        if (this.parts.shackles) this.parts.shackles.visible = on;
+    }
+
+    attachTo(parent) {
+        if (this.root.parent) this.root.parent.remove(this.root);
+        parent.add(this.root);
+    }
+
+    update(dt, game) {
+        if (!this.active) return;
+        this.ai.update(dt, game);
+        this.facing = angleDamp(this.facing, this.ai.facing, 8, dt);
+        this.root.position.copy(this.position);
+        this.root.rotation.y = this.facing;
+        applyLocomotion(this.animator, this.speed, false, true, false, false, false);
+        if (this.ai.state === 'HIDE' || this.ai.state === 'SCARED') this.animator.play('Idle');
+        this.animator.update(dt);
+    }
+}

--- a/labs/guerreiro-castelo/js/characters/Dico.js
+++ b/labs/guerreiro-castelo/js/characters/Dico.js
@@ -1,0 +1,14 @@
+import { CharacterAnimator, applyLocomotion } from './builders.js';
+
+export class Dico {
+    constructor(built) {
+        this.root = built.group;
+        this.parts = built.parts;
+        this.animator = new CharacterAnimator(built.group, built.clips);
+    }
+
+    update(dt, state) {
+        applyLocomotion(this.animator, state.speed || 0, state.crouch, state.grounded !== false, state.attack, state.block, state.interact);
+        this.animator.update(dt);
+    }
+}

--- a/labs/guerreiro-castelo/js/characters/Friend.js
+++ b/labs/guerreiro-castelo/js/characters/Friend.js
@@ -1,0 +1,18 @@
+import { buildFriend, CharacterAnimator, applyLocomotion } from './builders.js';
+import { FollowerAI } from '../ai/FollowerAI.js';
+
+export class Friend {
+    constructor(parent, variant = 0, offset = { x: 0.8, z: -0.8 }) {
+        const built = buildFriend(variant);
+        this.root = built.group;
+        this.animator = new CharacterAnimator(built.group, built.clips);
+        parent.add(this.root);
+        this.ai = new FollowerAI(this.root, offset);
+    }
+
+    update(dt, player) {
+        this.ai.update(dt, player);
+        applyLocomotion(this.animator, this.ai.speed, false, true, false, false, false);
+        this.animator.update(dt);
+    }
+}

--- a/labs/guerreiro-castelo/js/characters/Guard.js
+++ b/labs/guerreiro-castelo/js/characters/Guard.js
@@ -1,0 +1,62 @@
+import * as THREE from 'three';
+import { buildGuard, CharacterAnimator, applyLocomotion } from './builders.js';
+import { GuardAI } from '../ai/GuardAI.js';
+import { angleDamp } from '../utils/math.js';
+
+export class Guard {
+    constructor(scene, opts = {}) {
+        const built = buildGuard(opts);
+        this.root = built.group;
+        this.parts = built.parts;
+        this.animator = new CharacterAnimator(built.group, built.clips);
+        scene.add(this.root);
+        this.position = new THREE.Vector3();
+        this.facing = 0;
+        this.ai = new GuardAI(this, opts);
+        this.health = 3;
+        this.maxHealth = 3;
+        this.alive = true;
+        this.fat = Boolean(opts.fat);
+        this.archer = Boolean(opts.archer);
+        this.hasKeys = Boolean(opts.fat);
+        this.speed = 0;
+        this.hitT = 0;
+    }
+
+    spawn(x, y, z, yaw = 0) {
+        this.position.set(x, y, z);
+        this.facing = yaw;
+        this.ai.home.set(x, y, z);
+        this.ai.facing = yaw;
+        this.root.position.copy(this.position);
+        this.root.rotation.y = yaw;
+        this.alive = true;
+        this.health = this.maxHealth;
+    }
+
+    takeHit(amount = 1) {
+        if (!this.alive) return;
+        this.health -= amount;
+        this.hitT = 0.2;
+        if (this.health <= 0) {
+            this.alive = false;
+            this.ai.state = 'IDLE';
+        }
+    }
+
+    update(dt, game) {
+        if (!this.alive) {
+            this.root.rotation.x = Math.min(1.4, this.root.rotation.x + dt * 3);
+            return;
+        }
+        this.hitT = Math.max(0, this.hitT - dt);
+        this.ai.update(dt, game);
+        this.facing = angleDamp(this.facing, this.ai.facing, 8, dt);
+        this.root.position.copy(this.position);
+        this.root.rotation.y = this.facing;
+        if (this.ai.state === 'SLEEP') this.animator.play('Idle');
+        else applyLocomotion(this.animator, this.speed, false, true, this.ai.state === 'ATTACK', false, false);
+        this.animator.update(dt);
+        if (this.parts.keys) this.parts.keys.visible = this.hasKeys;
+    }
+}

--- a/labs/guerreiro-castelo/js/characters/Ravi.js
+++ b/labs/guerreiro-castelo/js/characters/Ravi.js
@@ -1,0 +1,15 @@
+import { buildRavi, CharacterAnimator } from './builders.js';
+
+export class Ravi {
+    constructor(parent) {
+        const built = buildRavi();
+        this.root = built.group;
+        this.parts = built.parts;
+        this.animator = new CharacterAnimator(built.group, built.clips);
+        parent.add(this.root);
+    }
+
+    update(dt) {
+        this.animator.update(dt);
+    }
+}

--- a/labs/guerreiro-castelo/js/characters/Teco.js
+++ b/labs/guerreiro-castelo/js/characters/Teco.js
@@ -10,6 +10,7 @@ export class Teco {
         this.parts = built.parts;
         this.animator = new CharacterAnimator(built.group, built.clips);
         scene.add(this.root);
+        this.root.traverse((c) => { if (c.isMesh) c.userData.ignoreCamera = true; });
         this.position = new THREE.Vector3();
         this.facing = 0;
         this.ai = new MonkeyAI(this);

--- a/labs/guerreiro-castelo/js/characters/Teco.js
+++ b/labs/guerreiro-castelo/js/characters/Teco.js
@@ -1,0 +1,43 @@
+import * as THREE from 'three';
+import { buildTeco, CharacterAnimator } from './builders.js';
+import { MonkeyAI } from '../ai/MonkeyAI.js';
+import { angleDamp } from '../utils/math.js';
+
+export class Teco {
+    constructor(scene) {
+        const built = buildTeco();
+        this.root = built.group;
+        this.parts = built.parts;
+        this.animator = new CharacterAnimator(built.group, built.clips);
+        scene.add(this.root);
+        this.position = new THREE.Vector3();
+        this.facing = 0;
+        this.ai = new MonkeyAI(this);
+        this.onShoulder = false;
+        this.visible = true;
+    }
+
+    spawn(x, y, z) {
+        this.position.set(x, y, z);
+        this.root.position.copy(this.position);
+        this.ai.reset();
+    }
+
+    attachTo(parent) {
+        if (this.root.parent) this.root.parent.remove(this.root);
+        parent.add(this.root);
+    }
+
+    play(name) {
+        this.animator.play(name, 0.12);
+    }
+
+    update(dt, game) {
+        this.ai.update(dt, game);
+        this.facing = angleDamp(this.facing, this.ai.facing, 10, dt);
+        this.root.position.copy(this.position);
+        this.root.rotation.y = this.facing;
+        this.root.visible = this.visible;
+        this.animator.update(dt);
+    }
+}

--- a/labs/guerreiro-castelo/js/characters/Tiger.js
+++ b/labs/guerreiro-castelo/js/characters/Tiger.js
@@ -1,0 +1,36 @@
+import * as THREE from 'three';
+import { buildTiger, CharacterAnimator } from './builders.js';
+import { TigerAI } from '../ai/TigerAI.js';
+
+export class Tiger {
+    constructor(scene) {
+        const built = buildTiger();
+        this.root = built.group;
+        this.parts = built.parts;
+        this.animator = new CharacterAnimator(built.group, built.clips);
+        scene.add(this.root);
+        this.position = new THREE.Vector3();
+        this.facing = 0;
+        this.ai = new TigerAI(this);
+        this.active = false;
+        this.root.visible = false;
+    }
+
+    spawn(x, y, z, yaw = 0) {
+        this.position.set(x, y, z);
+        this.facing = yaw;
+        this.root.position.copy(this.position);
+        this.root.rotation.y = yaw;
+        this.root.visible = true;
+        this.active = true;
+        this.ai.reset();
+    }
+
+    update(dt, game) {
+        if (!this.active) return;
+        this.ai.update(dt, game);
+        this.root.position.copy(this.position);
+        this.root.rotation.y = this.facing;
+        this.animator.update(dt);
+    }
+}

--- a/labs/guerreiro-castelo/js/characters/builders.js
+++ b/labs/guerreiro-castelo/js/characters/builders.js
@@ -1,0 +1,635 @@
+/**
+ * Humanoides procedurais com ossos nomeados + AnimationMixer.
+ * Fallbacks apresentáveis para quando o GLB não existe.
+ */
+
+import * as THREE from 'three';
+import { leatherTexture, clothTexture } from '../world/Textures.js';
+
+const matCache = new Map();
+
+export function std(color, roughness = 0.78, metalness = 0.04, extra = {}) {
+    const key = `s:${color}:${roughness}:${metalness}:${JSON.stringify(extra)}`;
+    if (!matCache.has(key)) {
+        matCache.set(key, new THREE.MeshStandardMaterial({ color, roughness, metalness, ...extra }));
+    }
+    return matCache.get(key);
+}
+
+export function mapped(map, color = 0xffffff, roughness = 0.86, metalness = 0.03) {
+    return new THREE.MeshStandardMaterial({ map, color, roughness, metalness });
+}
+
+export function enableShadows(root) {
+    root.traverse((c) => {
+        if (c.isMesh) {
+            c.castShadow = true;
+            c.receiveShadow = true;
+        }
+    });
+}
+
+function nameBone(obj, name) {
+    obj.name = name;
+    return obj;
+}
+
+function makeClips(parts) {
+    const clips = {};
+    const mk = (name, duration, channels) => {
+        const tracks = channels.map((ch) => {
+            const n = 8;
+            const times = [];
+            const values = [];
+            for (let i = 0; i <= n; i++) {
+                const t = (i / n) * duration;
+                times.push(t);
+                values.push(Math.sin((i / n) * Math.PI * 2 + ch.phase) * ch.amp + (ch.base || 0));
+            }
+            return new THREE.NumberKeyframeTrack(`${ch.target.name}.rotation[${ch.axis}]`, times, values);
+        });
+        clips[name] = new THREE.AnimationClip(name, duration, tracks);
+    };
+
+    mk('Idle', 2.4, [
+        { target: parts.chest, axis: 'x', amp: 0.03, phase: 0 },
+        { target: parts.head, axis: 'y', amp: 0.04, phase: 1 }
+    ]);
+    mk('Walk', 0.85, [
+        { target: parts.legL, axis: 'x', amp: 0.55, phase: 0 },
+        { target: parts.legR, axis: 'x', amp: 0.55, phase: Math.PI },
+        { target: parts.armL, axis: 'x', amp: 0.45, phase: Math.PI },
+        { target: parts.armR, axis: 'x', amp: 0.45, phase: 0 }
+    ]);
+    mk('Run', 0.55, [
+        { target: parts.legL, axis: 'x', amp: 0.85, phase: 0 },
+        { target: parts.legR, axis: 'x', amp: 0.85, phase: Math.PI },
+        { target: parts.armL, axis: 'x', amp: 0.7, phase: Math.PI },
+        { target: parts.armR, axis: 'x', amp: 0.7, phase: 0 },
+        { target: parts.chest, axis: 'z', amp: 0.06, phase: 0 }
+    ]);
+    mk('Sprint', 0.42, [
+        { target: parts.legL, axis: 'x', amp: 1.05, phase: 0 },
+        { target: parts.legR, axis: 'x', amp: 1.05, phase: Math.PI },
+        { target: parts.armL, axis: 'x', amp: 0.9, phase: Math.PI },
+        { target: parts.armR, axis: 'x', amp: 0.9, phase: 0 }
+    ]);
+    mk('Crouch', 1.2, [
+        { target: parts.legL, axis: 'x', amp: 0.12, phase: 0, base: 0.55 },
+        { target: parts.legR, axis: 'x', amp: 0.12, phase: Math.PI, base: 0.55 }
+    ]);
+    mk('Attack', 0.45, [
+        { target: parts.armR, axis: 'x', amp: 1.1, phase: 0, base: -0.4 },
+        { target: parts.chest, axis: 'y', amp: 0.25, phase: 0 }
+    ]);
+    mk('Block', 0.8, [
+        { target: parts.armL, axis: 'x', amp: 0.05, phase: 0, base: -0.9 }
+    ]);
+    mk('Interact', 0.9, [
+        { target: parts.armR, axis: 'x', amp: 0.4, phase: 0, base: -0.6 }
+    ]);
+    mk('Jump', 0.6, [
+        { target: parts.legL, axis: 'x', amp: 0.2, phase: 0, base: 0.4 },
+        { target: parts.legR, axis: 'x', amp: 0.2, phase: 0, base: 0.4 }
+    ]);
+    return clips;
+}
+
+export class CharacterAnimator {
+    constructor(root, clips) {
+        this.mixer = new THREE.AnimationMixer(root);
+        this.actions = {};
+        for (const [name, clip] of Object.entries(clips)) {
+            const action = this.mixer.clipAction(clip);
+            action.enabled = true;
+            this.actions[name] = action;
+        }
+        this.current = null;
+        this.currentName = 'Idle';
+        this.play('Idle', 0);
+    }
+
+    play(name, fade = 0.18) {
+        const next = this.actions[name] || this.actions.Idle;
+        if (!next || this.current === next) return;
+        next.reset();
+        next.setEffectiveWeight(1);
+        next.play();
+        if (this.current) this.current.crossFadeTo(next, fade, false);
+        else next.fadeIn(fade);
+        this.current = next;
+        this.currentName = name;
+    }
+
+    update(dt) {
+        this.mixer.update(dt);
+    }
+}
+
+function addEyes(head, skin, sx, color = 0x2a2418) {
+    for (const s of [-1, 1]) {
+        const white = new THREE.Mesh(new THREE.SphereGeometry(0.028, 8, 6), std(0xf4efe6, 0.35));
+        white.position.set(s * sx, 0.04, 0.12);
+        head.add(white);
+        const iris = new THREE.Mesh(new THREE.SphereGeometry(0.016, 8, 6), std(color, 0.35));
+        iris.position.set(s * sx, 0.04, 0.142);
+        head.add(iris);
+        const pupil = new THREE.Mesh(new THREE.SphereGeometry(0.008, 6, 5), std(0x111111, 0.2));
+        pupil.position.set(s * sx, 0.04, 0.154);
+        head.add(pupil);
+    }
+}
+
+function curlyHair(head, mat, radius, count, yOff = 0.1) {
+    for (let i = 0; i < count; i++) {
+        const curl = new THREE.Mesh(new THREE.SphereGeometry(0.045, 8, 6), mat);
+        const a = (i / count) * Math.PI * 2;
+        const h = 0.04 + (i % 3) * 0.03;
+        curl.position.set(Math.cos(a) * radius, yOff + h, Math.sin(a) * radius * 0.9);
+        head.add(curl);
+    }
+}
+
+/**
+ * Ossos compartilhados: hips, spine, chest, head, armL/R, legL/R.
+ */
+export function buildHumanoid({
+    height = 1.8,
+    thin = 1,
+    skin = 0xe0b089,
+    hair = 0x1a120e,
+    shirt = 0x4a3a2a,
+    pants = 0x2c2418,
+    boots = 0x3a2414,
+    eye = 0x3a2a18
+} = {}) {
+    const scale = height / 1.8;
+    const group = new THREE.Group();
+    const skinM = std(skin, 0.7);
+    const shirtM = mapped(clothTexture(), shirt, 0.9);
+    const pantsM = mapped(clothTexture(), pants, 0.88);
+    const bootM = mapped(leatherTexture(), boots, 0.7, 0.05);
+    const hairM = std(hair, 0.92);
+
+    const hips = nameBone(new THREE.Group(), 'hips');
+    group.add(hips);
+
+    const legL = nameBone(new THREE.Group(), 'legL');
+    const legR = nameBone(new THREE.Group(), 'legR');
+    legL.position.set(-0.12 * thin * scale, 0.92 * scale, 0);
+    legR.position.set(0.12 * thin * scale, 0.92 * scale, 0);
+    hips.add(legL, legR);
+
+    for (const leg of [legL, legR]) {
+        const thigh = new THREE.Mesh(new THREE.CylinderGeometry(0.07 * thin * scale, 0.06 * thin * scale, 0.46 * scale, 8), pantsM);
+        thigh.position.y = -0.23 * scale;
+        leg.add(thigh);
+        const shin = new THREE.Mesh(new THREE.CylinderGeometry(0.055 * thin * scale, 0.05 * thin * scale, 0.42 * scale, 8), pantsM);
+        shin.position.y = -0.66 * scale;
+        leg.add(shin);
+        const foot = new THREE.Mesh(new THREE.BoxGeometry(0.1 * scale, 0.08 * scale, 0.22 * scale), bootM);
+        foot.position.set(0, -0.9 * scale, 0.04 * scale);
+        leg.add(foot);
+    }
+
+    const spine = nameBone(new THREE.Group(), 'spine');
+    spine.position.y = 0.95 * scale;
+    hips.add(spine);
+
+    const chest = nameBone(new THREE.Group(), 'chest');
+    spine.add(chest);
+    const torso = new THREE.Mesh(
+        new THREE.CapsuleGeometry(0.2 * thin * scale, 0.42 * scale, 6, 10),
+        shirtM
+    );
+    torso.position.y = 0.28 * scale;
+    chest.add(torso);
+
+    const armL = nameBone(new THREE.Group(), 'armL');
+    const armR = nameBone(new THREE.Group(), 'armR');
+    armL.position.set(-0.26 * thin * scale, 0.42 * scale, 0);
+    armR.position.set(0.26 * thin * scale, 0.42 * scale, 0);
+    chest.add(armL, armR);
+    for (const arm of [armL, armR]) {
+        const upper = new THREE.Mesh(new THREE.CylinderGeometry(0.05 * scale, 0.045 * scale, 0.32 * scale, 8), shirtM);
+        upper.position.y = -0.16 * scale;
+        arm.add(upper);
+        const fore = new THREE.Mesh(new THREE.CylinderGeometry(0.042 * scale, 0.038 * scale, 0.3 * scale, 8), skinM);
+        fore.position.y = -0.46 * scale;
+        arm.add(fore);
+        const hand = new THREE.Mesh(new THREE.SphereGeometry(0.045 * scale, 8, 6), skinM);
+        hand.position.y = -0.64 * scale;
+        arm.add(hand);
+        arm.userData.hand = hand;
+    }
+
+    const head = nameBone(new THREE.Group(), 'head');
+    head.position.y = 0.62 * scale;
+    chest.add(head);
+    const skull = new THREE.Mesh(new THREE.SphereGeometry(0.125 * scale, 14, 12), skinM);
+    skull.scale.set(0.92, 1.05, 0.95);
+    head.add(skull);
+    addEyes(head, skinM, 0.045 * scale, eye);
+
+    const parts = { hips, spine, chest, head, armL, armR, legL, legR, group, scale, skinM, hairM };
+    const clips = makeClips(parts);
+    enableShadows(group);
+    group.userData.parts = parts;
+    group.userData.clips = clips;
+    return { group, parts, clips };
+}
+
+export function buildDico() {
+    const { group, parts, clips } = buildHumanoid({
+        height: 1.9,
+        thin: 0.88,
+        skin: 0xd9a878,
+        hair: 0x1a140f,
+        shirt: 0x4a3a2c,
+        pants: 0x2a2218,
+        boots: 0x3a2416,
+        eye: 0x3d4a28
+    });
+
+    curlyHair(parts.head, parts.hairM, 0.12, 16, 0.08);
+    const bang = new THREE.Mesh(new THREE.SphereGeometry(0.07, 8, 6), parts.hairM);
+    bang.position.set(0, 0.12, 0.08);
+    parts.head.add(bang);
+
+    const mustache = new THREE.Mesh(new THREE.BoxGeometry(0.09, 0.015, 0.03), parts.hairM);
+    mustache.position.set(0, -0.02, 0.12);
+    parts.head.add(mustache);
+    const goatee = new THREE.Mesh(new THREE.SphereGeometry(0.03, 8, 6), parts.hairM);
+    goatee.scale.set(0.7, 1.1, 0.6);
+    goatee.position.set(0, -0.08, 0.1);
+    parts.head.add(goatee);
+
+    const leather = mapped(leatherTexture(), 0x5a3a22, 0.7, 0.08);
+    const vest = new THREE.Mesh(new THREE.CylinderGeometry(0.2, 0.22, 0.36, 10), leather);
+    vest.position.y = 0.26;
+    parts.chest.add(vest);
+
+    const belt = new THREE.Mesh(new THREE.TorusGeometry(0.2, 0.025, 6, 16), std(0x3a2414, 0.6, 0.15));
+    belt.rotation.x = Math.PI / 2;
+    belt.position.y = 0.08;
+    parts.chest.add(belt);
+
+    const sword = new THREE.Group();
+    sword.name = 'sword';
+    const blade = new THREE.Mesh(new THREE.BoxGeometry(0.04, 0.72, 0.012), std(0xc5cdd6, 0.25, 0.85));
+    blade.position.y = 0.36;
+    sword.add(blade);
+    const guard = new THREE.Mesh(new THREE.BoxGeometry(0.16, 0.03, 0.03), std(0xb08a3a, 0.35, 0.8));
+    sword.add(guard);
+    const hilt = new THREE.Mesh(new THREE.CylinderGeometry(0.02, 0.022, 0.14, 8), std(0x3a2414, 0.7));
+    hilt.position.y = -0.08;
+    sword.add(hilt);
+    sword.position.set(0.02, -0.2, 0.02);
+    sword.rotation.z = 0.15;
+    parts.armR.userData.hand.add(sword);
+
+    const shield = new THREE.Mesh(new THREE.CylinderGeometry(0.18, 0.18, 0.04, 10), mapped(leatherTexture(), 0x6b1c1c, 0.55, 0.2));
+    shield.rotation.z = Math.PI / 2;
+    shield.position.set(-0.08, -0.15, 0.06);
+    parts.armL.add(shield);
+
+    const torch = new THREE.Group();
+    torch.visible = false;
+    const stick = new THREE.Mesh(new THREE.CylinderGeometry(0.02, 0.025, 0.32, 6), std(0x4a3218, 0.9));
+    torch.add(stick);
+    const flame = new THREE.Mesh(
+        new THREE.SphereGeometry(0.06, 8, 6),
+        new THREE.MeshStandardMaterial({ color: 0xffaa33, emissive: 0xff7711, emissiveIntensity: 2.2 })
+    );
+    flame.position.y = 0.2;
+    torch.add(flame);
+    torch.position.set(0.05, -0.2, 0.05);
+    parts.armL.userData.hand.add(torch);
+    parts.torch = torch;
+    parts.torchFlame = flame;
+    parts.sword = sword;
+    parts.shield = shield;
+
+    enableShadows(group);
+    return { group, parts, clips };
+}
+
+export function buildRavi() {
+    const { group, parts, clips } = buildHumanoid({
+        height: 1.05,
+        thin: 0.95,
+        skin: 0xe8c49a,
+        hair: 0xd8c48a,
+        shirt: 0x3a5a8a,
+        pants: 0x4a3a28,
+        boots: 0x5a3a22,
+        eye: 0x4a6a8a
+    });
+    curlyHair(parts.head, std(0xe8d4a0, 0.9), 0.08, 14, 0.06);
+    const blanket = new THREE.Mesh(new THREE.BoxGeometry(0.55, 0.08, 0.7), std(0x6a2a2a, 0.92));
+    blanket.position.set(0, 0.4, 0.05);
+    blanket.visible = true;
+    group.add(blanket);
+    parts.blanket = blanket;
+    return { group, parts, clips };
+}
+
+export function buildCamila() {
+    const { group, parts, clips } = buildHumanoid({
+        height: 1.68,
+        thin: 0.9,
+        skin: 0xf0c8a8,
+        hair: 0xe8d48a,
+        shirt: 0xc9b8d4,
+        pants: 0x8a6a9a,
+        boots: 0x5a3a44,
+        eye: 0x4a6a8a
+    });
+    const hairM = std(0xe8d48a, 0.55);
+    const hair = new THREE.Mesh(new THREE.CapsuleGeometry(0.12, 0.35, 6, 10), hairM);
+    hair.position.set(0, 0.02, -0.04);
+    parts.head.add(hair);
+    const bangs = new THREE.Mesh(new THREE.BoxGeometry(0.2, 0.04, 0.08), hairM);
+    bangs.position.set(0, 0.1, 0.1);
+    parts.head.add(bangs);
+    const dress = new THREE.Mesh(new THREE.ConeGeometry(0.32, 0.7, 10), std(0xc9b8d4, 0.88));
+    dress.position.y = 0.55;
+    parts.hips.add(dress);
+    const shackles = new THREE.Group();
+    const left = new THREE.Mesh(new THREE.TorusGeometry(0.05, 0.012, 6, 12), std(0x888888, 0.4, 0.8));
+    left.position.set(-0.12, 0.9, 0.12);
+    const right = left.clone();
+    right.position.x = 0.12;
+    const chain = new THREE.Mesh(new THREE.CylinderGeometry(0.012, 0.012, 0.24, 6), std(0x777777, 0.4, 0.8));
+    chain.rotation.z = Math.PI / 2;
+    chain.position.set(0, 0.9, 0.12);
+    shackles.add(left, right, chain);
+    parts.hips.add(shackles);
+    parts.shackles = shackles;
+    return { group, parts, clips };
+}
+
+export function buildGuard({ fat = false, archer = false } = {}) {
+    const { group, parts, clips } = buildHumanoid({
+        height: fat ? 1.7 : 1.82,
+        thin: fat ? 1.35 : 1.08,
+        skin: 0xd2a07a,
+        hair: 0x3a2a18,
+        shirt: 0x4a4a3a,
+        pants: 0x2a2a22,
+        boots: 0x3a2a18,
+        eye: 0x2a2a18
+    });
+    const helm = new THREE.Mesh(new THREE.SphereGeometry(0.15, 10, 8, 0, Math.PI * 2, 0, Math.PI * 0.58), std(0x8a8a82, 0.35, 0.7));
+    helm.position.y = 0.04;
+    parts.head.add(helm);
+    const tunic = new THREE.Mesh(
+        new THREE.CylinderGeometry(fat ? 0.32 : 0.22, fat ? 0.28 : 0.2, 0.5, 10),
+        std(0x5a1c1c, 0.85)
+    );
+    tunic.position.y = 0.22;
+    parts.chest.add(tunic);
+    if (fat) {
+        const belly = new THREE.Mesh(new THREE.SphereGeometry(0.28, 12, 10), std(0x5a1c1c, 0.88));
+        belly.position.y = 0.12;
+        parts.chest.add(belly);
+    }
+    const spear = new THREE.Group();
+    const shaft = new THREE.Mesh(new THREE.CylinderGeometry(0.018, 0.018, 1.6, 6), std(0x5a3a18, 0.8));
+    spear.add(shaft);
+    const tip = new THREE.Mesh(new THREE.ConeGeometry(0.04, 0.16, 6), std(0xb0b8c0, 0.3, 0.8));
+    tip.position.y = 0.86;
+    spear.add(tip);
+    spear.position.set(0.05, -0.2, 0.1);
+    parts.armR.userData.hand.add(spear);
+    if (archer) {
+        spear.visible = false;
+        const bow = new THREE.Mesh(new THREE.TorusGeometry(0.28, 0.018, 6, 16, Math.PI), std(0x5a3a18, 0.7));
+        bow.rotation.y = Math.PI / 2;
+        parts.armL.add(bow);
+    }
+    const keys = new THREE.Group();
+    for (let i = 0; i < 3; i++) {
+        const k = new THREE.Mesh(new THREE.BoxGeometry(0.04, 0.12, 0.02), std(0xc9a227, 0.4, 0.7));
+        k.position.set(0.08, 0.7 + i * 0.02, 0.14);
+        k.rotation.z = 0.3 * i;
+        keys.add(k);
+    }
+    keys.visible = fat;
+    parts.hips.add(keys);
+    parts.keys = keys;
+    parts.spear = spear;
+    return { group, parts, clips };
+}
+
+export function buildFriend(variant = 0) {
+    const palettes = [
+        { shirt: 0x3a4a3a, pants: 0x2a2218, hair: 0x3a2414 },
+        { shirt: 0x3a3a5a, pants: 0x2a2a22, hair: 0x1a1a12 },
+        { shirt: 0x5a3a2a, pants: 0x3a2a18, hair: 0x6a4a22 }
+    ];
+    const p = palettes[variant % 3];
+    const built = buildHumanoid({
+        height: 1.78 + variant * 0.04,
+        thin: 1,
+        shirt: p.shirt,
+        pants: p.pants,
+        hair: p.hair
+    });
+    curlyHair(built.parts.head, std(p.hair, 0.9), 0.11, 10, 0.08);
+    const pack = new THREE.Mesh(new THREE.BoxGeometry(0.28, 0.32, 0.16), mapped(leatherTexture(), 0x4a3218, 0.8));
+    pack.position.set(0, 0.28, -0.22);
+    built.parts.chest.add(pack);
+    return built;
+}
+
+export function buildTeco() {
+    const group = new THREE.Group();
+    const fur = std(0x6a4a2a, 0.9);
+    const dark = std(0x3a2a18, 0.88);
+    const face = std(0xe0b090, 0.65);
+
+    const hips = nameBone(new THREE.Group(), 'hips');
+    group.add(hips);
+    const body = new THREE.Mesh(new THREE.SphereGeometry(0.12, 12, 10), fur);
+    body.scale.set(0.9, 1.15, 0.8);
+    body.position.y = 0.22;
+    hips.add(body);
+
+    const chest = nameBone(new THREE.Group(), 'chest');
+    chest.position.y = 0.28;
+    hips.add(chest);
+
+    const head = nameBone(new THREE.Group(), 'head');
+    head.position.y = 0.16;
+    chest.add(head);
+    const skull = new THREE.Mesh(new THREE.SphereGeometry(0.09, 12, 10), fur);
+    head.add(skull);
+    const muzzle = new THREE.Mesh(new THREE.SphereGeometry(0.05, 10, 8), face);
+    muzzle.scale.set(1, 0.8, 1.2);
+    muzzle.position.set(0, -0.02, 0.07);
+    head.add(muzzle);
+    addEyes(head, face, 0.03, 0x221808);
+    for (const s of [-1, 1]) {
+        const ear = new THREE.Mesh(new THREE.SphereGeometry(0.035, 8, 6), fur);
+        ear.position.set(s * 0.08, 0.06, 0);
+        head.add(ear);
+    }
+
+    const armL = nameBone(new THREE.Group(), 'armL');
+    const armR = nameBone(new THREE.Group(), 'armR');
+    armL.position.set(-0.12, 0.06, 0);
+    armR.position.set(0.12, 0.06, 0);
+    chest.add(armL, armR);
+    for (const arm of [armL, armR]) {
+        const m = new THREE.Mesh(new THREE.CylinderGeometry(0.025, 0.02, 0.22, 6), fur);
+        m.position.y = -0.1;
+        arm.add(m);
+        const hand = new THREE.Mesh(new THREE.SphereGeometry(0.03, 6, 5), dark);
+        hand.position.y = -0.22;
+        arm.add(hand);
+        arm.userData.hand = hand;
+    }
+
+    const legL = nameBone(new THREE.Group(), 'legL');
+    const legR = nameBone(new THREE.Group(), 'legR');
+    legL.position.set(-0.06, 0.12, 0);
+    legR.position.set(0.06, 0.12, 0);
+    hips.add(legL, legR);
+    for (const leg of [legL, legR]) {
+        const m = new THREE.Mesh(new THREE.CylinderGeometry(0.028, 0.022, 0.18, 6), fur);
+        m.position.y = -0.08;
+        leg.add(m);
+        const foot = new THREE.Mesh(new THREE.SphereGeometry(0.03, 6, 5), dark);
+        foot.scale.set(1, 0.6, 1.4);
+        foot.position.set(0, -0.18, 0.02);
+        leg.add(foot);
+    }
+
+    const tail = nameBone(new THREE.Group(), 'tail');
+    tail.position.set(0, 0.16, -0.1);
+    hips.add(tail);
+    const tailM = new THREE.Mesh(new THREE.CylinderGeometry(0.018, 0.01, 0.32, 6), fur);
+    tailM.rotation.x = 0.9;
+    tailM.position.set(0, 0.05, -0.12);
+    tail.add(tailM);
+
+    const parts = { hips, chest, head, armL, armR, legL, legR, tail, group };
+    const clips = makeClips(parts);
+    const extra = [
+        new THREE.NumberKeyframeTrack('tail.rotation[1]', [0, 0.4, 0.8], [0.4, -0.4, 0.4])
+    ];
+    clips.Climb = new THREE.AnimationClip('Climb', 0.6, [
+        new THREE.NumberKeyframeTrack('armL.rotation[0]', [0, 0.3, 0.6], [0.8, -0.8, 0.8]),
+        new THREE.NumberKeyframeTrack('armR.rotation[0]', [0, 0.3, 0.6], [-0.8, 0.8, -0.8]),
+        new THREE.NumberKeyframeTrack('legL.rotation[0]', [0, 0.3, 0.6], [-0.5, 0.5, -0.5])
+    ]);
+    clips.Grab = new THREE.AnimationClip('Grab', 0.5, extra);
+    clips.Shoulder = clips.Idle;
+    clips.Scared = new THREE.AnimationClip('Scared', 0.4, [
+        new THREE.NumberKeyframeTrack('head.rotation[0]', [0, 0.2, 0.4], [0.2, -0.1, 0.2])
+    ]);
+    clips.Celebrate = new THREE.AnimationClip('Celebrate', 0.6, [
+        new THREE.NumberKeyframeTrack('armL.rotation[0]', [0, 0.3, 0.6], [-1.2, -0.2, -1.2]),
+        new THREE.NumberKeyframeTrack('armR.rotation[0]', [0, 0.3, 0.6], [-0.2, -1.2, -0.2])
+    ]);
+    enableShadows(group);
+    group.userData.parts = parts;
+    group.userData.clips = clips;
+    return { group, parts, clips };
+}
+
+export function buildTiger() {
+    const group = new THREE.Group();
+    const orange = std(0xc45a18, 0.75);
+    const white = std(0xeee6d6, 0.8);
+    const black = std(0x1a120c, 0.85);
+
+    const body = new THREE.Mesh(new THREE.CapsuleGeometry(0.38, 1.15, 8, 12), orange);
+    body.rotation.z = Math.PI / 2;
+    body.position.set(0, 0.55, 0);
+    group.add(body);
+
+    const belly = new THREE.Mesh(new THREE.CapsuleGeometry(0.22, 0.9, 6, 10), white);
+    belly.rotation.z = Math.PI / 2;
+    belly.position.set(0, 0.38, 0.05);
+    group.add(belly);
+
+    const head = nameBone(new THREE.Group(), 'head');
+    head.position.set(0.85, 0.62, 0);
+    group.add(head);
+    const skull = new THREE.Mesh(new THREE.SphereGeometry(0.28, 12, 10), orange);
+    skull.scale.set(1.15, 0.9, 0.85);
+    head.add(skull);
+    const muzzle = new THREE.Mesh(new THREE.SphereGeometry(0.14, 10, 8), white);
+    muzzle.position.set(0.18, -0.04, 0);
+    head.add(muzzle);
+    const nose = new THREE.Mesh(new THREE.SphereGeometry(0.05, 8, 6), black);
+    nose.position.set(0.3, 0.02, 0);
+    head.add(nose);
+    for (const s of [-1, 1]) {
+        const ear = new THREE.Mesh(new THREE.ConeGeometry(0.08, 0.12, 6), orange);
+        ear.position.set(-0.05, 0.24, s * 0.14);
+        head.add(ear);
+        const eye = new THREE.Mesh(new THREE.SphereGeometry(0.035, 8, 6), std(0x1a3a08, 0.3));
+        eye.position.set(0.16, 0.08, s * 0.12);
+        head.add(eye);
+    }
+
+    for (const [x, z] of [[-0.35, 0.22], [-0.35, -0.22], [0.35, 0.22], [0.35, -0.22]]) {
+        const leg = new THREE.Mesh(new THREE.CylinderGeometry(0.09, 0.07, 0.45, 8), orange);
+        leg.position.set(x, 0.22, z);
+        group.add(leg);
+        const paw = new THREE.Mesh(new THREE.SphereGeometry(0.1, 8, 6), black);
+        paw.scale.set(1, 0.5, 1.2);
+        paw.position.set(x, 0.04, z);
+        group.add(paw);
+    }
+
+    const tail = nameBone(new THREE.Group(), 'tail');
+    tail.position.set(-0.75, 0.7, 0);
+    group.add(tail);
+    const tailM = new THREE.Mesh(new THREE.CylinderGeometry(0.05, 0.03, 0.9, 6), orange);
+    tailM.rotation.z = 0.8;
+    tailM.position.set(-0.25, 0.2, 0);
+    tail.add(tailM);
+
+    for (let i = 0; i < 12; i++) {
+        const stripe = new THREE.Mesh(new THREE.BoxGeometry(0.06, 0.42, 0.55), black);
+        stripe.position.set(-0.4 + i * 0.12, 0.62, 0);
+        stripe.rotation.y = 0.15;
+        group.add(stripe);
+    }
+
+    const parts = { head, tail, group };
+    const clips = {
+        Idle: new THREE.AnimationClip('Idle', 2, [
+            new THREE.NumberKeyframeTrack('head.rotation[1]', [0, 1, 2], [0.1, -0.1, 0.1])
+        ]),
+        Walk: new THREE.AnimationClip('Walk', 0.8, [
+            new THREE.NumberKeyframeTrack('head.rotation[0]', [0, 0.4, 0.8], [0.05, -0.05, 0.05])
+        ]),
+        Growl: new THREE.AnimationClip('Growl', 0.6, [
+            new THREE.NumberKeyframeTrack('head.rotation[0]', [0, 0.3, 0.6], [0, -0.25, 0])
+        ]),
+        Jump: new THREE.AnimationClip('Jump', 0.5, [
+            new THREE.NumberKeyframeTrack('head.rotation[0]', [0, 0.25, 0.5], [-0.2, 0.3, -0.2])
+        ])
+    };
+    enableShadows(group);
+    group.userData.parts = parts;
+    group.userData.clips = clips;
+    return { group, parts, clips };
+}
+
+export function applyLocomotion(animator, speed, crouch, grounded, attacking, blocking, interacting) {
+    if (attacking) animator.play('Attack', 0.08);
+    else if (blocking) animator.play('Block', 0.1);
+    else if (interacting) animator.play('Interact', 0.1);
+    else if (!grounded) animator.play('Jump', 0.08);
+    else if (crouch) animator.play(speed > 0.15 ? 'Walk' : 'Crouch', 0.15);
+    else if (speed > 5.4) animator.play('Sprint', 0.12);
+    else if (speed > 3.2) animator.play('Run', 0.12);
+    else if (speed > 0.2) animator.play('Walk', 0.14);
+    else animator.play('Idle', 0.2);
+}

--- a/labs/guerreiro-castelo/js/core/AssetManager.js
+++ b/labs/guerreiro-castelo/js/core/AssetManager.js
@@ -59,7 +59,6 @@ export class AssetManager {
 
     async preloadEssential(onProgress) {
         this.onProgress = onProgress;
-        const water = await this.loadTexture(ASSETS.waterNormals);
-        return { waterNormals: water };
+        return { waterNormals: null };
     }
 }

--- a/labs/guerreiro-castelo/js/core/AssetManager.js
+++ b/labs/guerreiro-castelo/js/core/AssetManager.js
@@ -1,0 +1,65 @@
+/**
+ * Carrega GLB/texturas via THREE.LoadingManager.
+ * Se o arquivo não existir, devolve null e o chamador usa fallback procedural.
+ */
+
+import * as THREE from 'three';
+import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+import { DRACOLoader } from 'three/addons/loaders/DRACOLoader.js';
+import { ASSETS } from './assets.js';
+
+export class AssetManager {
+    constructor() {
+        this.manager = new THREE.LoadingManager();
+        this.gltf = new GLTFLoader(this.manager);
+        const draco = new DRACOLoader(this.manager);
+        draco.setDecoderPath('https://cdn.jsdelivr.net/npm/three@0.185.1/examples/jsm/libs/draco/');
+        this.gltf.setDRACOLoader(draco);
+        this.tex = new THREE.TextureLoader(this.manager);
+        this.cache = new Map();
+        this.progress = 0;
+        this.failed = [];
+        this.manager.onProgress = (_url, loaded, total) => {
+            this.progress = total ? loaded / total : 1;
+            this.onProgress?.(this.progress);
+        };
+        this.manager.onError = (url) => {
+            console.warn('[AssetManager] falhou:', url);
+            this.failed.push(url);
+        };
+    }
+
+    async loadTexture(url) {
+        if (this.cache.has(url)) return this.cache.get(url);
+        try {
+            const tex = await this.tex.loadAsync(url);
+            tex.colorSpace = THREE.SRGBColorSpace;
+            this.cache.set(url, tex);
+            return tex;
+        } catch (err) {
+            console.warn('[AssetManager] textura indisponível:', url, err?.message || err);
+            this.cache.set(url, null);
+            return null;
+        }
+    }
+
+    async tryGltf(key) {
+        const url = ASSETS[key];
+        if (!url) return null;
+        if (this.cache.has(url)) return this.cache.get(url);
+        try {
+            const gltf = await this.gltf.loadAsync(url);
+            this.cache.set(url, gltf);
+            return gltf;
+        } catch {
+            this.cache.set(url, null);
+            return null;
+        }
+    }
+
+    async preloadEssential(onProgress) {
+        this.onProgress = onProgress;
+        const water = await this.loadTexture(ASSETS.waterNormals);
+        return { waterNormals: water };
+    }
+}

--- a/labs/guerreiro-castelo/js/core/AudioManager.js
+++ b/labs/guerreiro-castelo/js/core/AudioManager.js
@@ -1,0 +1,209 @@
+/**
+ * Áudio procedural — categorias master/music/ambient/sfx/dialogue.
+ * THREE.AudioListener é anexado à câmera; SFX posicionais usam PositionalAudio.
+ */
+
+import * as THREE from 'three';
+import { clamp } from '../utils/math.js';
+
+const THEMES = {
+    home: { base: 196, mode: [0, 2, 4, 7, 9], tempo: 0.55, filter: 700, drone: 98 },
+    sea: { base: 147, mode: [0, 2, 4, 7, 11], tempo: 0.7, filter: 900, drone: 73 },
+    storm: { base: 98, mode: [0, 3, 5, 6, 10], tempo: 0.38, filter: 320, drone: 49 },
+    land: { base: 174, mode: [0, 2, 3, 7, 9], tempo: 0.62, filter: 800, drone: 87 },
+    castle: { base: 130, mode: [0, 3, 5, 7, 10], tempo: 0.48, filter: 420, drone: 65 },
+    stealth: { base: 110, mode: [0, 1, 4, 5, 8], tempo: 0.4, filter: 280, drone: 55 },
+    tiger: { base: 82, mode: [0, 3, 6, 7, 10], tempo: 0.42, filter: 360, drone: 41 },
+    chase: { base: 196, mode: [0, 2, 3, 7, 10], tempo: 1.15, filter: 1400, drone: 98 },
+    calm: { base: 220, mode: [0, 2, 4, 5, 7, 9], tempo: 0.5, filter: 1100, drone: 110 },
+    ending: { base: 196, mode: [0, 2, 4, 7, 9], tempo: 0.48, filter: 900, drone: 98 }
+};
+
+export class AudioManager {
+    constructor() {
+        this.listener = new THREE.AudioListener();
+        this.ctx = null;
+        this.master = null;
+        this.buses = {};
+        this.muted = false;
+        this.volume = { master: 0.75, music: 0.55, ambient: 0.45, sfx: 0.8, dialogue: 0.9 };
+        this.theme = 'home';
+        this._t = 0;
+        this._step = 0;
+        this._enabled = false;
+        this._ambients = [];
+    }
+
+    async unlock() {
+        if (this.ctx) {
+            if (this.ctx.state === 'suspended') await this.ctx.resume();
+            return;
+        }
+        const Ctx = window.AudioContext || window.webkitAudioContext;
+        if (!Ctx) return;
+        this.ctx = this.listener.context || new Ctx();
+        this.master = this.ctx.createGain();
+        this.master.gain.value = this.muted ? 0 : this.volume.master;
+        this.master.connect(this.ctx.destination);
+
+        for (const name of ['music', 'ambient', 'sfx', 'dialogue']) {
+            const g = this.ctx.createGain();
+            g.gain.value = this.volume[name];
+            g.connect(this.master);
+            this.buses[name] = g;
+        }
+
+        this.filter = this.ctx.createBiquadFilter();
+        this.filter.type = 'lowpass';
+        this.filter.frequency.value = 700;
+        this.filter.connect(this.buses.music);
+
+        this.delay = this.ctx.createDelay();
+        this.delay.delayTime.value = 0.32;
+        const fb = this.ctx.createGain();
+        fb.gain.value = 0.18;
+        this.filter.connect(this.delay);
+        this.delay.connect(fb);
+        fb.connect(this.delay);
+        this.delay.connect(this.buses.music);
+
+        this._startDrone();
+        this._enabled = true;
+    }
+
+    attach(camera) {
+        if (this.listener.parent) this.listener.parent.remove(this.listener);
+        camera.add(this.listener);
+    }
+
+    setMuted(muted) {
+        this.muted = muted;
+        if (this.master) {
+            this.master.gain.setTargetAtTime(muted ? 0 : this.volume.master, this.ctx.currentTime, 0.05);
+        }
+    }
+
+    setBusVolume(bus, value) {
+        this.volume[bus] = clamp(value, 0, 1);
+        const node = bus === 'master' ? this.master : this.buses[bus];
+        if (node && this.ctx) {
+            const v = bus === 'master' && this.muted ? 0 : this.volume[bus];
+            node.gain.setTargetAtTime(v, this.ctx.currentTime, 0.05);
+        }
+    }
+
+    setTheme(id) {
+        this.theme = THEMES[id] ? id : 'home';
+        const t = THEMES[this.theme];
+        if (this.filter && this.ctx) {
+            this.filter.frequency.setTargetAtTime(t.filter, this.ctx.currentTime, 0.5);
+        }
+        if (this.droneOsc && this.ctx) {
+            this.droneOsc.frequency.setTargetAtTime(t.drone, this.ctx.currentTime, 0.9);
+            this.droneOsc2.frequency.setTargetAtTime(t.drone * 1.5, this.ctx.currentTime, 0.9);
+        }
+    }
+
+    _startDrone() {
+        const t = THEMES[this.theme];
+        this.droneOsc = this.ctx.createOscillator();
+        this.droneOsc.type = 'sine';
+        this.droneOsc.frequency.value = t.drone;
+        this.droneGain = this.ctx.createGain();
+        this.droneGain.gain.value = 0.045;
+        this.droneOsc.connect(this.droneGain).connect(this.filter);
+        this.droneOsc.start();
+
+        this.droneOsc2 = this.ctx.createOscillator();
+        this.droneOsc2.type = 'triangle';
+        this.droneOsc2.frequency.value = t.drone * 1.5;
+        const g2 = this.ctx.createGain();
+        g2.gain.value = 0.02;
+        this.droneOsc2.connect(g2).connect(this.filter);
+        this.droneOsc2.start();
+    }
+
+    update(dt) {
+        if (!this._enabled || this.muted) return;
+        this._t += dt;
+        const theme = THEMES[this.theme];
+        this._step += dt * theme.tempo;
+        if (this._step > 1) {
+            this._step -= 1;
+            this._note(theme);
+        }
+        for (const amb of this._ambients) amb(this._t, dt);
+    }
+
+    _note(theme) {
+        const osc = this.ctx.createOscillator();
+        osc.type = this.theme === 'chase' ? 'sawtooth' : 'sine';
+        const deg = theme.mode[(Math.random() * theme.mode.length) | 0];
+        osc.frequency.value = theme.base * Math.pow(2, deg / 12);
+        const g = this.ctx.createGain();
+        g.gain.value = 0.04;
+        g.gain.exponentialRampToValueAtTime(0.0001, this.ctx.currentTime + 1.4);
+        osc.connect(g).connect(this.filter);
+        osc.start();
+        osc.stop(this.ctx.currentTime + 1.5);
+    }
+
+    tone(freq, dur = 0.2, type = 'sine', gain = 0.12, bus = 'sfx') {
+        if (!this._enabled || this.muted) return;
+        const osc = this.ctx.createOscillator();
+        osc.type = type;
+        osc.frequency.value = freq;
+        const g = this.ctx.createGain();
+        g.gain.value = gain;
+        g.gain.exponentialRampToValueAtTime(0.0001, this.ctx.currentTime + dur);
+        osc.connect(g).connect(this.buses[bus] || this.buses.sfx);
+        osc.start();
+        osc.stop(this.ctx.currentTime + dur + 0.05);
+    }
+
+    noise(dur = 0.3, gain = 0.08, bus = 'sfx') {
+        if (!this._enabled || this.muted) return;
+        const n = this.ctx.createBuffer(1, this.ctx.sampleRate * dur, this.ctx.sampleRate);
+        const data = n.getChannelData(0);
+        for (let i = 0; i < data.length; i++) data[i] = Math.random() * 2 - 1;
+        const src = this.ctx.createBufferSource();
+        src.buffer = n;
+        const g = this.ctx.createGain();
+        g.gain.value = gain;
+        g.gain.exponentialRampToValueAtTime(0.0001, this.ctx.currentTime + dur);
+        const f = this.ctx.createBiquadFilter();
+        f.type = 'bandpass';
+        f.frequency.value = 800;
+        src.connect(f).connect(g).connect(this.buses[bus] || this.buses.sfx);
+        src.start();
+    }
+
+    play(name) {
+        switch (name) {
+            case 'interact': this.tone(520, 0.12, 'triangle', 0.08); break;
+            case 'pickup': this.tone(880, 0.18, 'sine', 0.1); this.tone(1320, 0.22, 'sine', 0.05); break;
+            case 'fail': this.tone(140, 0.35, 'sawtooth', 0.07); break;
+            case 'success': this.tone(523, 0.2, 'sine', 0.08); this.tone(784, 0.28, 'sine', 0.06); break;
+            case 'click': this.tone(2400, 0.06, 'square', 0.03); break;
+            case 'clink': this.tone(1800, 0.08, 'triangle', 0.06); this.tone(2400, 0.1, 'sine', 0.04); break;
+            case 'door': this.noise(0.4, 0.06); this.tone(90, 0.4, 'sine', 0.08); break;
+            case 'thunder': this.noise(1.4, 0.22, 'ambient'); this.tone(48, 1.6, 'sawtooth', 0.08, 'ambient'); break;
+            case 'hit': this.noise(0.12, 0.1); this.tone(90, 0.12, 'square', 0.08); break;
+            case 'block': this.tone(200, 0.1, 'square', 0.07); break;
+            case 'bell': this.tone(620, 1.8, 'sine', 0.12, 'ambient'); this.tone(930, 1.8, 'sine', 0.06, 'ambient'); break;
+            case 'growl': this.tone(70, 0.6, 'sawtooth', 0.1); this.noise(0.5, 0.08); break;
+            case 'fire': this.noise(0.3, 0.03, 'ambient'); break;
+            case 'arrow': this.noise(0.08, 0.05); this.tone(1400, 0.08, 'triangle', 0.04); break;
+            case 'impact': this.noise(0.15, 0.08); this.tone(110, 0.15, 'sine', 0.08); break;
+            case 'wave': this.noise(0.8, 0.05, 'ambient'); break;
+            case 'snore': this.tone(90, 0.5, 'sine', 0.04, 'dialogue'); break;
+            case 'speech': this.tone(180 + Math.random() * 80, 0.08, 'triangle', 0.03, 'dialogue'); break;
+            default: this.tone(440, 0.1, 'sine', 0.05);
+        }
+    }
+
+    footstep(crouch) {
+        this.tone(crouch ? 70 : 95, 0.07, 'sine', crouch ? 0.03 : 0.05);
+        this.noise(0.06, crouch ? 0.02 : 0.04);
+    }
+}

--- a/labs/guerreiro-castelo/js/core/Game.js
+++ b/labs/guerreiro-castelo/js/core/Game.js
@@ -399,7 +399,8 @@ export class Game {
 
     render() {
         this.renderer.toneMappingExposure = this.weather.exposure ?? 1;
-        this.renderer.render(this.scene, this.camera);
+        if (this.composer && this.quality.bloom) this.composer.render();
+        else this.renderer.render(this.scene, this.camera);
     }
 
     onResize() {

--- a/labs/guerreiro-castelo/js/core/Game.js
+++ b/labs/guerreiro-castelo/js/core/Game.js
@@ -1,0 +1,415 @@
+/**
+ * Orquestrador: renderer, loop, estágios, fade, pause, checkpoints.
+ */
+
+import * as THREE from 'three';
+import { EffectComposer } from 'three/addons/postprocessing/EffectComposer.js';
+import { RenderPass } from 'three/addons/postprocessing/RenderPass.js';
+import { UnrealBloomPass } from 'three/addons/postprocessing/UnrealBloomPass.js';
+import { OutputPass } from 'three/addons/postprocessing/OutputPass.js';
+
+import { QUALITY } from './QualitySettings.js';
+import { SETTINGS_KEY } from './assets.js';
+import { AssetManager } from './AssetManager.js';
+import { InputManager } from './InputManager.js';
+import { AudioManager } from './AudioManager.js';
+import { SceneManager, CHECKPOINT_STAGE } from './SceneManager.js';
+import { Player } from '../player/Player.js';
+import { ThirdPersonCamera } from '../player/ThirdPersonCamera.js';
+import { Teco } from '../characters/Teco.js';
+import { Camila } from '../characters/Camila.js';
+import { QuestManager } from '../game/QuestManager.js';
+import { InteractionSystem } from '../game/InteractionSystem.js';
+import { CombatSystem } from '../game/CombatSystem.js';
+import { CheckpointManager } from '../game/CheckpointManager.js';
+import { DialogueManager } from '../game/DialogueManager.js';
+import { CutsceneManager } from '../game/CutsceneManager.js';
+import { StoryDirector } from '../game/StoryDirector.js';
+import { CollisionWorld } from '../world/CollisionWorld.js';
+import { Ocean } from '../world/Ocean.js';
+import { StormController } from '../world/StormController.js';
+import { WeatherSystem } from '../world/WeatherSystem.js';
+import { ArrowSystem } from '../world/ArrowSystem.js';
+import { HUD } from '../ui/HUD.js';
+import { Menu } from '../ui/Menu.js';
+import { PauseMenu } from '../ui/PauseMenu.js';
+import { clamp, detectMobile, detectSoftwareGL } from '../utils/math.js';
+
+export class Game {
+    constructor() {
+        this.canvas = document.getElementById('scene');
+        this.hud = new HUD();
+        this.checkpoints = new CheckpointManager();
+        this.quests = new QuestManager();
+        this.dialogue = new DialogueManager();
+        this.combat = new CombatSystem();
+        this.collision = new CollisionWorld();
+        this.assets = new AssetManager();
+        this.audio = new AudioManager();
+        this.input = new InputManager(this.canvas);
+        this.story = new StoryDirector(this);
+        this.inventory = { keys: 0, cellKey: false };
+        this.settings = this.loadSettings();
+        this.state = 'boot';
+        this.paused = false;
+        this.fade = 1;
+        this.fadeTarget = 1;
+        this.fadeCb = null;
+        this.clockTime = 0;
+        this.fpsAccum = 0;
+        this.fpsFrames = 0;
+        this.stageId = null;
+        this.levels = [];
+        this.level = null;
+        this._failing = false;
+    }
+
+    loadSettings() {
+        const fallback = { quality: 'high', master: 0.75, music: 0.55, muted: false };
+        try {
+            const raw = localStorage.getItem(SETTINGS_KEY);
+            return raw ? { ...fallback, ...JSON.parse(raw) } : fallback;
+        } catch {
+            return fallback;
+        }
+    }
+
+    saveSettings() {
+        try {
+            localStorage.setItem(SETTINGS_KEY, JSON.stringify(this.settings));
+        } catch { /* privado */ }
+    }
+
+    resolveQuality() {
+        let id = this.settings.quality;
+        if (id === 'auto') {
+            if (detectMobile() || detectSoftwareGL()) id = 'low';
+            else id = 'high';
+        }
+        return QUALITY[id] || QUALITY.high;
+    }
+
+    async init() {
+        this.hud.setLoading(0.08, 'Preparando o mar…');
+        this.quality = this.resolveQuality();
+
+        this.renderer = new THREE.WebGLRenderer({
+            canvas: this.canvas,
+            antialias: this.quality.aa,
+            powerPreference: 'high-performance'
+        });
+        this.renderer.setPixelRatio(Math.min(window.devicePixelRatio, this.quality.pixelRatio));
+        this.renderer.setSize(window.innerWidth, window.innerHeight);
+        this.renderer.shadowMap.enabled = true;
+        this.renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+        this.renderer.outputColorSpace = THREE.SRGBColorSpace;
+        this.renderer.toneMapping = THREE.ACESFilmicToneMapping;
+        this.renderer.toneMappingExposure = 1;
+
+        this.scene = new THREE.Scene();
+        this.camera = new THREE.PerspectiveCamera(55, window.innerWidth / window.innerHeight, 0.12, this.quality.far);
+        this.cameraRig = new ThirdPersonCamera(this.camera, this.scene);
+        this.cutscenes = new CutsceneManager(this.cameraRig);
+        this.interact = new InteractionSystem(this.camera);
+        this.audio.attach(this.camera);
+
+        this.weather = new WeatherSystem(this.scene, this.renderer);
+        this.weather.setShadowSize(this.quality.shadows);
+        this.hud.setLoading(0.28, 'Ondas e céu…');
+
+        const essential = await this.assets.preloadEssential((p) => this.hud.setLoading(0.28 + p * 0.4, 'Carregando…'));
+        this.ocean = new Ocean(this.scene, essential.waterNormals, this.quality);
+        this.storm = new StormController(this.scene, this.quality);
+        this.arrows = new ArrowSystem(this.scene);
+
+        this.player = new Player(this.scene, this.collision);
+        this.teco = new Teco(this.scene);
+        this.camila = new Camila(this.scene);
+        this.player.root.visible = false;
+        this.teco.root.visible = false;
+        this.camila.root.visible = false;
+        this.scenes = new SceneManager(this);
+
+        this._setupComposer();
+        this.menu = new Menu(this);
+        this.pauseMenu = new PauseMenu(this);
+        this._bindSettings();
+        window.addEventListener('resize', () => this.onResize());
+        this.quests.onChange = (q) => this.hud.showObjective(q.text, q.id === 'flee');
+
+        this.hud.setLoading(1, 'Pronto');
+        this.hud.hideLoading();
+        this.state = 'menu';
+        this.menu.show(true);
+        this.hud.showHud(false);
+        this.renderMenuPreview();
+    }
+
+    _setupComposer() {
+        try {
+            this.composer = new EffectComposer(this.renderer);
+            this.composer.addPass(new RenderPass(this.scene, this.camera));
+            this.bloom = new UnrealBloomPass(
+                new THREE.Vector2(window.innerWidth, window.innerHeight),
+                this.quality.bloom ? 0.18 : 0,
+                0.4,
+                0.85
+            );
+            this.composer.addPass(this.bloom);
+            this.composer.addPass(new OutputPass());
+        } catch (err) {
+            console.warn('[Game] pós-processamento indisponível', err);
+            this.composer = null;
+            this.quality.bloom = false;
+        }
+    }
+
+    _bindSettings() {
+        const q = document.getElementById('qualitySelect');
+        const vol = document.getElementById('volumeSlider');
+        q.value = this.settings.quality;
+        vol.value = Math.round(this.settings.master * 100);
+        document.getElementById('volumeValue').textContent = vol.value;
+        q.addEventListener('change', () => {
+            this.settings.quality = q.value;
+            this.saveSettings();
+            this.quality = this.resolveQuality();
+            this.renderer.setPixelRatio(Math.min(window.devicePixelRatio, this.quality.pixelRatio));
+            this.bloom.strength = this.quality.bloom ? 0.18 : 0;
+            this.weather.setShadowSize(this.quality.shadows);
+        });
+        vol.addEventListener('input', () => {
+            this.settings.master = vol.value / 100;
+            document.getElementById('volumeValue').textContent = vol.value;
+            this.audio.setBusVolume('master', this.settings.master);
+            this.saveSettings();
+        });
+        document.getElementById('btnPlayAgain')?.addEventListener('click', () => this.newGame());
+        document.getElementById('btnEndMenu')?.addEventListener('click', () => this.quitToMenu());
+    }
+
+    renderMenuPreview() {
+        this.weather.apply('dawn');
+        this.camera.position.set(8, 6, 16);
+        this.camera.lookAt(0, 2, 0);
+        this.fade = 0;
+        this.hud.setFade(0);
+    }
+
+    async newGame() {
+        await this.audio.unlock();
+        this.checkpoints.clear();
+        this.story.resetFlags();
+        this.inventory = { keys: 0, cellKey: false };
+        this.player.heal();
+        this.menu.show(false);
+        this.hud.showHud(true);
+        this.state = 'playing';
+        this.paused = false;
+        await this.loadStage('home', 'home_intro');
+        this.input.requestLock();
+    }
+
+    async continueGame() {
+        await this.audio.unlock();
+        const data = this.checkpoints.load();
+        if (!data) return this.newGame();
+        this.story.applySave(data);
+        this.menu.show(false);
+        this.hud.showHud(true);
+        this.state = 'playing';
+        const stage = CHECKPOINT_STAGE[data.checkpoint] || 'home';
+        await this.loadStage(stage, data.checkpoint);
+        this.input.requestLock();
+    }
+
+    async loadStage(stageId, checkpoint) {
+        this.hud.setLoading(0.4, 'Atravessando…');
+        document.getElementById('loadingOverlay').hidden = false;
+        this.stageId = stageId;
+        this.fade = 1;
+        this.hud.setFade(1);
+        try {
+            this.player.root.visible = true;
+            this.teco.root.visible = true;
+            await this.scenes.load(stageId, checkpoint);
+        } catch (err) {
+            console.error('[Game] falha ao carregar estágio', stageId, err);
+            this.hud.showToast('Algo deu errado. Tentando de novo…');
+        }
+        this.hud.hideLoading();
+        this.hud.setHealth(this.player.health, this.player.maxHealth);
+        if (this.quests.current) this.hud.showObjective(this.quests.current.text);
+        this.fadeTo(0);
+        this._failing = false;
+    }
+
+    fadeTo(target, cb, speed = 1.2) {
+        if (target > 1) {
+            this.fadeTarget = 1;
+            this.fadeSpeed = 1 / target;
+            this.fadeCb = cb || null;
+            return;
+        }
+        this.fadeTarget = target;
+        this.fadeSpeed = speed;
+        this.fadeCb = cb || null;
+    }
+
+    failCheckpoint(reason) {
+        if (this._failing) return;
+        this._failing = true;
+        this.audio.play('fail');
+        this.hud.showToast(reason || 'Tente novamente');
+        this.fadeTo(1, () => this.reloadCheckpoint(), 2.2);
+    }
+
+    async reloadCheckpoint() {
+        const cp = this.checkpoints.current || this.checkpoints.data.checkpoint || 'ship_start';
+        const stage = CHECKPOINT_STAGE[cp] || this.stageId;
+        this.player.heal();
+        await this.loadStage(stage, cp);
+    }
+
+    setPaused(v) {
+        this.paused = v;
+        this.pauseMenu.show(v);
+        this.input.enabled = !v && this.state === 'playing';
+        if (v) this.input.exitLock();
+        else this.input.requestLock();
+    }
+
+    quitToMenu() {
+        this.setPaused(false);
+        this.state = 'menu';
+        this.hud.showHud(false);
+        this.pauseMenu.show(false);
+        document.getElementById('endOverlay').hidden = true;
+        this.menu.show(true);
+        this.input.exitLock();
+        this.scenes.unload();
+        this.renderMenuPreview();
+    }
+
+    showEnding() {
+        this.state = 'ending';
+        this.input.enabled = false;
+        this.input.exitLock();
+        const end = document.getElementById('endOverlay');
+        end.hidden = false;
+        this.hud.showHud(false);
+        this.audio.setTheme('ending');
+    }
+
+    update(dt) {
+        this.clockTime += dt;
+        this.input.update();
+
+        if (this.input.consume('pause') && this.state === 'playing') {
+            this.setPaused(!this.paused);
+        }
+        if (this.paused) {
+            this.audio.update(dt * 0.2);
+            return;
+        }
+
+        if (this.fade !== this.fadeTarget) {
+            const dir = Math.sign(this.fadeTarget - this.fade);
+            this.fade = clamp(this.fade + dir * dt * (this.fadeSpeed || 1.2), 0, 1);
+            this.hud.setFade(this.fade);
+            if (Math.abs(this.fade - this.fadeTarget) < 0.02) {
+                this.fade = this.fadeTarget;
+                this.hud.setFade(this.fade);
+                const cb = this.fadeCb;
+                this.fadeCb = null;
+                cb?.();
+            }
+        }
+
+        if (this.state !== 'playing' && this.state !== 'ending') {
+            this.ocean.update(dt, this.clockTime);
+            return;
+        }
+
+        this.cutscenes.update(dt);
+        this.dialogue.update(dt);
+        if (this.input.consume('advance')) {
+            this.dialogue.skip();
+            if (this.cutscenes.blocking) this.cutscenes.skip();
+        }
+
+        this.collision.update(dt);
+        this.storm.update(dt, this);
+        this.ocean.update(dt, this.clockTime);
+
+        const look = this.input.consumeLook();
+        const zoom = this.input.consumeZoom();
+
+        if (!this.cutscenes.blocking && this.player.controller.mode !== 'locked') {
+            const foot = this.player.update(dt, this.input, this.cameraRig.yaw);
+            if (foot) this.audio.footstep(this.player.crouching);
+            this.teco.update(dt, this);
+            this.camila.update(dt, this);
+            this.combat.update(dt, this);
+            this.arrows.update(dt, this);
+            const item = this.interact.update(this.player, this);
+            this.hud.setPrompt(item);
+            if (this.input.consume('interact')) {
+                if (item) {
+                    this.player.interactT = 0.4;
+                    this.audio.play('interact');
+                    this.interact.tryInteract(this.player, this);
+                }
+            }
+        } else if (this.player.controller.mode === 'helm') {
+            this.player.update(dt, this.input, this.cameraRig.yaw);
+            this.teco.update(dt, this);
+            this.camila.update(dt, this);
+            this.arrows.update(dt, this);
+        } else {
+            this.player.animator.update(dt);
+            this.teco.animator.update(dt);
+        }
+
+        this.cameraRig.update(dt, this.player, look, zoom, this.player.sprinting);
+        this.scenes.update(dt);
+        this.quests.update(dt);
+        this.audio.update(dt);
+        this.hud.setDialogue(this.dialogue.current);
+        this.hud.setHealth(this.player.health, this.player.maxHealth);
+        this.hud.update(dt);
+
+        if (this.input.consume('tab') && this.quests.current) {
+            this.hud.showObjective(this.quests.current.text);
+        }
+
+        if (!this.player.alive && this.state === 'playing') {
+            this.failCheckpoint('Dico caiu…');
+        }
+
+        this.fpsAccum += dt;
+        this.fpsFrames++;
+        if (this.fpsAccum > 0.5) {
+            this.hud.setFps(Math.round(this.fpsFrames / this.fpsAccum));
+            this.fpsAccum = 0;
+            this.fpsFrames = 0;
+        }
+    }
+
+    render() {
+        this.renderer.toneMappingExposure = this.weather.exposure ?? 1;
+        if (this.composer && this.quality.bloom) this.composer.render();
+        else this.renderer.render(this.scene, this.camera);
+    }
+
+    onResize() {
+        const w = window.innerWidth;
+        const h = window.innerHeight;
+        this.camera.aspect = w / h;
+        this.camera.updateProjectionMatrix();
+        this.renderer.setSize(w, h);
+        this.composer?.setSize(w, h);
+        this.bloom?.setSize(w, h);
+        this.renderer.setPixelRatio(Math.min(window.devicePixelRatio, this.quality.pixelRatio));
+    }
+}

--- a/labs/guerreiro-castelo/js/core/Game.js
+++ b/labs/guerreiro-castelo/js/core/Game.js
@@ -100,6 +100,7 @@ export class Game {
         });
         this.renderer.setPixelRatio(Math.min(window.devicePixelRatio, this.quality.pixelRatio));
         this.renderer.setSize(window.innerWidth, window.innerHeight);
+        this.renderer.setClearColor(0x87b8d0, 1);
         this.renderer.shadowMap.enabled = true;
         this.renderer.shadowMap.type = THREE.PCFSoftShadowMap;
         this.renderer.outputColorSpace = THREE.SRGBColorSpace;

--- a/labs/guerreiro-castelo/js/core/Game.js
+++ b/labs/guerreiro-castelo/js/core/Game.js
@@ -101,7 +101,7 @@ export class Game {
         this.renderer.setPixelRatio(Math.min(window.devicePixelRatio, this.quality.pixelRatio));
         this.renderer.setSize(window.innerWidth, window.innerHeight);
         this.renderer.setClearColor(0x87b8d0, 1);
-        this.renderer.shadowMap.enabled = true;
+        this.renderer.shadowMap.enabled = this.quality.id !== 'low';
         this.renderer.shadowMap.type = THREE.PCFSoftShadowMap;
         this.renderer.outputColorSpace = THREE.SRGBColorSpace;
         this.renderer.toneMapping = THREE.ACESFilmicToneMapping;
@@ -399,8 +399,7 @@ export class Game {
 
     render() {
         this.renderer.toneMappingExposure = this.weather.exposure ?? 1;
-        if (this.composer && this.quality.bloom) this.composer.render();
-        else this.renderer.render(this.scene, this.camera);
+        this.renderer.render(this.scene, this.camera);
     }
 
     onResize() {

--- a/labs/guerreiro-castelo/js/core/InputManager.js
+++ b/labs/guerreiro-castelo/js/core/InputManager.js
@@ -1,0 +1,141 @@
+/**
+ * Input: teclado, mouse, pointer lock e um stick virtual para toque.
+ */
+
+export class InputManager {
+    constructor(dom) {
+        this.dom = dom;
+        this.keys = Object.create(null);
+        this.move = { x: 0, z: 0, sprint: false, crouch: false, jump: false };
+        this.look = { x: 0, y: 0 };
+        this.zoom = 0;
+        this.locked = false;
+        this.interact = false;
+        this.attack = false;
+        this.block = false;
+        this.pause = false;
+        this.tab = false;
+        this.advance = false;
+        this._lookBuffer = { x: 0, y: 0 };
+        this.enabled = true;
+        this._onKeyDown = this.onKeyDown.bind(this);
+        this._onKeyUp = this.onKeyUp.bind(this);
+        this._onMouseMove = this.onMouseMove.bind(this);
+        this._onMouseDown = this.onMouseDown.bind(this);
+        this._onWheel = this.onWheel.bind(this);
+        this._onLockChange = this.onLockChange.bind(this);
+        this._onContext = (e) => e.preventDefault();
+        window.addEventListener('keydown', this._onKeyDown);
+        window.addEventListener('keyup', this._onKeyUp);
+        document.addEventListener('mousemove', this._onMouseMove);
+        dom.addEventListener('mousedown', this._onMouseDown);
+        dom.addEventListener('wheel', this._onWheel, { passive: false });
+        document.addEventListener('pointerlockchange', this._onLockChange);
+        dom.addEventListener('contextmenu', this._onContext);
+    }
+
+    requestLock() {
+        if (this.locked) return;
+        this.dom.requestPointerLock?.();
+    }
+
+    exitLock() {
+        if (document.pointerLockElement) document.exitPointerLock();
+    }
+
+    onLockChange() {
+        this.locked = document.pointerLockElement === this.dom;
+    }
+
+    onKeyDown(e) {
+        if (e.repeat) return;
+        if (e.code === 'Tab') e.preventDefault();
+        this.keys[e.code] = true;
+        if (e.code === 'KeyE') this.interact = true;
+        if (e.code === 'KeyF') this.attack = true;
+        if (e.code === 'Space') {
+            e.preventDefault();
+            this.move.jump = true;
+            this.advance = true;
+        }
+        if (e.code === 'Escape') this.pause = true;
+        if (e.code === 'Tab') this.tab = true;
+        if (e.code === 'Enter') this.advance = true;
+    }
+
+    onKeyUp(e) {
+        this.keys[e.code] = false;
+    }
+
+    onMouseMove(e) {
+        if (!this.locked || !this.enabled) return;
+        this._lookBuffer.x += e.movementX;
+        this._lookBuffer.y += e.movementY;
+    }
+
+    onMouseDown(e) {
+        if (e.button === 0 && !this.locked && this.enabled) this.requestLock();
+    }
+
+    onWheel(e) {
+        if (!this.locked) return;
+        e.preventDefault();
+        this.zoom += Math.sign(e.deltaY);
+    }
+
+    consumeLook() {
+        const x = this._lookBuffer.x;
+        const y = this._lookBuffer.y;
+        this._lookBuffer.x = 0;
+        this._lookBuffer.y = 0;
+        return { x, y };
+    }
+
+    consumeZoom() {
+        const z = this.zoom;
+        this.zoom = 0;
+        return z;
+    }
+
+    consume(flag) {
+        const v = this[flag];
+        this[flag] = false;
+        return v;
+    }
+
+    update() {
+        if (!this.enabled) {
+            this.move.x = 0;
+            this.move.z = 0;
+            this.move.sprint = false;
+            this.move.crouch = false;
+            return;
+        }
+        let x = 0;
+        let z = 0;
+        if (this.keys.KeyA || this.keys.ArrowLeft) x -= 1;
+        if (this.keys.KeyD || this.keys.ArrowRight) x += 1;
+        if (this.keys.KeyW || this.keys.ArrowUp) z -= 1;
+        if (this.keys.KeyS || this.keys.ArrowDown) z += 1;
+        const len = Math.hypot(x, z);
+        if (len > 1) {
+            x /= len;
+            z /= len;
+        }
+        this.move.x = x;
+        this.move.z = z;
+        this.move.sprint = Boolean(this.keys.ShiftLeft || this.keys.ShiftRight);
+        this.move.crouch = Boolean(this.keys.KeyC);
+        this.block = Boolean(this.keys.KeyQ);
+    }
+
+    dispose() {
+        window.removeEventListener('keydown', this._onKeyDown);
+        window.removeEventListener('keyup', this._onKeyUp);
+        document.removeEventListener('mousemove', this._onMouseMove);
+        this.dom.removeEventListener('mousedown', this._onMouseDown);
+        this.dom.removeEventListener('wheel', this._onWheel);
+        document.removeEventListener('pointerlockchange', this._onLockChange);
+        this.dom.removeEventListener('contextmenu', this._onContext);
+    }
+}

--- a/labs/guerreiro-castelo/js/core/QualitySettings.js
+++ b/labs/guerreiro-castelo/js/core/QualitySettings.js
@@ -1,0 +1,52 @@
+/** Presets gráficos. Não alteram gameplay, só custo visual. */
+
+export const QUALITY = {
+    low: {
+        id: 'low',
+        pixelRatio: 1,
+        shadows: 512,
+        bloom: false,
+        particles: 0.35,
+        vegetation: 0.4,
+        far: 220,
+        water: 128,
+        shadowCasters: 12,
+        aa: false
+    },
+    medium: {
+        id: 'medium',
+        pixelRatio: 1.25,
+        shadows: 1024,
+        bloom: true,
+        particles: 0.65,
+        vegetation: 0.7,
+        far: 320,
+        water: 256,
+        shadowCasters: 22,
+        aa: true
+    },
+    high: {
+        id: 'high',
+        pixelRatio: 1.75,
+        shadows: 2048,
+        bloom: true,
+        particles: 1,
+        vegetation: 1,
+        far: 460,
+        water: 512,
+        shadowCasters: 36,
+        aa: true
+    },
+    ultra: {
+        id: 'ultra',
+        pixelRatio: 2,
+        shadows: 4096,
+        bloom: true,
+        particles: 1.25,
+        vegetation: 1.2,
+        far: 640,
+        water: 512,
+        shadowCasters: 48,
+        aa: true
+    }
+};

--- a/labs/guerreiro-castelo/js/core/SceneManager.js
+++ b/labs/guerreiro-castelo/js/core/SceneManager.js
@@ -87,6 +87,7 @@ export class SceneManager {
         this.game.cameraRig.setObstacles(obstacles);
         for (const lv of levels) lv.enter(checkpoint);
         this._applyCheckpointSpawn(checkpoint);
+        this.game.cameraRig.snapToPlayer(this.game.player);
         return levels;
     }
 

--- a/labs/guerreiro-castelo/js/core/SceneManager.js
+++ b/labs/guerreiro-castelo/js/core/SceneManager.js
@@ -1,0 +1,154 @@
+import { HomeLevel } from '../levels/HomeLevel.js';
+import { ShipLevel } from '../levels/ShipLevel.js';
+import { BeachLevel } from '../levels/BeachLevel.js';
+import { ForestLevel } from '../levels/ForestLevel.js';
+import { CastleExteriorLevel } from '../levels/CastleExteriorLevel.js';
+import { SecretEntranceLevel } from '../levels/SecretEntranceLevel.js';
+import { CastleInteriorLevel } from '../levels/CastleInteriorLevel.js';
+import { TigerRoomLevel } from '../levels/TigerRoomLevel.js';
+import { EscapeLevel } from '../levels/EscapeLevel.js';
+import { ShipEscapeLevel } from '../levels/ShipEscapeLevel.js';
+import { EndingLevel } from '../levels/EndingLevel.js';
+import { disposeSceneGroup } from '../utils/dispose.js';
+
+const FACTORIES = {
+    home: HomeLevel,
+    homeEnd: HomeLevel,
+    ship: ShipLevel,
+    beach: BeachLevel,
+    forest: ForestLevel,
+    castle_ext: CastleExteriorLevel,
+    secret: SecretEntranceLevel,
+    interior: CastleInteriorLevel,
+    tiger: TigerRoomLevel,
+    escape: EscapeLevel,
+    shipEscape: ShipEscapeLevel,
+    ending: EndingLevel
+};
+
+export const STAGES = {
+    home: ['home'],
+    homeEnd: ['homeEnd'],
+    ship: ['ship'],
+    island: ['beach', 'forest', 'castle_ext', 'secret'],
+    interior: ['interior', 'tiger'],
+    escape: ['escape'],
+    shipEscape: ['shipEscape'],
+    ending: ['ending']
+};
+
+export const CHECKPOINT_STAGE = {
+    home_intro: 'home',
+    ship_start: 'ship',
+    storm_start: 'ship',
+    storm_rope: 'ship',
+    castle_beach: 'island',
+    castle_exterior: 'island',
+    secret_door: 'island',
+    sleeping_guard: 'interior',
+    princess_cell: 'interior',
+    tiger_room: 'interior',
+    princess_rescued: 'interior',
+    escape_start: 'escape',
+    beach_escape: 'escape',
+    ship_escape: 'shipEscape',
+    ending: 'ending'
+};
+
+export class SceneManager {
+    constructor(game) {
+        this.game = game;
+        this.levels = [];
+        this.stageId = null;
+    }
+
+    async load(stageId, checkpoint) {
+        await this.unload();
+        this.stageId = stageId;
+        const ids = STAGES[stageId] || [stageId];
+        this.game.collision.clear();
+        this.game.interact.clear();
+        this.game.arrows.clear();
+        const levels = [];
+        for (const id of ids) {
+            const Ctor = FACTORIES[id];
+            if (!Ctor) continue;
+            const level = new Ctor(this.game);
+            await level.build();
+            levels.push(level);
+        }
+        this.levels = levels;
+        this.game.levels = levels;
+        this.game.level = levels[0];
+        const obstacles = [];
+        for (const lv of levels) {
+            if (lv.obstacles) obstacles.push(...lv.obstacles);
+        }
+        this.game.cameraRig.setObstacles(obstacles);
+        for (const lv of levels) lv.enter(checkpoint);
+        this._applyCheckpointSpawn(checkpoint);
+        return levels;
+    }
+
+    _applyCheckpointSpawn(cp) {
+        const p = this.game.player;
+        const t = this.game.teco;
+        switch (cp) {
+            case 'storm_start':
+                this.game.level?.beginNight?.();
+                break;
+            case 'storm_rope':
+                this.game.level.phase = 'storm';
+                this.game.level.nightStarted = true;
+                this.game.weather.apply('storm');
+                this.game.storm.setIntensity(0.85);
+                this.game.level.ship.userData.rope.visible = true;
+                this.game.level.ropeItem.enabled = true;
+                p.spawn(0, 1.44, 5, 0);
+                break;
+            case 'castle_exterior':
+                p.spawn(0, 0, -70, Math.PI);
+                t.spawn(0.6, 0, -69);
+                break;
+            case 'secret_door':
+                p.spawn(-16, 0, -92, Math.PI * 0.5);
+                t.spawn(-15, 0, -92);
+                break;
+            case 'princess_cell':
+                p.spawn(0, 3.2, -34, Math.PI);
+                t.spawn(0.4, 3.2, -33);
+                break;
+            case 'tiger_room':
+                p.spawn(10, 3.2, -18, 0);
+                t.spawn(9.5, 3.2, -18);
+                break;
+            case 'princess_rescued':
+                p.spawn(0, 3.2, -36, 0);
+                t.spawn(0.4, 3.2, -35);
+                this.game.camila.spawn(0.8, 3.2, -37);
+                this.game.camila.setShackles(false);
+                this.game.camila.freed = true;
+                this.game.camila.ai.follow();
+                break;
+            case 'beach_escape':
+                p.spawn(0, 0, 12, 0);
+                t.spawn(0.5, 0, 11);
+                break;
+            default:
+                break;
+        }
+    }
+
+    update(dt) {
+        for (const lv of this.levels) lv.update(dt, this.game);
+    }
+
+    async unload() {
+        for (const lv of this.levels) {
+            lv.exit();
+            if (lv.group) disposeSceneGroup(lv.group, this.game.scene);
+        }
+        this.levels = [];
+        this.game.level = null;
+    }
+}

--- a/labs/guerreiro-castelo/js/core/SceneManager.js
+++ b/labs/guerreiro-castelo/js/core/SceneManager.js
@@ -86,6 +86,7 @@ export class SceneManager {
         this.game.cameraRig.setObstacles(obstacles);
         for (const lv of levels) lv.enter(checkpoint);
         this._applyCheckpointSpawn(checkpoint);
+        this.game.scene.updateMatrixWorld(true);
         this.game.cameraRig.snapToPlayer(this.game.player);
         return levels;
     }

--- a/labs/guerreiro-castelo/js/core/SceneManager.js
+++ b/labs/guerreiro-castelo/js/core/SceneManager.js
@@ -9,7 +9,6 @@ import { TigerRoomLevel } from '../levels/TigerRoomLevel.js';
 import { EscapeLevel } from '../levels/EscapeLevel.js';
 import { ShipEscapeLevel } from '../levels/ShipEscapeLevel.js';
 import { EndingLevel } from '../levels/EndingLevel.js';
-import { disposeSceneGroup } from '../utils/dispose.js';
 
 const FACTORIES = {
     home: HomeLevel,
@@ -147,7 +146,9 @@ export class SceneManager {
     async unload() {
         for (const lv of this.levels) {
             lv.exit();
-            if (lv.group) disposeSceneGroup(lv.group, this.game.scene);
+            if (lv.group) {
+                this.game.scene.remove(lv.group);
+            }
         }
         this.levels = [];
         this.game.level = null;

--- a/labs/guerreiro-castelo/js/core/assets.js
+++ b/labs/guerreiro-castelo/js/core/assets.js
@@ -1,0 +1,19 @@
+/**
+ * Manifest único de assets. Se um GLB não existir, o AssetManager
+ * usa fallback procedural sem alterar a lógica de gameplay.
+ */
+export const ASSETS = {
+    dico: './assets/models/dico.glb',
+    ravi: './assets/models/ravi.glb',
+    camila: './assets/models/camila.glb',
+    teco: './assets/models/teco.glb',
+    guard: './assets/models/guard.glb',
+    tiger: './assets/models/tiger.glb',
+    friend: './assets/models/friend.glb',
+    ship: './assets/models/ship.glb',
+    castle: './assets/models/castle.glb',
+    waterNormals: 'https://cdn.jsdelivr.net/npm/three@0.185.1/examples/textures/waternormals.jpg'
+};
+
+export const STORAGE_KEY = 'guerreiro-castelo-save-v1';
+export const SETTINGS_KEY = 'guerreiro-castelo-settings-v1';

--- a/labs/guerreiro-castelo/js/game/CheckpointManager.js
+++ b/labs/guerreiro-castelo/js/game/CheckpointManager.js
@@ -1,0 +1,61 @@
+import { STORAGE_KEY } from '../core/assets.js';
+
+export const CHECKPOINTS = [
+    'home_intro',
+    'ship_start',
+    'storm_start',
+    'storm_rope',
+    'castle_beach',
+    'castle_exterior',
+    'secret_door',
+    'sleeping_guard',
+    'princess_cell',
+    'tiger_room',
+    'princess_rescued',
+    'escape_start',
+    'beach_escape',
+    'ship_escape',
+    'ending'
+];
+
+export class CheckpointManager {
+    constructor() {
+        this.current = 'home_intro';
+        this.data = this.load() || { checkpoint: 'home_intro', flags: {}, inventory: {} };
+    }
+
+    load() {
+        try {
+            const raw = localStorage.getItem(STORAGE_KEY);
+            return raw ? JSON.parse(raw) : null;
+        } catch {
+            return null;
+        }
+    }
+
+    hasSave() {
+        return Boolean(this.load()?.checkpoint);
+    }
+
+    save(id, extra = {}) {
+        this.current = id;
+        this.data = {
+            checkpoint: id,
+            flags: extra.flags || this.data.flags || {},
+            inventory: extra.inventory || this.data.inventory || {},
+            quest: extra.quest || this.data.quest,
+            level: extra.level || this.data.level
+        };
+        try {
+            localStorage.setItem(STORAGE_KEY, JSON.stringify(this.data));
+        } catch { /* privado */ }
+    }
+
+    clear() {
+        this.current = 'home_intro';
+        this.data = { checkpoint: 'home_intro', flags: {}, inventory: {} };
+        try {
+            localStorage.removeItem(STORAGE_KEY);
+        } catch { /* privado */ }
+    }
+}

--- a/labs/guerreiro-castelo/js/game/CombatSystem.js
+++ b/labs/guerreiro-castelo/js/game/CombatSystem.js
@@ -1,0 +1,32 @@
+/** Combate curto — Dico ataca em combo, guarda reage, sem gore. */
+
+export class CombatSystem {
+    constructor() {
+        this.combo = 0;
+        this.comboT = 0;
+        this.guards = [];
+    }
+
+    setGuards(list) {
+        this.guards = list;
+    }
+
+    update(dt, game) {
+        this.comboT = Math.max(0, this.comboT - dt);
+        if (this.comboT <= 0) this.combo = 0;
+        const player = game.player;
+        if (player.attackT > 0.28 && player.attackT < 0.38) {
+            for (const g of this.guards) {
+                if (!g.alive) continue;
+                const d = Math.hypot(g.position.x - player.position.x, g.position.z - player.position.z);
+                if (d < 1.9) {
+                    g.takeHit(1);
+                    this.combo++;
+                    this.comboT = 0.8;
+                    game.audio.play('hit');
+                    game.cameraRig.addShake(0.08, 0.15);
+                }
+            }
+        }
+    }
+}

--- a/labs/guerreiro-castelo/js/game/CutsceneManager.js
+++ b/labs/guerreiro-castelo/js/game/CutsceneManager.js
@@ -1,0 +1,77 @@
+/**
+ * Cutscenes curtas: interpola câmera, bloqueia controle, dispara eventos.
+ */
+
+import * as THREE from 'three';
+import { getEasing } from '../utils/easing.js';
+
+export class CutsceneManager {
+    constructor(cameraRig) {
+        this.rig = cameraRig;
+        this.blocking = false;
+        this.t = 0;
+        this.duration = 0;
+        this.fromPos = new THREE.Vector3();
+        this.toPos = new THREE.Vector3();
+        this.fromLook = new THREE.Vector3();
+        this.toLook = new THREE.Vector3();
+        this.ease = getEasing('inOutCubic');
+        this.midAt = 0.5;
+        this.midFired = false;
+        this.onMid = null;
+        this.onEnd = null;
+        this._pos = new THREE.Vector3();
+        this._look = new THREE.Vector3();
+    }
+
+    play({
+        from, to, lookFrom, lookTo, duration = 3, easing = 'inOutCubic',
+        onMid = null, onEnd = null, midAt = 0.5
+    }) {
+        this.blocking = true;
+        this.rig.cutscene = true;
+        this.t = 0;
+        this.duration = duration;
+        this.fromPos.copy(from);
+        this.toPos.copy(to);
+        this.fromLook.copy(lookFrom);
+        this.toLook.copy(lookTo);
+        this.ease = getEasing(easing);
+        this.onMid = onMid;
+        this.onEnd = onEnd;
+        this.midAt = midAt;
+        this.midFired = false;
+        this.rig.setCutscenePose(from, lookFrom);
+    }
+
+    skip() {
+        if (!this.blocking) return;
+        this.t = this.duration;
+        this._finish();
+    }
+
+    _finish() {
+        this.blocking = false;
+        this.rig.cutscene = false;
+        this.rig.setCutscenePose(this.toPos, this.toLook);
+        const cb = this.onEnd;
+        this.onEnd = null;
+        this.onMid = null;
+        cb?.();
+    }
+
+    update(dt) {
+        if (!this.blocking) return;
+        this.t += dt;
+        const u = Math.min(1, this.t / this.duration);
+        const e = this.ease(u);
+        this._pos.lerpVectors(this.fromPos, this.toPos, e);
+        this._look.lerpVectors(this.fromLook, this.toLook, e);
+        this.rig.setCutscenePose(this._pos, this._look);
+        if (!this.midFired && u >= this.midAt) {
+            this.midFired = true;
+            this.onMid?.();
+        }
+        if (u >= 1) this._finish();
+    }
+}

--- a/labs/guerreiro-castelo/js/game/DialogueManager.js
+++ b/labs/guerreiro-castelo/js/game/DialogueManager.js
@@ -1,0 +1,48 @@
+/**
+ * Diálogos discretos na parte inferior.
+ * DICO
+ * Segurem firme!
+ */
+
+export class DialogueManager {
+    constructor() {
+        this.queue = [];
+        this.current = null;
+        this.timer = 0;
+        this.blocking = false;
+        this.onDone = null;
+    }
+
+    say(speaker, text, duration = 3.2) {
+        this.queue.push({ speaker, text, duration });
+        if (!this.current) this._next();
+    }
+
+    play(lines, onDone) {
+        this.queue.push(...lines);
+        this.onDone = onDone || null;
+        this.blocking = true;
+        if (!this.current) this._next();
+    }
+
+    _next() {
+        this.current = this.queue.shift() || null;
+        this.timer = this.current ? this.current.duration : 0;
+        if (!this.current) {
+            this.blocking = false;
+            const cb = this.onDone;
+            this.onDone = null;
+            cb?.();
+        }
+    }
+
+    skip() {
+        if (this.current) this._next();
+    }
+
+    update(dt) {
+        if (!this.current) return;
+        this.timer -= dt;
+        if (this.timer <= 0) this._next();
+    }
+}

--- a/labs/guerreiro-castelo/js/game/InteractionSystem.js
+++ b/labs/guerreiro-castelo/js/game/InteractionSystem.js
@@ -1,0 +1,70 @@
+/**
+ * Interação por raycast da câmera. Objetos implementam:
+ * { interactionLabel, interactionDistance, interact(player, game) }
+ */
+
+import * as THREE from 'three';
+
+export class InteractionSystem {
+    constructor(camera) {
+        this.camera = camera;
+        this.items = [];
+        this.ray = new THREE.Raycaster();
+        this.ray.far = 6;
+        this.prompt = null;
+        this._dir = new THREE.Vector3();
+        this._origin = new THREE.Vector3();
+    }
+
+    clear() {
+        this.items.length = 0;
+        this.prompt = null;
+    }
+
+    add(item) {
+        this.items.push(item);
+        return item;
+    }
+
+    remove(item) {
+        const i = this.items.indexOf(item);
+        if (i >= 0) this.items.splice(i, 1);
+    }
+
+    update(player, game) {
+        this.prompt = null;
+        if (game.cutscenes?.blocking) return null;
+        this.camera.getWorldDirection(this._dir);
+        this._origin.copy(this.camera.position);
+        let best = null;
+        let bestScore = Infinity;
+
+        for (const item of this.items) {
+            if (item.enabled === false) continue;
+            const obj = item.object;
+            if (!obj) continue;
+            obj.getWorldPosition(this._origin);
+            const dist = this._origin.distanceTo(player.position);
+            const maxd = item.interactionDistance ?? 2.2;
+            if (dist > maxd) continue;
+            const to = this._origin.clone().sub(this.camera.position).normalize();
+            this.camera.getWorldDirection(this._dir);
+            const dot = this._dir.dot(to);
+            if (dot < 0.35 && dist > 1.1) continue;
+            const score = dist * (1.4 - dot);
+            if (score < bestScore) {
+                bestScore = score;
+                best = item;
+            }
+        }
+
+        this.prompt = best;
+        return best;
+    }
+
+    tryInteract(player, game) {
+        if (!this.prompt) return false;
+        this.prompt.interact?.(player, game);
+        return true;
+    }
+}

--- a/labs/guerreiro-castelo/js/game/QuestManager.js
+++ b/labs/guerreiro-castelo/js/game/QuestManager.js
@@ -1,0 +1,58 @@
+/**
+ * Objetivos da aventura. O HUD mostra o atual; Tab reexibe.
+ */
+
+export const QUEST_ORDER = [
+    { id: 'explore_ship', text: 'Explore o navio' },
+    { id: 'talk_crew', text: 'Fale com seus companheiros' },
+    { id: 'horizon', text: 'Observe o horizonte' },
+    { id: 'check_helm', text: 'Verifique o leme' },
+    { id: 'free_helm', text: 'Liberte o leme' },
+    { id: 'steer_rock', text: 'Desvie da rocha' },
+    { id: 'reach_castle', text: 'Chegue até o castelo' },
+    { id: 'other_entrance', text: 'Encontre outra entrada' },
+    { id: 'hidden_door', text: 'Chegue até a entrada escondida' },
+    { id: 'open_door', text: 'Abra a porta' },
+    { id: 'stealth_up', text: 'Suba sem ser descoberto' },
+    { id: 'steal_keys', text: 'Pegue as chaves' },
+    { id: 'find_camila', text: 'Encontre a princesa' },
+    { id: 'cell_key', text: 'Encontre a chave da cela' },
+    { id: 'teco_tiger', text: 'Peça ajuda a Teco' },
+    { id: 'back_camila', text: 'Volte para Camila' },
+    { id: 'free_camila', text: 'Liberte Camila' },
+    { id: 'flee', text: 'FUJA DO CASTELO' },
+    { id: 'reach_ship', text: 'Chegue ao navio' },
+    { id: 'untie', text: 'Solte as amarras' },
+    { id: 'raise_sail', text: 'Levante a vela' },
+    { id: 'take_helm', text: 'Assuma o leme' },
+    { id: 'escaped', text: 'Você escapou' }
+];
+
+export class QuestManager {
+    constructor() {
+        this.current = QUEST_ORDER[0];
+        this.completed = new Set();
+        this.bannerT = 0;
+        this.onChange = null;
+    }
+
+    set(id) {
+        const q = QUEST_ORDER.find((x) => x.id === id);
+        if (!q) return;
+        this.current = q;
+        this.bannerT = 4.2;
+        this.onChange?.(q);
+    }
+
+    complete(id) {
+        this.completed.add(id);
+        const i = QUEST_ORDER.findIndex((x) => x.id === id);
+        if (i >= 0 && i + 1 < QUEST_ORDER.length && this.current.id === id) {
+            this.set(QUEST_ORDER[i + 1].id);
+        }
+    }
+
+    update(dt) {
+        if (this.bannerT > 0) this.bannerT -= dt;
+    }
+}

--- a/labs/guerreiro-castelo/js/game/StoryDirector.js
+++ b/labs/guerreiro-castelo/js/game/StoryDirector.js
@@ -1,0 +1,205 @@
+/**
+ * Encadeia os 12 capítulos. Níveis não ficam isolados — o diretor avança sozinho.
+ */
+
+export class StoryDirector {
+    constructor(game) {
+        this.game = game;
+        this.chapter = 1;
+        this.phase = 'menu';
+        this.flags = {
+            talkedFriends: false,
+            horizon: false,
+            helm: false,
+            tecoPlay: false,
+            ropeFreed: false,
+            rockCleared: false,
+            reachedCastle: false,
+            otherEntrance: false,
+            atSecretDoor: false,
+            doorOpen: false,
+            keysTaken: false,
+            foundCamila: false,
+            triedKeys: 0,
+            cellKey: false,
+            cellOpen: false,
+            shacklesOpen: false,
+            alarm: false,
+            atShip: false,
+            untied: false,
+            sailUp: false,
+            escaped: false
+        };
+        this._busy = false;
+    }
+
+    resetFlags() {
+        for (const k of Object.keys(this.flags)) {
+            this.flags[k] = typeof this.flags[k] === 'number' ? 0 : false;
+        }
+    }
+
+    notify(event, extra) {
+        const g = this.game;
+        switch (event) {
+            case 'talk_friends':
+                this.flags.talkedFriends = true;
+                this._checkShipExplore();
+                break;
+            case 'horizon':
+                this.flags.horizon = true;
+                g.quests.complete('horizon');
+                this._checkShipExplore();
+                break;
+            case 'helm':
+                this.flags.helm = true;
+                g.quests.complete('check_helm');
+                this._checkShipExplore();
+                break;
+            case 'teco_play':
+                this.flags.tecoPlay = true;
+                this._checkShipExplore();
+                break;
+            case 'rope_freed':
+                this.flags.ropeFreed = true;
+                g.quests.set('steer_rock');
+                g.checkpoints.save('storm_rope', this._saveBlob());
+                g.dialogue.say('DICO', 'Assuma o leme!');
+                g.level?.beginHelm?.();
+                break;
+            case 'rock_hit':
+                g.failCheckpoint('A rocha…');
+                break;
+            case 'rock_cleared':
+                this.flags.rockCleared = true;
+                this._busy = true;
+                g.level?.endStorm?.();
+                g.fadeTo(1.6, () => {
+                    g.loadStage('island', 'castle_beach');
+                    this._busy = false;
+                });
+                break;
+            case 'castle_view':
+                this.flags.reachedCastle = true;
+                g.quests.set('other_entrance');
+                g.dialogue.say('AMIGO', 'Como vamos entrar aí?');
+                g.checkpoints.save('castle_exterior', this._saveBlob());
+                break;
+            case 'teco_tree':
+                this.flags.otherEntrance = true;
+                g.quests.set('hidden_door');
+                g.dialogue.say('DICO', 'O que você encontrou, Teco?');
+                g.dialogue.say('DICO', 'Vamos por ali.');
+                break;
+            case 'at_secret':
+                this.flags.atSecretDoor = true;
+                g.quests.set('open_door');
+                g.checkpoints.save('secret_door', this._saveBlob());
+                break;
+            case 'door_open':
+                this.flags.doorOpen = true;
+                g.quests.set('stealth_up');
+                g.fadeTo(1.1, () => g.loadStage('interior', 'sleeping_guard'));
+                break;
+            case 'keys':
+                this.flags.keysTaken = true;
+                g.inventory.keys = 3;
+                g.quests.set('find_camila');
+                g.hud.showToast('3 chaves encontradas');
+                g.checkpoints.save('sleeping_guard', this._saveBlob());
+                break;
+            case 'found_camila':
+                this.flags.foundCamila = true;
+                g.quests.set('cell_key');
+                g.checkpoints.save('princess_cell', this._saveBlob());
+                break;
+            case 'wrong_key':
+                this.flags.triedKeys += 1;
+                break;
+            case 'cell_key':
+                this.flags.cellKey = true;
+                g.inventory.cellKey = true;
+                g.hud.showToast('Chave da cela');
+                g.quests.set('back_camila');
+                g.checkpoints.save('tiger_room', this._saveBlob());
+                break;
+            case 'cell_open':
+                this.flags.cellOpen = true;
+                g.quests.set('free_camila');
+                break;
+            case 'shackles':
+                this.flags.shacklesOpen = true;
+                g.camila.setShackles(false);
+                g.camila.freed = true;
+                g.camila.ai.follow();
+                g.dialogue.say('CAMILA', 'Obrigada!');
+                g.dialogue.say('DICO', 'Agora precisamos sair daqui.');
+                g.checkpoints.save('princess_rescued', this._saveBlob());
+                break;
+            case 'alarm':
+                this.flags.alarm = true;
+                g.audio.setTheme('chase');
+                g.audio.play('bell');
+                g.quests.set('flee');
+                g.hud.showObjective('FUJA DO CASTELO', true);
+                g.dialogue.say('GUARDA', 'A princesa está fugindo!');
+                g.dialogue.say('DICO', 'Corram!');
+                g.camila.ai.run();
+                g.checkpoints.save('escape_start', this._saveBlob());
+                g.fadeTo(0.8, () => g.loadStage('escape', 'escape_start'));
+                break;
+            case 'reach_ship':
+                this.flags.atShip = true;
+                g.quests.set('untie');
+                g.checkpoints.save('ship_escape', this._saveBlob());
+                g.fadeTo(0.8, () => g.loadStage('shipEscape', 'ship_escape'));
+                break;
+            case 'untie':
+                this.flags.untied = true;
+                g.quests.set('raise_sail');
+                break;
+            case 'sail':
+                this.flags.sailUp = true;
+                g.quests.set('take_helm');
+                break;
+            case 'escaped':
+                this.flags.escaped = true;
+                g.quests.set('escaped');
+                g.hud.showToast('Você escapou');
+                g.fadeTo(1.8, () => g.loadStage('ending', 'ending'));
+                break;
+            case 'the_end':
+                g.showEnding();
+                break;
+            default:
+                if (extra) console.log('[story]', event, extra);
+        }
+    }
+
+    _checkShipExplore() {
+        const f = this.flags;
+        const n = [f.talkedFriends, f.horizon, f.helm, f.tecoPlay].filter(Boolean).length;
+        if (n >= 1 && this.game.quests.current.id === 'explore_ship') {
+            this.game.quests.set('talk_crew');
+        }
+        if (f.talkedFriends && this.game.quests.current.id === 'talk_crew') this.game.quests.set('horizon');
+        if (f.talkedFriends && f.horizon && f.helm && f.tecoPlay) {
+            this.game.level?.beginNight?.();
+        }
+    }
+
+    _saveBlob() {
+        return {
+            flags: { ...this.flags },
+            inventory: { ...this.game.inventory },
+            quest: this.game.quests.current.id,
+            level: this.game.stageId
+        };
+    }
+
+    applySave(data) {
+        Object.assign(this.flags, data.flags || {});
+        this.game.inventory = { keys: 0, cellKey: false, ...data.inventory };
+        if (data.quest) this.game.quests.set(data.quest);
+    }
+}

--- a/labs/guerreiro-castelo/js/levels/BeachLevel.js
+++ b/labs/guerreiro-castelo/js/levels/BeachLevel.js
@@ -1,0 +1,96 @@
+import * as THREE from 'three';
+import { Level } from './Level.js';
+import { sandTexture, grassTexture } from '../world/Textures.js';
+import { makeRock, makeGrassInstanced, makeBush } from '../world/Environment.js';
+
+export class BeachLevel extends Level {
+    get id() {
+        return 'beach';
+    }
+
+    async build() {
+        this.group = new THREE.Group();
+        this.group.position.set(0, 0, 0);
+        const sand = new THREE.Mesh(
+            new THREE.CircleGeometry(42, 32),
+            new THREE.MeshStandardMaterial({ map: sandTexture(), roughness: 0.95, color: 0xe8d2a8 })
+        );
+        sand.rotation.x = -Math.PI / 2;
+        sand.position.y = 0.02;
+        sand.receiveShadow = true;
+        this.group.add(sand);
+
+        const grass = new THREE.Mesh(
+            new THREE.CircleGeometry(38, 24),
+            new THREE.MeshStandardMaterial({ map: grassTexture(), roughness: 0.92 })
+        );
+        grass.rotation.x = -Math.PI / 2;
+        grass.position.set(0, 0.04, -22);
+        grass.receiveShadow = true;
+        this.group.add(grass);
+
+        for (let i = 0; i < 10; i++) {
+            const r = makeRock(0.8 + Math.random());
+            r.position.set((Math.random() - 0.5) * 22, 0.2, 6 + Math.random() * 10);
+            this.group.add(r);
+        }
+        const wood = new THREE.Mesh(
+            new THREE.BoxGeometry(1.6, 0.18, 0.35),
+            new THREE.MeshStandardMaterial({ color: 0x6a4a28, roughness: 0.9 })
+        );
+        wood.position.set(-4, 0.12, 8);
+        wood.rotation.y = 0.4;
+        this.group.add(wood);
+
+        const grassI = makeGrassInstanced(180, 28, this.game.quality.vegetation);
+        grassI.position.z = -8;
+        this.group.add(grassI);
+        for (let i = 0; i < 8; i++) {
+            const b = makeBush();
+            b.position.set((Math.random() - 0.5) * 18, 0.2, -8 + Math.random() * 8);
+            this.group.add(b);
+        }
+
+        this.game.collision.addFloor(0, -4, 70, 70, 0);
+        this.game.scene.add(this.group);
+        this.obstacles = [];
+        this.group.traverse((c) => { if (c.isMesh) this.obstacles.push(c); });
+
+        this.gulls = [];
+        for (let i = 0; i < 4; i++) {
+            const gull = new THREE.Mesh(
+                new THREE.ConeGeometry(0.15, 0.5, 4),
+                new THREE.MeshStandardMaterial({ color: 0xf2f0ea })
+            );
+            gull.position.set(-8 + i * 5, 6 + i, 10);
+            this.group.add(gull);
+            this.gulls.push({ m: gull, p: i });
+        }
+    }
+
+    enter() {
+        const g = this.game;
+        g.player.attachTo(g.scene);
+        g.teco.attachTo(g.scene);
+        g.camila.attachTo(g.scene);
+        g.player.spawn(0, 0, 10, Math.PI);
+        g.teco.spawn(0.7, 0, 9);
+        g.weather.apply('dawn');
+        g.audio.setTheme('land');
+        g.storm.setIntensity(0);
+        g.quests.set('reach_castle');
+        g.hud.showObjective('Chegue até o castelo');
+        g.input.enabled = true;
+        g.player.controller.setMode('walk');
+        g.input.requestLock();
+    }
+
+    update(dt) {
+        this.time += dt;
+        for (const g of this.gulls) {
+            g.m.position.x = Math.sin(this.time * 0.4 + g.p) * 12;
+            g.m.position.z = 8 + Math.cos(this.time * 0.3 + g.p) * 6;
+            g.m.position.y = 5 + Math.sin(this.time * 2 + g.p) * 0.6;
+        }
+    }
+}

--- a/labs/guerreiro-castelo/js/levels/CastleExteriorLevel.js
+++ b/labs/guerreiro-castelo/js/levels/CastleExteriorLevel.js
@@ -1,0 +1,128 @@
+import * as THREE from 'three';
+import { Level } from './Level.js';
+import { buildCastle, addCastleColliders } from '../world/Castle.js';
+import { makeTree } from '../world/Environment.js';
+import { grassTexture } from '../world/Textures.js';
+import { buildGuard, CharacterAnimator } from '../characters/builders.js';
+
+export class CastleExteriorLevel extends Level {
+    get id() {
+        return 'castle_ext';
+    }
+
+    async build() {
+        this.group = new THREE.Group();
+        this.group.position.set(0, 0, -88);
+        const ground = new THREE.Mesh(
+            new THREE.PlaneGeometry(90, 70),
+            new THREE.MeshStandardMaterial({ map: grassTexture(), roughness: 0.9, color: 0x8a8a70 })
+        );
+        ground.rotation.x = -Math.PI / 2;
+        ground.receiveShadow = true;
+        this.group.add(ground);
+
+        this.castle = buildCastle();
+        this.group.add(this.castle);
+        addCastleColliders(this.game.collision, 0, -88);
+
+        this.lookout = makeTree();
+        this.lookout.position.set(-18, 0, 4);
+        this.group.add(this.lookout);
+
+        const gateProxy = new THREE.Object3D();
+        gateProxy.position.set(0, 1, 16);
+        this.group.add(gateProxy);
+        this.addInteract({
+            object: gateProxy,
+            interactionLabel: 'Portão (protegido)',
+            interactionDistance: 4,
+            interact: (_p, game) => {
+                game.dialogue.say('DICO', 'Não por aqui. Há arqueiros demais.');
+                if (!this._viewed) {
+                    this._viewed = true;
+                    game.story.notify('castle_view');
+                }
+            }
+        });
+
+        this.addInteract({
+            object: this.lookout,
+            interactionLabel: 'Mandar Teco',
+            interactionDistance: 3,
+            interact: (_p, game) => this.sendTecoTree(game)
+        });
+
+        const secret = this.castle.userData.secretDoor;
+        this.addInteract({
+            object: secret,
+            interactionLabel: 'Chegar à porta',
+            interactionDistance: 2.6,
+            interact: (_p, game) => {
+                game.story.notify('at_secret');
+                game.quests.set('open_door');
+            }
+        });
+
+        this.archers = [];
+        for (let i = -2; i <= 2; i++) {
+            const a = buildGuard({ archer: true });
+            a.group.position.set(i * 3.2, 18.2, 14.2);
+            this.castle.add(a.group);
+            this.archers.push(new CharacterAnimator(a.group, a.clips));
+        }
+
+        this.game.scene.add(this.group);
+        this.obstacles = [];
+        this.group.traverse((c) => { if (c.isMesh) this.obstacles.push(c); });
+        this.tecoSent = false;
+        this.nearCastle = false;
+    }
+
+    sendTecoTree(game) {
+        if (this.tecoSent) return;
+        this.tecoSent = true;
+        const base = this.lookout.getWorldPosition(new THREE.Vector3());
+        const local = (x, y, z) => {
+            const v = new THREE.Vector3(x, y, z);
+            game.teco.root.parent.worldToLocal(v);
+            return v;
+        };
+        const path = [
+            local(base.x, 1.2, base.z),
+            local(base.x, 4.2, base.z),
+            local(base.x, 6.5, base.z)
+        ];
+        game.teco.ai.command(path, {
+            climb: true,
+            onComplete: () => {
+                game.story.notify('teco_tree');
+                game.teco.ai.command([
+                    local(game.player.position.x, game.player.position.y, game.player.position.z)
+                ], { onComplete: () => {} });
+            }
+        });
+    }
+
+    update(dt) {
+        this.time += dt;
+        for (const a of this.archers) a.update(dt);
+        const p = this.game.player.worldPosition();
+        if (!this.nearCastle && p.z < -70) {
+            this.nearCastle = true;
+            this.game.story.notify('castle_view');
+            this.game.cutscenes.play({
+                from: new THREE.Vector3(p.x + 4, p.y + 8, p.z + 10),
+                to: new THREE.Vector3(p.x + 8, p.y + 16, p.z + 6),
+                lookFrom: new THREE.Vector3(0, 12, -88),
+                lookTo: new THREE.Vector3(0, 20, -100),
+                duration: 3.6
+            });
+        }
+        const door = this.castle.userData.secretDoor;
+        door.getWorldPosition(this._wp || (this._wp = new THREE.Vector3()));
+        if (!this._atDoor && this._wp.distanceTo(p) < 3.2) {
+            this._atDoor = true;
+            this.game.story.notify('at_secret');
+        }
+    }
+}

--- a/labs/guerreiro-castelo/js/levels/CastleInteriorLevel.js
+++ b/labs/guerreiro-castelo/js/levels/CastleInteriorLevel.js
@@ -1,0 +1,270 @@
+import * as THREE from 'three';
+import { Level } from './Level.js';
+import { castleStoneTexture, woodTexture } from '../world/Textures.js';
+import { std } from '../characters/builders.js';
+import { makeTorch, EnvironmentFX } from '../world/Environment.js';
+import { Guard } from '../characters/Guard.js';
+function stoneMat() {
+    return new THREE.MeshStandardMaterial({ map: castleStoneTexture(), roughness: 0.9, color: 0x8a8478 });
+}
+
+export class CastleInteriorLevel extends Level {
+    get id() {
+        return 'interior';
+    }
+
+    async build() {
+        this.group = new THREE.Group();
+        this.fx = new EnvironmentFX();
+        const stone = stoneMat();
+        const wood = new THREE.MeshStandardMaterial({ map: woodTexture(), roughness: 0.85 });
+
+        const room = (w, h, d, x, y, z, open = []) => {
+            const floor = new THREE.Mesh(new THREE.BoxGeometry(w, 0.2, d), stone);
+            floor.position.set(x, y - 0.1, z);
+            floor.receiveShadow = true;
+            this.group.add(floor);
+            this.game.collision.addFloor(x, z, w, d, y);
+            const ceil = new THREE.Mesh(new THREE.BoxGeometry(w, 0.2, d), stone);
+            ceil.position.set(x, y + h, z);
+            this.group.add(ceil);
+            if (!open.includes('-z')) this.game.collision.addWall(x, z - d / 2, w, 0.3, h, y);
+            if (!open.includes('+z')) this.game.collision.addWall(x, z + d / 2, w, 0.3, h, y);
+            if (!open.includes('-x')) this.game.collision.addWall(x - w / 2, z, 0.3, d, h, y);
+            if (!open.includes('+x')) this.game.collision.addWall(x + w / 2, z, 0.3, d, h, y);
+        };
+
+        room(6, 3.4, 10, 0, 0, 0, ['-z']);
+        const stairs = new THREE.Group();
+        for (let i = 0; i < 10; i++) {
+            const st = new THREE.Mesh(new THREE.BoxGeometry(2.2, 0.22, 0.7), stone);
+            st.position.set(0, 0.11 + i * 0.32, -6 - i * 0.55);
+            stairs.add(st);
+            this.game.collision.addFloor(0, -6 - i * 0.55, 2.2, 0.7, 0.22 + i * 0.32);
+        }
+        this.group.add(stairs);
+
+        room(10, 3.6, 12, 0, 3.2, -18, ['+z', '-z', '-x', '+x']);
+        room(8, 3.4, 10, 0, 3.2, -32, ['+z', '-z']);
+        room(6, 3.2, 6, -10, 3.2, -18, ['+x']);
+        room(6, 3.2, 6, 12, 3.2, -18, ['-x']);
+
+        const openings = [
+            [0, 1.6, -5, 2, 2.4, 0.4],
+            [0, 4.6, -24, 2.2, 2.6, 0.4],
+            [-5, 4.6, -18, 0.4, 2.4, 2],
+            [5.2, 4.6, -18, 0.4, 2.4, 2]
+        ];
+        for (const o of openings) {
+            const hole = new THREE.Mesh(new THREE.BoxGeometry(o[3], o[4], o[5]), std(0x080604, 1));
+            hole.position.set(o[0], o[1], o[2]);
+            this.group.add(hole);
+        }
+
+        this.cellDoor = new THREE.Mesh(new THREE.BoxGeometry(1.6, 2.4, 0.12), wood);
+        this.cellDoor.position.set(0, 4.4, -37.1);
+        this.group.add(this.cellDoor);
+        const bars = new THREE.Group();
+        for (let i = 0; i < 6; i++) {
+            const b = new THREE.Mesh(new THREE.CylinderGeometry(0.03, 0.03, 2.2, 5), std(0x555555, 0.4, 0.7));
+            b.position.set(-0.6 + i * 0.24, 4.4, -37);
+            bars.add(b);
+        }
+        this.group.add(bars);
+        this.bars = bars;
+
+        const torch1 = makeTorch();
+        torch1.position.set(-2.4, 1.4, -2);
+        this.group.add(torch1);
+        this.fx.addFire(torch1);
+        const torch2 = makeTorch();
+        torch2.position.set(2.6, 4.6, -18);
+        this.group.add(torch2);
+        this.fx.addFire(torch2);
+
+        for (let i = 0; i < 4; i++) {
+            const rat = new THREE.Mesh(new THREE.SphereGeometry(0.08, 6, 5), std(0x3a3a32, 0.9));
+            rat.scale.set(1.4, 0.7, 2);
+            rat.position.set(-1 + i * 0.7, 0.08, -1 + (i % 2));
+            this.group.add(rat);
+            this._rats = this._rats || [];
+            this._rats.push(rat);
+        }
+
+        const vase = new THREE.Mesh(new THREE.CylinderGeometry(0.12, 0.16, 0.4, 8), std(0x6a4a2a, 0.7));
+        vase.position.set(3.2, 3.42, -14);
+        vase.name = 'vase';
+        this.group.add(vase);
+        this.addInteract({
+            object: vase,
+            interactionLabel: 'Não tocar',
+            interactionDistance: 1.6,
+            interact: (_p, game) => {
+                vase.rotation.z = 1.2;
+                vase.position.y = 3.22;
+                game.collision.emitNoise(3.2, -14, 1.4, 0.8);
+                game.audio.play('fail');
+                game.hud.showStealth(true, 0.8);
+            }
+        });
+
+        this.sleeping = new Guard(this.group, { fat: true, sleep: true });
+        this.sleeping.spawn(1.4, 3.2, -16.5, 1.2);
+        this.game.combat.setGuards([this.sleeping]);
+
+        this.addInteract({
+            object: this.sleeping.root,
+            interactionLabel: 'Pegar chaves',
+            interactionDistance: 1.7,
+            interact: (_p, game) => this.stealKeys(game)
+        });
+
+        this.game.camila.attachTo(this.group);
+        this.game.camila.spawn(0, 3.2, -39.5);
+        this.game.camila.setShackles(true);
+        this.game.camila.ai.state = 'WAIT';
+        this.game.camila.root.visible = true;
+        this.game.camila.active = true;
+
+        this.addInteract({
+            object: this.game.camila.root,
+            interactionLabel: 'Conversar',
+            interactionDistance: 2.4,
+            interact: (_p, game) => this.talkCamila(game)
+        });
+        this.addInteract({
+            object: this.cellDoor,
+            interactionLabel: 'Usar chave',
+            interactionDistance: 2.2,
+            interact: (_p, game) => this.tryCell(game)
+        });
+
+        const drip = new THREE.PointLight(0x6688aa, 0.15, 6);
+        drip.position.set(2, 2, -4);
+        this.group.add(drip);
+        this.torchLight = new THREE.PointLight(0xff9030, 1.1, 8);
+        this.group.add(this.torchLight);
+
+        this.game.scene.add(this.group);
+        this.obstacles = [];
+        this.group.traverse((c) => { if (c.isMesh) this.obstacles.push(c); });
+        this.keysTaken = false;
+        this.cellTried = 0;
+        this.alarmArmed = false;
+    }
+
+    enter() {
+        const g = this.game;
+        g.player.attachTo(this.group);
+        g.teco.attachTo(this.group);
+        g.camila.attachTo(this.group);
+        g.player.spawn(0, 0, 3.2, Math.PI);
+        g.teco.spawn(0.5, 0, 2.6);
+        g.player.setTorch(true);
+        g.weather.apply('interior');
+        g.audio.setTheme('stealth');
+        g.storm.setIntensity(0);
+        g.ocean.water.visible = false;
+        g.quests.set('stealth_up');
+        g.dialogue.say('DICO', 'Devagar…');
+        g.teco.ai.state = 'PERCHED';
+        g.cameraRig.setObstacles(this.obstacles);
+        g.input.enabled = true;
+        g.player.controller.setMode('walk');
+        g.hud.showStealth(true, 0);
+        g.input.requestLock();
+    }
+
+    stealKeys(game) {
+        if (this.keysTaken) return;
+        this.keysTaken = true;
+        this.sleeping.hasKeys = false;
+        game.audio.play('clink');
+        game.dialogue.say('GUARDA', '…hmm…');
+        game.hud.showStealth(true, 0.7);
+        game.story.notify('keys');
+        this.sleeping.ai.suspicion = 0.4;
+        this.sleeping.root.rotation.y += 0.5;
+        setTimeout(() => {
+            if (this.sleeping.ai.state === 'SLEEP') {
+                this.sleeping.root.rotation.y -= 0.5;
+            }
+        }, 1800);
+    }
+
+    talkCamila(game) {
+        if (!game.story.flags.foundCamila) {
+            game.dialogue.play([
+                { speaker: 'DICO', text: 'Princesa, viemos salvar você.', duration: 3 },
+                { speaker: 'CAMILA', text: 'Vocês vieram mesmo!', duration: 2.8 },
+                { speaker: 'DICO', text: 'Vou tirar você daí.', duration: 2.6 }
+            ]);
+            game.story.notify('found_camila');
+        } else if (game.story.flags.cellOpen && !game.story.flags.shacklesOpen) {
+            this.tryShackles(game);
+        }
+    }
+
+    tryCell(game) {
+        if (game.story.flags.cellOpen) return;
+        if (game.inventory.cellKey) {
+            this.cellDoor.rotation.y = 1.5;
+            this.bars.visible = false;
+            game.audio.play('click');
+            game.audio.play('door');
+            game.story.notify('cell_open');
+            game.dialogue.say('DICO', 'A chave certa.');
+            return;
+        }
+        if (!game.inventory.keys) {
+            game.dialogue.say('DICO', 'Preciso de uma chave.');
+            return;
+        }
+        this.cellTried += 1;
+        game.story.notify('wrong_key');
+        game.audio.play('fail');
+        const n = this.cellTried;
+        if (n === 1) game.dialogue.say('DICO', 'Não é esta…');
+        else if (n === 2) game.dialogue.say('DICO', 'Tampouco esta.');
+        else game.dialogue.say('DICO', 'Nenhuma das três. Teco, a fechadura é outra.');
+    }
+
+    tryShackles(game) {
+        game.audio.play('fail');
+        game.dialogue.say('DICO', 'Primeira… não. Segunda… nada.');
+        setTimeout(() => {
+            game.audio.play('click');
+            game.story.notify('shackles');
+            this.alarmArmed = true;
+        }, 1600);
+    }
+
+    update(dt) {
+        this.time += dt;
+        this.fx.update(this.time);
+        this.sleeping.update(dt, this.game);
+        if (this._rats) {
+            for (let i = 0; i < this._rats.length; i++) {
+                this._rats[i].position.x = Math.sin(this.time * 1.5 + i) * 1.4 - 1;
+            }
+        }
+        const p = this.game.player.position;
+        this.torchLight.position.set(p.x + 0.3, p.y + 1.5, p.z + 0.2);
+        this.torchLight.intensity = 1 + Math.sin(this.time * 10) * 0.15;
+
+        const noise = this.game.player.noise;
+        this.game.hud.showStealth(true, Math.min(1, this.sleeping.ai.suspicion + noise * 0.3));
+
+        if (this.alarmArmed && p.z > -22 && p.y > 2.5 && !this.game.story.flags.alarm) {
+            this.sleeping.ai.state = 'CHASE';
+            this.game.story.notify('alarm');
+        }
+    }
+
+    exit() {
+        super.exit();
+        this.game.player.setTorch(false);
+        this.game.hud.showStealth(false);
+        this.game.ocean.water.visible = true;
+    }
+}

--- a/labs/guerreiro-castelo/js/levels/EndingLevel.js
+++ b/labs/guerreiro-castelo/js/levels/EndingLevel.js
@@ -1,0 +1,85 @@
+import * as THREE from 'three';
+import { Level } from './Level.js';
+import { buildShip } from '../world/Ship.js';
+import { buildFriend, CharacterAnimator } from '../characters/builders.js';
+
+export class EndingLevel extends Level {
+    get id() {
+        return 'ending';
+    }
+
+    async build() {
+        this.group = new THREE.Group();
+        this.ship = buildShip();
+        this.group.add(this.ship);
+        this.game.scene.add(this.group);
+
+        this.friends = [];
+        for (let i = 0; i < 3; i++) {
+            const f = buildFriend(i);
+            f.group.position.set(-1.4 + i, 1.44, 1.5);
+            this.ship.add(f.group);
+            this.friends.push(new CharacterAnimator(f.group, f.clips));
+        }
+        this.phase = 'sail';
+        this.t = 0;
+    }
+
+    enter() {
+        const g = this.game;
+        g.player.attachTo(this.ship);
+        g.teco.attachTo(this.ship);
+        g.camila.attachTo(this.ship);
+        g.player.spawn(0.4, 1.44, 3, Math.PI);
+        g.teco.spawn(0.6, 1.52, 3);
+        g.teco.ai.state = 'PERCHED';
+        g.camila.spawn(-0.8, 1.44, 2.4);
+        g.camila.active = true;
+        g.camila.root.visible = true;
+        g.camila.ai.state = 'WAIT';
+        g.player.controller.setMode('locked');
+        g.input.enabled = false;
+        g.weather.apply('day');
+        g.audio.setTheme('calm');
+        g.storm.setIntensity(0);
+        g.ocean.water.visible = true;
+        g.ocean.setStorm(0.12);
+
+        g.dialogue.play(
+            [
+                { speaker: 'CAMILA', text: 'Eu achei que nunca sairia daquele lugar.', duration: 4 },
+                { speaker: 'CAMILA', text: 'Obrigada. A todos vocês.', duration: 3.2 }
+            ],
+            () => this.pullBack()
+        );
+    }
+
+    pullBack() {
+        const g = this.game;
+        g.cutscenes.play({
+            from: new THREE.Vector3(2, 3, 8),
+            to: new THREE.Vector3(18, 22, 40),
+            lookFrom: new THREE.Vector3(0, 2, 0),
+            lookTo: new THREE.Vector3(0, 4, -10),
+            duration: 6,
+            onEnd: () => {
+                g.fadeTo(1.6, () => g.loadStage('homeEnd', 'ending'));
+            }
+        });
+    }
+
+    update(dt) {
+        this.t += dt;
+        this.group.position.z -= dt * 2.2;
+        const wave = this.game.ocean.sample(0, this.group.position.z, this.t);
+        this.ship.position.y = wave.y * 0.3;
+        this.ship.rotation.x = wave.pitch * 0.3;
+        this.ship.rotation.z = wave.roll * 0.3;
+        for (const a of this.friends) a.update(dt);
+    }
+
+    exit() {
+        super.exit();
+        this.game.input.enabled = true;
+    }
+}

--- a/labs/guerreiro-castelo/js/levels/EscapeLevel.js
+++ b/labs/guerreiro-castelo/js/levels/EscapeLevel.js
@@ -1,0 +1,129 @@
+import * as THREE from 'three';
+import { Level } from './Level.js';
+import { makeTree, makeGrassInstanced } from '../world/Environment.js';
+import { grassTexture, sandTexture } from '../world/Textures.js';
+import { buildGuard, CharacterAnimator } from '../characters/builders.js';
+import { seeded } from '../utils/math.js';
+
+export class EscapeLevel extends Level {
+    get id() {
+        return 'escape';
+    }
+
+    async build() {
+        this.group = new THREE.Group();
+        const grass = new THREE.Mesh(
+            new THREE.PlaneGeometry(50, 90),
+            new THREE.MeshStandardMaterial({ map: grassTexture(), roughness: 0.92 })
+        );
+        grass.rotation.x = -Math.PI / 2;
+        grass.receiveShadow = true;
+        this.group.add(grass);
+        const sand = new THREE.Mesh(
+            new THREE.CircleGeometry(22, 24),
+            new THREE.MeshStandardMaterial({ map: sandTexture(), roughness: 0.95 })
+        );
+        sand.rotation.x = -Math.PI / 2;
+        sand.position.set(0, 0.03, 38);
+        this.group.add(sand);
+
+        const rng = seeded(9);
+        this.trees = [];
+        for (let i = 0; i < 22; i++) {
+            const t = makeTree(rng);
+            t.position.set((rng() - 0.5) * 28, 0, -20 + rng() * 50);
+            this.group.add(t);
+            this.trees.push(t);
+        }
+        this.group.add(makeGrassInstanced(160, 40, this.game.quality.vegetation));
+
+        this.archers = [];
+        for (let i = 0; i < 3; i++) {
+            const a = buildGuard({ archer: true });
+            a.group.position.set(-8 + i * 8, 10, -28);
+            this.group.add(a.group);
+            this.archers.push({ root: a.group, anim: new CharacterAnimator(a.group, a.clips), t: i * 0.4 });
+        }
+
+        const shipHint = new THREE.Mesh(
+            new THREE.BoxGeometry(6, 3, 14),
+            new THREE.MeshStandardMaterial({ color: 0x8a6238, roughness: 0.85 })
+        );
+        shipHint.position.set(0, 1.6, 46);
+        this.group.add(shipHint);
+        this.shipHint = shipHint;
+
+        this.game.collision.addFloor(0, 10, 60, 100, 0);
+        this.game.scene.add(this.group);
+        this.obstacles = [];
+        this.group.traverse((c) => { if (c.isMesh) this.obstacles.push(c); });
+        this.game.arrows.setColliders(this.obstacles);
+        this.fireT = 0;
+        this.called = false;
+    }
+
+    enter() {
+        const g = this.game;
+        g.player.attachTo(g.scene);
+        g.teco.attachTo(g.scene);
+        g.camila.attachTo(g.scene);
+        g.player.spawn(0, 0, -24, 0);
+        g.teco.spawn(0.5, 0, -23);
+        g.camila.spawn(-0.8, 0, -25);
+        g.camila.active = true;
+        g.camila.root.visible = true;
+        g.camila.ai.run();
+        g.weather.apply('day');
+        g.audio.setTheme('chase');
+        g.quests.set('reach_ship');
+        g.hud.showObjective('Chegue ao navio', true);
+        g.dialogue.say('ARQUEIRO', 'Ali estão eles!');
+        g.input.enabled = true;
+        g.player.controller.setMode('walk');
+        g.cameraRig.setObstacles(this.obstacles);
+        g.arrows.onHitPlayer = () => {
+            if (g.player.hurt(1)) {
+                g.audio.play('hit');
+                g.cameraRig.addShake(0.16, 0.25);
+                if (!g.player.alive) g.failCheckpoint('Uma flecha…');
+            }
+        };
+        g.input.requestLock();
+    }
+
+    update(dt) {
+        this.time += dt;
+        this.fireT += dt;
+        for (const a of this.archers) {
+            a.anim.update(dt);
+            a.t += dt;
+            if (a.t > 1.15) {
+                a.t = 0;
+                const origin = a.root.getWorldPosition(new THREE.Vector3()).add(new THREE.Vector3(0, 1.4, 0));
+                const target = this.game.player.worldPosition().clone();
+                target.x += (Math.random() - 0.5) * 4;
+                target.z += (Math.random() - 0.5) * 3;
+                target.y += 1;
+                const dir = target.sub(origin).normalize();
+                this.game.arrows.fire(origin, dir, 26 + Math.random() * 8);
+                this.game.audio.play('arrow');
+            }
+        }
+        const p = this.game.player.position;
+        if (p.z > 8 && !this.called) {
+            this.called = true;
+            this.game.dialogue.say('DICO', 'Não parem!');
+            this.game.teco.ai.state = 'SCARED';
+            this.game.teco.ai.timer = 0;
+        }
+        if (p.z > 40) {
+            this.game.story.notify('reach_ship');
+        }
+    }
+
+    exit() {
+        super.exit();
+        this.game.arrows.clear();
+        this.game.arrows.onHitPlayer = null;
+    }
+}

--- a/labs/guerreiro-castelo/js/levels/ForestLevel.js
+++ b/labs/guerreiro-castelo/js/levels/ForestLevel.js
@@ -1,0 +1,56 @@
+import * as THREE from 'three';
+import { Level } from './Level.js';
+import { makeTree, makeBush, makeRock, makeGrassInstanced } from '../world/Environment.js';
+import { grassTexture } from '../world/Textures.js';
+import { seeded } from '../utils/math.js';
+
+export class ForestLevel extends Level {
+    get id() {
+        return 'forest';
+    }
+
+    async build() {
+        this.group = new THREE.Group();
+        this.group.position.set(0, 0, -36);
+        const rng = seeded(42);
+        const ground = new THREE.Mesh(
+            new THREE.PlaneGeometry(48, 50),
+            new THREE.MeshStandardMaterial({ map: grassTexture(), roughness: 0.92 })
+        );
+        ground.rotation.x = -Math.PI / 2;
+        ground.receiveShadow = true;
+        this.group.add(ground);
+
+        this.trees = [];
+        for (let i = 0; i < 28 * this.game.quality.vegetation; i++) {
+            const t = makeTree(rng);
+            let x = (rng() - 0.5) * 36;
+            let z = (rng() - 0.5) * 42;
+            if (Math.abs(x) < 2.4) x += x < 0 ? -3 : 3;
+            t.position.set(x, 0, z);
+            this.group.add(t);
+            this.trees.push(t);
+            this.game.collision.addWall(x, z - 36, 0.8, 0.8, 4);
+        }
+        for (let i = 0; i < 12; i++) {
+            const b = makeBush();
+            b.position.set((rng() - 0.5) * 20, 0.2, (rng() - 0.5) * 30);
+            this.group.add(b);
+        }
+        const rocks = makeRock(1.2);
+        rocks.position.set(3, 0.2, 8);
+        this.group.add(rocks);
+        this.group.add(makeGrassInstanced(220, 40, this.game.quality.vegetation));
+
+        this.game.scene.add(this.group);
+        this.obstacles = [];
+        this.group.traverse((c) => { if (c.isMesh) this.obstacles.push(c); });
+    }
+
+    update() {
+        for (const t of this.trees) {
+            const c = t.children[1];
+            if (c) c.rotation.y = Math.sin(this.game.clockTime * 0.4) * 0.04;
+        }
+    }
+}

--- a/labs/guerreiro-castelo/js/levels/HomeLevel.js
+++ b/labs/guerreiro-castelo/js/levels/HomeLevel.js
@@ -1,0 +1,167 @@
+import * as THREE from 'three';
+import { Level } from './Level.js';
+import { buildHomeInterior, addHomeColliders } from '../world/Home.js';
+import { buildRavi, CharacterAnimator } from '../characters/builders.js';
+import { EnvironmentFX } from '../world/Environment.js';
+
+export class HomeLevel extends Level {
+    get id() {
+        return 'home';
+    }
+
+    async build() {
+        const g = buildHomeInterior();
+        this.group = g;
+        this.fx = new EnvironmentFX();
+        this.fx.addFire(g.userData.fire);
+        addHomeColliders(this.game.collision);
+
+        const ravi = buildRavi();
+        ravi.group.position.set(0.55, 0, 1.55);
+        ravi.group.rotation.y = -0.6;
+        g.add(ravi.group);
+        this.ravi = ravi;
+        this.raviAnim = new CharacterAnimator(ravi.group, ravi.clips);
+
+        const lamp = new THREE.PointLight(0xff9030, 1.35, 7);
+        lamp.position.set(0, 1.1, -2.8);
+        g.add(lamp);
+        this.hearthLight = lamp;
+
+        const fill = new THREE.PointLight(0xffc8a0, 0.35, 10);
+        fill.position.set(1.5, 2.2, 1);
+        g.add(fill);
+
+        this.game.scene.add(g);
+        this.obstacles = [];
+        g.traverse((c) => {
+            if (c.isMesh) this.obstacles.push(c);
+        });
+    }
+
+    enter(checkpoint) {
+        const g = this.game;
+        g.player.attachTo(this.group);
+        g.teco.attachTo(this.group);
+        g.teco.root.visible = false;
+        g.player.spawn(0.15, 0, 1.7, Math.PI);
+        g.player.controller.setMode('locked');
+        g.input.enabled = false;
+        g.weather.apply('night');
+        g.audio.setTheme('home');
+        g.storm.setIntensity(0);
+        g.ocean.water.visible = false;
+        g.cameraRig.setObstacles(this.obstacles);
+
+        if (checkpoint === 'ending') {
+            this._endingBeat();
+            return;
+        }
+
+        g.cutscenes.play({
+            from: new THREE.Vector3(2.8, 1.6, 3.2),
+            to: new THREE.Vector3(1.4, 1.45, 2.6),
+            lookFrom: new THREE.Vector3(0, 1.1, 1.2),
+            lookTo: new THREE.Vector3(0.2, 1.2, 1.5),
+            duration: 4.2,
+            onEnd: () => this._introDialogue()
+        });
+    }
+
+    _introDialogue() {
+        const g = this.game;
+        g.dialogue.play(
+            [
+                { speaker: 'RAVI', text: 'Pai, conta uma história?', duration: 3.1 },
+                { speaker: 'DICO', text: 'Tenho uma história muito boa.', duration: 3.2 },
+                { speaker: 'RAVI', text: 'Tem aventura?', duration: 2.6 },
+                { speaker: 'DICO', text: 'Tem aventura, navio, castelo e até uma princesa.', duration: 4.2 },
+                { speaker: 'DICO', text: 'Tudo começou quando eu e meus amigos fomos resgatar uma princesa…', duration: 4.4 }
+            ],
+            () => this._intoFire()
+        );
+    }
+
+    _intoFire() {
+        const g = this.game;
+        g.cutscenes.play({
+            from: new THREE.Vector3(1.2, 1.4, 2.4),
+            to: new THREE.Vector3(0.1, 0.9, -2.2),
+            lookFrom: new THREE.Vector3(0, 1.1, 0.4),
+            lookTo: new THREE.Vector3(0, 0.7, -3.1),
+            duration: 3.6,
+            onMid: () => g.hud.showChapter('', ''),
+            onEnd: () => {
+                g.audio.play('wave');
+                g.fadeTo(1.4, () => {
+                    g.loadStage('ship', 'ship_start');
+                });
+            }
+        });
+    }
+
+    _endingBeat() {
+        const g = this.game;
+        g.player.spawn(0.15, 0, 1.7, Math.PI);
+        g.player.controller.setMode('locked');
+        g.teco.root.visible = false;
+        g.cutscenes.play({
+            from: new THREE.Vector3(2.2, 1.5, 3),
+            to: new THREE.Vector3(1.3, 1.4, 2.5),
+            lookFrom: new THREE.Vector3(0.2, 1.2, 1.4),
+            lookTo: new THREE.Vector3(0.2, 1.2, 1.5),
+            duration: 2.5,
+            onEnd: () => {
+                g.dialogue.play(
+                    [
+                        { speaker: 'RAVI', text: 'E depois?', duration: 2.6 },
+                        { speaker: 'DICO', text: 'Depois nós voltamos para casa.', duration: 3.4 },
+                        { speaker: 'RAVI', text: 'E o Teco?', duration: 2.8 }
+                    ],
+                    () => this._tecoJoke()
+                );
+            }
+        });
+    }
+
+    _tecoJoke() {
+        const g = this.game;
+        const shiny = this.group.userData.shiny;
+        g.audio.play('click');
+        if (shiny) {
+            const start = shiny.position.clone();
+            let t = 0;
+            this._fly = (dt) => {
+                t += dt;
+                shiny.position.x = start.x + t * 1.8;
+                shiny.position.y = start.y + Math.sin(t * 6) * 0.1 + t * 0.2;
+                if (t > 1.2) {
+                    shiny.visible = false;
+                    this._fly = null;
+                    g.dialogue.say('DICO', '…', 1.2);
+                    setTimeout(() => g.story.notify('the_end'), 1600);
+                }
+            };
+        } else {
+            g.story.notify('the_end');
+        }
+    }
+
+    update(dt) {
+        this.time += dt;
+        this.fx.update(this.time);
+        this.raviAnim?.update(dt);
+        if (this.hearthLight) {
+            this.hearthLight.intensity = 1.2 + Math.sin(this.time * 9) * 0.2;
+        }
+        this._fly?.(dt);
+    }
+
+    exit() {
+        super.exit();
+        this.game.ocean.water.visible = true;
+        this.game.player.controller.setMode('walk');
+        this.game.input.enabled = true;
+        this.game.teco.root.visible = true;
+    }
+}

--- a/labs/guerreiro-castelo/js/levels/Level.js
+++ b/labs/guerreiro-castelo/js/levels/Level.js
@@ -1,0 +1,32 @@
+/** Nível base — grupo, colisão e ciclo de vida. */
+
+export class Level {
+    constructor(game) {
+        this.game = game;
+        this.group = null;
+        this.interactables = [];
+        this.obstacles = [];
+        this.npcs = [];
+        this.time = 0;
+    }
+
+    get id() {
+        return 'level';
+    }
+
+    async build() {}
+
+    enter() {}
+
+    exit() {
+        this.interactables.length = 0;
+    }
+
+    update() {}
+
+    addInteract(item) {
+        this.interactables.push(item);
+        this.game.interact.add(item);
+        return item;
+    }
+}

--- a/labs/guerreiro-castelo/js/levels/SecretEntranceLevel.js
+++ b/labs/guerreiro-castelo/js/levels/SecretEntranceLevel.js
@@ -1,0 +1,74 @@
+import * as THREE from 'three';
+import { Level } from './Level.js';
+import { woodTexture, mossTexture, rustTexture } from '../world/Textures.js';
+import { std } from '../characters/builders.js';
+
+export class SecretEntranceLevel extends Level {
+    get id() {
+        return 'secret';
+    }
+
+    async build() {
+        this.group = new THREE.Group();
+        this.group.position.set(-18, 0, -94);
+        const wood = new THREE.MeshStandardMaterial({ map: woodTexture(), roughness: 0.85 });
+        const frame = new THREE.Mesh(new THREE.BoxGeometry(2.2, 3.2, 0.4), wood);
+        frame.position.y = 1.6;
+        this.group.add(frame);
+        this.door = new THREE.Mesh(new THREE.BoxGeometry(1.4, 2.4, 0.16), wood);
+        this.door.position.set(0, 1.25, 0.1);
+        this.group.add(this.door);
+        const lock = new THREE.Mesh(
+            new THREE.BoxGeometry(0.2, 0.24, 0.12),
+            new THREE.MeshStandardMaterial({ map: rustTexture(), color: 0x8a4a18, metalness: 0.6, roughness: 0.5 })
+        );
+        lock.position.set(0.45, 1.2, 0.22);
+        this.group.add(lock);
+        const moss = new THREE.Mesh(
+            new THREE.PlaneGeometry(2.6, 3.4),
+            new THREE.MeshStandardMaterial({ map: mossTexture(), side: THREE.DoubleSide, roughness: 0.9 })
+        );
+        moss.position.set(0, 1.5, -0.25);
+        this.group.add(moss);
+        const roots = new THREE.Mesh(new THREE.CylinderGeometry(0.05, 0.08, 2.2, 5), std(0x3a2a14, 0.9));
+        roots.rotation.z = 0.6;
+        roots.position.set(-0.8, 0.8, 0.2);
+        this.group.add(roots);
+
+        this.addInteract({
+            object: this.door,
+            interactionLabel: 'Abrir',
+            interactionDistance: 2.2,
+            interact: (_p, game) => {
+                game.dialogue.say('DICO', 'Trancada.');
+            }
+        });
+        this.addInteract({
+            object: lock,
+            interactionLabel: 'Pedir ajuda a Teco',
+            interactionDistance: 2.4,
+            interact: (_p, game) => this.sendTeco(game)
+        });
+
+        this.game.scene.add(this.group);
+        this.opened = false;
+    }
+
+    sendTeco(game) {
+        if (this.opened) return;
+        const dest = this.lockWorld || this.door.getWorldPosition(new THREE.Vector3());
+        dest.y += 0.4;
+        const local = dest.clone();
+        game.teco.root.parent.worldToLocal(local);
+        game.teco.ai.command([game.teco.position.clone(), local], {
+            onComplete: () => {
+                this.opened = true;
+                game.audio.play('click');
+                game.dialogue.say('DICO', 'Muito bem, Teco.');
+                this.door.rotation.y = -1.4;
+                game.audio.play('door');
+                game.story.notify('door_open');
+            }
+        });
+    }
+}

--- a/labs/guerreiro-castelo/js/levels/ShipEscapeLevel.js
+++ b/labs/guerreiro-castelo/js/levels/ShipEscapeLevel.js
@@ -1,0 +1,162 @@
+import * as THREE from 'three';
+import { Level } from './Level.js';
+import { buildShip, addShipColliders } from '../world/Ship.js';
+import { makeRock } from '../world/Environment.js';
+import { buildFriend, CharacterAnimator } from '../characters/builders.js';
+
+export class ShipEscapeLevel extends Level {
+    get id() {
+        return 'ship_escape';
+    }
+
+    async build() {
+        this.group = new THREE.Group();
+        this.ship = buildShip();
+        this.group.add(this.ship);
+        this.game.scene.add(this.group);
+        addShipColliders(this.game.collision);
+
+        this.friends = [];
+        for (let i = 0; i < 3; i++) {
+            const f = buildFriend(i);
+            f.group.position.set(-1.5 + i * 1.4, 1.44, 2);
+            this.ship.add(f.group);
+            this.friends.push(new CharacterAnimator(f.group, f.clips));
+        }
+
+        this.addInteract({
+            object: this.ship.userData.mooring,
+            interactionLabel: 'Soltar amarra',
+            interactionDistance: 2.4,
+            interact: (_p, game) => {
+                if (this.untied) return;
+                this.untied = true;
+                this.ship.userData.mooring.visible = false;
+                game.audio.play('interact');
+                game.story.notify('untie');
+            }
+        });
+        this.addInteract({
+            object: this.ship.userData.sail,
+            interactionLabel: 'Levantar a vela',
+            interactionDistance: 4,
+            interact: (_p, game) => {
+                if (!this.untied || this.sail) return;
+                this.sail = true;
+                game.audio.play('success');
+                game.story.notify('sail');
+            }
+        });
+        this.addInteract({
+            object: this.ship.userData.helm,
+            interactionLabel: 'Assumir o leme',
+            interactionDistance: 2.2,
+            interact: (_p, game) => {
+                if (!this.sail) {
+                    game.dialogue.say('DICO', 'A vela primeiro!');
+                    return;
+                }
+                this.beginHelm();
+            }
+        });
+
+        this.rocks = [];
+        for (const [x, z] of [[-8, -18], [9, -28], [0, -40]]) {
+            const r = makeRock(5);
+            r.scale.set(3, 6, 4);
+            r.position.set(x, 1.5, z);
+            this.game.scene.add(r);
+            this.rocks.push(r);
+        }
+
+        this.obstacles = [];
+        this.ship.traverse((c) => { if (c.isMesh) this.obstacles.push(c); });
+        this.game.arrows.setColliders(this.obstacles.concat(this.rocks));
+        this.phase = 'prep';
+        this.steer = 0;
+        this.shipX = 0;
+        this.shipZ = 0;
+        this.untied = false;
+        this.sail = false;
+        this.arrowT = 0;
+    }
+
+    enter() {
+        const g = this.game;
+        g.player.attachTo(this.ship);
+        g.teco.attachTo(this.ship);
+        g.camila.attachTo(this.ship);
+        g.player.spawn(0, 1.44, 6, Math.PI);
+        g.teco.spawn(0.6, 1.5, 5.4);
+        g.camila.spawn(-0.8, 1.44, 5);
+        g.camila.ai.state = 'WAIT';
+        g.weather.apply('day');
+        g.audio.setTheme('chase');
+        g.ocean.water.visible = true;
+        g.quests.set('untie');
+        g.input.enabled = true;
+        g.player.controller.setMode('walk');
+        g.cameraRig.setObstacles(this.obstacles);
+        g.arrows.onHitPlayer = () => {
+            if (g.player.hurt(0.5)) g.cameraRig.addShake(0.1, 0.2);
+        };
+        g.input.requestLock();
+        g.dialogue.say('DICO', 'Soltem as amarras!');
+    }
+
+    beginHelm() {
+        this.phase = 'helm';
+        this.game.player.controller.setMode('helm');
+        this.game.player.spawn(0, 2.23, 7.1, Math.PI);
+        this.game.hud.showObjective('Saia da costa sem bater');
+        this.game.dialogue.say('DICO', 'Vento nas velas!');
+    }
+
+    update(dt) {
+        this.time += dt;
+        const wave = this.game.ocean.sample(this.shipX, this.shipZ, this.time);
+        this.ship.position.y = wave.y * 0.35;
+        this.ship.rotation.x = wave.pitch * 0.4;
+        this.ship.rotation.z = wave.roll * 0.4;
+        this.ship.userData.helm.rotation.z = this.steer * 0.5;
+        for (const a of this.friends) a.update(dt);
+
+        this.arrowT += dt;
+        if (this.phase !== 'done' && this.arrowT > 0.9 && this.shipZ > -25) {
+            this.arrowT = 0;
+            const origin = new THREE.Vector3((Math.random() - 0.5) * 16, 8, 18);
+            const dir = new THREE.Vector3((Math.random() - 0.5) * 0.3, -0.1, -1).normalize();
+            this.game.arrows.fire(origin, dir, 22);
+            this.game.audio.play('arrow');
+        }
+
+        if (this.phase === 'helm') {
+            const input = this.game.input;
+            this.steer += input.move.x * dt * 1.5;
+            this.steer = Math.max(-1, Math.min(1, this.steer));
+            this.shipX += this.steer * 8 * dt;
+            this.shipZ -= 14 * dt;
+            this.group.position.set(this.shipX, 0, this.shipZ);
+            for (const r of this.rocks) {
+                if (Math.hypot(this.shipX - r.position.x, this.shipZ - r.position.z) < 6.5) {
+                    this.game.failCheckpoint('Pedras na costa…');
+                    this.phase = 'dead';
+                    return;
+                }
+            }
+            if (this.shipZ < -55) {
+                this.phase = 'done';
+                this.game.player.controller.setMode('locked');
+                this.game.story.notify('escaped');
+            }
+        }
+    }
+
+    exit() {
+        super.exit();
+        for (const r of this.rocks) this.game.scene.remove(r);
+        this.game.arrows.clear();
+        this.game.arrows.onHitPlayer = null;
+        this.game.player.controller.setMode('walk');
+    }
+}

--- a/labs/guerreiro-castelo/js/levels/ShipLevel.js
+++ b/labs/guerreiro-castelo/js/levels/ShipLevel.js
@@ -1,0 +1,263 @@
+import * as THREE from 'three';
+import { Level } from './Level.js';
+import { buildShip, addShipColliders } from '../world/Ship.js';
+import { buildFriend, CharacterAnimator } from '../characters/builders.js';
+import { makeRock } from '../world/Environment.js';
+
+export class ShipLevel extends Level {
+    get id() {
+        return 'ship';
+    }
+
+    async build() {
+        this.group = new THREE.Group();
+        this.ship = buildShip();
+        this.group.add(this.ship);
+        this.game.scene.add(this.group);
+
+        addShipColliders(this.game.collision);
+
+        this.friends = [];
+        const spots = [
+            { x: -1.6, z: -2.2, y: 1.44, yaw: 0.4, line: ['AMIGO', 'Camila está do outro lado do mar. Vamos buscá-la.'] },
+            { x: 1.8, z: 1.4, y: 1.44, yaw: -0.8, line: ['AMIGO', 'Espadas, cordas, água… está tudo a bordo.'] },
+            { x: -1.4, z: 4.6, y: 1.44, yaw: 2.4, line: ['AMIGO', 'Teco já subiu em três barris hoje.'] }
+        ];
+        spots.forEach((s, i) => {
+            const f = buildFriend(i);
+            f.group.position.set(s.x, s.y, s.z);
+            f.group.rotation.y = s.yaw;
+            this.ship.add(f.group);
+            const anim = new CharacterAnimator(f.group, f.clips);
+            this.friends.push({ root: f.group, anim, line: s.line });
+            this.addInteract({
+                object: f.group,
+                interactionLabel: 'Conversar',
+                interactionDistance: 2.4,
+                interact: (_p, game) => {
+                    game.dialogue.say(s.line[0], s.line[1]);
+                    game.audio.play('speech');
+                    game.story.notify('talk_friends');
+                    game.quests.complete('talk_crew');
+                }
+            });
+        });
+
+        const horizon = new THREE.Object3D();
+        horizon.position.set(0, 1.8, -7.5);
+        this.ship.add(horizon);
+        this.addInteract({
+            object: horizon,
+            interactionLabel: 'Observar o horizonte',
+            interactionDistance: 2.8,
+            interact: (_p, game) => {
+                game.dialogue.say('DICO', 'Do outro lado do mar… uma cidade, e um castelo.');
+                game.story.notify('horizon');
+            }
+        });
+
+        this.addInteract({
+            object: this.ship.userData.helm,
+            interactionLabel: 'Verificar o leme',
+            interactionDistance: 2.2,
+            interact: (_p, game) => {
+                if (this.phase === 'explore') {
+                    game.dialogue.say('DICO', 'O leme responde. O mar está calmo… por enquanto.');
+                    game.story.notify('helm');
+                } else if (this.phase === 'helm' || this.phase === 'storm') {
+                    this.beginHelm();
+                }
+            }
+        });
+
+        this.addInteract({
+            object: this.game.teco.root,
+            interactionLabel: 'Interagir com Teco',
+            interactionDistance: 2.4,
+            interact: (_p, game) => {
+                game.dialogue.say('DICO', 'Fica perto, Teco.');
+                game.teco.play('Celebrate');
+                game.teco.ai.state = 'CELEBRATE';
+                game.teco.ai.timer = 0;
+                game.story.notify('teco_play');
+            }
+        });
+
+        this.ropeItem = this.addInteract({
+            object: this.ship.userData.rope,
+            interactionLabel: 'Mandar Teco',
+            interactionDistance: 3.4,
+            enabled: false,
+            interact: (_p, game) => this.sendTecoRope(game)
+        });
+
+        this.rock = makeRock(6);
+        this.rock.scale.set(4.5, 8, 5);
+        this.rock.position.set(2, 2, -70);
+        this.game.scene.add(this.rock);
+        this.rock.visible = false;
+
+        this.obstacles = [];
+        this.ship.traverse((c) => {
+            if (c.isMesh) this.obstacles.push(c);
+        });
+
+        this.phase = 'explore';
+        this.steer = 0;
+        this.shipZ = 0;
+        this.shipX = 0;
+        this.nightStarted = false;
+    }
+
+    enter() {
+        const g = this.game;
+        g.player.attachTo(this.ship);
+        g.teco.attachTo(this.ship);
+        g.camila.attachTo(this.ship);
+        g.player.spawn(0, 1.44, 3.2, Math.PI);
+        g.teco.spawn(0.8, 1.5, 2.4);
+        g.player.controller.setMode('walk');
+        g.input.enabled = true;
+        g.weather.apply('day');
+        g.audio.setTheme('sea');
+        g.storm.setIntensity(0);
+        g.ocean.water.visible = true;
+        g.quests.set('explore_ship');
+        g.checkpoints.save('ship_start', g.story._saveBlob());
+        g.cameraRig.setObstacles(this.obstacles);
+        g.cameraRig.yaw = Math.PI;
+        g.hud.showObjective('Explore o navio');
+        g.input.requestLock();
+    }
+
+    beginNight() {
+        if (this.nightStarted) return;
+        this.nightStarted = true;
+        const g = this.game;
+        g.hud.showChapter('Terceira noite', '');
+        g.fadeTo(1.2, () => {
+            this.phase = 'storm';
+            g.weather.apply('storm');
+            g.audio.setTheme('storm');
+            g.storm.setIntensity(0.85);
+            g.dialogue.say('DICO', 'Segurem firme!');
+            g.quests.set('free_helm');
+            g.checkpoints.save('storm_start', g.story._saveBlob());
+            this.ship.userData.rope.visible = true;
+            this.ropeItem.enabled = true;
+            this.rock.visible = true;
+            g.cameraRig.addShake(0.04, 8);
+            g.player.spawn(0, 1.44, 4.5, 0);
+            g.fadeTo(0, null, 0.9);
+        });
+    }
+
+    sendTecoRope(game) {
+        this.ropeItem.enabled = false;
+        game.dialogue.say('DICO', 'Cuidado, Teco!');
+        const path = [
+            new THREE.Vector3(1.8, 1.7, 2),
+            new THREE.Vector3(2.1, 2.1, 4.2),
+            new THREE.Vector3(1.2, 2.6, 6.4),
+            new THREE.Vector3(0.3, 2.7, 7.4)
+        ];
+        game.teco.ai.command(path, {
+            climb: true,
+            onComplete: () => {
+                this.ship.userData.rope.visible = false;
+                game.audio.play('success');
+                game.story.notify('rope_freed');
+            }
+        });
+    }
+
+    beginHelm() {
+        const g = this.game;
+        this.phase = 'helm';
+        g.player.controller.setMode('helm');
+        g.player.spawn(0, 2.23, 7.1, Math.PI);
+        g.hud.showObjective('Assuma o leme — desvie da rocha');
+        this.shipZ = 0;
+        this.shipX = 0;
+        this.steer = 0;
+        this.rock.position.set(3, 2, -55);
+        this.rock.visible = true;
+    }
+
+    endStorm() {
+        const g = this.game;
+        this.phase = 'dawn';
+        g.player.controller.setMode('locked');
+        g.storm.setIntensity(0.15);
+        g.weather.apply('dawn');
+        g.audio.setTheme('land');
+        const castleHint = new THREE.Mesh(
+            new THREE.BoxGeometry(18, 28, 18),
+            new THREE.MeshStandardMaterial({ color: 0x8a8070, roughness: 0.9 })
+        );
+        castleHint.position.set(8, 16, -160);
+        this.game.scene.add(castleHint);
+        this._hint = castleHint;
+        g.cutscenes.play({
+            from: new THREE.Vector3(4, 8, 16),
+            to: new THREE.Vector3(10, 14, 6),
+            lookFrom: new THREE.Vector3(8, 10, -40),
+            lookTo: new THREE.Vector3(8, 18, -160),
+            duration: 5.2,
+            onEnd: () => {}
+        });
+    }
+
+    update(dt) {
+        this.time += dt;
+        const wave = this.game.ocean.sample(this.shipX, this.shipZ, this.time);
+        const storm = this.game.storm.rainIntensity;
+        this.ship.position.y = wave.y * (0.4 + storm);
+        this.ship.rotation.x = wave.pitch * (0.5 + storm);
+        this.ship.rotation.z = wave.roll * (0.5 + storm);
+        this.ship.rotation.y = wave.yaw;
+
+        const sail = this.ship.userData.sail;
+        if (sail) {
+            sail.rotation.y = Math.sin(this.time * (1 + storm * 3)) * (0.04 + storm * 0.12);
+        }
+        this.ship.userData.helm.rotation.z = this.steer * 0.6;
+
+        for (const f of this.friends) f.anim.update(dt);
+
+        if (this.phase === 'helm') {
+            const input = this.game.input;
+            this.steer += input.move.x * dt * 1.4;
+            this.steer = Math.max(-1, Math.min(1, this.steer));
+            this.shipX += this.steer * 7 * dt;
+            this.shipZ -= 16 * dt;
+            this.group.position.set(this.shipX, 0, this.shipZ);
+            this.game.storm.follow(this.group.position);
+
+            const rock = this.rock.position;
+            const sx = this.shipX;
+            const sz = this.shipZ;
+            const dx = sx - rock.x;
+            const dz = sz - rock.z;
+            if (Math.hypot(dx, dz) < 7.5) {
+                this.game.story.notify('rock_hit');
+                this.phase = 'dead';
+            } else if (sz < rock.z - 10) {
+                this.game.story.notify('rock_cleared');
+                this.phase = 'clear';
+            }
+        }
+
+        if (this.phase === 'storm') {
+            this.game.cameraRig.addShake(0.015, 0.2);
+            this.game.storm.follow(this.ship.getWorldPosition(new THREE.Vector3()));
+        }
+    }
+
+    exit() {
+        super.exit();
+        this.game.scene.remove(this.rock);
+        if (this._hint) this.game.scene.remove(this._hint);
+        this.game.player.controller.setMode('walk');
+    }
+}

--- a/labs/guerreiro-castelo/js/levels/ShipLevel.js
+++ b/labs/guerreiro-castelo/js/levels/ShipLevel.js
@@ -128,6 +128,15 @@ export class ShipLevel extends Level {
         g.checkpoints.save('ship_start', g.story._saveBlob());
         g.cameraRig.setObstacles(this.obstacles);
         g.cameraRig.yaw = Math.PI;
+        g.cameraRig.pitch = 0.28;
+        g.cameraRig.cutscene = false;
+        this.ship.updateMatrixWorld(true);
+        g.player.root.updateMatrixWorld(true);
+        g.cameraRig.snapToPlayer(g.player);
+        g.camera.position.set(0, 6.5, 9.5);
+        g.camera.lookAt(0, 2, 1);
+        g.cameraRig.currentPos.copy(g.camera.position);
+        g.cameraRig.smoothLook.set(0, 2, 1);
         g.hud.showObjective('Explore o navio');
         g.input.requestLock();
     }

--- a/labs/guerreiro-castelo/js/levels/ShipLevel.js
+++ b/labs/guerreiro-castelo/js/levels/ShipLevel.js
@@ -14,6 +14,8 @@ export class ShipLevel extends Level {
         this.ship = buildShip();
         this.group.add(this.ship);
         this.game.scene.add(this.group);
+        const fill = new THREE.HemisphereLight(0xc8e4ff, 0x3a2a18, 0.4);
+        this.ship.add(fill);
 
         addShipColliders(this.game.collision);
 

--- a/labs/guerreiro-castelo/js/levels/TigerRoomLevel.js
+++ b/labs/guerreiro-castelo/js/levels/TigerRoomLevel.js
@@ -1,0 +1,134 @@
+import * as THREE from 'three';
+import { Level } from './Level.js';
+import { castleStoneTexture, woodTexture } from '../world/Textures.js';
+import { std } from '../characters/builders.js';
+import { Tiger } from '../characters/Tiger.js';
+
+export class TigerRoomLevel extends Level {
+    get id() {
+        return 'tiger';
+    }
+
+    async build() {
+        this.group = new THREE.Group();
+        this.group.position.set(12, 3.2, -18);
+        const stone = new THREE.MeshStandardMaterial({ map: castleStoneTexture(), roughness: 0.9 });
+        const floor = new THREE.Mesh(new THREE.BoxGeometry(12, 0.2, 12), stone);
+        floor.position.y = -0.1;
+        floor.receiveShadow = true;
+        this.group.add(floor);
+        this.game.collision.addFloor(12, -18, 12, 12, 3.2);
+
+        const walls = [
+            [0, 2, -6, 12, 4.2, 0.3],
+            [0, 2, 6, 12, 4.2, 0.3],
+            [-6, 2, 0, 0.3, 4.2, 12],
+            [6, 2, 0, 0.3, 4.2, 12]
+        ];
+        for (const w of walls) {
+            const m = new THREE.Mesh(new THREE.BoxGeometry(w[3], w[4], w[5]), stone);
+            m.position.set(w[0], w[1], w[2]);
+            this.group.add(m);
+        }
+        this.game.collision.addWall(12, -24, 12, 0.4, 4, 3.2);
+        this.game.collision.addWall(12, -12, 12, 0.4, 4, 3.2);
+        this.game.collision.addWall(6, -18, 0.4, 12, 4, 3.2);
+        this.game.collision.addWall(18, -18, 0.4, 12, 4, 3.2);
+
+        const doorHole = new THREE.Mesh(new THREE.BoxGeometry(0.5, 2.6, 2.2), std(0x0a0806, 1));
+        doorHole.position.set(-5.8, 1.3, 0);
+        this.group.add(doorHole);
+
+        for (const [x, y, z] of [
+            [-3, 2.6, -2], [0, 3.1, 1], [2.4, 3.4, -1], [4, 3.6, 2]
+        ]) {
+            const beam = new THREE.Mesh(
+                new THREE.BoxGeometry(0.7, 0.25, 2.2),
+                new THREE.MeshStandardMaterial({ map: woodTexture(), roughness: 0.85 })
+            );
+            beam.position.set(x, y, z);
+            this.group.add(beam);
+        }
+        const ledge = new THREE.Mesh(new THREE.BoxGeometry(1.2, 0.3, 1.2), stone);
+        ledge.position.set(-4, 2.2, 3.4);
+        this.group.add(ledge);
+
+        this.keyMesh = new THREE.Mesh(
+            new THREE.BoxGeometry(0.12, 0.35, 0.06),
+            new THREE.MeshStandardMaterial({ color: 0xd4b45a, metalness: 0.8, roughness: 0.3, emissive: 0x553300, emissiveIntensity: 0.5 })
+        );
+        this.keyMesh.position.set(4.6, 2.4, -4.4);
+        this.group.add(this.keyMesh);
+
+        this.tiger = new Tiger(this.group);
+        this.tiger.spawn(1.2, 0, -1.5, Math.PI);
+        this.tiger.ai.setBounds(-4, 4, -4, 4);
+        this.game.tiger = this.tiger;
+
+        this.addInteract({
+            object: this.keyMesh,
+            interactionLabel: 'Mandar Teco',
+            interactionDistance: 8,
+            interact: (_p, game) => this.sendTeco(game)
+        });
+
+        const dim = new THREE.PointLight(0xffaa66, 0.45, 10);
+        dim.position.set(0, 3, 0);
+        this.group.add(dim);
+
+        this.game.scene.add(this.group);
+        this.sent = false;
+        this.greeted = false;
+    }
+
+    sendTeco(game) {
+        if (this.sent || game.inventory.cellKey) return;
+        this.sent = true;
+        game.dialogue.say('DICO', 'Teco… consegue pegar aquela chave?');
+        const parent = game.teco.root.parent;
+        const wp = (x, y, z) => {
+            const v = new THREE.Vector3(x, y, z);
+            this.group.localToWorld(v);
+            parent.worldToLocal(v);
+            return v;
+        };
+        const path = [
+            wp(-4, 2.4, 3.4),
+            wp(-3, 2.8, -2),
+            wp(0, 3.3, 1),
+            wp(2.4, 3.6, -1),
+            wp(4.2, 3.8, 2),
+            wp(4.6, 2.6, -4.2)
+        ];
+        game.teco.ai.command(path, {
+            climb: true,
+            scared: true,
+            celebrate: true,
+            onComplete: () => {
+                this.keyMesh.visible = false;
+                game.audio.play('pickup');
+                game.dialogue.say('TECO', 'Consegui!');
+                game.dialogue.say('DICO', 'Muito bem!');
+                game.story.notify('cell_key');
+                const back = wp(game.player.position.x, game.player.position.y + 0.2, game.player.position.z);
+                game.teco.ai.command([back], { onComplete: () => {} });
+            }
+        });
+    }
+
+    update(dt) {
+        this.tiger.update(dt, this.game);
+        const p = this.game.player.worldPosition();
+        const room = this.group.position;
+        const inside = Math.abs(p.x - room.x) < 5.5 && Math.abs(p.z - room.z) < 5.5;
+        if (inside && !this.greeted) {
+            this.greeted = true;
+            this.game.audio.setTheme('tiger');
+            this.game.dialogue.say('TIGRE', 'Grrrrrr!');
+            this.game.audio.play('growl');
+            this.tiger.ai.state = 'THREATEN';
+            this.game.checkpoints.save('tiger_room', this.game.story._saveBlob());
+        }
+        this.keyMesh.rotation.y += dt * 1.2;
+    }
+}

--- a/labs/guerreiro-castelo/js/main.js
+++ b/labs/guerreiro-castelo/js/main.js
@@ -1,0 +1,22 @@
+import * as THREE from 'three';
+import { Game } from './core/Game.js';
+
+const game = new Game();
+const clock = new THREE.Clock();
+
+function animate() {
+    requestAnimationFrame(animate);
+    const delta = Math.min(clock.getDelta(), 0.05);
+    game.update(delta);
+    game.render();
+}
+
+game.init()
+    .then(() => animate())
+    .catch((err) => {
+        console.error('[Guerreiro] falha na inicialização', err);
+        const el = document.getElementById('loadingText');
+        if (el) el.textContent = 'Não foi possível iniciar. Recarregue a página.';
+    });
+
+window.__game = game;

--- a/labs/guerreiro-castelo/js/player/CapsuleCollider.js
+++ b/labs/guerreiro-castelo/js/player/CapsuleCollider.js
@@ -1,0 +1,20 @@
+/** Cápsula do jogador — raio + altura, usada pela física e pelo stealth. */
+
+export class CapsuleCollider {
+    constructor({ radius = 0.32, height = 1.78 } = {}) {
+        this.radius = radius;
+        this.height = height;
+        this.crouchHeight = 1.15;
+        this.standingHeight = height;
+        this.crouching = false;
+    }
+
+    setCrouch(v) {
+        this.crouching = v;
+        this.height = v ? this.crouchHeight : this.standingHeight;
+    }
+
+    get eyeHeight() {
+        return this.height * 0.92;
+    }
+}

--- a/labs/guerreiro-castelo/js/player/Player.js
+++ b/labs/guerreiro-castelo/js/player/Player.js
@@ -1,0 +1,138 @@
+/**
+ * Dico jogável — vida, tocha, combate leve, animação.
+ */
+
+import * as THREE from 'three';
+import { CapsuleCollider } from './CapsuleCollider.js';
+import { PlayerController } from './PlayerController.js';
+import { buildDico, CharacterAnimator, applyLocomotion } from '../characters/builders.js';
+import { angleDamp } from '../utils/math.js';
+
+export class Player {
+    constructor(scene, collision) {
+        const built = buildDico();
+        this.root = built.group;
+        this.parts = built.parts;
+        this.animator = new CharacterAnimator(built.group, built.clips);
+        scene.add(this.root);
+
+        this.position = new THREE.Vector3(0, 0, 0);
+        this.facing = 0;
+        this.yaw = 0;
+        this.speed = 0;
+        this.grounded = true;
+        this.crouching = false;
+        this.sprinting = false;
+        this.alive = true;
+        this.health = 5;
+        this.maxHealth = 5;
+        this.invuln = 0;
+        this.attackT = 0;
+        this.blockT = 0;
+        this.interactT = 0;
+        this.noise = 0;
+        this.torchOn = false;
+        this.collider = new CapsuleCollider({ radius: 0.32, height: 1.78 });
+        this.controller = new PlayerController(this, collision);
+        this.footTimer = 0;
+        this.parent = scene;
+        this._worldPos = new THREE.Vector3();
+    }
+
+    attachTo(parent) {
+        if (this.root.parent) this.root.parent.remove(this.root);
+        parent.add(this.root);
+        this.parent = parent;
+    }
+
+    spawn(x, y, z, yaw = 0) {
+        this.position.set(x, y, z);
+        this.facing = yaw;
+        this.yaw = yaw;
+        this.health = this.maxHealth;
+        this.alive = true;
+        this.invuln = 0;
+        this.controller.vx = 0;
+        this.controller.vz = 0;
+        this.controller.vy = 0;
+        this.sync();
+    }
+
+    setTorch(on) {
+        this.torchOn = on;
+        if (this.parts.torch) this.parts.torch.visible = on;
+    }
+
+    hurt(amount = 1) {
+        if (this.invuln > 0 || !this.alive) return false;
+        if (this.blockT > 0) amount *= 0.35;
+        this.health -= amount;
+        this.invuln = 0.9;
+        if (this.health <= 0) {
+            this.health = 0;
+            this.alive = false;
+        }
+        return true;
+    }
+
+    heal() {
+        this.health = this.maxHealth;
+        this.alive = true;
+    }
+
+    worldPosition() {
+        this.root.getWorldPosition(this._worldPos);
+        return this._worldPos;
+    }
+
+    sync() {
+        this.root.position.copy(this.position);
+        this.root.rotation.y = this.facing;
+        this.root.scale.setScalar(this.crouching ? 0.92 : 1);
+    }
+
+    update(dt, input, camYaw) {
+        this.invuln = Math.max(0, this.invuln - dt);
+        this.attackT = Math.max(0, this.attackT - dt);
+        this.blockT = Math.max(0, this.blockT - dt);
+        this.interactT = Math.max(0, this.interactT - dt);
+
+        if (input.attack && this.attackT <= 0) {
+            this.attackT = 0.45;
+            input.attack = false;
+        }
+        if (input.block) this.blockT = 0.1;
+
+        const speed = this.controller.update(dt, input, camYaw) ?? 0;
+        this.facing = angleDamp(this.facing, this.controller.mode === 'walk' ? this.facing : this.facing, 10, dt);
+        if (speed > 0.25 && this.controller.mode === 'walk') {
+            this.facing = angleDamp(this.facing, Math.atan2(this.controller.vx, this.controller.vz), 12, dt);
+        }
+
+        if (speed > 0.4 && this.grounded) {
+            this.footTimer += dt * (this.sprinting ? 3.2 : 2.2);
+            if (this.footTimer > 1) {
+                this.footTimer = 0;
+                this._footstep = true;
+            }
+        }
+
+        applyLocomotion(
+            this.animator,
+            speed,
+            this.crouching,
+            this.grounded,
+            this.attackT > 0.1,
+            this.blockT > 0,
+            this.interactT > 0
+        );
+        this.animator.update(dt);
+
+        if (this.parts.torchFlame) {
+            const s = 0.9 + Math.sin(performance.now() * 0.012) * 0.15;
+            this.parts.torchFlame.scale.setScalar(s);
+        }
+        this.sync();
+        return this._footstep ? (this._footstep = false, true) : false;
+    }
+}

--- a/labs/guerreiro-castelo/js/player/Player.js
+++ b/labs/guerreiro-castelo/js/player/Player.js
@@ -15,6 +15,7 @@ export class Player {
         this.parts = built.parts;
         this.animator = new CharacterAnimator(built.group, built.clips);
         scene.add(this.root);
+        this.root.traverse((c) => { if (c.isMesh) c.userData.ignoreCamera = true; });
 
         this.position = new THREE.Vector3(0, 0, 0);
         this.facing = 0;

--- a/labs/guerreiro-castelo/js/player/PlayerController.js
+++ b/labs/guerreiro-castelo/js/player/PlayerController.js
@@ -1,0 +1,93 @@
+/**
+ * Controlador de movimento: aceleração, gravidade, pulo, sprint, agachar.
+ */
+
+import { clamp } from '../utils/math.js';
+
+export class PlayerController {
+    constructor(player, collision) {
+        this.player = player;
+        this.collision = collision;
+        this.walkSpeed = 2.35;
+        this.runSpeed = 4.15;
+        this.sprintSpeed = 6.1;
+        this.crouchSpeed = 1.15;
+        this.accel = 14;
+        this.decel = 16;
+        this.gravity = 22;
+        this.jumpSpeed = 7.2;
+        this.vx = 0;
+        this.vz = 0;
+        this.vy = 0;
+        this.mode = 'walk';
+    }
+
+    setMode(mode) {
+        this.mode = mode;
+    }
+
+    update(dt, input, camYaw) {
+        const p = this.player;
+        if (this.mode === 'helm' || this.mode === 'locked') {
+            this.vx = 0;
+            this.vz = 0;
+            p.speed = 0;
+            return;
+        }
+
+        const crouch = input.move.crouch && p.grounded;
+        p.collider.setCrouch(crouch);
+        p.crouching = crouch;
+
+        let wish = this.walkSpeed;
+        if (crouch) wish = this.crouchSpeed;
+        else if (input.move.sprint) wish = this.sprintSpeed;
+        else if (Math.hypot(input.move.x, input.move.z) > 0.15) wish = this.runSpeed;
+
+        const sin = Math.sin(camYaw);
+        const cos = Math.cos(camYaw);
+        const fx = -sin;
+        const fz = -cos;
+        const rx = cos;
+        const rz = -sin;
+        const wishX = (fx * -input.move.z + rx * input.move.x);
+        const wishZ = (fz * -input.move.z + rz * input.move.x);
+        const wlen = Math.hypot(wishX, wishZ);
+        const tx = wlen > 0.001 ? (wishX / wlen) * wish : 0;
+        const tz = wlen > 0.001 ? (wishZ / wlen) * wish : 0;
+
+        const rate = wlen > 0.05 ? this.accel : this.decel;
+        this.vx += (tx - this.vx) * Math.min(1, rate * dt);
+        this.vz += (tz - this.vz) * Math.min(1, rate * dt);
+
+        if (p.grounded && input.move.jump) {
+            this.vy = this.jumpSpeed;
+            p.grounded = false;
+        }
+        input.move.jump = false;
+
+        this.vy -= this.gravity * dt;
+        let y = p.position.y + this.vy * dt;
+
+        const res = this.collision.resolveCapsule(
+            p.position.x, y, p.position.z,
+            p.collider.radius, p.collider.height,
+            this.vx, this.vz, 1, 0.4
+        );
+
+        p.position.set(res.x, res.y, res.z);
+        p.grounded = res.grounded;
+        if (res.grounded && this.vy < 0) this.vy = 0;
+        if (y < res.y && this.vy < 0) this.vy = 0;
+
+        const speed = Math.hypot(this.vx, this.vz);
+        p.speed = speed;
+        p.sprinting = speed > 5.2 && input.move.sprint && !crouch;
+        if (speed > 0.35) {
+            p.facing = Math.atan2(this.vx, this.vz);
+        }
+
+        p.noise = crouch ? 0.22 : speed > 5.2 ? 1.35 : speed > 3 ? 0.85 : speed > 0.2 ? 0.55 : 0.05;
+        return speed;
+    }
+}

--- a/labs/guerreiro-castelo/js/player/ThirdPersonCamera.js
+++ b/labs/guerreiro-castelo/js/player/ThirdPersonCamera.js
@@ -41,12 +41,35 @@ export class ThirdPersonCamera {
     }
 
     setObstacles(meshes) {
-        this._obstacles = meshes;
+        this._obstacles = meshes.filter((m) => {
+            if (!m || !m.isMesh) return false;
+            if (m.userData.ignoreCamera) return false;
+            if (m.name === 'sail') return false;
+            return true;
+        });
     }
 
     addShake(amp = 0.12, time = 0.25) {
         this.shake = Math.max(this.shake, time);
         this.shakeAmp = Math.max(this.shakeAmp, amp);
+    }
+
+    snapToPlayer(player) {
+        this.cutscene = false;
+        const origin = player.worldPosition ? player.worldPosition() : player.position;
+        this.smoothLook.set(origin.x, origin.y + this.lookHeight, origin.z);
+        const cosP = Math.cos(this.pitch);
+        const sinP = Math.sin(this.pitch);
+        const sinY = Math.sin(this.yaw);
+        const cosY = Math.cos(this.yaw);
+        this.currentPos.set(
+            origin.x + sinY * cosP * this.distance + cosY * this.shoulder,
+            origin.y + this.lookHeight + sinP * this.distance,
+            origin.z + cosY * cosP * this.distance - sinY * this.shoulder
+        );
+        this.camera.position.copy(this.currentPos);
+        this.camera.lookAt(this.smoothLook);
+        this.camera.updateMatrixWorld();
     }
 
     lookAtImmediate(target) {

--- a/labs/guerreiro-castelo/js/player/ThirdPersonCamera.js
+++ b/labs/guerreiro-castelo/js/player/ThirdPersonCamera.js
@@ -1,0 +1,136 @@
+/**
+ * Câmera em terceira pessoa — ombro, órbita, zoom, raycast contra paredes.
+ * Nunca é parenteda no personagem.
+ */
+
+import * as THREE from 'three';
+import { clamp, damp } from '../utils/math.js';
+
+const _from = new THREE.Vector3();
+const _to = new THREE.Vector3();
+const _desired = new THREE.Vector3();
+const _look = new THREE.Vector3();
+const _up = new THREE.Vector3(0, 1, 0);
+const _hit = new THREE.Vector3();
+
+export class ThirdPersonCamera {
+    constructor(camera, scene) {
+        this.camera = camera;
+        this.scene = scene;
+        this.yaw = 0;
+        this.pitch = 0.32;
+        this.distance = 4.4;
+        this.targetDistance = 4.4;
+        this.minDistance = 1.4;
+        this.maxDistance = 7.2;
+        this.pitchMin = -0.55;
+        this.pitchMax = 1.15;
+        this.shoulder = 0.55;
+        this.lookHeight = 1.55;
+        this.fov = 55;
+        this.targetFov = 55;
+        this.shake = 0;
+        this.shakeAmp = 0;
+        this.locked = false;
+        this.ray = new THREE.Raycaster();
+        this.ray.far = 12;
+        this._obstacles = [];
+        this.currentPos = new THREE.Vector3(0, 2, 6);
+        this.smoothLook = new THREE.Vector3();
+        this.cutscene = false;
+    }
+
+    setObstacles(meshes) {
+        this._obstacles = meshes;
+    }
+
+    addShake(amp = 0.12, time = 0.25) {
+        this.shake = Math.max(this.shake, time);
+        this.shakeAmp = Math.max(this.shakeAmp, amp);
+    }
+
+    lookAtImmediate(target) {
+        this.smoothLook.copy(target);
+        this.currentPos.copy(this.camera.position);
+    }
+
+    update(dt, player, lookDelta, zoomDelta, sprinting) {
+        if (this.cutscene) return;
+
+        this.yaw -= lookDelta.x * 0.00215;
+        this.pitch = clamp(this.pitch - lookDelta.y * 0.0019, this.pitchMin, this.pitchMax);
+        this.targetDistance = clamp(this.targetDistance + zoomDelta * 0.45, this.minDistance, this.maxDistance);
+        this.distance = damp(this.distance, this.targetDistance, 8, dt);
+
+        this.targetFov = sprinting ? 62 : 55;
+        this.fov = damp(this.fov, this.targetFov, 4, dt);
+        this.camera.fov = this.fov;
+        this.camera.updateProjectionMatrix();
+
+        const origin = player.worldPosition ? player.worldPosition() : player.position;
+        const lookY = origin.y + (player.crouching ? 1.15 : this.lookHeight);
+        _look.set(origin.x, lookY, origin.z);
+
+        const cosP = Math.cos(this.pitch);
+        const sinP = Math.sin(this.pitch);
+        const sinY = Math.sin(this.yaw);
+        const cosY = Math.cos(this.yaw);
+
+        const backX = sinY * cosP;
+        const backZ = cosY * cosP;
+        const rightX = cosY;
+        const rightZ = -sinY;
+
+        _desired.set(
+            _look.x + backX * this.distance + rightX * this.shoulder,
+            _look.y + sinP * this.distance,
+            _look.z + backZ * this.distance + rightZ * this.shoulder
+        );
+
+        let dist = this.distance;
+        if (this._obstacles.length) {
+            _from.copy(_look);
+            _to.copy(_desired).sub(_from);
+            const len = _to.length();
+            if (len > 0.01) {
+                this.ray.set(_from, _to.normalize());
+                this.ray.far = len;
+                const hits = this.ray.intersectObjects(this._obstacles, true);
+                if (hits.length) {
+                    const h = hits[0];
+                    dist = Math.max(0.6, h.distance - 0.28);
+                    _desired.copy(_from).addScaledVector(this.ray.ray.direction, dist);
+                }
+            }
+        }
+
+        this.currentPos.x = damp(this.currentPos.x, _desired.x, 14, dt);
+        this.currentPos.y = damp(this.currentPos.y, _desired.y, 12, dt);
+        this.currentPos.z = damp(this.currentPos.z, _desired.z, 14, dt);
+        this.smoothLook.x = damp(this.smoothLook.x, _look.x, 16, dt);
+        this.smoothLook.y = damp(this.smoothLook.y, _look.y, 16, dt);
+        this.smoothLook.z = damp(this.smoothLook.z, _look.z, 16, dt);
+
+        if (this.shake > 0) {
+            this.shake -= dt;
+            const a = this.shakeAmp * (this.shake / 0.25);
+            this.currentPos.x += (Math.random() - 0.5) * a;
+            this.currentPos.y += (Math.random() - 0.5) * a * 0.6;
+        }
+
+        this.camera.position.copy(this.currentPos);
+        this.camera.up.copy(_up);
+        this.camera.lookAt(this.smoothLook);
+        _hit.copy(_desired);
+    }
+
+    /**
+     * Cutscene: interpola posição e lookAt. Chamado pelo CutsceneManager.
+     */
+    setCutscenePose(pos, look) {
+        this.camera.position.copy(pos);
+        this.camera.lookAt(look);
+        this.currentPos.copy(pos);
+        this.smoothLook.copy(look);
+    }
+}

--- a/labs/guerreiro-castelo/js/ui/HUD.js
+++ b/labs/guerreiro-castelo/js/ui/HUD.js
@@ -1,0 +1,125 @@
+/**
+ * HUD cinematográfico: vida, objetivo, interação, diálogo, stealth.
+ */
+
+export class HUD {
+    constructor() {
+        this.el = {
+            hud: document.getElementById('hud'),
+            hearts: document.getElementById('hearts'),
+            objective: document.getElementById('objective'),
+            prompt: document.getElementById('prompt'),
+            dialogue: document.getElementById('dialogue'),
+            speaker: document.getElementById('speaker'),
+            line: document.getElementById('line'),
+            stealth: document.getElementById('stealth'),
+            stealthFill: document.getElementById('stealthFill'),
+            toast: document.getElementById('toast'),
+            chapter: document.getElementById('chapterCard'),
+            chapterTitle: document.getElementById('chapterTitle'),
+            fade: document.getElementById('fade'),
+            loading: document.getElementById('loadingOverlay'),
+            loadingFill: document.getElementById('loadingFill'),
+            loadingPct: document.getElementById('loadingPct'),
+            fps: document.getElementById('fpsCounter')
+        };
+        this._toastT = 0;
+        this._chapterT = 0;
+    }
+
+    setLoading(p, text) {
+        if (this.el.loadingFill) this.el.loadingFill.style.width = `${Math.round(p * 100)}%`;
+        if (this.el.loadingPct) this.el.loadingPct.textContent = `${Math.round(p * 100)}%`;
+        if (text) {
+            const t = document.getElementById('loadingText');
+            if (t) t.textContent = text;
+        }
+    }
+
+    hideLoading() {
+        this.el.loading.hidden = true;
+    }
+
+    showHud(v) {
+        this.el.hud.hidden = !v;
+    }
+
+    setHealth(hp, max) {
+        this.el.hearts.innerHTML = '';
+        for (let i = 0; i < max; i++) {
+            const s = document.createElement('span');
+            s.className = 'heart' + (i < hp ? '' : ' is-empty');
+            s.textContent = '❤';
+            this.el.hearts.appendChild(s);
+        }
+    }
+
+    showObjective(text, urgent = false) {
+        this.el.objective.textContent = text;
+        this.el.objective.dataset.urgent = urgent ? 'true' : 'false';
+        this.el.objective.parentElement.classList.add('is-flash');
+        setTimeout(() => this.el.objective.parentElement.classList.remove('is-flash'), 2400);
+    }
+
+    setPrompt(item) {
+        if (!item) {
+            this.el.prompt.hidden = true;
+            return;
+        }
+        this.el.prompt.hidden = false;
+        this.el.prompt.innerHTML = `<kbd>E</kbd> ${item.interactionLabel || 'Interagir'}`;
+    }
+
+    setDialogue(line) {
+        if (!line) {
+            this.el.dialogue.hidden = true;
+            return;
+        }
+        this.el.dialogue.hidden = false;
+        this.el.speaker.textContent = line.speaker;
+        this.el.line.textContent = line.text;
+    }
+
+    showStealth(on, amount = 0) {
+        this.el.stealth.hidden = !on;
+        if (this.el.stealthFill) this.el.stealthFill.style.width = `${Math.round(amount * 100)}%`;
+        this.el.stealth.dataset.danger = amount > 0.65 ? 'true' : 'false';
+    }
+
+    showToast(text) {
+        this.el.toast.hidden = false;
+        this.el.toast.textContent = text;
+        this._toastT = 3.2;
+    }
+
+    showChapter(title, sub) {
+        this.el.chapter.hidden = false;
+        this.el.chapterTitle.textContent = title;
+        const s = document.getElementById('chapterSub');
+        if (s) s.textContent = sub || '';
+        this._chapterT = 3.5;
+    }
+
+    setFade(v) {
+        this.el.fade.style.opacity = String(v);
+    }
+
+    setFps(n) {
+        if (this.el.fps) this.el.fps.textContent = `${n} fps`;
+    }
+
+    flashStealth(text) {
+        if (text) this.showToast(text);
+    }
+
+    update(dt) {
+        if (this._toastT > 0) {
+            this._toastT -= dt;
+            if (this._toastT <= 0) this.el.toast.hidden = true;
+        }
+        if (this._chapterT > 0) {
+            this._chapterT -= dt;
+            if (this._chapterT <= 0) this.el.chapter.hidden = true;
+        }
+    }
+}

--- a/labs/guerreiro-castelo/js/ui/Menu.js
+++ b/labs/guerreiro-castelo/js/ui/Menu.js
@@ -1,0 +1,33 @@
+export class Menu {
+    constructor(game) {
+        this.game = game;
+        this.root = document.getElementById('menuOverlay');
+        this.controls = document.getElementById('controlsOverlay');
+        this.settings = document.getElementById('settingsOverlay');
+        document.getElementById('btnNewGame').addEventListener('click', () => game.newGame());
+        document.getElementById('btnContinue').addEventListener('click', () => game.continueGame());
+        document.getElementById('btnControls').addEventListener('click', () => this.showControls(true));
+        document.getElementById('btnSettings').addEventListener('click', () => this.showSettings(true));
+        document.getElementById('btnCloseControls').addEventListener('click', () => this.showControls(false));
+        document.getElementById('btnCloseSettings').addEventListener('click', () => this.showSettings(false));
+        this.syncContinue();
+    }
+
+    syncContinue() {
+        const btn = document.getElementById('btnContinue');
+        btn.disabled = !this.game.checkpoints.hasSave();
+    }
+
+    show(v) {
+        this.root.hidden = !v;
+        if (v) this.syncContinue();
+    }
+
+    showControls(v) {
+        this.controls.hidden = !v;
+    }
+
+    showSettings(v) {
+        this.settings.hidden = !v;
+    }
+}

--- a/labs/guerreiro-castelo/js/ui/PauseMenu.js
+++ b/labs/guerreiro-castelo/js/ui/PauseMenu.js
@@ -1,0 +1,20 @@
+export class PauseMenu {
+    constructor(game) {
+        this.game = game;
+        this.root = document.getElementById('pauseOverlay');
+        document.getElementById('btnResume').addEventListener('click', () => game.setPaused(false));
+        document.getElementById('btnRestartCp').addEventListener('click', () => {
+            game.setPaused(false);
+            game.reloadCheckpoint();
+        });
+        document.getElementById('btnPauseSettings').addEventListener('click', () => {
+            this.root.hidden = true;
+            document.getElementById('settingsOverlay').hidden = false;
+        });
+        document.getElementById('btnQuitMenu').addEventListener('click', () => game.quitToMenu());
+    }
+
+    show(v) {
+        this.root.hidden = !v;
+    }
+}

--- a/labs/guerreiro-castelo/js/utils/dispose.js
+++ b/labs/guerreiro-castelo/js/utils/dispose.js
@@ -1,0 +1,24 @@
+/** Dispose recursivo de geometria, materiais e texturas. */
+
+export function disposeObject(root) {
+    if (!root) return;
+    root.traverse((node) => {
+        if (node.geometry) node.geometry.dispose();
+        const mats = node.material;
+        if (!mats) return;
+        const list = Array.isArray(mats) ? mats : [mats];
+        for (const mat of list) {
+            for (const key of Object.keys(mat)) {
+                const value = mat[key];
+                if (value && value.isTexture) value.dispose();
+            }
+            mat.dispose();
+        }
+    });
+}
+
+export function disposeSceneGroup(group, parent) {
+    if (!group) return;
+    parent?.remove(group);
+    disposeObject(group);
+}

--- a/labs/guerreiro-castelo/js/utils/easing.js
+++ b/labs/guerreiro-castelo/js/utils/easing.js
@@ -1,0 +1,26 @@
+/** Curvas de interpolação para cutscenes e transições. */
+
+export const easeInOutCubic = (t) =>
+    t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2;
+
+export const easeInOutQuad = (t) =>
+    t < 0.5 ? 2 * t * t : 1 - Math.pow(-2 * t + 2, 2) / 2;
+
+export const easeOutCubic = (t) => 1 - Math.pow(1 - t, 3);
+
+export const easeInCubic = (t) => t * t * t;
+
+export const easeOutQuad = (t) => 1 - (1 - t) * (1 - t);
+
+export const easeInOutSine = (t) => -(Math.cos(Math.PI * t) - 1) / 2;
+
+export function getEasing(name) {
+    switch (name) {
+        case 'inCubic': return easeInCubic;
+        case 'outCubic': return easeOutCubic;
+        case 'inOutQuad': return easeInOutQuad;
+        case 'outQuad': return easeOutQuad;
+        case 'inOutSine': return easeInOutSine;
+        default: return easeInOutCubic;
+    }
+}

--- a/labs/guerreiro-castelo/js/utils/math.js
+++ b/labs/guerreiro-castelo/js/utils/math.js
@@ -1,0 +1,89 @@
+/** Utilitários numéricos, ruído e detecção de dispositivo. */
+
+export const clamp = (v, min, max) => (v < min ? min : v > max ? max : v);
+export const lerp = (a, b, t) => a + (b - a) * t;
+export const damp = (current, target, lambda, dt) =>
+    lerp(current, target, 1 - Math.exp(-lambda * dt));
+
+export const smoothstep = (edge0, edge1, x) => {
+    const t = clamp((x - edge0) / (edge1 - edge0), 0, 1);
+    return t * t * (3 - 2 * t);
+};
+
+export const randRange = (min, max) => min + Math.random() * (max - min);
+export const pick = (arr) => arr[(Math.random() * arr.length) | 0];
+
+export function hash2(x, y, seed = 0) {
+    const n = Math.sin(x * 127.1 + y * 311.7 + seed * 74.7) * 43758.5453;
+    return n - Math.floor(n);
+}
+
+export function valueNoise(x, y, seed = 0) {
+    const x0 = Math.floor(x);
+    const y0 = Math.floor(y);
+    const fx = x - x0;
+    const fy = y - y0;
+    const sx = fx * fx * (3 - 2 * fx);
+    const sy = fy * fy * (3 - 2 * fy);
+    const a = hash2(x0, y0, seed);
+    const b = hash2(x0 + 1, y0, seed);
+    const c = hash2(x0, y0 + 1, seed);
+    const d = hash2(x0 + 1, y0 + 1, seed);
+    return lerp(lerp(a, b, sx), lerp(c, d, sx), sy);
+}
+
+export function fbm(x, y, seed = 0, octaves = 4) {
+    let sum = 0;
+    let amp = 0.5;
+    let freq = 1;
+    for (let i = 0; i < octaves; i++) {
+        sum += valueNoise(x * freq, y * freq, seed + i * 19) * amp;
+        amp *= 0.5;
+        freq *= 2;
+    }
+    return sum;
+}
+
+export function seeded(seed) {
+    let s = seed >>> 0;
+    return () => {
+        s = (s * 1664525 + 1013904223) >>> 0;
+        return s / 4294967296;
+    };
+}
+
+export function detectMobile() {
+    if (typeof navigator === 'undefined') return false;
+    const coarse = window.matchMedia?.('(pointer: coarse)')?.matches;
+    const narrow = Math.min(window.innerWidth, window.innerHeight) < 760;
+    return Boolean(coarse && narrow) || /Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
+}
+
+const SOFTWARE_GL = /swiftshader|llvmpipe|softpipe|microsoft basic render|\bcpu\b|software/i;
+
+export function detectSoftwareGL() {
+    try {
+        const canvas = document.createElement('canvas');
+        const gl = canvas.getContext('webgl2') || canvas.getContext('webgl');
+        if (!gl) return true;
+        const ext = gl.getExtension('WEBGL_debug_renderer_info');
+        const name = ext ? gl.getParameter(ext.UNMASKED_RENDERER_WEBGL) : gl.getParameter(gl.RENDERER);
+        return SOFTWARE_GL.test(String(name || ''));
+    } catch {
+        return false;
+    }
+}
+
+export function angleLerp(a, b, t) {
+    let d = ((b - a + Math.PI) % (Math.PI * 2)) - Math.PI;
+    if (d < -Math.PI) d += Math.PI * 2;
+    return a + d * t;
+}
+
+export function angleDamp(a, b, lambda, dt) {
+    return angleLerp(a, b, 1 - Math.exp(-lambda * dt));
+}
+
+export function saturate(v) {
+    return clamp(v, 0, 1);
+}

--- a/labs/guerreiro-castelo/js/utils/pool.js
+++ b/labs/guerreiro-castelo/js/utils/pool.js
@@ -1,0 +1,26 @@
+/** Object pool genérico — evita `new` no loop de jogo. */
+
+export class Pool {
+    constructor(factory, initial = 0) {
+        this.factory = factory;
+        this.free = [];
+        this.live = [];
+        for (let i = 0; i < initial; i++) this.free.push(factory());
+    }
+
+    obtain() {
+        const item = this.free.pop() || this.factory();
+        this.live.push(item);
+        return item;
+    }
+
+    release(item) {
+        const i = this.live.indexOf(item);
+        if (i >= 0) this.live.splice(i, 1);
+        this.free.push(item);
+    }
+
+    releaseAll() {
+        while (this.live.length) this.free.push(this.live.pop());
+    }
+}

--- a/labs/guerreiro-castelo/js/world/ArrowSystem.js
+++ b/labs/guerreiro-castelo/js/world/ArrowSystem.js
@@ -1,0 +1,112 @@
+/**
+ * Pool de flechas: trajetória, gravidade, colisão, impacto, reciclagem.
+ */
+
+import * as THREE from 'three';
+import { Pool } from '../utils/pool.js';
+
+export class ArrowSystem {
+    constructor(scene) {
+        this.scene = scene;
+        this.pool = new Pool(() => this._make(), 16);
+        this.active = [];
+        this.gravity = 18;
+        this.colliders = [];
+        this.onHitPlayer = null;
+        this.geo = new THREE.CylinderGeometry(0.015, 0.015, 0.55, 5);
+        this.mat = new THREE.MeshStandardMaterial({ color: 0x5a3a18, roughness: 0.6 });
+        this.tipMat = new THREE.MeshStandardMaterial({ color: 0xb0b8c0, metalness: 0.8, roughness: 0.3 });
+        this._n = new THREE.Vector3();
+    }
+
+    _make() {
+        const g = new THREE.Group();
+        const shaft = new THREE.Mesh(this.geo, this.mat);
+        shaft.rotation.x = Math.PI / 2;
+        g.add(shaft);
+        const tip = new THREE.Mesh(new THREE.ConeGeometry(0.03, 0.1, 5), this.tipMat);
+        tip.rotation.x = Math.PI / 2;
+        tip.position.z = 0.3;
+        g.add(tip);
+        g.visible = false;
+        this.scene.add(g);
+        return {
+            mesh: g,
+            vel: new THREE.Vector3(),
+            alive: false,
+            stuck: 0,
+            from: 'world'
+        };
+    }
+
+    setColliders(meshes) {
+        this.colliders = meshes;
+    }
+
+    fire(origin, direction, speed = 28) {
+        const a = this.pool.obtain();
+        a.mesh.position.copy(origin);
+        a.mesh.visible = true;
+        a.vel.copy(direction).normalize().multiplyScalar(speed);
+        a.alive = true;
+        a.stuck = 0;
+        a.mesh.lookAt(origin.clone().add(a.vel));
+        this.active.push(a);
+        return a;
+    }
+
+    update(dt, game) {
+        const ray = game._arrowRay || (game._arrowRay = new THREE.Raycaster());
+        for (let i = this.active.length - 1; i >= 0; i--) {
+            const a = this.active[i];
+            if (a.stuck > 0) {
+                a.stuck -= dt;
+                if (a.stuck <= 0) {
+                    a.mesh.visible = false;
+                    this.active.splice(i, 1);
+                    this.pool.release(a);
+                }
+                continue;
+            }
+            a.vel.y -= this.gravity * dt;
+            const next = a.mesh.position.clone().addScaledVector(a.vel, dt);
+            const dist = a.mesh.position.distanceTo(next);
+            ray.set(a.mesh.position, this._n.copy(a.vel).normalize());
+            ray.far = dist + 0.1;
+            let hit = null;
+            if (this.colliders.length) {
+                const hits = ray.intersectObjects(this.colliders, true);
+                if (hits.length) hit = hits[0];
+            }
+            const p = game.player.position;
+            const toP = Math.hypot(next.x - p.x, next.y - (p.y + 1), next.z - p.z);
+            if (toP < 0.45) {
+                this.onHitPlayer?.(1);
+                a.stuck = 0.01;
+                a.mesh.visible = false;
+                continue;
+            }
+            if (hit || next.y < 0.02) {
+                a.mesh.position.copy(hit ? hit.point : next);
+                a.stuck = 2.4;
+                game.audio.play('impact');
+                continue;
+            }
+            a.mesh.position.copy(next);
+            a.mesh.lookAt(next.clone().add(a.vel));
+            if (a.mesh.position.length() > 400) {
+                a.mesh.visible = false;
+                this.active.splice(i, 1);
+                this.pool.release(a);
+            }
+        }
+    }
+
+    clear() {
+        for (const a of this.active) {
+            a.mesh.visible = false;
+            this.pool.release(a);
+        }
+        this.active.length = 0;
+    }
+}

--- a/labs/guerreiro-castelo/js/world/Castle.js
+++ b/labs/guerreiro-castelo/js/world/Castle.js
@@ -1,0 +1,145 @@
+/**
+ * Castelo em escala — muralhas, torres, ameias, portão, bandeiras, musgo.
+ */
+
+import * as THREE from 'three';
+import { castleStoneTexture, mossTexture, flagTexture, woodTexture } from './Textures.js';
+import { std } from '../characters/builders.js';
+import { makeTorch } from './Environment.js';
+
+export function buildCastle() {
+    const root = new THREE.Group();
+    root.name = 'castle';
+    const stone = new THREE.MeshStandardMaterial({
+        map: castleStoneTexture(),
+        roughness: 0.88,
+        color: 0xc8c0b0
+    });
+    const moss = new THREE.MeshStandardMaterial({ map: mossTexture(), roughness: 0.92, color: 0x5a7a40 });
+    const wood = new THREE.MeshStandardMaterial({ map: woodTexture(), roughness: 0.84 });
+
+    const wallH = 18;
+    const wallT = 2.4;
+    const court = 28;
+
+    const mkWall = (w, d, x, z) => {
+        const m = new THREE.Mesh(new THREE.BoxGeometry(w, wallH, d), stone);
+        m.position.set(x, wallH / 2, z);
+        m.castShadow = true;
+        m.receiveShadow = true;
+        root.add(m);
+        const mossBand = new THREE.Mesh(new THREE.BoxGeometry(w * 0.98, 2.2, d * 1.02), moss);
+        mossBand.position.set(x, 1.1, z);
+        root.add(mossBand);
+        addCrenels(root, stone, x, z, w, d, wallH);
+    };
+
+    mkWall(court + wallT, wallT, 0, -court / 2);
+    mkWall(court + wallT, wallT, 0, court / 2);
+    mkWall(wallT, court, -court / 2, 0);
+    mkWall(wallT, court, court / 2, 0);
+
+    for (const [x, z] of [
+        [-court / 2, -court / 2],
+        [court / 2, -court / 2],
+        [-court / 2, court / 2],
+        [court / 2, court / 2]
+    ]) {
+        const tower = new THREE.Mesh(new THREE.CylinderGeometry(3.2, 3.6, 26, 10), stone);
+        tower.position.set(x, 13, z);
+        tower.castShadow = true;
+        root.add(tower);
+        const roof = new THREE.Mesh(new THREE.ConeGeometry(3.8, 4.5, 10), std(0x5a1c1c, 0.75));
+        roof.position.set(x, 28, z);
+        root.add(roof);
+        const flag = makeFlag();
+        flag.position.set(x, 31, z);
+        root.add(flag);
+    }
+
+    const keep = new THREE.Mesh(new THREE.BoxGeometry(12, 22, 12), stone);
+    keep.position.set(0, 11, -2);
+    keep.castShadow = true;
+    root.add(keep);
+    const keepRoof = new THREE.Mesh(new THREE.BoxGeometry(13, 1.2, 13), std(0x4a1818, 0.7));
+    keepRoof.position.set(0, 22.4, -2);
+    root.add(keepRoof);
+
+    const gate = new THREE.Mesh(new THREE.BoxGeometry(7, 10, 1.2), wood);
+    gate.position.set(0, 5, court / 2 + 0.4);
+    gate.name = 'mainGate';
+    root.add(gate);
+    const arch = new THREE.Mesh(new THREE.TorusGeometry(3.6, 0.7, 8, 16, Math.PI), stone);
+    arch.position.set(0, 9.5, court / 2 + 0.5);
+    arch.rotation.y = Math.PI;
+    root.add(arch);
+
+    const walk = new THREE.Mesh(new THREE.BoxGeometry(court, 0.4, 2), stone);
+    walk.position.set(0, wallH - 0.5, court / 2 - 0.2);
+    walk.name = 'archerWalk';
+    root.add(walk);
+
+    for (let i = -3; i <= 3; i++) {
+        const torch = makeTorch();
+        torch.position.set(i * 3.2, 6, court / 2 + 1.3);
+        root.add(torch);
+    }
+
+    const secret = new THREE.Group();
+    secret.name = 'secretDoor';
+    const door = new THREE.Mesh(new THREE.BoxGeometry(1.3, 2.2, 0.18), wood);
+    secret.add(door);
+    const lock = new THREE.Mesh(new THREE.BoxGeometry(0.18, 0.22, 0.1), std(0x6a3a12, 0.5, 0.6));
+    lock.position.set(0.4, 0, 0.12);
+    secret.add(lock);
+    secret.position.set(-court / 2 - 1.3, 1.15, -6);
+    root.add(secret);
+
+    const vine = new THREE.Mesh(new THREE.PlaneGeometry(2.4, 4.2), moss);
+    vine.position.set(-court / 2 - 1.35, 2.2, -6);
+    vine.rotation.y = Math.PI / 2;
+    root.add(vine);
+
+    root.userData.secretDoor = secret;
+    root.userData.gate = gate;
+    root.userData.court = court;
+    return root;
+}
+
+function addCrenels(root, mat, x, z, w, d, h) {
+    const alongX = w > d;
+    const len = alongX ? w : d;
+    const n = Math.floor(len / 2.2);
+    for (let i = 0; i < n; i++) {
+        const t = (i / n - 0.5) * len;
+        const c = new THREE.Mesh(new THREE.BoxGeometry(alongX ? 1.1 : d + 0.4, 1.4, alongX ? d + 0.4 : 1.1), mat);
+        c.position.set(alongX ? x + t : x, h + 0.7, alongX ? z : z + t);
+        root.add(c);
+    }
+}
+
+function makeFlag() {
+    const g = new THREE.Group();
+    const pole = new THREE.Mesh(new THREE.CylinderGeometry(0.04, 0.04, 3.2, 5), std(0x3a2a18, 0.8));
+    pole.position.y = 1.6;
+    g.add(pole);
+    const cloth = new THREE.Mesh(
+        new THREE.PlaneGeometry(1.6, 0.9, 4, 2),
+        new THREE.MeshStandardMaterial({ map: flagTexture('#6b1c1c'), side: THREE.DoubleSide, roughness: 0.8 })
+    );
+    cloth.position.set(0.8, 2.7, 0);
+    cloth.name = 'flag';
+    g.add(cloth);
+    return g;
+}
+
+export function addCastleColliders(collision, ox, oz) {
+    const court = 28;
+    const t = 2.4;
+    const h = 18;
+    collision.addWall(ox, oz - court / 2, court + t, t, h);
+    collision.addWall(ox, oz + court / 2, court + t, t, h);
+    collision.addWall(ox - court / 2, oz, t, court, h);
+    collision.addWall(ox + court / 2, oz, t, court, h);
+    collision.addWall(ox, oz + court / 2 + 0.4, 7, 1.2, 10);
+}

--- a/labs/guerreiro-castelo/js/world/CollisionWorld.js
+++ b/labs/guerreiro-castelo/js/world/CollisionWorld.js
@@ -1,0 +1,141 @@
+/**
+ * Mundo de colisão sem engine externa.
+ * Caixas AABB, chão, degraus pequenos e rampas até o limite.
+ */
+
+import * as THREE from 'three';
+import { clamp } from '../utils/math.js';
+
+const _center = new THREE.Vector3();
+const _size = new THREE.Vector3();
+
+export class CollisionWorld {
+    constructor() {
+        this.boxes = [];
+        this.triggers = [];
+        this.noiseSources = [];
+    }
+
+    clear() {
+        this.boxes.length = 0;
+        this.triggers.length = 0;
+        this.noiseSources.length = 0;
+    }
+
+    addBox(minx, miny, minz, maxx, maxy, maxz, opts = {}) {
+        this.boxes.push({
+            min: new THREE.Vector3(minx, miny, minz),
+            max: new THREE.Vector3(maxx, maxy, maxz),
+            solid: opts.solid !== false,
+            climb: Boolean(opts.climb),
+            oneWay: Boolean(opts.oneWay),
+            id: opts.id || null
+        });
+    }
+
+    addFloor(x, z, w, d, y = 0) {
+        this.addBox(x - w / 2, y - 0.4, z - d / 2, x + w / 2, y, z + d / 2, { id: 'floor' });
+    }
+
+    addWall(x, z, w, d, h, y = 0) {
+        this.addBox(x - w / 2, y, z - d / 2, x + w / 2, y + h, z + d / 2);
+    }
+
+    addTrigger(id, minx, miny, minz, maxx, maxy, maxz) {
+        this.triggers.push({
+            id,
+            min: new THREE.Vector3(minx, miny, minz),
+            max: new THREE.Vector3(maxx, maxy, maxz),
+            inside: false
+        });
+    }
+
+    emitNoise(x, z, amount, ttl = 0.4) {
+        this.noiseSources.push({ x, z, amount, ttl });
+    }
+
+    update(dt) {
+        for (let i = this.noiseSources.length - 1; i >= 0; i--) {
+            this.noiseSources[i].ttl -= dt;
+            if (this.noiseSources[i].ttl <= 0) this.noiseSources.splice(i, 1);
+        }
+    }
+
+    groundHeight(x, z, fromY, radius = 0.28) {
+        let best = -Infinity;
+        for (const b of this.boxes) {
+            if (!b.solid) continue;
+            if (x + radius < b.min.x || x - radius > b.max.x) continue;
+            if (z + radius < b.min.z || z - radius > b.max.z) continue;
+            if (b.max.y > fromY + 0.55) continue;
+            if (b.max.y > best) best = b.max.y;
+        }
+        return best === -Infinity ? null : best;
+    }
+
+    /**
+     * Resolve cápsula contra AABBs. Step offset ~0.4, rampas até ~50°.
+     * @returns {{x:number,y:number,z:number,grounded:boolean,hit:boolean}}
+     */
+    resolveCapsule(px, py, pz, radius, height, vx, vz, dt, step = 0.42) {
+        let x = px + vx * dt;
+        let z = pz + vz * dt;
+        let y = py;
+        let hit = false;
+
+        for (let pass = 0; pass < 3; pass++) {
+            for (const b of this.boxes) {
+                if (!b.solid) continue;
+                const top = b.max.y;
+                const bottom = b.min.y;
+                if (y + height < bottom || y > top + 0.02) continue;
+                const nx = clamp(x, b.min.x, b.max.x);
+                const nz = clamp(z, b.min.z, b.max.z);
+                const dx = x - nx;
+                const dz = z - nz;
+                const d2 = dx * dx + dz * dz;
+                if (d2 >= radius * radius) continue;
+
+                const stepH = top - y;
+                if (stepH > 0 && stepH <= step && y + 0.05 >= bottom) {
+                    y = top;
+                    continue;
+                }
+
+                const dist = Math.sqrt(d2) || 0.0001;
+                const push = radius - dist + 0.001;
+                x += (dx / dist) * push;
+                z += (dz / dist) * push;
+                hit = true;
+            }
+        }
+
+        const fromY = Math.max(y, py) + height;
+        const ground = this.groundHeight(x, z, fromY, radius * 0.85);
+        let grounded = false;
+        if (ground !== null) {
+            if (y <= ground + 0.08) {
+                y = ground;
+                grounded = true;
+            }
+        }
+
+        return { x, y, z, grounded, hit };
+    }
+
+    overlappingTriggers(x, y, z) {
+        const hits = [];
+        for (const t of this.triggers) {
+            const inside = x >= t.min.x && x <= t.max.x && y >= t.min.y && y <= t.max.y && z >= t.min.z && z <= t.max.z;
+            t.inside = inside;
+            if (inside) hits.push(t.id);
+        }
+        return hits;
+    }
+
+    debugBox(box) {
+        box.getCenter(_center);
+        box.getSize(_size);
+        return { center: _center, size: _size };
+    }
+}

--- a/labs/guerreiro-castelo/js/world/Environment.js
+++ b/labs/guerreiro-castelo/js/world/Environment.js
@@ -1,0 +1,149 @@
+/**
+ * Fogo, fumaça, tochas e instâncias de vegetação.
+ */
+
+import * as THREE from 'three';
+import { barkTexture, leafTexture, grassTexture, mossTexture } from './Textures.js';
+import { std } from '../characters/builders.js';
+
+export function makeTorch() {
+    const g = new THREE.Group();
+    const stick = new THREE.Mesh(new THREE.CylinderGeometry(0.03, 0.04, 0.5, 6), std(0x4a3218, 0.9));
+    stick.position.y = 0.25;
+    g.add(stick);
+    const flame = new THREE.Mesh(
+        new THREE.ConeGeometry(0.07, 0.22, 6),
+        new THREE.MeshStandardMaterial({ color: 0xffaa33, emissive: 0xff6611, emissiveIntensity: 2.4 })
+    );
+    flame.position.y = 0.58;
+    g.add(flame);
+    g.userData.flame = flame;
+    return g;
+}
+
+export function makeFire(size = 1) {
+    const g = new THREE.Group();
+    const logs = new THREE.Mesh(new THREE.CylinderGeometry(0.08 * size, 0.08 * size, 0.7 * size, 6), std(0x3a2414, 0.9));
+    logs.rotation.z = Math.PI / 2;
+    g.add(logs);
+    const logs2 = logs.clone();
+    logs2.rotation.y = 1.1;
+    g.add(logs2);
+    const flame = new THREE.Mesh(
+        new THREE.ConeGeometry(0.22 * size, 0.7 * size, 7),
+        new THREE.MeshStandardMaterial({
+            color: 0xff8020,
+            emissive: 0xff5500,
+            emissiveIntensity: 2.8,
+            transparent: true,
+            opacity: 0.92
+        })
+    );
+    flame.position.y = 0.35 * size;
+    g.add(flame);
+    const glow = new THREE.PointLight(0xff6a22, 1.6 * size, 8 * size);
+    glow.position.y = 0.4 * size;
+    glow.castShadow = false;
+    g.add(glow);
+    g.userData.flame = flame;
+    g.userData.glow = glow;
+    return g;
+}
+
+export function updateFire(group, t) {
+    if (!group?.userData.flame) return;
+    const s = 0.85 + Math.sin(t * 11) * 0.12 + Math.sin(t * 17) * 0.06;
+    group.userData.flame.scale.set(s, 0.9 + Math.sin(t * 9) * 0.15, s);
+    if (group.userData.glow) group.userData.glow.intensity = 1.3 + Math.sin(t * 13) * 0.35;
+}
+
+export function makeTree(rng = Math.random) {
+    const g = new THREE.Group();
+    const h = 3.2 + rng() * 2.4;
+    const trunk = new THREE.Mesh(
+        new THREE.CylinderGeometry(0.16, 0.22, h, 7),
+        new THREE.MeshStandardMaterial({ map: barkTexture(), roughness: 0.92 })
+    );
+    trunk.position.y = h / 2;
+    trunk.castShadow = true;
+    g.add(trunk);
+    const canopy = new THREE.Mesh(
+        new THREE.SphereGeometry(1.3 + rng() * 0.6, 10, 8),
+        new THREE.MeshStandardMaterial({ map: leafTexture(), color: 0x3a7a28, roughness: 0.85 })
+    );
+    canopy.position.y = h + 0.4;
+    canopy.castShadow = true;
+    g.add(canopy);
+    const c2 = canopy.clone();
+    c2.scale.setScalar(0.7);
+    c2.position.set((rng() - 0.5) * 0.8, h + 0.8, (rng() - 0.5) * 0.8);
+    g.add(c2);
+    return g;
+}
+
+export function makeBush() {
+    const m = new THREE.Mesh(
+        new THREE.SphereGeometry(0.45, 8, 6),
+        new THREE.MeshStandardMaterial({ map: mossTexture(), color: 0x3a6a28, roughness: 0.9 })
+    );
+    m.scale.set(1.2, 0.7, 1);
+    m.castShadow = true;
+    return m;
+}
+
+export function makeRock(s = 1) {
+    const m = new THREE.Mesh(
+        new THREE.DodecahedronGeometry(0.5 * s, 0),
+        new THREE.MeshStandardMaterial({ color: 0x6a665c, roughness: 0.95 })
+    );
+    m.scale.set(1 + Math.random() * 0.4, 0.6 + Math.random() * 0.5, 1 + Math.random() * 0.3);
+    m.castShadow = true;
+    m.receiveShadow = true;
+    return m;
+}
+
+export function grassBladeGeo() {
+    return new THREE.PlaneGeometry(0.12, 0.45);
+}
+
+export function makeGrassInstanced(count, spread, qualityScale = 1) {
+    const n = Math.floor(count * qualityScale);
+    const mesh = new THREE.InstancedMesh(
+        grassBladeGeo(),
+        new THREE.MeshStandardMaterial({
+            map: grassTexture(),
+            color: 0x4a8a30,
+            side: THREE.DoubleSide,
+            roughness: 0.9
+        }),
+        n
+    );
+    const dummy = new THREE.Object3D();
+    for (let i = 0; i < n; i++) {
+        dummy.position.set((Math.random() - 0.5) * spread, 0.2, (Math.random() - 0.5) * spread);
+        dummy.rotation.y = Math.random() * Math.PI;
+        dummy.scale.setScalar(0.7 + Math.random() * 0.8);
+        dummy.updateMatrix();
+        mesh.setMatrixAt(i, dummy.matrix);
+    }
+    mesh.instanceMatrix.needsUpdate = true;
+    return mesh;
+}
+
+export class EnvironmentFX {
+    constructor() {
+        this.fires = [];
+    }
+
+    addFire(f) {
+        this.fires.push(f);
+    }
+
+    update(t) {
+        for (const f of this.fires) updateFire(f, t);
+    }
+
+    clear() {
+        this.fires.length = 0;
+    }
+}

--- a/labs/guerreiro-castelo/js/world/Home.js
+++ b/labs/guerreiro-castelo/js/world/Home.js
@@ -1,0 +1,149 @@
+/**
+ * Sala rústica da casa — lareira, sofá, tapete, estante, brinquedos.
+ */
+
+import * as THREE from 'three';
+import {
+    woodTexture, darkWoodTexture, plasterTexture, rugTexture, clothTexture
+} from './Textures.js';
+import { std } from '../characters/builders.js';
+import { makeFire } from './Environment.js';
+
+export function buildHomeInterior() {
+    const g = new THREE.Group();
+    const plaster = new THREE.MeshStandardMaterial({ map: plasterTexture(), roughness: 0.9, color: 0xe8d8c0 });
+    const wood = new THREE.MeshStandardMaterial({ map: woodTexture(), roughness: 0.8 });
+    const dark = new THREE.MeshStandardMaterial({ map: darkWoodTexture(), roughness: 0.85 });
+
+    const floor = new THREE.Mesh(new THREE.BoxGeometry(10, 0.2, 8), dark);
+    floor.position.y = -0.1;
+    floor.receiveShadow = true;
+    g.add(floor);
+
+    const ceil = new THREE.Mesh(new THREE.BoxGeometry(10, 0.2, 8), wood);
+    ceil.position.y = 3.4;
+    g.add(ceil);
+
+    const wall = (w, h, d, x, y, z) => {
+        const m = new THREE.Mesh(new THREE.BoxGeometry(w, h, d), plaster);
+        m.position.set(x, y, z);
+        m.castShadow = true;
+        m.receiveShadow = true;
+        g.add(m);
+        return m;
+    };
+    wall(10, 3.6, 0.25, 0, 1.7, -4);
+    wall(10, 3.6, 0.25, 0, 1.7, 4);
+    wall(0.25, 3.6, 8, -5, 1.7, 0);
+    wall(0.25, 3.6, 8, 5, 1.7, 0);
+
+    const fireplace = new THREE.Mesh(new THREE.BoxGeometry(2.4, 2.2, 0.7), dark);
+    fireplace.position.set(0, 1.1, -3.55);
+    g.add(fireplace);
+    const opening = new THREE.Mesh(new THREE.BoxGeometry(1.5, 1.2, 0.4), std(0x1a1008, 1));
+    opening.position.set(0, 0.75, -3.2);
+    g.add(opening);
+    const fire = makeFire(0.85);
+    fire.position.set(0, 0.15, -3.15);
+    fire.name = 'hearth';
+    g.add(fire);
+
+    const mantel = new THREE.Mesh(new THREE.BoxGeometry(2.6, 0.12, 0.5), wood);
+    mantel.position.set(0, 2.15, -3.45);
+    g.add(mantel);
+
+    const rug = new THREE.Mesh(
+        new THREE.BoxGeometry(3.2, 0.04, 2.4),
+        new THREE.MeshStandardMaterial({ map: rugTexture(), roughness: 0.9 })
+    );
+    rug.position.set(0, 0.03, 0.3);
+    rug.receiveShadow = true;
+    g.add(rug);
+
+    const sofa = new THREE.Group();
+    const seat = new THREE.Mesh(
+        new THREE.BoxGeometry(2.4, 0.4, 0.9),
+        new THREE.MeshStandardMaterial({ map: clothTexture(), color: 0x6a3a28, roughness: 0.88 })
+    );
+    seat.position.y = 0.4;
+    sofa.add(seat);
+    const back = new THREE.Mesh(new THREE.BoxGeometry(2.4, 0.9, 0.2), std(0x5a3222, 0.88));
+    back.position.set(0, 0.85, -0.4);
+    sofa.add(back);
+    const frame = new THREE.Mesh(new THREE.BoxGeometry(2.5, 0.18, 1), wood);
+    frame.position.y = 0.18;
+    sofa.add(frame);
+    sofa.position.set(0, 0, 1.4);
+    sofa.name = 'sofa';
+    g.add(sofa);
+
+    const shelf = new THREE.Mesh(new THREE.BoxGeometry(1.4, 2.2, 0.35), wood);
+    shelf.position.set(-4.2, 1.2, -2.4);
+    g.add(shelf);
+    for (let i = 0; i < 12; i++) {
+        const book = new THREE.Mesh(
+            new THREE.BoxGeometry(0.12, 0.28, 0.22),
+            std([0x6b1c1c, 0x1c3a6b, 0x3a5a1c, 0x5a3a1c][i % 4], 0.8)
+        );
+        book.position.set(-4.2 + (i % 6) * 0.16 - 0.4, 0.55 + Math.floor(i / 6) * 0.7, -2.4);
+        g.add(book);
+    }
+
+    const table = new THREE.Mesh(new THREE.BoxGeometry(0.8, 0.5, 0.8), wood);
+    table.position.set(3.2, 0.28, 1.2);
+    table.name = 'sideTable';
+    g.add(table);
+    const shiny = new THREE.Mesh(
+        new THREE.SphereGeometry(0.08, 10, 8),
+        new THREE.MeshStandardMaterial({ color: 0xd4b45a, metalness: 0.9, roughness: 0.25, emissive: 0x332200, emissiveIntensity: 0.4 })
+    );
+    shiny.position.set(3.2, 0.62, 1.2);
+    shiny.name = 'shinyToy';
+    g.add(shiny);
+
+    const horse = new THREE.Mesh(new THREE.BoxGeometry(0.35, 0.22, 0.12), std(0x8a5a2a, 0.8));
+    horse.position.set(-3.4, 0.14, 2.2);
+    g.add(horse);
+    const ball = new THREE.Mesh(new THREE.SphereGeometry(0.12, 10, 8), std(0x8a1c1c, 0.6));
+    ball.position.set(-3.1, 0.12, 2.5);
+    g.add(ball);
+
+    for (const x of [-2.6, 2.6]) {
+        const frameW = new THREE.Mesh(new THREE.BoxGeometry(1.1, 1.2, 0.08), wood);
+        frameW.position.set(x, 1.8, -3.88);
+        g.add(frameW);
+        const glass = new THREE.Mesh(
+            new THREE.PlaneGeometry(0.9, 1),
+            new THREE.MeshStandardMaterial({ color: 0x0a1228, emissive: 0x081018, emissiveIntensity: 0.2 })
+        );
+        glass.position.set(x, 1.8, -3.82);
+        g.add(glass);
+        const stars = new THREE.Points(
+            new THREE.BufferGeometry().setFromPoints([
+                new THREE.Vector3(-0.2, 0.2, 0),
+                new THREE.Vector3(0.15, 0.35, 0),
+                new THREE.Vector3(0.3, -0.1, 0)
+            ]),
+            new THREE.PointsMaterial({ color: 0xfff4cc, size: 0.04 })
+        );
+        stars.position.set(x, 1.9, -3.8);
+        g.add(stars);
+    }
+
+    const lamp = new THREE.PointLight(0xffb070, 0.55, 9);
+    lamp.position.set(-2.4, 2.4, 1.5);
+    g.add(lamp);
+
+    g.userData.fire = fire;
+    g.userData.shiny = shiny;
+    return g;
+}
+
+export function addHomeColliders(collision) {
+    collision.addFloor(0, 0, 10, 8, 0);
+    collision.addWall(0, -4, 10, 0.3, 3.6);
+    collision.addWall(0, 4, 10, 0.3, 3.6);
+    collision.addWall(-5, 0, 0.3, 8, 3.6);
+    collision.addWall(5, 0, 0.3, 8, 3.6);
+    collision.addWall(0, -3.55, 2.4, 0.7, 2.2);
+}

--- a/labs/guerreiro-castelo/js/world/Ocean.js
+++ b/labs/guerreiro-castelo/js/world/Ocean.js
@@ -1,62 +1,123 @@
 /**
- * Oceano com Water do Three.js. Reage ao clima (calmaria vs tempestade).
+ * Oceano reativo ao clima. Tenta o Water oficial do Three.js;
+ * se o mirror/RT falhar, usa um shader próprio sem render target.
  */
 
 import * as THREE from 'three';
 import { Water } from 'three/addons/objects/Water.js';
 import { waterNormalTexture } from './Textures.js';
 
+const WAVE_VERT = /* glsl */ `
+uniform float uTime;
+uniform float uIntensity;
+varying vec2 vUv;
+varying float vWave;
+void main() {
+  vUv = uv;
+  vec3 p = position;
+  float k = uIntensity;
+  float w =
+    sin(p.x * 0.08 + uTime * 1.4) * 0.35 * k +
+    sin(p.y * 0.05 + uTime * 1.1) * 0.45 * k +
+    sin((p.x + p.y) * 0.03 + uTime * 0.7) * 0.25 * k;
+  p.z += w;
+  vWave = w;
+  gl_Position = projectionMatrix * modelViewMatrix * vec4(p, 1.0);
+}
+`;
+
+const WAVE_FRAG = /* glsl */ `
+uniform vec3 uColor;
+uniform vec3 uDeep;
+uniform float uFoam;
+varying vec2 vUv;
+varying float vWave;
+void main() {
+  float f = smoothstep(0.15, 0.45, vWave) * uFoam;
+  vec3 col = mix(uDeep, uColor, 0.45 + vWave * 0.3);
+  col = mix(col, vec3(0.85, 0.92, 0.95), f * 0.45);
+  gl_FragColor = vec4(col, 1.0);
+}
+`;
+
 export class Ocean {
     constructor(scene, normals, quality) {
-        let water;
+        this.intensity = 0.25;
+        this._foam = 0;
+        this.time = 0;
+        this.water = (quality.id === 'ultra' ? this._tryOfficialWater(scene, normals, quality) : null)
+            || this._shaderWater(scene, quality);
+        this.water.position.y = 0;
+        scene.add(this.water);
+        this._sun = new THREE.Vector3(0.4, 0.6, 0.2);
+    }
+
+    _tryOfficialWater(scene, normals, quality) {
         try {
+            if (quality.id === 'low') return null;
             const geo = new THREE.PlaneGeometry(2000, 2000);
             const waterNormals = normals || waterNormalTexture();
             waterNormals.wrapS = waterNormals.wrapT = THREE.RepeatWrapping;
-            water = new Water(geo, {
-                textureWidth: quality.water,
-                textureHeight: quality.water,
+            const water = new Water(geo, {
+                textureWidth: Math.min(256, quality.water),
+                textureHeight: Math.min(256, quality.water),
                 waterNormals,
                 sunDirection: new THREE.Vector3(0.4, 0.6, 0.2).normalize(),
                 sunColor: 0xf2e6c4,
                 waterColor: 0x0a3a4a,
                 distortionScale: 2.8,
-                fog: true
+                fog: Boolean(scene.fog)
             });
             water.rotation.x = -Math.PI / 2;
+            water.userData.kind = 'three-water';
+            return water;
         } catch (err) {
-            console.warn('[Ocean] Water addon indisponível, usando plano.', err);
-            water = new THREE.Mesh(
-                new THREE.PlaneGeometry(2000, 2000),
-                new THREE.MeshStandardMaterial({ color: 0x0a3a4a, roughness: 0.3, metalness: 0.2 })
-            );
-            water.rotation.x = -Math.PI / 2;
-            water.material.uniforms = { time: { value: 0 }, distortionScale: { value: 2 }, waterColor: { value: new THREE.Color(0x0a3a4a) }, sunDirection: { value: new THREE.Vector3() }, sunColor: { value: new THREE.Color() } };
+            console.warn('[Ocean] Water addon indisponível, shader próprio.', err);
+            return null;
         }
-        this.water = water;
-        this.water.position.y = 0;
-        scene.add(this.water);
-        this.intensity = 0.25;
-        this._foam = 0;
+    }
+
+    _shaderWater(scene, quality) {
+        const seg = quality.water >= 512 ? 80 : 48;
+        const geo = new THREE.PlaneGeometry(2000, 2000, seg, seg);
+        const mat = new THREE.ShaderMaterial({
+            uniforms: {
+                uTime: { value: 0 },
+                uIntensity: { value: 0.25 },
+                uFoam: { value: 0 },
+                uColor: { value: new THREE.Color(0x1a6a7a) },
+                uDeep: { value: new THREE.Color(0x062030) }
+            },
+            vertexShader: WAVE_VERT,
+            fragmentShader: WAVE_FRAG,
+            fog: false
+        });
+        const mesh = new THREE.Mesh(geo, mat);
+        mesh.rotation.x = -Math.PI / 2;
+        mesh.userData.kind = 'shader-water';
+        mesh.receiveShadow = true;
+        return mesh;
     }
 
     setSun(dir, color) {
+        this._sun.copy(dir);
         const u = this.water.material.uniforms;
-        u.sunDirection.value.copy(dir).normalize();
-        if (color) u.sunColor.value.set(color);
+        if (u?.sunDirection) u.sunDirection.value.copy(dir).normalize();
+        if (color && u?.sunColor) u.sunColor.value.set(color);
     }
 
     setStorm(amount) {
         this.intensity = 0.25 + amount * 2.4;
         this._foam = amount;
         const u = this.water.material.uniforms;
-        u.distortionScale.value = 2.2 + amount * 6;
-        u.waterColor.value.set(amount > 0.4 ? 0x071820 : 0x0a3a4a);
+        if (!u) return;
+        if (u.distortionScale) u.distortionScale.value = 2.2 + amount * 6;
+        if (u.waterColor) u.waterColor.value.set(amount > 0.4 ? 0x071820 : 0x0a3a4a);
+        if (u.uIntensity) u.uIntensity.value = this.intensity;
+        if (u.uFoam) u.uFoam.value = amount;
+        if (u.uColor) u.uColor.value.set(amount > 0.4 ? 0x1a3040 : 0x1a6a7a);
     }
 
-    /**
-     * Amostra de onda para o navio: verticalOffset, pitch, roll.
-     */
     sample(x, z, time) {
         const k = this.intensity;
         const y =
@@ -70,6 +131,10 @@ export class Ocean {
     }
 
     update(dt, time) {
-        this.water.material.uniforms.time.value = time * (0.4 + this.intensity * 0.5);
+        this.time = time;
+        const u = this.water.material.uniforms;
+        if (!u) return;
+        if (u.time) u.time.value = time * (0.4 + this.intensity * 0.5);
+        if (u.uTime) u.uTime.value = time;
     }
 }

--- a/labs/guerreiro-castelo/js/world/Ocean.js
+++ b/labs/guerreiro-castelo/js/world/Ocean.js
@@ -1,0 +1,75 @@
+/**
+ * Oceano com Water do Three.js. Reage ao clima (calmaria vs tempestade).
+ */
+
+import * as THREE from 'three';
+import { Water } from 'three/addons/objects/Water.js';
+import { waterNormalTexture } from './Textures.js';
+
+export class Ocean {
+    constructor(scene, normals, quality) {
+        let water;
+        try {
+            const geo = new THREE.PlaneGeometry(2000, 2000);
+            const waterNormals = normals || waterNormalTexture();
+            waterNormals.wrapS = waterNormals.wrapT = THREE.RepeatWrapping;
+            water = new Water(geo, {
+                textureWidth: quality.water,
+                textureHeight: quality.water,
+                waterNormals,
+                sunDirection: new THREE.Vector3(0.4, 0.6, 0.2).normalize(),
+                sunColor: 0xf2e6c4,
+                waterColor: 0x0a3a4a,
+                distortionScale: 2.8,
+                fog: true
+            });
+            water.rotation.x = -Math.PI / 2;
+        } catch (err) {
+            console.warn('[Ocean] Water addon indisponível, usando plano.', err);
+            water = new THREE.Mesh(
+                new THREE.PlaneGeometry(2000, 2000),
+                new THREE.MeshStandardMaterial({ color: 0x0a3a4a, roughness: 0.3, metalness: 0.2 })
+            );
+            water.rotation.x = -Math.PI / 2;
+            water.material.uniforms = { time: { value: 0 }, distortionScale: { value: 2 }, waterColor: { value: new THREE.Color(0x0a3a4a) }, sunDirection: { value: new THREE.Vector3() }, sunColor: { value: new THREE.Color() } };
+        }
+        this.water = water;
+        this.water.position.y = 0;
+        scene.add(this.water);
+        this.intensity = 0.25;
+        this._foam = 0;
+    }
+
+    setSun(dir, color) {
+        const u = this.water.material.uniforms;
+        u.sunDirection.value.copy(dir).normalize();
+        if (color) u.sunColor.value.set(color);
+    }
+
+    setStorm(amount) {
+        this.intensity = 0.25 + amount * 2.4;
+        this._foam = amount;
+        const u = this.water.material.uniforms;
+        u.distortionScale.value = 2.2 + amount * 6;
+        u.waterColor.value.set(amount > 0.4 ? 0x071820 : 0x0a3a4a);
+    }
+
+    /**
+     * Amostra de onda para o navio: verticalOffset, pitch, roll.
+     */
+    sample(x, z, time) {
+        const k = this.intensity;
+        const y =
+            Math.sin(x * 0.08 + time * 1.4) * 0.35 * k +
+            Math.sin(z * 0.05 + time * 1.1) * 0.45 * k +
+            Math.sin((x + z) * 0.03 + time * 0.7) * 0.25 * k;
+        const pitch = Math.cos(z * 0.05 + time * 1.1) * 0.06 * k;
+        const roll = Math.cos(x * 0.08 + time * 1.4) * 0.07 * k;
+        const yaw = Math.sin(time * 0.3) * 0.01 * k;
+        return { y, pitch, roll, yaw };
+    }
+
+    update(dt, time) {
+        this.water.material.uniforms.time.value = time * (0.4 + this.intensity * 0.5);
+    }
+}

--- a/labs/guerreiro-castelo/js/world/Ocean.js
+++ b/labs/guerreiro-castelo/js/world/Ocean.js
@@ -78,24 +78,29 @@ export class Ocean {
     }
 
     _shaderWater(scene, quality) {
-        const seg = quality.water >= 512 ? 80 : 48;
-        const geo = new THREE.PlaneGeometry(2000, 2000, seg, seg);
-        const mat = new THREE.ShaderMaterial({
-            uniforms: {
-                uTime: { value: 0 },
-                uIntensity: { value: 0.25 },
-                uFoam: { value: 0 },
-                uColor: { value: new THREE.Color(0x1a6a7a) },
-                uDeep: { value: new THREE.Color(0x062030) }
-            },
-            vertexShader: WAVE_VERT,
-            fragmentShader: WAVE_FRAG,
-            fog: false
+        const geo = new THREE.PlaneGeometry(2000, 2000, 1, 1);
+        const mat = new THREE.MeshStandardMaterial({
+            color: 0x1a6a82,
+            roughness: 0.28,
+            metalness: 0.12,
+            envMapIntensity: 0
         });
         const mesh = new THREE.Mesh(geo, mat);
         mesh.rotation.x = -Math.PI / 2;
-        mesh.userData.kind = 'shader-water';
+        mesh.userData.kind = 'simple-water';
         mesh.receiveShadow = true;
+        mesh.material.uniforms = {
+            time: { value: 0 },
+            distortionScale: { value: 2 },
+            waterColor: { value: mat.color },
+            sunDirection: { value: new THREE.Vector3() },
+            sunColor: { value: new THREE.Color() },
+            uTime: { value: 0 },
+            uIntensity: { value: 0.25 },
+            uFoam: { value: 0 },
+            uColor: { value: mat.color },
+            uDeep: { value: new THREE.Color(0x062030) }
+        };
         return mesh;
     }
 

--- a/labs/guerreiro-castelo/js/world/Ship.js
+++ b/labs/guerreiro-castelo/js/world/Ship.js
@@ -1,0 +1,138 @@
+/**
+ * Navio medieval de madeira — convés, mastro, vela, leme, barris, cordas.
+ */
+
+import * as THREE from 'three';
+import { woodTexture, clothTexture, darkWoodTexture } from './Textures.js';
+import { std } from '../characters/builders.js';
+
+export function buildShip() {
+    const ship = new THREE.Group();
+    ship.name = 'ship';
+    const wood = new THREE.MeshStandardMaterial({ map: woodTexture(), roughness: 0.82, color: 0xc4a06a });
+    const dark = new THREE.MeshStandardMaterial({ map: darkWoodTexture(), roughness: 0.85 });
+
+    const hull = new THREE.Mesh(new THREE.BoxGeometry(7.2, 2.2, 18), wood);
+    hull.position.y = 0.2;
+    hull.castShadow = true;
+    hull.receiveShadow = true;
+    ship.add(hull);
+
+    const bow = new THREE.Mesh(new THREE.ConeGeometry(2.2, 4.5, 4), wood);
+    bow.rotation.x = -Math.PI / 2;
+    bow.position.set(0, 0.4, -10.2);
+    ship.add(bow);
+
+    const deck = new THREE.Mesh(new THREE.BoxGeometry(6.6, 0.18, 16.5), dark);
+    deck.position.y = 1.35;
+    deck.receiveShadow = true;
+    ship.add(deck);
+
+    const railGeo = new THREE.BoxGeometry(0.12, 0.55, 16);
+    const railL = new THREE.Mesh(railGeo, wood);
+    railL.position.set(-3.2, 1.7, 0);
+    const railR = railL.clone();
+    railR.position.x = 3.2;
+    ship.add(railL, railR);
+
+    const qdeck = new THREE.Mesh(new THREE.BoxGeometry(6.4, 0.16, 4.2), dark);
+    qdeck.position.set(0, 2.15, 6.2);
+    qdeck.receiveShadow = true;
+    ship.add(qdeck);
+    const qwall = new THREE.Mesh(new THREE.BoxGeometry(6.4, 0.9, 0.2), wood);
+    qwall.position.set(0, 1.8, 4.1);
+    ship.add(qwall);
+
+    const mast = new THREE.Mesh(new THREE.CylinderGeometry(0.16, 0.2, 11, 8), dark);
+    mast.position.set(0, 6.8, -0.5);
+    mast.castShadow = true;
+    ship.add(mast);
+
+    const yard = new THREE.Mesh(new THREE.CylinderGeometry(0.08, 0.08, 8, 6), dark);
+    yard.rotation.z = Math.PI / 2;
+    yard.position.set(0, 10.2, -0.5);
+    ship.add(yard);
+
+    const sail = new THREE.Mesh(
+        new THREE.PlaneGeometry(7.2, 6.5, 8, 6),
+        new THREE.MeshStandardMaterial({
+            map: clothTexture(),
+            color: 0xe8dcc4,
+            side: THREE.DoubleSide,
+            roughness: 0.9
+        })
+    );
+    sail.position.set(0, 7.4, -0.7);
+    sail.name = 'sail';
+    ship.add(sail);
+
+    const helm = new THREE.Group();
+    helm.name = 'helm';
+    const wheel = new THREE.Mesh(new THREE.TorusGeometry(0.42, 0.05, 8, 16), std(0x5a3a18, 0.6, 0.1));
+    for (let i = 0; i < 8; i++) {
+        const spoke = new THREE.Mesh(new THREE.BoxGeometry(0.05, 0.8, 0.05), std(0x5a3a18, 0.7));
+        spoke.rotation.z = (i / 8) * Math.PI;
+        helm.add(spoke);
+    }
+    helm.add(wheel);
+    helm.position.set(0, 2.7, 7.4);
+    ship.add(helm);
+
+    const post = new THREE.Mesh(new THREE.CylinderGeometry(0.08, 0.08, 1.1, 6), dark);
+    post.position.set(0, 2.2, 7.4);
+    ship.add(post);
+
+    for (const x of [-2.2, 2.2]) {
+        for (const z of [-4, -1, 2]) {
+            const barrel = new THREE.Mesh(new THREE.CylinderGeometry(0.38, 0.38, 0.7, 10), wood);
+            barrel.position.set(x, 1.72, z);
+            barrel.castShadow = true;
+            barrel.name = 'barrel';
+            ship.add(barrel);
+        }
+    }
+
+    const crate = new THREE.Mesh(new THREE.BoxGeometry(0.8, 0.6, 0.8), wood);
+    crate.position.set(1.8, 1.72, 5.2);
+    crate.name = 'crate';
+    ship.add(crate);
+
+    const rope = new THREE.Mesh(
+        new THREE.TubeGeometry(new THREE.CatmullRomCurve3([
+            new THREE.Vector3(-2.4, 1.5, 3),
+            new THREE.Vector3(-1.2, 2.4, 4.5),
+            new THREE.Vector3(0.2, 2.2, 6.8),
+            new THREE.Vector3(0.4, 2.6, 7.5)
+        ]), 16, 0.03, 5, false),
+        std(0x8a6a3a, 0.8)
+    );
+    rope.name = 'stormRope';
+    rope.visible = false;
+    ship.add(rope);
+
+    const mooring = new THREE.Mesh(new THREE.CylinderGeometry(0.04, 0.04, 2.4, 5), std(0x8a6a3a, 0.8));
+    mooring.rotation.z = 0.7;
+    mooring.position.set(2.6, 1.4, 8.2);
+    mooring.name = 'mooring';
+    ship.add(mooring);
+
+    const cabin = new THREE.Mesh(new THREE.BoxGeometry(4.2, 1.6, 3.2), wood);
+    cabin.position.set(0, 2.15, -5.4);
+    ship.add(cabin);
+
+    ship.userData.sail = sail;
+    ship.userData.helm = helm;
+    ship.userData.rope = rope;
+    ship.userData.mooring = mooring;
+    ship.userData.mast = mast;
+    return ship;
+}
+
+export function addShipColliders(collision, ox = 0, oy = 0, oz = 0) {
+    collision.addFloor(ox, oz, 6.4, 16, oy + 1.44);
+    collision.addFloor(ox, oz + 6.2, 6.2, 4.2, oy + 2.23);
+    collision.addWall(ox - 3.25, oz, 0.25, 16, 1.2, oy + 1.44);
+    collision.addWall(ox + 3.25, oz, 0.25, 16, 1.2, oy + 1.44);
+    collision.addWall(ox, oz + 4.1, 6.4, 0.25, 0.9, oy + 1.44);
+    collision.addWall(ox, oz - 5.4, 4.2, 3.2, 1.6, oy + 1.44);
+}

--- a/labs/guerreiro-castelo/js/world/StormController.js
+++ b/labs/guerreiro-castelo/js/world/StormController.js
@@ -1,0 +1,107 @@
+/**
+ * Tempestade: chuva, vento, ondas, fog, relâmpago (luz real, não flash de tela).
+ */
+
+import * as THREE from 'three';
+import { clamp, damp } from '../utils/math.js';
+
+export class StormController {
+    constructor(scene, quality) {
+        this.scene = scene;
+        this.rainIntensity = 0;
+        this.windIntensity = 0;
+        this.waveIntensity = 0;
+        this.fogDensity = 0.012;
+        this.lightLevel = 1;
+        this.lightning = 0;
+        this.thunderDelay = -1;
+        this.target = 0;
+        this.time = 0;
+
+        const count = Math.floor(900 * quality.particles);
+        this._rainGeo = new THREE.BufferGeometry();
+        const pos = new Float32Array(count * 3);
+        for (let i = 0; i < count; i++) {
+            pos[i * 3] = (Math.random() - 0.5) * 40;
+            pos[i * 3 + 1] = Math.random() * 18;
+            pos[i * 3 + 2] = (Math.random() - 0.5) * 40;
+        }
+        this._rainGeo.setAttribute('position', new THREE.BufferAttribute(pos, 3));
+        this.rain = new THREE.Points(
+            this._rainGeo,
+            new THREE.PointsMaterial({
+                color: 0xa8c4d8,
+                size: 0.08,
+                transparent: true,
+                opacity: 0,
+                depthWrite: false
+            })
+        );
+        this.rain.visible = false;
+        scene.add(this.rain);
+
+        this.flashLight = new THREE.DirectionalLight(0xc8d8ff, 0);
+        this.flashLight.position.set(-4, 18, 6);
+        scene.add(this.flashLight);
+        this._count = count;
+        this.origin = new THREE.Vector3();
+    }
+
+    setIntensity(v) {
+        this.target = clamp(v, 0, 1);
+    }
+
+    follow(origin) {
+        this.origin.copy(origin);
+        this.rain.position.copy(origin);
+    }
+
+    update(dt, game) {
+        this.time += dt;
+        this.rainIntensity = damp(this.rainIntensity, this.target, 1.2, dt);
+        this.windIntensity = this.rainIntensity;
+        this.waveIntensity = this.rainIntensity;
+        this.fogDensity = 0.008 + this.rainIntensity * 0.028;
+        this.lightLevel = 1 - this.rainIntensity * 0.55;
+
+        if (this.rainIntensity > 0.05) {
+            this.rain.visible = true;
+            this.rain.material.opacity = this.rainIntensity * 0.65;
+            const arr = this._rainGeo.attributes.position.array;
+            const vy = (18 + this.rainIntensity * 22) * dt;
+            const wind = this.windIntensity * 8 * dt;
+            for (let i = 0; i < this._count; i++) {
+                arr[i * 3] += wind;
+                arr[i * 3 + 1] -= vy;
+                if (arr[i * 3 + 1] < 0) {
+                    arr[i * 3] = (Math.random() - 0.5) * 40;
+                    arr[i * 3 + 1] = 16 + Math.random() * 6;
+                    arr[i * 3 + 2] = (Math.random() - 0.5) * 40;
+                }
+            }
+            this._rainGeo.attributes.position.needsUpdate = true;
+        } else {
+            this.rain.visible = false;
+        }
+
+        if (this.rainIntensity > 0.45 && Math.random() < dt * 0.22) {
+            this.lightning = 0.12 + Math.random() * 0.08;
+            this.thunderDelay = 0.4 + Math.random() * 1.4;
+        }
+        if (this.lightning > 0) {
+            this.lightning -= dt;
+            this.flashLight.intensity = this.lightning > 0.04 ? 3.2 : 0.4;
+        } else {
+            this.flashLight.intensity = 0;
+        }
+        if (this.thunderDelay >= 0) {
+            this.thunderDelay -= dt;
+            if (this.thunderDelay < 0) game.audio.play('thunder');
+        }
+
+        if (game.scene.fog) {
+            game.scene.fog.density = this.fogDensity;
+        }
+        game.ocean?.setStorm(this.waveIntensity);
+    }
+}

--- a/labs/guerreiro-castelo/js/world/Textures.js
+++ b/labs/guerreiro-castelo/js/world/Textures.js
@@ -1,0 +1,356 @@
+/**
+ * Texturas procedurais em canvas — o lab não depende de PNG externos.
+ */
+
+import * as THREE from 'three';
+import { hash2 } from '../utils/math.js';
+
+const cache = new Map();
+
+function canvas(size, height = size) {
+    const el = document.createElement('canvas');
+    el.width = size;
+    el.height = height;
+    return el;
+}
+
+function toTexture(el, { repeat = [1, 1], srgb = true, aniso = 4, normal = false } = {}) {
+    const tex = new THREE.CanvasTexture(el);
+    tex.wrapS = tex.wrapT = THREE.RepeatWrapping;
+    tex.repeat.set(repeat[0], repeat[1]);
+    tex.anisotropy = aniso;
+    if (srgb && !normal) tex.colorSpace = THREE.SRGBColorSpace;
+    tex.needsUpdate = true;
+    return tex;
+}
+
+function cached(key, factory) {
+    if (!cache.has(key)) cache.set(key, factory());
+    return cache.get(key);
+}
+
+function grain(ctx, w, h, amount, seed = 0) {
+    const img = ctx.getImageData(0, 0, w, h);
+    const data = img.data;
+    for (let i = 0, p = 0; i < data.length; i += 4, p++) {
+        const x = p % w;
+        const y = (p / w) | 0;
+        const n = (hash2(x, y, seed) - 0.5) * amount;
+        data[i] = Math.max(0, Math.min(255, data[i] + n));
+        data[i + 1] = Math.max(0, Math.min(255, data[i + 1] + n));
+        data[i + 2] = Math.max(0, Math.min(255, data[i + 2] + n));
+    }
+    ctx.putImageData(img, 0, 0);
+}
+
+export function woodTexture() {
+    return cached('wood', () => {
+        const size = 256;
+        const el = canvas(size);
+        const ctx = el.getContext('2d');
+        ctx.fillStyle = '#6b4423';
+        ctx.fillRect(0, 0, size, size);
+        for (let i = 0; i < 28; i++) {
+            ctx.strokeStyle = i % 2 ? '#5a3818' : '#7a5530';
+            ctx.lineWidth = 6 + hash2(i, 2) * 8;
+            ctx.globalAlpha = 0.45;
+            ctx.beginPath();
+            ctx.moveTo(0, i * 10);
+            ctx.bezierCurveTo(80, i * 10 + 8, 160, i * 10 - 6, size, i * 10 + 4);
+            ctx.stroke();
+        }
+        grain(ctx, size, size, 28, 4);
+        return toTexture(el, { repeat: [4, 4] });
+    });
+}
+
+export function darkWoodTexture() {
+    return cached('darkwood', () => {
+        const size = 256;
+        const el = canvas(size);
+        const ctx = el.getContext('2d');
+        ctx.fillStyle = '#3a2414';
+        ctx.fillRect(0, 0, size, size);
+        for (let i = 0; i < 22; i++) {
+            ctx.strokeStyle = '#2a180c';
+            ctx.lineWidth = 5;
+            ctx.globalAlpha = 0.5;
+            ctx.beginPath();
+            ctx.moveTo(0, i * 12);
+            ctx.lineTo(size, i * 12 + 3);
+            ctx.stroke();
+        }
+        grain(ctx, size, size, 22, 6);
+        return toTexture(el, { repeat: [3, 3] });
+    });
+}
+
+export function stoneTexture() {
+    return cached('stone', () => {
+        const size = 256;
+        const el = canvas(size);
+        const ctx = el.getContext('2d');
+        ctx.fillStyle = '#6a665e';
+        ctx.fillRect(0, 0, size, size);
+        for (let i = 0; i < 80; i++) {
+            const x = hash2(i, 1) * size;
+            const y = hash2(i, 2) * size;
+            ctx.fillStyle = hash2(i, 3) > 0.5 ? '#7a766e' : '#5a564e';
+            ctx.globalAlpha = 0.5;
+            ctx.fillRect(x, y, 18 + hash2(i, 4) * 30, 12 + hash2(i, 5) * 20);
+        }
+        grain(ctx, size, size, 36, 9);
+        return toTexture(el, { repeat: [8, 8] });
+    });
+}
+
+export function castleStoneTexture() {
+    return cached('castlestone', () => {
+        const size = 512;
+        const el = canvas(size);
+        const ctx = el.getContext('2d');
+        ctx.fillStyle = '#7a7468';
+        ctx.fillRect(0, 0, size, size);
+        const bw = 64;
+        const bh = 32;
+        for (let y = 0, row = 0; y < size; y += bh, row++) {
+            const ox = (row % 2) * (bw / 2);
+            for (let x = -bw; x < size; x += bw) {
+                const shade = 108 + hash2(x, y, 2) * 40;
+                ctx.fillStyle = `rgb(${shade},${shade - 8},${shade - 18})`;
+                ctx.globalAlpha = 1;
+                ctx.fillRect(x + ox + 1, y + 1, bw - 2, bh - 2);
+                ctx.strokeStyle = 'rgba(40,36,30,0.45)';
+                ctx.strokeRect(x + ox + 1, y + 1, bw - 2, bh - 2);
+            }
+        }
+        grain(ctx, size, size, 24, 11);
+        return toTexture(el, { repeat: [6, 8] });
+    });
+}
+
+export function mossTexture() {
+    return cached('moss', () => {
+        const size = 256;
+        const el = canvas(size);
+        const ctx = el.getContext('2d');
+        ctx.fillStyle = '#3a5a28';
+        ctx.fillRect(0, 0, size, size);
+        for (let i = 0; i < 400; i++) {
+            ctx.fillStyle = hash2(i, 1) > 0.5 ? '#4a7a32' : '#2a4a18';
+            ctx.globalAlpha = 0.55;
+            ctx.beginPath();
+            ctx.arc(hash2(i, 2) * size, hash2(i, 3) * size, 2 + hash2(i, 4) * 6, 0, Math.PI * 2);
+            ctx.fill();
+        }
+        grain(ctx, size, size, 20, 3);
+        return toTexture(el, { repeat: [6, 6] });
+    });
+}
+
+export function grassTexture() {
+    return cached('grass', () => {
+        const size = 256;
+        const el = canvas(size);
+        const ctx = el.getContext('2d');
+        ctx.fillStyle = '#3d6a28';
+        ctx.fillRect(0, 0, size, size);
+        for (let i = 0; i < 1100; i++) {
+            const x = hash2(i, 2) * size;
+            const y = hash2(i, 9) * size;
+            ctx.strokeStyle = hash2(i, 4) > 0.5 ? '#5a8a38' : '#2a5218';
+            ctx.globalAlpha = 0.5;
+            ctx.beginPath();
+            ctx.moveTo(x, y);
+            ctx.lineTo(x + (hash2(i, 5) - 0.5) * 4, y - 6 - hash2(i, 6) * 8);
+            ctx.stroke();
+        }
+        grain(ctx, size, size, 22, 3);
+        return toTexture(el, { repeat: [14, 14] });
+    });
+}
+
+export function sandTexture() {
+    return cached('sand', () => {
+        const size = 256;
+        const el = canvas(size);
+        const ctx = el.getContext('2d');
+        ctx.fillStyle = '#cbb48a';
+        ctx.fillRect(0, 0, size, size);
+        grain(ctx, size, size, 42, 12);
+        for (let i = 0; i < 40; i++) {
+            ctx.strokeStyle = 'rgba(160,130,80,0.25)';
+            ctx.beginPath();
+            ctx.moveTo(0, hash2(i, 1) * size);
+            ctx.bezierCurveTo(80, hash2(i, 2) * size, 180, hash2(i, 3) * size, size, hash2(i, 4) * size);
+            ctx.stroke();
+        }
+        return toTexture(el, { repeat: [10, 10] });
+    });
+}
+
+export function leatherTexture() {
+    return cached('leather', () => {
+        const size = 128;
+        const el = canvas(size);
+        const ctx = el.getContext('2d');
+        ctx.fillStyle = '#5a3a22';
+        ctx.fillRect(0, 0, size, size);
+        grain(ctx, size, size, 36, 7);
+        return toTexture(el, { repeat: [2, 2] });
+    });
+}
+
+export function clothTexture() {
+    return cached('cloth', () => {
+        const size = 128;
+        const el = canvas(size);
+        const ctx = el.getContext('2d');
+        ctx.fillStyle = '#4a3a2a';
+        ctx.fillRect(0, 0, size, size);
+        for (let y = 0; y < size; y += 3) {
+            ctx.fillStyle = y % 6 === 0 ? '#524232' : '#423222';
+            ctx.fillRect(0, y, size, 1);
+        }
+        grain(ctx, size, size, 18, 2);
+        return toTexture(el, { repeat: [3, 3] });
+    });
+}
+
+export function rustTexture() {
+    return cached('rust', () => {
+        const size = 128;
+        const el = canvas(size);
+        const ctx = el.getContext('2d');
+        ctx.fillStyle = '#6a3a18';
+        ctx.fillRect(0, 0, size, size);
+        grain(ctx, size, size, 50, 15);
+        return toTexture(el, { repeat: [2, 2] });
+    });
+}
+
+export function plasterTexture() {
+    return cached('plaster', () => {
+        const size = 256;
+        const el = canvas(size);
+        const ctx = el.getContext('2d');
+        ctx.fillStyle = '#c4b49a';
+        ctx.fillRect(0, 0, size, size);
+        grain(ctx, size, size, 28, 5);
+        return toTexture(el, { repeat: [3, 3] });
+    });
+}
+
+export function rugTexture() {
+    return cached('rug', () => {
+        const size = 256;
+        const el = canvas(size);
+        const ctx = el.getContext('2d');
+        ctx.fillStyle = '#1e3a7a';
+        ctx.fillRect(0, 0, size, size);
+        ctx.strokeStyle = '#c9a227';
+        ctx.lineWidth = 8;
+        ctx.strokeRect(16, 16, size - 32, size - 32);
+        ctx.strokeRect(32, 32, size - 64, size - 64);
+        for (let i = 0; i < 8; i++) {
+            ctx.strokeStyle = i % 2 ? '#2a4a8a' : '#16306a';
+            ctx.beginPath();
+            ctx.arc(size / 2, size / 2, 20 + i * 10, 0, Math.PI * 2);
+            ctx.stroke();
+        }
+        grain(ctx, size, size, 16, 1);
+        return toTexture(el, { repeat: [1, 1] });
+    });
+}
+
+export function leafTexture() {
+    return cached('leaf', () => {
+        const size = 128;
+        const el = canvas(size);
+        const ctx = el.getContext('2d');
+        ctx.fillStyle = '#2f6a24';
+        ctx.fillRect(0, 0, size, size);
+        for (let i = 0; i < 80; i++) {
+            ctx.fillStyle = hash2(i, 1) > 0.5 ? '#3e8a30' : '#245818';
+            ctx.globalAlpha = 0.6;
+            ctx.beginPath();
+            ctx.ellipse(hash2(i, 2) * size, hash2(i, 3) * size, 8, 14, hash2(i, 4) * 3, 0, Math.PI * 2);
+            ctx.fill();
+        }
+        return toTexture(el, { repeat: [2, 2] });
+    });
+}
+
+export function barkTexture() {
+    return cached('bark', () => {
+        const size = 256;
+        const el = canvas(size);
+        const ctx = el.getContext('2d');
+        ctx.fillStyle = '#4a321c';
+        ctx.fillRect(0, 0, size, size);
+        for (let i = 0; i < 18; i++) {
+            ctx.strokeStyle = '#2e1e10';
+            ctx.lineWidth = 4 + hash2(i, 1) * 6;
+            ctx.globalAlpha = 0.6;
+            ctx.beginPath();
+            ctx.moveTo(i * 14, 0);
+            ctx.bezierCurveTo(i * 14 + 6, 80, i * 14 - 4, 160, i * 14 + 2, size);
+            ctx.stroke();
+        }
+        grain(ctx, size, size, 24, 8);
+        return toTexture(el, { repeat: [2, 4] });
+    });
+}
+
+export function waterNormalTexture() {
+    return cached('watern', () => {
+        const size = 256;
+        const el = canvas(size);
+        const ctx = el.getContext('2d');
+        const img = ctx.createImageData(size, size);
+        for (let y = 0; y < size; y++) {
+            for (let x = 0; x < size; x++) {
+                const n1 = hash2(x * 0.08, y * 0.08, 1);
+                const n2 = hash2(x * 0.2, y * 0.2, 4);
+                const nx = (n1 - 0.5) * 0.6 + 0.5;
+                const ny = (n2 - 0.5) * 0.6 + 0.5;
+                const i = (y * size + x) * 4;
+                img.data[i] = nx * 255;
+                img.data[i + 1] = ny * 255;
+                img.data[i + 2] = 255;
+                img.data[i + 3] = 255;
+            }
+        }
+        ctx.putImageData(img, 0, 0);
+        return toTexture(el, { repeat: [8, 8], srgb: false, normal: true });
+    });
+}
+
+export function flagTexture(color = '#6b1c1c') {
+    return cached(`flag:${color}`, () => {
+        const el = canvas(128, 80);
+        const ctx = el.getContext('2d');
+        ctx.fillStyle = color;
+        ctx.fillRect(0, 0, 128, 80);
+        ctx.fillStyle = '#d4b45a';
+        ctx.beginPath();
+        ctx.moveTo(64, 18);
+        ctx.lineTo(70, 36);
+        ctx.lineTo(90, 36);
+        ctx.lineTo(74, 48);
+        ctx.lineTo(80, 66);
+        ctx.lineTo(64, 54);
+        ctx.lineTo(48, 66);
+        ctx.lineTo(54, 48);
+        ctx.lineTo(38, 36);
+        ctx.lineTo(58, 36);
+        ctx.closePath();
+        ctx.fill();
+        return toTexture(el, { repeat: [1, 1] });
+    });
+}
+
+export function clearTextureCache() {
+    for (const tex of cache.values()) tex.dispose();
+    cache.clear();
+}

--- a/labs/guerreiro-castelo/js/world/WeatherSystem.js
+++ b/labs/guerreiro-castelo/js/world/WeatherSystem.js
@@ -1,0 +1,129 @@
+/**
+ * Céu (Sky addon), sol/lua, fog e PMREM para PBR.
+ */
+
+import * as THREE from 'three';
+import { Sky } from 'three/addons/objects/Sky.js';
+
+export class WeatherSystem {
+    constructor(scene, renderer) {
+        this.scene = scene;
+        this.sky = new Sky();
+        this.sky.scale.setScalar(4500);
+        scene.add(this.sky);
+        this.sun = new THREE.Vector3();
+        this.hemi = new THREE.HemisphereLight(0xb8d0e8, 0x3a2a18, 0.55);
+        scene.add(this.hemi);
+        this.dir = new THREE.DirectionalLight(0xfff2d0, 1.6);
+        this.dir.castShadow = true;
+        this.dir.shadow.mapSize.set(2048, 2048);
+        this.dir.shadow.camera.near = 1;
+        this.dir.shadow.camera.far = 180;
+        this.dir.shadow.camera.left = -40;
+        this.dir.shadow.camera.right = 40;
+        this.dir.shadow.camera.top = 40;
+        this.dir.shadow.camera.bottom = -40;
+        this.dir.shadow.bias = -0.0003;
+        scene.add(this.dir);
+        this.pmrem = new THREE.PMREMGenerator(renderer);
+        this.preset = 'day';
+        this.apply('day');
+    }
+
+    apply(preset) {
+        this.preset = preset;
+        const u = this.sky.material.uniforms;
+        let elevation = 18;
+        let azimuth = 160;
+        let turbidity = 4;
+        let rayleigh = 1.2;
+        let exposure = 1;
+        let hemi = 0.55;
+        let dirI = 1.6;
+        let fogCol = 0x9ec4d4;
+        let fogDen = 0.006;
+
+        if (preset === 'night') {
+            elevation = -4;
+            azimuth = 200;
+            turbidity = 2;
+            rayleigh = 0.4;
+            exposure = 0.45;
+            hemi = 0.18;
+            dirI = 0.15;
+            fogCol = 0x0a1020;
+            fogDen = 0.02;
+            this.dir.color.set(0x8899cc);
+            this.hemi.color.set(0x334466);
+            this.hemi.groundColor.set(0x1a1210);
+        } else if (preset === 'storm') {
+            elevation = 8;
+            azimuth = 140;
+            turbidity = 12;
+            rayleigh = 0.6;
+            exposure = 0.55;
+            hemi = 0.22;
+            dirI = 0.35;
+            fogCol = 0x4a5560;
+            fogDen = 0.018;
+            this.dir.color.set(0xc0c8d0);
+            this.hemi.color.set(0x6a7380);
+            this.hemi.groundColor.set(0x2a2420);
+        } else if (preset === 'dawn') {
+            elevation = 6;
+            azimuth = 110;
+            turbidity = 6;
+            rayleigh = 2.2;
+            exposure = 0.9;
+            hemi = 0.5;
+            dirI = 1.3;
+            fogCol = 0xf0c8a0;
+            fogDen = 0.008;
+            this.dir.color.set(0xffd0a0);
+            this.hemi.color.set(0xffe0c0);
+            this.hemi.groundColor.set(0x4a3020);
+        } else if (preset === 'interior') {
+            elevation = 12;
+            turbidity = 8;
+            rayleigh = 0.3;
+            exposure = 0.35;
+            hemi = 0.08;
+            dirI = 0.05;
+            fogCol = 0x0c0a08;
+            fogDen = 0.045;
+            this.dir.color.set(0xffcc88);
+        } else {
+            this.dir.color.set(0xfff2d0);
+            this.hemi.color.set(0xb8d0e8);
+            this.hemi.groundColor.set(0x3a2a18);
+        }
+
+        u.turbidity.value = turbidity;
+        u.rayleigh.value = rayleigh;
+        u.mieCoefficient.value = 0.005;
+        u.mieDirectionalG.value = 0.8;
+        const phi = THREE.MathUtils.degToRad(90 - elevation);
+        const theta = THREE.MathUtils.degToRad(azimuth);
+        this.sun.setFromSphericalCoords(1, phi, theta);
+        u.sunPosition.value.copy(this.sun);
+        this.dir.position.copy(this.sun).multiplyScalar(40);
+        this.dir.intensity = dirI;
+        this.hemi.intensity = hemi;
+        this.scene.fog = new THREE.FogExp2(fogCol, fogDen);
+        this.scene.background = new THREE.Color(fogCol);
+        this.exposure = exposure;
+        try {
+            const env = this.pmrem.fromScene(this.sky);
+            this.scene.environment = env.texture;
+        } catch {
+            /* Sky PMREM pode falhar em software GL */
+        }
+        return exposure;
+    }
+
+    setShadowSize(size) {
+        this.dir.shadow.mapSize.set(size, size);
+        this.dir.shadow.map?.dispose();
+        this.dir.shadow.map = null;
+    }
+}

--- a/labs/guerreiro-castelo/js/world/WeatherSystem.js
+++ b/labs/guerreiro-castelo/js/world/WeatherSystem.js
@@ -14,6 +14,8 @@ export class WeatherSystem {
         this.sun = new THREE.Vector3();
         this.hemi = new THREE.HemisphereLight(0xb8d0e8, 0x3a2a18, 0.55);
         scene.add(this.hemi);
+        this.ambient = new THREE.AmbientLight(0xfff4e8, 0.28);
+        scene.add(this.ambient);
         this.dir = new THREE.DirectionalLight(0xfff2d0, 1.6);
         this.dir.castShadow = true;
         this.dir.shadow.mapSize.set(2048, 2048);
@@ -109,6 +111,7 @@ export class WeatherSystem {
         this.dir.position.copy(this.sun).multiplyScalar(40);
         this.dir.intensity = dirI;
         this.hemi.intensity = hemi;
+        if (this.ambient) this.ambient.intensity = preset === 'interior' ? 0.08 : preset === 'night' ? 0.12 : 0.28;
         this.scene.fog = new THREE.FogExp2(fogCol, fogDen);
         this.scene.background = new THREE.Color(fogCol);
         this.exposure = exposure;

--- a/labs/guerreiro-castelo/js/world/WeatherSystem.js
+++ b/labs/guerreiro-castelo/js/world/WeatherSystem.js
@@ -14,7 +14,7 @@ export class WeatherSystem {
         this.sun = new THREE.Vector3();
         this.hemi = new THREE.HemisphereLight(0xb8d0e8, 0x3a2a18, 0.55);
         scene.add(this.hemi);
-        this.ambient = new THREE.AmbientLight(0xfff4e8, 0.28);
+        this.ambient = new THREE.AmbientLight(0xfff4e8, 0.55);
         scene.add(this.ambient);
         this.dir = new THREE.DirectionalLight(0xfff2d0, 1.6);
         this.dir.castShadow = true;
@@ -111,16 +111,13 @@ export class WeatherSystem {
         this.dir.position.copy(this.sun).multiplyScalar(40);
         this.dir.intensity = dirI;
         this.hemi.intensity = hemi;
-        if (this.ambient) this.ambient.intensity = preset === 'interior' ? 0.08 : preset === 'night' ? 0.12 : 0.28;
+        if (this.ambient) {
+            this.ambient.intensity = preset === 'interior' ? 0.12 : preset === 'night' ? 0.18 : 0.55;
+        }
         this.scene.fog = new THREE.FogExp2(fogCol, fogDen);
         this.scene.background = new THREE.Color(fogCol);
         this.exposure = exposure;
-        try {
-            const env = this.pmrem.fromScene(this.sky);
-            this.scene.environment = env.texture;
-        } catch {
-            /* Sky PMREM pode falhar em software GL */
-        }
+        this.scene.environment = null;
         return exposure;
     }
 

--- a/labs/index.html
+++ b/labs/index.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Labs — Diogo Paulino | Jogos 3D, código, música e IA</title>
-  <meta name="description" content="43 experimentos de Diogo Paulino: jogos 3D, ferramentas, música e inteligência artificial em HTML, CSS e JavaScript puro.">
+  <meta name="description" content="44 experimentos de Diogo Paulino: jogos 3D, ferramentas, música e inteligência artificial em HTML, CSS e JavaScript puro.">
   <meta name="author" content="Diogo Paulino">
   <meta name="robots" content="index, follow">
   <meta name="theme-color" content="#fafbfc">
@@ -16,14 +16,14 @@
   <meta property="og:site_name" content="Diogo Paulino · Labs">
   <meta property="og:title" content="Labs — Diogo Paulino | Jogos 3D, código, música e IA">
   <meta property="og:description"
-    content="43 laboratórios de Diogo Paulino: mundos 3D, jogos, ferramentas, música e IA em HTML, CSS e JavaScript puro.">
+    content="44 laboratórios de Diogo Paulino: mundos 3D, jogos, ferramentas, música e IA em HTML, CSS e JavaScript puro.">
   <meta property="og:url" content="https://diogopaulino.com.br/labs/">
   <meta property="og:image" content="https://diogopaulino.com.br/assets/img/diogo.jpeg">
   <meta property="og:image:alt" content="Diogo Paulino">
   <meta property="og:locale" content="pt_BR">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Labs — Diogo Paulino | Jogos 3D, código, música e IA">
-  <meta name="twitter:description" content="43 experimentos de Diogo Paulino: jogos, código, música e inteligência artificial.">
+  <meta name="twitter:description" content="44 experimentos de Diogo Paulino: jogos, código, música e inteligência artificial.">
   <meta name="twitter:image" content="https://diogopaulino.com.br/assets/img/diogo.jpeg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -39,7 +39,7 @@
         "@id": "https://diogopaulino.com.br/labs/#page",
         "name": "Labs — Diogo Paulino",
         "url": "https://diogopaulino.com.br/labs/",
-        "description": "43 experimentos de Diogo Paulino: jogos 3D, ferramentas, música e inteligência artificial em HTML, CSS e JavaScript puro.",
+        "description": "44 experimentos de Diogo Paulino: jogos 3D, ferramentas, música e inteligência artificial em HTML, CSS e JavaScript puro.",
         "inLanguage": "pt-BR",
         "isPartOf": {
           "@id": "https://diogopaulino.com.br/#website"
@@ -47,7 +47,7 @@
         "creator": {
           "@id": "https://diogopaulino.com.br/#person"
         },
-        "numberOfItems": 43,
+        "numberOfItems": 44,
         "mainEntity": {
           "@id": "https://diogopaulino.com.br/labs/#list"
         }
@@ -56,7 +56,7 @@
         "@type": "ItemList",
         "@id": "https://diogopaulino.com.br/labs/#list",
         "name": "Labs de Diogo Paulino",
-        "numberOfItems": 43,
+        "numberOfItems": 44,
         "itemListElement": [
           {
             "@type": "ListItem",
@@ -315,6 +315,12 @@
             "position": 43,
             "url": "https://diogopaulino.com.br/labs/pulsar/",
             "name": "Pulsar"
+          },
+          {
+            "@type": "ListItem",
+            "position": 44,
+            "url": "https://diogopaulino.com.br/labs/guerreiro-castelo/",
+            "name": "O Guerreiro e o Castelo"
           }
         ]
       },
@@ -641,6 +647,27 @@
             <span class="tag">three.js</span>
             <span class="tag">Retrô</span>
             <span class="tag">N64</span>
+          </div>
+        </div>
+      </a>
+      <a href="/labs/guerreiro-castelo/" class="project-card" data-groups="game,creative">
+        <div class="project-icon">
+          <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+            stroke-linecap="round" stroke-linejoin="round">
+            <path d="M4 19h16" />
+            <path d="M6 19V9l6-5 6 5v10" />
+            <path d="M10 19v-5h4v5" />
+            <path d="M3 11c2-1 4.5-2 9-2s7 1 9 2" opacity="0.55" />
+            <circle cx="17.5" cy="5.2" r="1.1" />
+          </svg>
+        </div>
+        <div class="project-content">
+          <h2>O Guerreiro e o Castelo</h2>
+          <p>Aventura 3D cinematográfica: Dico e Teco atravessam o mar, entram no castelo e resgatam Camila</p>
+          <div class="project-tags">
+            <span class="tag">three.js</span>
+            <span class="tag">3D</span>
+            <span class="tag">Aventura</span>
           </div>
         </div>
       </a>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -79,6 +79,12 @@
     <priority>0.7</priority>
   </url>
   <url>
+    <loc>https://diogopaulino.com.br/labs/guerreiro-castelo/</loc>
+    <lastmod>2026-08-14</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
     <loc>https://diogopaulino.com.br/labs/honor-front/</loc>
     <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 🎯 Objetivo

Entregar o lab jogável **O Guerreiro e o Castelo do Outro Lado do Mar**: aventura 3D em terceira pessoa (Three.js vanilla) com a história completa, do quarto à lareira até a fuga do castelo e o retorno para Ravi.

## ✨ O que mudou

- Novo lab em `/labs/guerreiro-castelo/` (HTML/CSS/JS + Three.js via import map, sem build)
- Gameplay conectado: casa → navio → tempestade → praia/floresta/castelo → stealth → tigre → fuga → navio → final
- Dico, Teco (companion), Camila, guarda, tigre, câmera 3ª pessoa, quests, checkpoints, diálogos e cutscenes
- Galeria, README e `sitemap.xml` atualizados
- Merge com `master`: catálogo em **48 experimentos** (Guerreiro + Lavandula, Nereida e Riftball)

## 🧪 Como testar

1. Na raiz do repo: `python3 -m http.server 8000`
2. Abrir [http://localhost:8000/](http://localhost:8000/) (home) e [http://localhost:8000/labs/](http://localhost:8000/labs/) (galeria)
3. Abrir [http://localhost:8000/labs/guerreiro-castelo/](http://localhost:8000/labs/guerreiro-castelo/)
4. **Novo jogo** → a história começa na sala; Espaço avança diálogos/cutscenes
5. No navio: andar (WASD), olhar (mouse), falar com amigos, horizonte, leme e Teco; a tempestade segue sozinha
6. Conferir pasta ↔ card da galeria ↔ README ↔ `sitemap.xml` ↔ canonical/OG (48 labs)

## ✅ Checklist

- [x] Links conferidos: pasta do lab ↔ card da galeria ↔ README ↔ sitemap
- [x] README atualizado (linha na tabela + URL + contagem no badge/texto)
- [x] SEO consistente: title, description, canonical, author, robots, OG, Twitter, JSON-LD (e contagem nos metas da galeria)
- [x] Testado via HTTP na raiz: menu, intro na lareira, transição para o navio 3D (convés, oceano, Dico e Teco visíveis), interação com Teco
- [x] Nada fora do escopo foi quebrado
- [x] Conflitos com `master` resolvidos (contagem 48; JSON-LD inclui Lavandula e Guerreiro)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ffe12-d35d-71f9-9834-bfb20adf2105?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ffe12-d35d-71f9-9834-bfb20adf2105&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

