### PR TITLE
🎨 Responsivo em todos os labs e regra no AGENTS.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,8 @@
 1. Na raiz do repo: `python3 -m http.server 8000`
 2. Abrir [http://localhost:8000/](http://localhost:8000/) (home) e [http://localhost:8000/labs/](http://localhost:8000/labs/) (galeria)
 3. Abrir o lab ou a página alterada e confirmar que CSS, JS e o voltar funcionam
-4. Se o lab for novo, renomeado ou removido: conferir pasta ↔ card da galeria ↔ README ↔ `sitemap.xml` ↔ canonical/OG
+4. Responsivo: DevTools em **375×667**, **390×844** e landscape curto (~667×375) — sem overflow horizontal, HUD/controles utilizáveis, alvos ≥ 44px
+5. Se o lab for novo, renomeado ou removido: conferir pasta ↔ card da galeria ↔ README ↔ `sitemap.xml` ↔ canonical/OG
 
 ## ✅ Checklist
 
@@ -20,4 +21,5 @@
 - [ ] README atualizado (linha na tabela + URL + contagem no badge/texto) — obrigatório em lab novo, renomeado ou removido
 - [ ] SEO consistente: title, description, canonical, author, robots, OG, Twitter, JSON-LD (e contagem nos metas da galeria)
 - [ ] Testado via HTTP na raiz, não via `file://`
+- [ ] Responsivo: 375px / 390px / landscape — overflow, HUD, toque, safe-area (`viewport-fit=cover`)
 - [ ] Nada fora do escopo foi quebrado

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,10 +14,30 @@ Portfólio e playground estático do Diogo Paulino. HTML, CSS e JS puro no GitHu
 
 - **Vanilla.** ES modules, CSS nativo (custom properties, flex/grid). Sem libs ou frameworks a menos que o usuário peça.
 - **UI.** Visual premium (dark mode elegante, microinterações). Sem bloco cinza no lugar de asset.
+- **Responsivo.** Todo lab — jogo, ferramenta, simulação ou instrumento — precisa funcionar muito bem em celular, tablet e desktop. Não é opcional nem “faço depois”. Ver seção Responsivo.
 - **Cirúrgico.** Não reescreva o que está fora do pedido. Preserve comentários e assinaturas existentes.
 - **HTML novo.** `title`, `viewport`, description, tags semânticas (`main`, `header`, `footer`) e o bloco de SEO abaixo.
 - **Jogo/simulação.** Documente regras e fórmulas no código.
 - **Dúvida de arquitetura.** Pergunte; não invente um rumo novo.
+
+## Responsivo (obrigatório)
+
+Aplica-se a **todo** lab novo ou alterado, e à home/galeria. Um layout que só cabe no desktop não entra.
+
+Alvos de teste (DevTools ou aparelho): **375×667** (iPhone SE), **390×844** (iPhone 14) e **landscape curto** (~667×375). Sem barra de rolagem horizontal. Sem HUD/controles cobrindo o que o usuário precisa ver ou tocar.
+
+Checklist:
+
+- **Viewport.** `width=device-width, initial-scale=1, viewport-fit=cover` (jogos fullscreen podem manter `maximum-scale=1` / `user-scalable=no`).
+- **Safe-area.** Notch e home indicator: `env(safe-area-inset-*)` no padding de header, HUD, overlays, docks e controles de toque. Sem `viewport-fit=cover`, o inset fica 0 no iPhone.
+- **Largura fluida.** Nada com largura fixa maior que o viewport. Use `min(…, 100%)`, `clamp()`, `minmax(0, 1fr)`. Canvas/stage escala com o container — nunca `width: 820px` sem `max-width: 100%`.
+- **Overflow.** `overflow-x: clip` no `html`/`body` quando o lab não precisa de scroll lateral. Grids com `minmax(300px, 1fr)` viram `1fr` abaixo de 768px.
+- **Toque.** Alvos interativos ≥ **44×44px**. Botões de HUD (mute, pause) não ficam embaixo dos controles de jogo. Mostrar pad/stick em `pointer: coarse` (e esconder em `pointer: fine` se o teclado/mouse basta).
+- **HUD e overlays.** Empilhar em 1 coluna no estreito; `max-height: min(92dvh, …)` + `overflow-y: auto` em menus. Landscape: compactar HUD, reduzir stick/pads, não deixar painel inferior cobrir o canvas.
+- **Tipografia.** `clamp()` / `vw` com teto; títulos longos com `ellipsis` ou quebra. Sem `white-space: nowrap` em frases que estouram 375px.
+- **Altura.** Preferir `100dvh` a `100vh` em apps fullscreen. Não force `min-height: 600px` em wrappers de ferramenta — no SE isso empurra o canvas para fora.
+
+Ao criar um lab, escreva os `@media` (pelo menos `max-width: 768px` e, se for jogo/fullscreen, `max-height: 520px and (orientation: landscape)`) na mesma mudança. Referência boa: `river-knight` (landscape + safe-area) e `labs/shared.css` (header 44px no mobile).
 
 ## Links e catálogo
 
@@ -32,6 +52,7 @@ Na mesma mudança:
 - `sitemap.xml`: `https://diogopaulino.com.br/labs/<slug>/`
 - Voltar: header `/labs/`, footer `/`
 - Teste servindo a **raiz**: `python3 -m http.server 8000` — nunca `file://` (quebra `/favicon.ico` e módulos ES)
+- Teste **responsivo**: 375px, 390px e landscape curto — overflow, HUD, toque, safe-area (seção Responsivo)
 
 ## SEO (sempre consistente)
 
@@ -58,4 +79,4 @@ Use [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md): emoj
 
 ## Cursor Cloud specific instructions
 
-Sirva a raiz por HTTP. Não rode `npm install`. Verificação = seção Links e catálogo + SEO. PRs = template acima.
+Sirva a raiz por HTTP. Não rode `npm install`. Verificação = seção Links e catálogo + SEO + Responsivo. PRs = template acima.

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -26,10 +26,20 @@
   }
 }
 
+html {
+  overflow-x: clip;
+  -webkit-text-size-adjust: 100%;
+  text-size-adjust: 100%;
+}
+
 body {
   margin: 0;
-  padding: 2rem 1rem;
+  padding: max(2rem, env(safe-area-inset-top, 0px))
+    max(1rem, env(safe-area-inset-right, 0px))
+    max(2rem, env(safe-area-inset-bottom, 0px))
+    max(1rem, env(safe-area-inset-left, 0px));
   min-height: 100vh;
+  min-height: 100dvh;
   background: var(--bg-body);
   display: flex;
   align-items: center;
@@ -37,6 +47,7 @@ body {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
   color: var(--text-primary);
   transition: background 0.4s cubic-bezier(0.4, 0, 0.2, 1), color 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+  overflow-x: clip;
 }
 
 .card-container.minimal {
@@ -71,8 +82,8 @@ body {
   position: absolute;
   top: 1.25rem;
   right: 1.25rem;
-  width: 40px;
-  height: 40px;
+  width: 44px;
+  height: 44px;
   border-radius: 999px;
   border: 1px solid transparent;
   background: transparent;
@@ -468,7 +479,10 @@ body {
 
 @media (max-width: 600px) {
   body {
-    padding: 1rem 0.875rem;
+    padding: max(1rem, env(safe-area-inset-top, 0px))
+      max(0.875rem, env(safe-area-inset-right, 0px))
+      max(1rem, env(safe-area-inset-bottom, 0px))
+      max(0.875rem, env(safe-area-inset-left, 0px));
     align-items: center;
   }
 
@@ -569,7 +583,10 @@ body {
 
 @media (max-width: 400px) {
   body {
-    padding: 0.75rem 0.625rem;
+    padding: max(0.75rem, env(safe-area-inset-top, 0px))
+      max(0.625rem, env(safe-area-inset-right, 0px))
+      max(0.75rem, env(safe-area-inset-bottom, 0px))
+      max(0.625rem, env(safe-area-inset-left, 0px));
   }
 
   .card-container.minimal {
@@ -579,8 +596,8 @@ body {
   }
 
   .theme-toggle {
-    width: 40px;
-    height: 40px;
+    width: 44px;
+    height: 44px;
     border-width: 1px;
   }
 

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <title>Diogo Paulino — Tech Manager, Design, Código e IA</title>
   <meta name="description"
     content="Diogo Paulino, Tech Manager. Portfólio e playground de labs em HTML, CSS e JavaScript: design UI/UX, código, música e inteligência artificial.">

--- a/labs/aetherion/index.html
+++ b/labs/aetherion/index.html
@@ -34,7 +34,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@500;600;700&family=Outfit:wght@300;400;500;600;700&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=7">
+    <link rel="stylesheet" href="/labs/shared.css?v=8">
     <link rel="stylesheet" href="style.css?v=1">
 
     <script type="importmap">

--- a/labs/aetherion/style.css
+++ b/labs/aetherion/style.css
@@ -696,3 +696,63 @@ kbd {
         display: none;
     }
 }
+/* --- lab-responsive-pass --- */
+.dock-btn, .warp-btns button { min-height: 44px; min-width: 44px; }
+
+@media (max-width: 820px) {
+    .catalog {
+        bottom: calc(5.5rem + var(--safe-bottom, 0px));
+        max-height: 4.5rem;
+    }
+    .dossier {
+        top: calc(4.2rem + var(--safe-top, 0px));
+        width: min(240px, calc(50vw - 0.5rem));
+        max-width: calc(100% - 1rem);
+    }
+    .dock { max-width: calc(100% - var(--safe-left, 0px) - var(--safe-right, 0px) - 1rem); }
+}
+
+@media (max-height: 520px) and (orientation: landscape) {
+    .catalog { bottom: calc(4.8rem + var(--safe-bottom, 0px)); }
+    .hint { display: none; }
+}
+
+/* --- mobile: HUD, toque, landscape curto --- */
+@media (pointer: coarse) {
+    .icon-button,
+    .icon-btn {
+        width: 44px;
+        height: 44px;
+        min-width: 44px;
+        min-height: 44px;
+    }
+}
+
+@media (max-width: 560px) {
+    .overlay,
+    .overlay-card,
+    .menu-card {
+        max-height: min(92dvh, 900px);
+    }
+    .overlay-card,
+    .menu-card {
+        overflow-y: auto;
+        -webkit-overflow-scrolling: touch;
+    }
+}
+
+@media (max-height: 520px) and (orientation: landscape) {
+    .hud-actions {
+        top: calc(0.75rem + var(--safe-top, env(safe-area-inset-top, 0px)));
+        bottom: auto;
+        right: calc(0.75rem + var(--safe-right, env(safe-area-inset-right, 0px)));
+    }
+    .icon-button,
+    .icon-btn {
+        width: 44px;
+        height: 44px;
+    }
+    .touch-controls {
+        height: min(42%, 38dvh);
+    }
+}

--- a/labs/armilla/index.html
+++ b/labs/armilla/index.html
@@ -34,7 +34,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,500;0,600;0,700;1,500&family=Outfit:wght@300;400;500;600;700&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=6">
+    <link rel="stylesheet" href="/labs/shared.css?v=8">
     <link rel="stylesheet" href="style.css">
 
     <script type="importmap">

--- a/labs/armilla/style.css
+++ b/labs/armilla/style.css
@@ -596,3 +596,29 @@ body.ui-hidden header[data-lab-header] {
         display: none;
     }
 }
+/* --- lab-responsive-pass --- */
+.icon-btn { width: 44px; height: 44px; min-width: 44px; min-height: 44px; }
+
+@media (max-width: 560px) {
+    .hud-left {
+        width: calc(100% - var(--safe-left, 0px) - var(--safe-right, 0px) - 1rem);
+        max-width: 100%;
+        bottom: max(5.4rem, calc(var(--safe-bottom, 0px) + 5rem));
+        max-height: 38dvh;
+        overflow-y: auto;
+    }
+    .dock {
+        bottom: max(1rem, var(--safe-bottom, 0px));
+        z-index: 14;
+        max-width: calc(100% - 1rem);
+    }
+}
+
+@media (max-height: 520px) and (orientation: landscape) {
+    .hud-left {
+        max-height: 30dvh;
+        width: min(220px, 40vw);
+        bottom: auto;
+        top: max(5rem, calc(var(--safe-top, 0px) + 4.2rem));
+    }
+}

--- a/labs/aurelia/index.html
+++ b/labs/aurelia/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Barlow+Condensed:wght@500;600;700;800&family=Outfit:wght@400;500;600;700&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=6">
+    <link rel="stylesheet" href="/labs/shared.css?v=8">
     <link rel="stylesheet" href="style.css">
 
     <script type="importmap">

--- a/labs/aurelia/style.css
+++ b/labs/aurelia/style.css
@@ -353,8 +353,8 @@ button {
 }
 
 .icon-button {
-    width: 40px;
-    height: 40px;
+    width: 44px;
+    height: 44px;
     display: grid;
     place-items: center;
     border-radius: 12px;
@@ -672,4 +672,64 @@ kbd {
 
 @media (pointer: coarse) {
     .touch-controls { display: flex; }
+}
+/* --- lab-responsive-pass --- */
+.overlay {
+    padding: calc(4.5rem + var(--safe-top, 0px))
+             calc(1rem + var(--safe-right, 0px))
+             calc(1.5rem + var(--safe-bottom, 0px))
+             calc(1rem + var(--safe-left, 0px));
+}
+
+@media (pointer: coarse) {
+    .hud-bottom { bottom: calc(8rem + var(--safe-bottom, 0px)); }
+    .cluster { width: min(150px, 40vw); height: min(150px, 40vw); }
+    .cluster-readout strong { font-size: clamp(1.6rem, 6vw, 2.2rem); }
+}
+
+@media (max-height: 520px) and (orientation: landscape) {
+    .hud-top { grid-template-columns: 1fr 1fr; }
+    .radio-panel { display: none; }
+    .cluster { width: 120px; height: 120px; }
+    .touch-controls { bottom: calc(5rem + var(--safe-bottom, 0px)); }
+}
+
+/* --- mobile: HUD, toque, landscape curto --- */
+@media (pointer: coarse) {
+    .icon-button,
+    .icon-btn {
+        width: 44px;
+        height: 44px;
+        min-width: 44px;
+        min-height: 44px;
+    }
+}
+
+@media (max-width: 560px) {
+    .overlay,
+    .overlay-card,
+    .menu-card {
+        max-height: min(92dvh, 900px);
+    }
+    .overlay-card,
+    .menu-card {
+        overflow-y: auto;
+        -webkit-overflow-scrolling: touch;
+    }
+}
+
+@media (max-height: 520px) and (orientation: landscape) {
+    .hud-actions {
+        top: calc(0.75rem + var(--safe-top, env(safe-area-inset-top, 0px)));
+        bottom: auto;
+        right: calc(0.75rem + var(--safe-right, env(safe-area-inset-right, 0px)));
+    }
+    .icon-button,
+    .icon-btn {
+        width: 44px;
+        height: 44px;
+    }
+    .touch-controls {
+        height: min(42%, 38dvh);
+    }
 }

--- a/labs/aurora-flow/index.html
+++ b/labs/aurora-flow/index.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <title>Aurora Flow | Diogo Paulino</title>
     <meta name="description"
         content="Aurora generativa: cortinas de luz, vórtices e tempestades de partículas que reagem ao seu movimento.">
@@ -26,7 +26,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Oxanium:wght@400;600;700;800&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=7">
+    <link rel="stylesheet" href="/labs/shared.css?v=8">
     <link rel="stylesheet" href="style.css">
     <script type="application/ld+json">
     {

--- a/labs/aurora-flow/style.css
+++ b/labs/aurora-flow/style.css
@@ -509,3 +509,9 @@ input[type="range"]::-moz-range-thumb {
         white-space: nowrap;
     }
 }
+/* --- lab-responsive-pass --- */
+@media (max-width: 720px) {
+    .dock { bottom: max(22px, env(safe-area-inset-bottom, 0px)); }
+    .icon-btn,
+    .tool-btn { min-width: 44px; min-height: 44px; }
+}

--- a/labs/beige-box/index.html
+++ b/labs/beige-box/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=Outfit:wght@300;400;500;600;700&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=7">
+    <link rel="stylesheet" href="/labs/shared.css?v=8">
     <link rel="stylesheet" href="style.css?v=1">
 
     <script type="importmap">

--- a/labs/beige-box/style.css
+++ b/labs/beige-box/style.css
@@ -435,3 +435,18 @@ button {
     .hint-bar { font-size: 0.64rem; }
     .hud-left { max-width: 100%; }
 }
+/* --- lab-responsive-pass --- */
+.icon-button { width: 2.75rem; height: 2.75rem; min-width: 44px; min-height: 44px; }
+
+@media (max-width: 720px) {
+    .hud-left {
+        max-width: min(18rem, calc(100% - var(--safe-left, 0px) - var(--safe-right, 0px) - 1rem));
+        padding: 0.65rem 0.8rem;
+        font-size: 0.92rem;
+    }
+}
+
+@media (max-height: 520px) and (orientation: landscape) {
+    .hud-left { max-width: 14rem; }
+    .hint-bar { display: none; }
+}

--- a/labs/calculator/index.html
+++ b/labs/calculator/index.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <title>Calculator | Diogo Paulino</title>
     <meta name="description"
         content="Calculadora online com modos simples, científico e conversor de moedas em tempo real.">
@@ -23,7 +23,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Calculator | Diogo Paulino">
     <meta name="twitter:description" content="Calculadora online com modos simples, científico e conversor de moedas em tempo real.">
-    <link rel="stylesheet" href="/labs/shared.css?v=7">
+    <link rel="stylesheet" href="/labs/shared.css?v=8">
     <link rel="stylesheet" href="style.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/labs/calculator/style.css
+++ b/labs/calculator/style.css
@@ -476,3 +476,13 @@ body {
 .btn-refresh.loading i {
     animation: spin 1s linear infinite;
 }
+/* --- lab-responsive-pass --- */
+@media (max-width: 480px) {
+    .mode-switch { flex-wrap: wrap; }
+    .mode-btn { flex: 1 1 calc(50% - 5px); min-height: 44px; }
+    .scientific-grid { gap: 8px; }
+    .scientific-grid .btn { padding: 12px 0; font-size: 0.95rem; min-height: 44px; }
+    .btn-swap { width: 44px; height: 44px; }
+    .btn-refresh { min-width: 44px; min-height: 44px; }
+    .calculator-wrapper.scientific-mode { max-width: 100%; }
+}

--- a/labs/cyberos/index.html
+++ b/labs/cyberos/index.html
@@ -29,7 +29,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=VT323&display=swap"
     rel="stylesheet">
-  <link rel="stylesheet" href="/labs/shared.css?v=7">
+  <link rel="stylesheet" href="/labs/shared.css?v=8">
   <link rel="stylesheet" href="style.css?v=2">
   <script type="application/ld+json">
   {

--- a/labs/cyberos/style.css
+++ b/labs/cyberos/style.css
@@ -925,3 +925,18 @@ select {
     transition-duration: 0.01ms !important;
   }
 }
+/* --- lab-responsive-pass --- */
+@media (max-width: 480px) {
+    .crt-screen > header[data-lab-header] {
+        padding-top: max(0.45rem, env(safe-area-inset-top, 0px));
+        padding-inline: max(0.75rem, env(safe-area-inset-left, 0px)) max(0.75rem, env(safe-area-inset-right, 0px));
+    }
+    .crt-screen .back-link {
+        min-width: 44px;
+        min-height: 44px;
+        padding: 0.45rem 0.75rem !important;
+    }
+    .dock { bottom: max(2.4rem, env(safe-area-inset-bottom, 0px)); }
+    .window { height: 52% !important; top: 10% !important; max-width: calc(100% - 1rem); }
+    .phos-btn { min-width: 44px; min-height: 44px; padding: 0.35rem 0.5rem; }
+}

--- a/labs/english-duo/index.html
+++ b/labs/english-duo/index.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <title>Talk | Diogo Paulino</title>
     <meta name="description" content="Aprenda idiomas de forma divertida e interativa com o Talk.">
     <link rel="canonical" href="https://diogopaulino.com.br/labs/english-duo/">
@@ -22,7 +22,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Talk | Diogo Paulino">
     <meta name="twitter:description" content="Aprenda idiomas de forma divertida e interativa com o Talk.">
-    <link rel="stylesheet" href="/labs/shared.css?v=7">
+    <link rel="stylesheet" href="/labs/shared.css?v=8">
     <link rel="stylesheet" href="style.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/labs/english-duo/style.css
+++ b/labs/english-duo/style.css
@@ -1764,3 +1764,13 @@ body {
         justify-content: center;
     }
 }
+/* --- lab-responsive-pass --- */
+@media (max-width: 768px) {
+    .sound-toggle,
+    .btn-back-lang { width: 44px; height: 44px; min-width: 44px; min-height: 44px; }
+}
+
+@media (max-width: 420px) {
+    .question-text { padding-right: 0; padding-bottom: 3rem; }
+    .btn-speak { top: auto; bottom: 0; }
+}

--- a/labs/f1-racing/index.html
+++ b/labs/f1-racing/index.html
@@ -28,7 +28,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
-    <link rel="stylesheet" href="/labs/shared.css?v=7">
+    <link rel="stylesheet" href="/labs/shared.css?v=8">
     <link rel="stylesheet" href="style.css?v=13">
     <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700&family=Orbitron:wght@500;600;700;800;900&display=swap"
         rel="stylesheet">

--- a/labs/f1-racing/style.css
+++ b/labs/f1-racing/style.css
@@ -467,7 +467,7 @@ button {
 .icon-button {
     display: grid;
     place-items: center;
-    width: 2.6rem;
+    width: 44px;
     aspect-ratio: 1;
     border-radius: 12px;
     border: 1px solid var(--line);
@@ -996,5 +996,64 @@ kbd {
     *, *::before, *::after {
         animation-duration: 0.01ms !important;
         transition-duration: 0.01ms !important;
+    }
+}
+/* --- lab-responsive-pass --- */
+@media (pointer: coarse) {
+    .pad-right {
+        max-width: none;
+        display: grid;
+        grid-template-columns: repeat(2, minmax(3.6rem, 4.4rem));
+        gap: 0.45rem;
+    }
+    .menu-card {
+        max-height: min(92dvh, 900px);
+        overflow-y: auto;
+    }
+}
+
+@media (max-height: 520px) and (orientation: landscape) {
+    .hud { padding-top: calc(var(--safe-top, 0px) + 3.2rem); }
+    .pad { width: 3.6rem; min-height: 44px; font-size: 0.65rem; }
+    .map-panel { width: 6rem; }
+}
+
+/* --- mobile: HUD, toque, landscape curto --- */
+@media (pointer: coarse) {
+    .icon-button,
+    .icon-btn {
+        width: 44px;
+        height: 44px;
+        min-width: 44px;
+        min-height: 44px;
+    }
+}
+
+@media (max-width: 560px) {
+    .overlay,
+    .overlay-card,
+    .menu-card {
+        max-height: min(92dvh, 900px);
+    }
+    .overlay-card,
+    .menu-card {
+        overflow-y: auto;
+        -webkit-overflow-scrolling: touch;
+    }
+}
+
+@media (max-height: 520px) and (orientation: landscape) {
+    .hud-actions {
+        top: calc(0.75rem + var(--safe-top, env(safe-area-inset-top, 0px)));
+        bottom: auto;
+        right: calc(0.75rem + var(--safe-right, env(safe-area-inset-right, 0px)));
+    }
+    .icon-button,
+    .icon-btn {
+        width: 44px;
+        height: 44px;
+    }
+    .touch-controls {
+        height: min(42%, 38dvh);
     }
 }

--- a/labs/grao/index.html
+++ b/labs/grao/index.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <title>Grão | Diogo Paulino</title>
     <meta name="description"
         content="Companheiro de cafeína no navegador: registre o café, veja quanto ainda circula no corpo e a que horas parar para dormir bem.">
@@ -29,7 +29,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=6">
+    <link rel="stylesheet" href="/labs/shared.css?v=8">
     <link rel="stylesheet" href="style.css">
     <script type="application/ld+json">
     {

--- a/labs/grao/style.css
+++ b/labs/grao/style.css
@@ -637,3 +637,9 @@ header .app-logo .logo-mark {
     .log-item .mg { grid-area: mg; }
     .log-item .remove { grid-area: remove; }
 }
+/* --- lab-responsive-pass --- */
+@media (max-width: 768px) {
+    .icon-btn,
+    .log-item .remove { width: 44px; height: 44px; min-width: 44px; min-height: 44px; }
+    .week-bars { gap: 0.35rem; }
+}

--- a/labs/gravity/index.html
+++ b/labs/gravity/index.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <title>Gravity | Diogo Paulino</title>
     <meta name="description" content="Simulação gravitacional interativa: sistemas solares, estrelas binárias, buracos negros e colisões galácticas em tempo real.">
     <link rel="canonical" href="https://diogopaulino.com.br/labs/gravity/">
@@ -25,7 +25,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=7">
+    <link rel="stylesheet" href="/labs/shared.css?v=8">
     <link rel="stylesheet" href="style.css">
     <script type="application/ld+json">
     {

--- a/labs/gravity/style.css
+++ b/labs/gravity/style.css
@@ -855,3 +855,11 @@ body.fullscreen:hover header {
         transition: none;
     }
 }
+/* --- lab-responsive-pass --- */
+.icon-btn,
+.toggle-controls-btn,
+.close-btn { min-width: 44px; min-height: 44px; }
+
+@media (max-width: 900px) {
+    footer { bottom: max(16px, env(safe-area-inset-bottom, 0px)); }
+}

--- a/labs/honor-front/index.html
+++ b/labs/honor-front/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@600;700;800&family=Oswald:wght@400;500;600;700&family=Outfit:wght@300;400;500;600;700&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=6">
+    <link rel="stylesheet" href="/labs/shared.css?v=8">
     <link rel="stylesheet" href="style.css?v=1">
 
     <script type="importmap">

--- a/labs/honor-front/style.css
+++ b/labs/honor-front/style.css
@@ -557,8 +557,8 @@ body[data-state="landing"] .game-shell > header .app-logo {
 }
 
 .icon-button {
-    width: 38px;
-    height: 38px;
+    width: 44px;
+    height: 44px;
     border-radius: 10px;
     background: var(--panel-strong);
     border: 1px solid var(--line-soft);
@@ -926,4 +926,63 @@ kbd {
     .hud-bottom { grid-template-columns: 1fr; }
     .hud-actions { justify-self: start; }
     .stats { grid-template-columns: 1fr; }
+}
+/* --- lab-responsive-pass --- */
+.overlay {
+    padding: calc(1.2rem + var(--safe-top, 0px))
+             calc(1.2rem + var(--safe-right, 0px))
+             calc(1.2rem + var(--safe-bottom, 0px))
+             calc(1.2rem + var(--safe-left, 0px));
+}
+
+@media (max-width: 860px) {
+    .hud-bottom { bottom: calc(8.5rem + var(--safe-bottom, 0px)); }
+    .stick { width: min(100px, 28vw); height: min(100px, 28vw); }
+}
+
+@media (max-height: 520px) and (orientation: landscape) {
+    .hud-top { gap: 0.35rem; }
+    .quest-panel { display: none; }
+    .health-panel { max-width: 180px; }
+    .stick { width: 88px; height: 88px; }
+}
+
+/* --- mobile: HUD, toque, landscape curto --- */
+@media (pointer: coarse) {
+    .icon-button,
+    .icon-btn {
+        width: 44px;
+        height: 44px;
+        min-width: 44px;
+        min-height: 44px;
+    }
+}
+
+@media (max-width: 560px) {
+    .overlay,
+    .overlay-card,
+    .menu-card {
+        max-height: min(92dvh, 900px);
+    }
+    .overlay-card,
+    .menu-card {
+        overflow-y: auto;
+        -webkit-overflow-scrolling: touch;
+    }
+}
+
+@media (max-height: 520px) and (orientation: landscape) {
+    .hud-actions {
+        top: calc(0.75rem + var(--safe-top, env(safe-area-inset-top, 0px)));
+        bottom: auto;
+        right: calc(0.75rem + var(--safe-right, env(safe-area-inset-right, 0px)));
+    }
+    .icon-button,
+    .icon-btn {
+        width: 44px;
+        height: 44px;
+    }
+    .touch-controls {
+        height: min(42%, 38dvh);
+    }
 }

--- a/labs/ilha-do-ambar/index.html
+++ b/labs/ilha-do-ambar/index.html
@@ -26,7 +26,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,500;0,600;0,700;1,500&family=Barlow:wght@400;500;600;700&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=6">
+    <link rel="stylesheet" href="/labs/shared.css?v=8">
     <link rel="stylesheet" href="style.css?v=1">
 
     <script type="importmap">

--- a/labs/ilha-do-ambar/style.css
+++ b/labs/ilha-do-ambar/style.css
@@ -345,8 +345,8 @@ button { background: none; border: 0; cursor: pointer; }
 }
 
 .icon-button {
-    width: 42px;
-    height: 42px;
+    width: 44px;
+    height: 44px;
     border-radius: 12px;
     background: var(--panel-strong);
     border: 1px solid var(--line);
@@ -679,5 +679,67 @@ body[data-state="pause"] [data-lab-footer] {
 
     .catalog {
         display: none;
+    }
+}
+/* --- lab-responsive-pass --- */
+@media (max-width: 860px) {
+    .prompt {
+        white-space: normal;
+        text-align: center;
+        max-width: min(320px, 90vw);
+        bottom: calc(6.5rem + var(--safe-bottom, 0px));
+    }
+}
+
+@media (max-width: 860px) {
+    .dossier {
+        bottom: calc(9rem + var(--safe-bottom, 0px));
+        width: min(260px, calc(100% - var(--safe-left, 0px) - var(--safe-right, 0px) - 1rem));
+    }
+}
+
+@media (max-height: 520px) and (orientation: landscape) {
+    .dossier { display: none; }
+    .hud-top { grid-template-columns: 1fr 1fr; }
+    .stick { width: 96px; height: 96px; }
+}
+
+/* --- mobile: HUD, toque, landscape curto --- */
+@media (pointer: coarse) {
+    .icon-button,
+    .icon-btn {
+        width: 44px;
+        height: 44px;
+        min-width: 44px;
+        min-height: 44px;
+    }
+}
+
+@media (max-width: 560px) {
+    .overlay,
+    .overlay-card,
+    .menu-card {
+        max-height: min(92dvh, 900px);
+    }
+    .overlay-card,
+    .menu-card {
+        overflow-y: auto;
+        -webkit-overflow-scrolling: touch;
+    }
+}
+
+@media (max-height: 520px) and (orientation: landscape) {
+    .hud-actions {
+        top: calc(0.75rem + var(--safe-top, env(safe-area-inset-top, 0px)));
+        bottom: auto;
+        right: calc(0.75rem + var(--safe-right, env(safe-area-inset-right, 0px)));
+    }
+    .icon-button,
+    .icon-btn {
+        width: 44px;
+        height: 44px;
+    }
+    .touch-controls {
+        height: min(42%, 38dvh);
     }
 }

--- a/labs/image-editor/index.html
+++ b/labs/image-editor/index.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <title>Image Editor | Diogo Paulino</title>
     <meta name="description" content="Editor de imagens no navegador: recorte, filtros, ajustes de brilho, contraste e saturação, tudo processado localmente sem enviar nada para servidor.">
     <link rel="canonical" href="https://diogopaulino.com.br/labs/image-editor/">
@@ -24,7 +24,7 @@
     <meta name="twitter:description" content="Editor de imagens no navegador: recorte, filtros, ajustes de brilho, contraste e saturação, tudo processado localmente sem enviar nada para servidor.">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="stylesheet" href="/labs/shared.css?v=7">
+    <link rel="stylesheet" href="/labs/shared.css?v=8">
     <link rel="stylesheet" href="style.css">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <script type="application/ld+json">

--- a/labs/image-editor/style.css
+++ b/labs/image-editor/style.css
@@ -5,16 +5,15 @@
     border-radius: 1.5rem;
     box-shadow: 0 4px 6px -1px var(--shadow-md), 0 2px 4px -1px var(--shadow-sm);
     overflow: hidden;
-    min-height: 600px;
+    min-height: min(600px, calc(100dvh - 10rem));
     border: 1px solid var(--border-subtle);
     --shadow-accent: var(--accent-glow);
 }
 
 .editor-wrapper {
     display: grid;
-    grid-template-columns: 1fr 320px;
-    grid-template-columns: 1fr 320px;
-    min-height: 600px;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 320px);
+    min-height: min(600px, calc(100dvh - 10rem));
     height: auto;
 }
 
@@ -392,4 +391,12 @@ input[type="range"]::-webkit-slider-thumb:hover {
     .preview-area {
         min-height: min(50vh, 360px);
     }
+}
+/* --- lab-responsive-pass --- */
+@media (max-width: 768px) {
+    .editor-container,
+    .editor-wrapper { min-height: 0; }
+    .preview-area { min-height: min(45dvh, 320px); }
+    .controls-area { max-height: none; }
+    .tab-btn { min-height: 44px; }
 }

--- a/labs/image-optimizer/index.html
+++ b/labs/image-optimizer/index.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <title>Image Optimizer | Diogo Paulino</title>
     <meta name="description" content="Otimize e converta suas imagens para JPG, PNG ou WEBP diretamente no navegador.">
     <link rel="canonical" href="https://diogopaulino.com.br/labs/image-optimizer/">
@@ -24,7 +24,7 @@
     <meta name="twitter:description" content="Otimize e converta suas imagens para JPG, PNG ou WEBP diretamente no navegador.">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="stylesheet" href="/labs/shared.css?v=7">
+    <link rel="stylesheet" href="/labs/shared.css?v=8">
     <link rel="stylesheet" href="style.css">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <script type="application/ld+json">

--- a/labs/image-optimizer/style.css
+++ b/labs/image-optimizer/style.css
@@ -173,7 +173,7 @@ input[type="number"] {
 /* Results Grid */
 .results-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(min(300px, 100%), 1fr));
     gap: 1.5rem;
 }
 
@@ -250,4 +250,11 @@ input[type="number"] {
     .container {
         padding: 1rem;
     }
+}
+/* --- lab-responsive-pass --- */
+@media (max-width: 768px) {
+    .results-grid { grid-template-columns: 1fr; }
+    .settings-group { min-width: 0; flex: 1 1 100%; }
+    .format-btn,
+    .download-btn { min-height: 44px; }
 }

--- a/labs/index.html
+++ b/labs/index.html
@@ -3,7 +3,7 @@
 
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <title>Labs — Diogo Paulino | Jogos 3D, código, música e IA</title>
   <meta name="description" content="43 experimentos de Diogo Paulino: jogos 3D, ferramentas, música e inteligência artificial em HTML, CSS e JavaScript puro.">
   <meta name="author" content="Diogo Paulino">
@@ -28,7 +28,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@100..900&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="/labs/shared.css?v=7">
+  <link rel="stylesheet" href="/labs/shared.css?v=8">
   <link rel="stylesheet" href="/labs/style.css">
   <script type="application/ld+json">
   {

--- a/labs/jornada-do-anel/index.html
+++ b/labs/jornada-do-anel/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;600;700;800&family=Outfit:wght@300;400;500;600;700&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=7">
+    <link rel="stylesheet" href="/labs/shared.css?v=8">
     <link rel="stylesheet" href="style.css?v=1">
 
     <script type="importmap">

--- a/labs/jornada-do-anel/style.css
+++ b/labs/jornada-do-anel/style.css
@@ -374,8 +374,8 @@ body[data-state="playing"] .game-shell > header .app-logo {
 }
 
 .icon-button {
-    width: 42px;
-    height: 42px;
+    width: 44px;
+    height: 44px;
     border-radius: 12px;
     background: var(--panel-strong);
     border: 1px solid var(--line-soft);
@@ -789,4 +789,62 @@ kbd {
     .overlay-card { padding: 1.15rem 1rem 1rem; }
     .menu-head h1 { font-size: 1.7rem; }
     .hud-actions { bottom: calc(7.5rem + var(--safe-bottom)); }
+}
+/* --- lab-responsive-pass --- */
+.overlay {
+    padding: calc(4.5rem + var(--safe-top, 0px))
+             calc(1rem + var(--safe-right, 0px))
+             calc(1.5rem + var(--safe-bottom, 0px))
+             calc(1rem + var(--safe-left, 0px));
+}
+
+@media (max-width: 860px) {
+    .menu-grid { grid-template-columns: 1fr; }
+}
+
+@media (max-height: 520px) and (orientation: landscape) {
+    .stick { width: 96px; height: 96px; bottom: calc(0.8rem + var(--safe-bottom, 0px)); }
+    .touch-buttons { flex-direction: row; gap: 0.35rem; bottom: calc(0.8rem + var(--safe-bottom, 0px)); }
+    .pad { min-width: 64px; min-height: 44px; padding: 0.5rem 0.65rem; font-size: 0.68rem; }
+    .look-zone { height: 70%; top: 15%; }
+}
+
+/* --- mobile: HUD, toque, landscape curto --- */
+@media (pointer: coarse) {
+    .icon-button,
+    .icon-btn {
+        width: 44px;
+        height: 44px;
+        min-width: 44px;
+        min-height: 44px;
+    }
+}
+
+@media (max-width: 560px) {
+    .overlay,
+    .overlay-card,
+    .menu-card {
+        max-height: min(92dvh, 900px);
+    }
+    .overlay-card,
+    .menu-card {
+        overflow-y: auto;
+        -webkit-overflow-scrolling: touch;
+    }
+}
+
+@media (max-height: 520px) and (orientation: landscape) {
+    .hud-actions {
+        top: calc(0.75rem + var(--safe-top, env(safe-area-inset-top, 0px)));
+        bottom: auto;
+        right: calc(0.75rem + var(--safe-right, env(safe-area-inset-right, 0px)));
+    }
+    .icon-button,
+    .icon-btn {
+        width: 44px;
+        height: 44px;
+    }
+    .touch-controls {
+        height: min(42%, 38dvh);
+    }
 }

--- a/labs/jungle-run/index.html
+++ b/labs/jungle-run/index.html
@@ -28,7 +28,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@600;900&family=Plus+Jakarta+Sans:wght@400;500;700;800&display=swap" rel="stylesheet">
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
-    <link rel="stylesheet" href="/labs/shared.css?v=7">
+    <link rel="stylesheet" href="/labs/shared.css?v=8">
     <link rel="stylesheet" href="style.css?v=3">
     <script src="https://cdn.jsdelivr.net/npm/pixi.js@8.6.6/dist/pixi.min.js" defer></script>
     <script type="application/ld+json">
@@ -274,6 +274,16 @@
                                 <span aria-hidden="true">→</span>
                             </button>
                         </div>
+                        <div class="control-climb">
+                            <button class="mobile-btn" id="climbUpBtn" type="button" aria-label="Subir cipó ou árvore">
+                                <span aria-hidden="true">▲</span>
+                                <small>SUBIR</small>
+                            </button>
+                            <button class="mobile-btn" id="climbDownBtn" type="button" aria-label="Descer cipó ou árvore">
+                                <span aria-hidden="true">▼</span>
+                                <small>DESCER</small>
+                            </button>
+                        </div>
                         <button class="mobile-btn jump-btn" id="jumpBtn" type="button"
                             aria-label="Saltar ou agarrar cipó">
                             <span aria-hidden="true">↑</span>
@@ -296,7 +306,7 @@
     </div>
 
     <script src="/labs/shared.js?v=7" defer></script>
-    <script src="script.js?v=4" defer></script>
+    <script src="script.js?v=5" defer></script>
 </body>
 
 </html>

--- a/labs/jungle-run/script.js
+++ b/labs/jungle-run/script.js
@@ -531,6 +531,8 @@ class JungleRun {
 
         this.bindHoldButton('leftBtn', 'left');
         this.bindHoldButton('rightBtn', 'right');
+        this.bindHoldButton('climbUpBtn', 'climbUp');
+        this.bindHoldButton('climbDownBtn', 'climbDown');
         this.bindHoldButton('jumpBtn', 'jump');
     }
 

--- a/labs/jungle-run/style.css
+++ b/labs/jungle-run/style.css
@@ -145,7 +145,7 @@ body.jungle-lab::before {
     width: 100% !important;
     height: 100% !important;
     display: block;
-    object-fit: cover;
+    object-fit: contain;
     object-position: center;
     touch-action: none;
 }
@@ -681,9 +681,14 @@ kbd {
     pointer-events: none;
 }
 
-.control-left {
+.control-left,
+.control-climb {
     display: flex;
     gap: 0.55rem;
+}
+
+.control-climb {
+    flex-direction: column;
 }
 
 .mobile-btn {
@@ -717,11 +722,17 @@ kbd {
     background: rgba(119, 93, 35, 0.5);
 }
 
-.jump-btn small {
+.jump-btn small,
+.control-climb .mobile-btn small {
     display: block;
     margin-top: -0.55rem;
     font-size: 0.42rem;
     letter-spacing: 0.12em;
+}
+
+.control-climb .mobile-btn {
+    height: 64px;
+    border-radius: 18px;
 }
 
 .frame-bottom {
@@ -812,7 +823,8 @@ button:focus-visible {
     }
 
     #gameCanvas {
-        object-position: 20% center;
+        object-fit: contain;
+        object-position: center;
     }
 
     .mobile-controls {
@@ -1219,4 +1231,13 @@ body.jungle-lab {
     font-size: 0.9rem;
     line-height: 1.5;
     text-align: center;
+}
+/* --- lab-responsive-pass --- */
+@media (max-width: 768px) {
+    #gameCanvas {
+        object-fit: contain;
+        object-position: center;
+        width: 100%;
+        height: 100%;
+    }
 }

--- a/labs/lander/index.html
+++ b/labs/lander/index.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <title>Lunar Lander | Diogo Paulino</title>
     <meta name="description" content="Pouso lunar com física realista: gravidade, inércia, consumo de combustível e terreno gerado por procedimento. Desça devagar e no ângulo certo.">
     <link rel="canonical" href="https://diogopaulino.com.br/labs/lander/">
@@ -24,7 +24,7 @@
     <meta name="twitter:description" content="Pouso lunar com física realista: gravidade, inércia, consumo de combustível e terreno gerado por procedimento. Desça devagar e no ângulo certo.">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="stylesheet" href="/labs/shared.css?v=7">
+    <link rel="stylesheet" href="/labs/shared.css?v=8">
     <link rel="stylesheet" href="style.css?v=4">
     <link href="https://fonts.googleapis.com/css2?family=VT323&display=swap" rel="stylesheet">
     <script type="application/ld+json">

--- a/labs/lander/style.css
+++ b/labs/lander/style.css
@@ -418,3 +418,17 @@ canvas {
         animation: none;
     }
 }
+/* --- lab-responsive-pass --- */
+@media (max-width: 600px) {
+    .win31-window { width: 100%; max-width: 100%; }
+    .hud-stats { min-width: 0; max-width: 48%; font-size: 12px; }
+    .onscreen-controls {
+        bottom: max(2px, env(safe-area-inset-bottom, 0px));
+        right: max(14px, env(safe-area-inset-right, 0px));
+    }
+}
+
+@media (max-height: 500px) and (orientation: landscape) {
+    .instructions, footer { display: none; }
+    .game-viewport { max-height: calc(100dvh - 6rem); }
+}

--- a/labs/lumina/index.html
+++ b/labs/lumina/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;600;700;800&family=Nunito:wght@400;600;700;800&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=6">
+    <link rel="stylesheet" href="/labs/shared.css?v=8">
     <link rel="stylesheet" href="style.css">
 
     <script type="importmap">

--- a/labs/lumina/style.css
+++ b/labs/lumina/style.css
@@ -306,8 +306,8 @@ button {
 }
 
 .icon-button {
-    width: 2.5rem;
-    height: 2.5rem;
+    width: 44px;
+    height: 44px;
     border-radius: 50%;
     background: var(--panel-strong);
     border: 1px solid var(--line);
@@ -661,5 +661,52 @@ kbd {
 @media (pointer: fine) {
     .touch-controls {
         display: none !important;
+    }
+}
+/* --- lab-responsive-pass --- */
+@media (max-width: 820px) {
+    .hud-actions {
+        top: calc(4.2rem + var(--safe-top, env(safe-area-inset-top, 0px)));
+    }
+    .message { bottom: calc(11rem + var(--safe-bottom, env(safe-area-inset-bottom, 0px))); }
+}
+
+/* --- mobile: HUD, toque, landscape curto --- */
+@media (pointer: coarse) {
+    .icon-button,
+    .icon-btn {
+        width: 44px;
+        height: 44px;
+        min-width: 44px;
+        min-height: 44px;
+    }
+}
+
+@media (max-width: 560px) {
+    .overlay,
+    .overlay-card,
+    .menu-card {
+        max-height: min(92dvh, 900px);
+    }
+    .overlay-card,
+    .menu-card {
+        overflow-y: auto;
+        -webkit-overflow-scrolling: touch;
+    }
+}
+
+@media (max-height: 520px) and (orientation: landscape) {
+    .hud-actions {
+        top: calc(0.75rem + var(--safe-top, env(safe-area-inset-top, 0px)));
+        bottom: auto;
+        right: calc(0.75rem + var(--safe-right, env(safe-area-inset-right, 0px)));
+    }
+    .icon-button,
+    .icon-btn {
+        width: 44px;
+        height: 44px;
+    }
+    .touch-controls {
+        height: min(42%, 38dvh);
     }
 }

--- a/labs/matrix/index.html
+++ b/labs/matrix/index.html
@@ -27,7 +27,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Share+Tech+Mono&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=7">
+    <link rel="stylesheet" href="/labs/shared.css?v=8">
     <link rel="stylesheet" href="style.css">
     <script type="application/ld+json">
     {

--- a/labs/matrix/style.css
+++ b/labs/matrix/style.css
@@ -1022,3 +1022,17 @@ body.cinema.pointer-idle .cinema-exit {
         animation: none;
     }
 }
+/* --- lab-responsive-pass --- */
+@media (max-width: 768px) {
+    header {
+        padding-top: max(0.9rem, env(safe-area-inset-top, 0px)) !important;
+        padding-inline: max(1rem, env(safe-area-inset-left, 0px)) max(1rem, env(safe-area-inset-right, 0px)) !important;
+    }
+    header .app-logo {
+        letter-spacing: 0.12em;
+        text-indent: 0;
+        font-size: clamp(0.8rem, 3.5vw, 0.95rem);
+    }
+    .icon-btn,
+    .close-btn { min-width: 44px; min-height: 44px; }
+}

--- a/labs/minesweeper/index.html
+++ b/labs/minesweeper/index.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <title>Campo Minado 95 | Diogo Paulino</title>
     <meta name="description" content="Clássico jogo de Campo Minado estilo Windows 95.">
     <link rel="canonical" href="https://diogopaulino.com.br/labs/minesweeper/">
@@ -22,7 +22,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Campo Minado 95 | Diogo Paulino">
     <meta name="twitter:description" content="Clássico jogo de Campo Minado estilo Windows 95.">
-    <link rel="stylesheet" href="/labs/shared.css?v=7">
+    <link rel="stylesheet" href="/labs/shared.css?v=8">
     <link rel="stylesheet" href="style.css">
     <script type="application/ld+json">
     {

--- a/labs/minesweeper/style.css
+++ b/labs/minesweeper/style.css
@@ -295,3 +295,8 @@ body {
         font-size: 11px;
     }
 }
+/* --- lab-responsive-pass --- */
+@media (max-width: 480px) {
+    .window { max-width: 100%; overflow-x: auto; }
+    .board { max-width: 100%; }
+}

--- a/labs/neon-rider/index.html
+++ b/labs/neon-rider/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Audiowide&family=Outfit:wght@400;500;600;700&family=Share+Tech+Mono&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=7">
+    <link rel="stylesheet" href="/labs/shared.css?v=8">
     <link rel="stylesheet" href="style.css?v=2">
 
     <script type="importmap">

--- a/labs/neon-rider/style.css
+++ b/labs/neon-rider/style.css
@@ -386,8 +386,8 @@ body[data-state="playing"] .game-shell > header .app-logo {
 }
 
 .icon-button {
-    width: 40px;
-    height: 40px;
+    width: 44px;
+    height: 44px;
     display: grid;
     place-items: center;
     border-radius: 12px;
@@ -744,4 +744,55 @@ kbd {
     .menu-head h1 { font-size: 1.7rem; }
     .hud-top { gap: 0.45rem; }
     .panel { padding: 0.45rem 0.6rem; }
+}
+/* --- lab-responsive-pass --- */
+@media (max-width: 560px) {
+    .hud-actions {
+        position: absolute;
+        top: calc(0.85rem + var(--safe-top, env(safe-area-inset-top, 0px)));
+        right: calc(1rem + var(--safe-right, env(safe-area-inset-right, 0px)));
+        bottom: auto;
+        grid-row: auto;
+        z-index: 22;
+    }
+}
+
+/* --- mobile: HUD, toque, landscape curto --- */
+@media (pointer: coarse) {
+    .icon-button,
+    .icon-btn {
+        width: 44px;
+        height: 44px;
+        min-width: 44px;
+        min-height: 44px;
+    }
+}
+
+@media (max-width: 560px) {
+    .overlay,
+    .overlay-card,
+    .menu-card {
+        max-height: min(92dvh, 900px);
+    }
+    .overlay-card,
+    .menu-card {
+        overflow-y: auto;
+        -webkit-overflow-scrolling: touch;
+    }
+}
+
+@media (max-height: 520px) and (orientation: landscape) {
+    .hud-actions {
+        top: calc(0.75rem + var(--safe-top, env(safe-area-inset-top, 0px)));
+        bottom: auto;
+        right: calc(0.75rem + var(--safe-right, env(safe-area-inset-right, 0px)));
+    }
+    .icon-button,
+    .icon-btn {
+        width: 44px;
+        height: 44px;
+    }
+    .touch-controls {
+        height: min(42%, 38dvh);
+    }
 }

--- a/labs/noctiluca/index.html
+++ b/labs/noctiluca/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,500;0,600;1,500&family=Outfit:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=7">
+    <link rel="stylesheet" href="/labs/shared.css?v=8">
     <link rel="stylesheet" href="style.css">
 
     <script type="importmap">

--- a/labs/noctiluca/style.css
+++ b/labs/noctiluca/style.css
@@ -351,8 +351,8 @@ body[data-state="playing"] .game-shell > header .app-logo {
 }
 
 .icon-button {
-    width: 38px;
-    height: 38px;
+    width: 44px;
+    height: 44px;
     border-radius: 50%;
     background: var(--panel-strong);
     border: 1px solid var(--line-soft);
@@ -707,4 +707,55 @@ body[data-state="playing"] .theme-switch-wrapper {
 @media (max-width: 560px) {
     .overlay-card { padding: 1rem; }
     .menu-head h1 { font-size: 2.4rem; }
+}
+/* --- lab-responsive-pass --- */
+@media (max-width: 560px) {
+    .hud-actions {
+        position: absolute;
+        top: calc(0.85rem + var(--safe-top, env(safe-area-inset-top, 0px)));
+        right: calc(1rem + var(--safe-right, env(safe-area-inset-right, 0px)));
+        bottom: auto;
+        grid-row: auto;
+        z-index: 22;
+    }
+}
+
+/* --- mobile: HUD, toque, landscape curto --- */
+@media (pointer: coarse) {
+    .icon-button,
+    .icon-btn {
+        width: 44px;
+        height: 44px;
+        min-width: 44px;
+        min-height: 44px;
+    }
+}
+
+@media (max-width: 560px) {
+    .overlay,
+    .overlay-card,
+    .menu-card {
+        max-height: min(92dvh, 900px);
+    }
+    .overlay-card,
+    .menu-card {
+        overflow-y: auto;
+        -webkit-overflow-scrolling: touch;
+    }
+}
+
+@media (max-height: 520px) and (orientation: landscape) {
+    .hud-actions {
+        top: calc(0.75rem + var(--safe-top, env(safe-area-inset-top, 0px)));
+        bottom: auto;
+        right: calc(0.75rem + var(--safe-right, env(safe-area-inset-right, 0px)));
+    }
+    .icon-button,
+    .icon-btn {
+        width: 44px;
+        height: 44px;
+    }
+    .touch-controls {
+        height: min(42%, 38dvh);
+    }
 }

--- a/labs/orbis/index.html
+++ b/labs/orbis/index.html
@@ -34,7 +34,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;600;700&family=Syne:wght@400;500;600;700;800&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=7">
+    <link rel="stylesheet" href="/labs/shared.css?v=8">
     <link rel="stylesheet" href="style.css">
 
     <script type="importmap">

--- a/labs/orbis/style.css
+++ b/labs/orbis/style.css
@@ -584,3 +584,61 @@ body[data-view="system"] #backSystem {
         transition: none;
     }
 }
+/* --- lab-responsive-pass --- */
+.icon-btn { width: 44px; height: 44px; min-width: 44px; min-height: 44px; }
+
+@media (max-width: 860px) {
+    .hud-left {
+        max-height: min(32dvh, calc(100dvh - var(--safe-top, 0px) - var(--safe-bottom, 0px) - 11rem));
+        overflow-y: auto;
+    }
+    .dock {
+        width: min(100%, calc(100% - var(--safe-left, 0px) - var(--safe-right, 0px) - 1rem));
+        max-width: 100%;
+    }
+}
+
+@media (max-height: 520px) and (orientation: landscape) {
+    .hud-left { max-height: 28dvh; width: min(220px, 42vw); }
+    .hud-right { display: none; }
+}
+
+/* --- mobile: HUD, toque, landscape curto --- */
+@media (pointer: coarse) {
+    .icon-button,
+    .icon-btn {
+        width: 44px;
+        height: 44px;
+        min-width: 44px;
+        min-height: 44px;
+    }
+}
+
+@media (max-width: 560px) {
+    .overlay,
+    .overlay-card,
+    .menu-card {
+        max-height: min(92dvh, 900px);
+    }
+    .overlay-card,
+    .menu-card {
+        overflow-y: auto;
+        -webkit-overflow-scrolling: touch;
+    }
+}
+
+@media (max-height: 520px) and (orientation: landscape) {
+    .hud-actions {
+        top: calc(0.75rem + var(--safe-top, env(safe-area-inset-top, 0px)));
+        bottom: auto;
+        right: calc(0.75rem + var(--safe-right, env(safe-area-inset-right, 0px)));
+    }
+    .icon-button,
+    .icon-btn {
+        width: 44px;
+        height: 44px;
+    }
+    .touch-controls {
+        height: min(42%, 38dvh);
+    }
+}

--- a/labs/paint/index.html
+++ b/labs/paint/index.html
@@ -25,7 +25,7 @@
     <meta property="og:locale" content="pt_BR">
     <meta property="og:image" content="https://diogopaulino.com.br/labs/paint/og-paint.jpg">
     <meta name="twitter:card" content="summary_large_image">
-    <link rel="stylesheet" href="/labs/shared.css?v=7">
+    <link rel="stylesheet" href="/labs/shared.css?v=8">
     <link rel="stylesheet" href="style.css?v=2">
     <script type="application/ld+json">
     {

--- a/labs/paint/style.css
+++ b/labs/paint/style.css
@@ -28,15 +28,18 @@ body {
     padding: 0 !important;
     display: block !important;
     height: 100vh;
+    height: 100dvh;
     overflow: hidden;
-    width: 100vw;
+    width: 100%;
+    overflow-x: clip;
 }
 
 .app-container {
     display: flex;
     flex-direction: column;
-    height: 100vh;
+    height: 100%;
     width: 100%;
+    min-height: 0;
 }
 
 /* Top Bar */
@@ -45,10 +48,12 @@ body {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: 0 20px;
+    padding: 0 max(20px, env(safe-area-inset-right, 0px)) 0 max(20px, env(safe-area-inset-left, 0px));
     background: var(--surface-color);
     border-bottom: 1px solid var(--border-color);
     z-index: 10;
+    min-width: 0;
+    gap: 8px;
 }
 
 .left-section {
@@ -349,4 +354,19 @@ input[type="range"]::-webkit-slider-thumb {
         flex-direction: row;
         width: auto;
     }
+}
+/* --- lab-responsive-pass --- */
+@media (max-width: 768px) {
+    .top-bar {
+        height: auto;
+        min-height: 60px;
+        flex-wrap: wrap;
+        gap: 8px;
+        padding: env(safe-area-inset-top, 0px) max(12px, env(safe-area-inset-right, 0px)) 8px max(12px, env(safe-area-inset-left, 0px));
+    }
+    .left-section,
+    .actions { flex-wrap: wrap; min-width: 0; }
+    .tool-btn,
+    button { min-width: 44px; min-height: 44px; }
+    .canvas-container { min-height: 40dvh; }
 }

--- a/labs/pandemonium/index.html
+++ b/labs/pandemonium/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Lilita+One&family=Outfit:wght@300;400;500;600;700;800&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=7">
+    <link rel="stylesheet" href="/labs/shared.css?v=8">
     <link rel="stylesheet" href="style.css?v=1">
 
     <script type="importmap">

--- a/labs/pandemonium/style.css
+++ b/labs/pandemonium/style.css
@@ -338,8 +338,8 @@ body[data-state="paused"] .lab-foot {
 }
 
 .icon-button {
-    width: 2.4rem;
-    height: 2.4rem;
+    width: 44px;
+    height: 44px;
     border-radius: 12px;
     background: var(--panel-strong);
     border: 1px solid var(--line);
@@ -739,4 +739,65 @@ kbd {
         height: 3.8rem;
     }
     .pad-jump { width: 4.6rem; }
+}
+/* --- lab-responsive-pass --- */
+.overlay {
+    padding: calc(1.2rem + var(--safe-top, 0px))
+             calc(1.2rem + var(--safe-right, 0px))
+             calc(1.2rem + var(--safe-bottom, 0px))
+             calc(1.2rem + var(--safe-left, 0px));
+}
+
+@media (max-width: 860px) {
+    .hud-actions {
+        transform: none;
+        top: calc(3.6rem + var(--safe-top, 0px));
+        bottom: auto;
+    }
+}
+
+@media (max-height: 520px) and (orientation: landscape) {
+    .hud-top { grid-template-columns: 1fr 1fr; }
+    .voyage-panel { grid-column: 1 / -1; }
+    .touch-controls { bottom: calc(0.6rem + var(--safe-bottom, 0px)); }
+}
+
+/* --- mobile: HUD, toque, landscape curto --- */
+@media (pointer: coarse) {
+    .icon-button,
+    .icon-btn {
+        width: 44px;
+        height: 44px;
+        min-width: 44px;
+        min-height: 44px;
+    }
+}
+
+@media (max-width: 560px) {
+    .overlay,
+    .overlay-card,
+    .menu-card {
+        max-height: min(92dvh, 900px);
+    }
+    .overlay-card,
+    .menu-card {
+        overflow-y: auto;
+        -webkit-overflow-scrolling: touch;
+    }
+}
+
+@media (max-height: 520px) and (orientation: landscape) {
+    .hud-actions {
+        top: calc(0.75rem + var(--safe-top, env(safe-area-inset-top, 0px)));
+        bottom: auto;
+        right: calc(0.75rem + var(--safe-right, env(safe-area-inset-right, 0px)));
+    }
+    .icon-button,
+    .icon-btn {
+        width: 44px;
+        height: 44px;
+    }
+    .touch-controls {
+        height: min(42%, 38dvh);
+    }
 }

--- a/labs/partitura/index.html
+++ b/labs/partitura/index.html
@@ -3,7 +3,7 @@
 
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover">
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="mobile-web-app-capable" content="yes">
   <title>Partitura: Maestro Quest | Diogo Paulino</title>
@@ -27,7 +27,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;500;700;800&family=Space+Mono:wght@400;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="/labs/shared.css?v=7">
+  <link rel="stylesheet" href="/labs/shared.css?v=8">
   <link rel="stylesheet" href="style.css">
   <script type="application/ld+json">
   {

--- a/labs/partitura/style.css
+++ b/labs/partitura/style.css
@@ -535,3 +535,19 @@ body {
 
 .floating-xp { position: absolute; font-family: var(--font-mono); font-weight: 800; font-size: 1.3rem; color: var(--neon-emerald); pointer-events: none; text-shadow: 0 0 8px var(--neon-emerald); z-index: 500; animation: floatUp 1s forwards; }
 @keyframes floatUp { 0% { opacity: 1; transform: translateY(0); } 100% { opacity: 0; transform: translateY(-38px) scale(1.3); } }
+/* --- lab-responsive-pass --- */
+@media (max-width: 768px) {
+    .maestro-container {
+        padding-inline: max(1rem, env(safe-area-inset-left, 0px)) max(1rem, env(safe-area-inset-right, 0px));
+        padding-bottom: max(0.5rem, env(safe-area-inset-bottom, 0px));
+        max-width: 100%;
+    }
+    .xp-bar-mini { width: min(150px, 40vw); }
+    .stats-summary-grid { grid-template-columns: repeat(2, 1fr); }
+    .tab-btn,
+    .toggle-btn-mini,
+    .btn-trophies-mini,
+    .trigger-pad { min-height: 44px; }
+    .close-btn { min-width: 44px; min-height: 44px; }
+    .hud-strip { flex-wrap: wrap; gap: 0.5rem; }
+}

--- a/labs/piano/index.html
+++ b/labs/piano/index.html
@@ -3,7 +3,7 @@
 
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover">
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="mobile-web-app-capable" content="yes">
   <title>Piano | Diogo Paulino</title>
@@ -24,7 +24,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Piano | Diogo Paulino">
     <meta name="twitter:description" content="Piano minimalista com sons ultra realistas. 4 oitavas completas.">
-  <link rel="stylesheet" href="/labs/shared.css?v=7">
+  <link rel="stylesheet" href="/labs/shared.css?v=8">
   <link rel="stylesheet" href="style.css">
   <script type="application/ld+json">
   {

--- a/labs/piano/style.css
+++ b/labs/piano/style.css
@@ -449,3 +449,8 @@ body {
     margin-bottom: 1rem;
   }
 }
+/* --- lab-responsive-pass --- */
+@media (max-width: 480px) {
+    .octave-btn { width: 44px; height: 44px; min-width: 44px; min-height: 44px; }
+    .controls { padding-bottom: max(0.875rem, env(safe-area-inset-bottom, 0px)); }
+}

--- a/labs/pomodoro/index.html
+++ b/labs/pomodoro/index.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <title>Pomodoro | Diogo Paulino</title>
     <meta name="description"
         content="Timer Pomodoro com tarefas, estatísticas, sons personalizáveis e notificações do navegador.">
@@ -26,7 +26,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=7">
+    <link rel="stylesheet" href="/labs/shared.css?v=8">
     <link rel="stylesheet" href="style.css?v=3">
     <script type="application/ld+json">
     {

--- a/labs/pomodoro/style.css
+++ b/labs/pomodoro/style.css
@@ -1030,3 +1030,13 @@ input[type="range"] {
         transition: none;
     }
 }
+/* --- lab-responsive-pass --- */
+@media (max-width: 480px) {
+    .mode-tabs { flex-wrap: wrap; justify-content: center; }
+    .mode-btn { flex: 1 1 auto; min-height: 44px; white-space: normal; }
+    .icon-btn,
+    .close-btn,
+    .task-remove { width: 44px; height: 44px; min-width: 44px; min-height: 44px; }
+    .task-check { width: 22px; height: 22px; }
+    .task-form { grid-template-columns: minmax(0, 1fr) 72px 44px; }
+}

--- a/labs/pulsar/index.html
+++ b/labs/pulsar/index.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <title>Pulsar | Diogo Paulino</title>
     <meta name="description"
         content="Instrumento musical generativo: toque na tela para criar orbes que pulsam, se conectam e compõem música ambiente sozinhos.">
@@ -26,7 +26,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Oxanium:wght@400;600;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=7">
+    <link rel="stylesheet" href="/labs/shared.css?v=8">
     <link rel="stylesheet" href="style.css">
     <script type="application/ld+json">
     {

--- a/labs/pulsar/style.css
+++ b/labs/pulsar/style.css
@@ -377,3 +377,12 @@ footer {
     .floating-toolbar { bottom: 20px; width: calc(100% - 32px); justify-content: space-between; }
     .tool-btn .preset-name { max-width: 80px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 }
+/* --- lab-responsive-pass --- */
+@media (max-width: 768px) {
+    .floating-toolbar {
+        bottom: max(24px, calc(env(safe-area-inset-bottom, 0px) + 12px));
+        max-width: calc(100% - 1.5rem);
+    }
+    .tool-btn,
+    #cyclePreset { min-height: 44px; min-width: 44px; padding: 12px; }
+}

--- a/labs/ravi-123/index.html
+++ b/labs/ravi-123/index.html
@@ -27,7 +27,7 @@
     content="Conte de 1 a 9 e ajude o Ravi a convidar heróis para a maior festa surpresa do reino. Pixel art 320×200, tudo em vanilla.">
   <meta property="og:locale" content="pt_BR">
 
-  <link rel="stylesheet" href="/labs/shared.css?v=7">
+  <link rel="stylesheet" href="/labs/shared.css?v=8">
   <link rel="stylesheet" href="style.css?v=23">
   <script type="application/ld+json">
   {

--- a/labs/ravi-123/style.css
+++ b/labs/ravi-123/style.css
@@ -128,7 +128,6 @@ header[data-lab-header] .subtitle {
   padding-right: calc(12px + env(safe-area-inset-right, 0px));
   padding-left: calc(12px + env(safe-area-inset-left, 0px));
   pointer-events: none;
-  z-index: 2;
 }
 
 .hud-spacer {
@@ -223,3 +222,5 @@ header[data-lab-header] .subtitle {
   white-space: nowrap;
   border: 0;
 }
+/* --- lab-responsive-pass --- */
+#hud { z-index: 30; }

--- a/labs/river-knight/index.html
+++ b/labs/river-knight/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;600;700;800&family=Outfit:wght@300;400;500;600;700&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=7">
+    <link rel="stylesheet" href="/labs/shared.css?v=8">
     <link rel="stylesheet" href="style.css?v=5">
 
     <script type="importmap">

--- a/labs/river-knight/style.css
+++ b/labs/river-knight/style.css
@@ -612,8 +612,8 @@ body:not([data-state="playing"]) .throw-meter {
 }
 
 .icon-button {
-    width: 40px;
-    height: 40px;
+    width: 44px;
+    height: 44px;
     display: grid;
     place-items: center;
     border-radius: 12px;
@@ -1267,4 +1267,13 @@ input[type="range"]::-moz-range-thumb {
         animation-iteration-count: 1 !important;
         transition-duration: 0.01ms !important;
     }
+}
+/* --- lab-responsive-pass --- */
+@media (max-width: 640px) {
+    .icon-button { width: 44px; height: 44px; }
+}
+
+@media (max-height: 520px) and (orientation: landscape) {
+    .touch-controls { height: 40%; }
+    .pad-throw { width: 80px; height: 80px; }
 }

--- a/labs/rock-kombat/index.html
+++ b/labs/rock-kombat/index.html
@@ -22,7 +22,7 @@
   <meta property="og:title" content="Rock Kombat — 2D Arcade Fight | Diogo Paulino">
   <meta property="og:description" content="Escolha sua lenda. Leia a distância. Domine o palco.">
   <meta property="og:url" content="https://diogopaulino.com.br/labs/rock-kombat/">
-  <link rel="stylesheet" href="/labs/shared.css?v=7">
+  <link rel="stylesheet" href="/labs/shared.css?v=8">
   <link rel="stylesheet" href="style.css?v=6">
   <script type="application/ld+json">
   {

--- a/labs/rock-kombat/style.css
+++ b/labs/rock-kombat/style.css
@@ -1678,4 +1678,15 @@ dialog h2 {
     scroll-behavior: auto !important;
   }
 }
+/* --- lab-responsive-pass --- */
+header {
+    padding-top: max(0px, env(safe-area-inset-top, 0px));
+}
 
+@media (orientation: landscape) and (max-height: 620px) {
+    .touch-controls {
+        bottom: calc(4px + env(safe-area-inset-bottom, 0px));
+        left: calc(5px + env(safe-area-inset-left, 0px));
+        right: calc(5px + env(safe-area-inset-right, 0px));
+    }
+}

--- a/labs/safari-dourado/index.html
+++ b/labs/safari-dourado/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@500;600;700;800&family=Outfit:wght@300;400;500;600;700&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=6">
+    <link rel="stylesheet" href="/labs/shared.css?v=8">
     <link rel="stylesheet" href="style.css?v=1">
 
     <script type="importmap">

--- a/labs/safari-dourado/style.css
+++ b/labs/safari-dourado/style.css
@@ -423,8 +423,8 @@ body[data-state="play"] .hud-actions {
 }
 
 .icon-button {
-    width: 38px;
-    height: 38px;
+    width: 44px;
+    height: 44px;
     border-radius: 10px;
     background: var(--panel);
     border: 1px solid var(--line-soft);
@@ -740,4 +740,63 @@ kbd {
     .overlay-card { padding: 20px; }
     .polaroid { display: none; }
     body[data-state="play"] .hud-actions { margin-top: 0; top: auto; bottom: calc(160px + var(--safe-bottom)); right: calc(18px + var(--safe-right)); }
+}
+/* --- lab-responsive-pass --- */
+.overlay {
+    padding: calc(1.2rem + var(--safe-top, 0px))
+             calc(1.2rem + var(--safe-right, 0px))
+             calc(1.2rem + var(--safe-bottom, 0px))
+             calc(1.2rem + var(--safe-left, 0px));
+}
+
+@media (max-width: 860px) {
+    .hud-top { top: calc(4.2rem + var(--safe-top, 0px)); }
+    .message { bottom: calc(11rem + var(--safe-bottom, 0px)); }
+    .prompt { bottom: calc(9.5rem + var(--safe-bottom, 0px)); max-width: min(92vw, 420px); }
+}
+
+@media (max-height: 520px) and (orientation: landscape) {
+    .hud-top { grid-template-columns: 1fr 1fr 1fr; gap: 8px; }
+    .journal-panel { display: none; }
+    .stick { width: 96px; height: 96px; }
+}
+
+/* --- mobile: HUD, toque, landscape curto --- */
+@media (pointer: coarse) {
+    .icon-button,
+    .icon-btn {
+        width: 44px;
+        height: 44px;
+        min-width: 44px;
+        min-height: 44px;
+    }
+}
+
+@media (max-width: 560px) {
+    .overlay,
+    .overlay-card,
+    .menu-card {
+        max-height: min(92dvh, 900px);
+    }
+    .overlay-card,
+    .menu-card {
+        overflow-y: auto;
+        -webkit-overflow-scrolling: touch;
+    }
+}
+
+@media (max-height: 520px) and (orientation: landscape) {
+    .hud-actions {
+        top: calc(0.75rem + var(--safe-top, env(safe-area-inset-top, 0px)));
+        bottom: auto;
+        right: calc(0.75rem + var(--safe-right, env(safe-area-inset-right, 0px)));
+    }
+    .icon-button,
+    .icon-btn {
+        width: 44px;
+        height: 44px;
+    }
+    .touch-controls {
+        height: min(42%, 38dvh);
+    }
 }

--- a/labs/santos-games/index.html
+++ b/labs/santos-games/index.html
@@ -29,7 +29,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Fredoka:wght@500;600;700&family=Nunito:wght@700;800;900&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=7">
+    <link rel="stylesheet" href="/labs/shared.css?v=8">
     <link rel="stylesheet" href="style.css?v=9">
     <script type="application/ld+json">
     {

--- a/labs/santos-games/src/core/pixel.js
+++ b/labs/santos-games/src/core/pixel.js
@@ -51,7 +51,8 @@ export class PixelSurface {
         const maxH = Math.max(32, (stage?.clientHeight || 224) - 4);
 
         const dpr = Math.min(window.devicePixelRatio || 1, 3);
-        const cssScale = Math.max(1, Math.floor(Math.min(maxW / W, maxH / H)));
+        const raw = Math.min(maxW / W, maxH / H);
+        const cssScale = raw >= 1 ? Math.max(1, Math.floor(raw)) : Math.max(0.5, raw);
         this.wrap.style.width = `${W * cssScale}px`;
         this.wrap.style.height = `${H * cssScale}px`;
 

--- a/labs/santos-games/style.css
+++ b/labs/santos-games/style.css
@@ -381,3 +381,15 @@ html, body {
     .sg-bg, .sg-sun, .sg-hint, .tp-tap { animation: none; }
     .sg-events li { transition: none; }
 }
+/* --- lab-responsive-pass --- */
+.sg-header, .sg-footer {
+    padding-left: max(1.1rem, env(safe-area-inset-left, 0px));
+    padding-right: max(1.1rem, env(safe-area-inset-right, 0px));
+}
+
+@media (max-height: 560px) and (orientation: landscape) {
+    .sg-shell { flex-direction: column; }
+    .sg-side { width: 100%; max-width: 100%; max-height: 38vh; overflow-y: auto; }
+    .sg-stage { min-height: 0; flex: 1; }
+    .sg-emu { max-width: 100%; height: auto; }
+}

--- a/labs/shared.css
+++ b/labs/shared.css
@@ -38,6 +38,8 @@
 
 html {
     overflow-x: clip;
+    -webkit-text-size-adjust: 100%;
+    text-size-adjust: 100%;
 }
 
 body {
@@ -342,6 +344,8 @@ footer a:hover {
     header .subtitle {
         font-size: 0.875rem;
         padding: 0 0.25rem;
+        max-width: 100%;
+        overflow-wrap: anywhere;
     }
 
     header .theme-toggle,

--- a/labs/silkline/index.html
+++ b/labs/silkline/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Outfit:wght@400;500;600;700&family=Share+Tech+Mono&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=6">
+    <link rel="stylesheet" href="/labs/shared.css?v=8">
     <link rel="stylesheet" href="style.css">
 
     <script type="importmap">

--- a/labs/silkline/style.css
+++ b/labs/silkline/style.css
@@ -386,8 +386,8 @@ body[data-state="playing"] .game-shell > header .app-logo {
 }
 
 .icon-button {
-    width: 40px;
-    height: 40px;
+    width: 44px;
+    height: 44px;
     display: grid;
     place-items: center;
     border-radius: 12px;
@@ -743,4 +743,55 @@ kbd {
     .menu-head h1 { font-size: 2rem; }
     .hud-top { gap: 0.45rem; }
     .panel { padding: 0.45rem 0.6rem; }
+}
+/* --- lab-responsive-pass --- */
+@media (max-width: 560px) {
+    .hud-actions {
+        position: absolute;
+        top: calc(0.85rem + var(--safe-top, env(safe-area-inset-top, 0px)));
+        right: calc(1rem + var(--safe-right, env(safe-area-inset-right, 0px)));
+        bottom: auto;
+        grid-row: auto;
+        z-index: 22;
+    }
+}
+
+/* --- mobile: HUD, toque, landscape curto --- */
+@media (pointer: coarse) {
+    .icon-button,
+    .icon-btn {
+        width: 44px;
+        height: 44px;
+        min-width: 44px;
+        min-height: 44px;
+    }
+}
+
+@media (max-width: 560px) {
+    .overlay,
+    .overlay-card,
+    .menu-card {
+        max-height: min(92dvh, 900px);
+    }
+    .overlay-card,
+    .menu-card {
+        overflow-y: auto;
+        -webkit-overflow-scrolling: touch;
+    }
+}
+
+@media (max-height: 520px) and (orientation: landscape) {
+    .hud-actions {
+        top: calc(0.75rem + var(--safe-top, env(safe-area-inset-top, 0px)));
+        bottom: auto;
+        right: calc(0.75rem + var(--safe-right, env(safe-area-inset-right, 0px)));
+    }
+    .icon-button,
+    .icon-btn {
+        width: 44px;
+        height: 44px;
+    }
+    .touch-controls {
+        height: min(42%, 38dvh);
+    }
 }

--- a/labs/snake/index.html
+++ b/labs/snake/index.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <title>Retro Snake | Diogo Paulino</title>
     <meta name="description"
         content="Snake retrô em um console portátil 8-bit: colete frutas, ganhe velocidade e bata o seu recorde direto no navegador.">
@@ -25,7 +25,7 @@
     <meta property="og:description"
         content="Snake retrô em um console portátil 8-bit: colete frutas, ganhe velocidade e bata o seu recorde.">
     <meta property="og:url" content="https://diogopaulino.com.br/labs/snake/">
-    <link rel="stylesheet" href="/labs/shared.css?v=7">
+    <link rel="stylesheet" href="/labs/shared.css?v=8">
     <link rel="stylesheet" href="style.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/labs/snake/style.css
+++ b/labs/snake/style.css
@@ -430,3 +430,14 @@ canvas {
         margin-bottom: calc((var(--device-scale) - 1) * 562px);
     }
 }
+/* --- lab-responsive-pass --- */
+@media (max-height: 500px) and (orientation: landscape) {
+    .game-boy,
+    .handheld-device {
+        --device-scale: min(1, calc((100dvh - 72px) / 560px));
+        transform: scale(var(--device-scale));
+        transform-origin: top center;
+        margin-bottom: calc((var(--device-scale) - 1) * 560px);
+    }
+    .instructions { display: none; }
+}

--- a/labs/space-shooter/index.html
+++ b/labs/space-shooter/index.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <title>Neon Invaders | Diogo Paulino</title>
     <meta name="description" content="Jogo de tiro espacial estilo arcade com gráficos neon.">
     <link rel="canonical" href="https://diogopaulino.com.br/labs/space-shooter/">
@@ -24,7 +24,7 @@
     <meta name="twitter:description" content="Jogo de tiro espacial estilo arcade com gráficos neon.">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="stylesheet" href="/labs/shared.css?v=7">
+    <link rel="stylesheet" href="/labs/shared.css?v=8">
     <link rel="stylesheet" href="style.css?v=3">
     <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
     <script type="application/ld+json">
@@ -195,7 +195,7 @@
     </div>
 
     <script src="/labs/shared.js?v=7" defer></script>
-    <script src="script.js?v=3" defer></script>
+    <script src="script.js?v=4" defer></script>
 </body>
 
 </html>

--- a/labs/space-shooter/script.js
+++ b/labs/space-shooter/script.js
@@ -97,7 +97,7 @@ function resize() {
     canvas.width = Math.floor(gameWidth * dpr);
     canvas.height = Math.floor(gameHeight * dpr);
 
-    ctx.scale(dpr, dpr);
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
 
     player.y = gameHeight - player.height - 26;
     player.x = previousWidth

--- a/labs/space-shooter/style.css
+++ b/labs/space-shooter/style.css
@@ -673,3 +673,11 @@ footer a {
         animation: none;
     }
 }
+/* --- lab-responsive-pass --- */
+@media (max-width: 900px) {
+    .touch-controls {
+        bottom: max(14px, env(safe-area-inset-bottom, 0px));
+        left: max(14px, env(safe-area-inset-left, 0px));
+        right: max(14px, env(safe-area-inset-right, 0px));
+    }
+}

--- a/labs/style.css
+++ b/labs/style.css
@@ -21,7 +21,8 @@
 }
 
 .filter-btn {
-  padding: 0.5rem 1.25rem;
+  padding: 0.625rem 1.25rem;
+  min-height: 44px;
   border-radius: 2rem;
   border: 1px solid var(--border-subtle);
   background: var(--bg-card);
@@ -205,7 +206,7 @@
 /* Responsive */
 @media (max-width: 1024px) {
   .projects-grid {
-    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(min(320px, 100%), 1fr));
   }
 }
 

--- a/labs/tamagotchi/index.html
+++ b/labs/tamagotchi/index.html
@@ -3,7 +3,7 @@
 
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <title>RakuRaku Dinokun / Dinkie Dino (1997) | Diogo Paulino</title>
   <meta name="description"
     content="Recriação pesquisada do RakuRaku Dinokun / Dinkie Dino: carcaça, LCD, controles e ciclo de cuidado em tempo real.">
@@ -23,7 +23,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="RakuRaku Dinokun / Dinkie Dino (1997) | Diogo Paulino">
     <meta name="twitter:description" content="Recriação pesquisada do RakuRaku Dinokun / Dinkie Dino: carcaça, LCD, controles e ciclo de cuidado em tempo real.">
-  <link rel="stylesheet" href="/labs/shared.css?v=7">
+  <link rel="stylesheet" href="/labs/shared.css?v=8">
   <link rel="stylesheet" href="style.css?v=12">
   <script type="application/ld+json">
   {

--- a/labs/tamagotchi/style.css
+++ b/labs/tamagotchi/style.css
@@ -757,3 +757,15 @@ header {
   .side-key,
   .bottom-key { transition: none; }
 }
+/* --- lab-responsive-pass --- */
+@media (max-width: 720px) {
+    .device-area {
+        padding-bottom: max(1.35rem, env(safe-area-inset-bottom, 0px));
+        width: 100%;
+        max-width: 100%;
+    }
+    .tama-shell {
+        width: min(568px, calc(100vw - 1.5rem));
+        max-width: 100%;
+    }
+}

--- a/labs/tetris/index.html
+++ b/labs/tetris/index.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <title>Tetris 90s | Diogo Paulino</title>
     <meta name="description" content="Jogue Tetris clássico estilo anos 90 no seu navegador.">
     <link rel="canonical" href="https://diogopaulino.com.br/labs/tetris/">
@@ -22,7 +22,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Tetris 90s | Diogo Paulino">
     <meta name="twitter:description" content="Jogue Tetris clássico estilo anos 90 no seu navegador.">
-    <link rel="stylesheet" href="/labs/shared.css?v=7">
+    <link rel="stylesheet" href="/labs/shared.css?v=8">
     <link rel="stylesheet" href="style.css">
     <script type="application/ld+json">
     {

--- a/labs/tetris/style.css
+++ b/labs/tetris/style.css
@@ -321,3 +321,14 @@ body {
         margin-bottom: calc((var(--device-scale) - 1) * 540px);
     }
 }
+/* --- lab-responsive-pass --- */
+@media (max-height: 500px) and (orientation: landscape) {
+    .game-boy,
+    .handheld-device {
+        --device-scale: min(1, calc((100dvh - 72px) / 560px));
+        transform: scale(var(--device-scale));
+        transform-origin: top center;
+        margin-bottom: calc((var(--device-scale) - 1) * 560px);
+    }
+    .instructions { display: none; }
+}

--- a/labs/toaster-64/index.html
+++ b/labs/toaster-64/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Press+Start+2P&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=7">
+    <link rel="stylesheet" href="/labs/shared.css?v=8">
     <link rel="stylesheet" href="style.css?v=1">
 
     <script type="importmap">

--- a/labs/toaster-64/style.css
+++ b/labs/toaster-64/style.css
@@ -333,8 +333,8 @@ button {
 }
 
 .icon-button {
-    width: 42px;
-    height: 42px;
+    width: 44px;
+    height: 44px;
     border-radius: 12px;
     background: var(--panel-strong);
     border: 1px solid var(--line);
@@ -699,5 +699,59 @@ kbd {
     }
     .throw-meter {
         display: none;
+    }
+}
+/* --- lab-responsive-pass --- */
+@media (pointer: coarse) {
+    .touch-controls {
+        padding-left: calc(1rem + var(--safe-left, 0px));
+        padding-right: calc(1rem + var(--safe-right, 0px));
+        padding-bottom: calc(0.6rem + var(--safe-bottom, 0px));
+    }
+}
+
+@media (max-height: 520px) and (orientation: landscape) {
+    .steer-zone { width: 100px; height: 100px; }
+    .pad { width: 72px; height: 72px; }
+    .hud-top { grid-template-columns: 1fr 1fr 1fr; }
+}
+
+/* --- mobile: HUD, toque, landscape curto --- */
+@media (pointer: coarse) {
+    .icon-button,
+    .icon-btn {
+        width: 44px;
+        height: 44px;
+        min-width: 44px;
+        min-height: 44px;
+    }
+}
+
+@media (max-width: 560px) {
+    .overlay,
+    .overlay-card,
+    .menu-card {
+        max-height: min(92dvh, 900px);
+    }
+    .overlay-card,
+    .menu-card {
+        overflow-y: auto;
+        -webkit-overflow-scrolling: touch;
+    }
+}
+
+@media (max-height: 520px) and (orientation: landscape) {
+    .hud-actions {
+        top: calc(0.75rem + var(--safe-top, env(safe-area-inset-top, 0px)));
+        bottom: auto;
+        right: calc(0.75rem + var(--safe-right, env(safe-area-inset-right, 0px)));
+    }
+    .icon-button,
+    .icon-btn {
+        width: 44px;
+        height: 44px;
+    }
+    .touch-controls {
+        height: min(42%, 38dvh);
     }
 }

--- a/labs/vector-fighter/index.html
+++ b/labs/vector-fighter/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Teko:wght@400;500;600;700&family=Outfit:wght@400;500;600;700&family=Share+Tech+Mono&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=6">
+    <link rel="stylesheet" href="/labs/shared.css?v=8">
     <link rel="stylesheet" href="style.css">
 
     <script type="importmap">

--- a/labs/vector-fighter/style.css
+++ b/labs/vector-fighter/style.css
@@ -287,8 +287,8 @@ body[data-state="fight"] .game-shell > header .app-logo {
 }
 
 .icon-button {
-    width: 42px;
-    height: 42px;
+    width: 44px;
+    height: 44px;
     border: 1px solid var(--line-soft);
     background: var(--panel);
     backdrop-filter: blur(var(--blur));
@@ -669,4 +669,58 @@ kbd {
     .roster { grid-template-columns: repeat(2, 1fr); }
     .settings-row { grid-template-columns: 1fr; }
     .fighter-hud strong { font-size: 1.1rem; }
+}
+/* --- lab-responsive-pass --- */
+@media (max-width: 840px), (pointer: coarse) {
+    .hud-actions {
+        top: calc(0.8rem + var(--safe-top, env(safe-area-inset-top, 0px)));
+        bottom: auto;
+    }
+}
+
+@media (max-width: 560px) {
+    .touch-btns { grid-template-columns: repeat(2, minmax(56px, 64px)); }
+    .pad { min-height: 48px; }
+    .stick { width: min(100px, 28vw); height: min(100px, 28vw); }
+    .overlay { padding-bottom: calc(1rem + var(--safe-bottom, env(safe-area-inset-bottom, 0px))); }
+}
+
+/* --- mobile: HUD, toque, landscape curto --- */
+@media (pointer: coarse) {
+    .icon-button,
+    .icon-btn {
+        width: 44px;
+        height: 44px;
+        min-width: 44px;
+        min-height: 44px;
+    }
+}
+
+@media (max-width: 560px) {
+    .overlay,
+    .overlay-card,
+    .menu-card {
+        max-height: min(92dvh, 900px);
+    }
+    .overlay-card,
+    .menu-card {
+        overflow-y: auto;
+        -webkit-overflow-scrolling: touch;
+    }
+}
+
+@media (max-height: 520px) and (orientation: landscape) {
+    .hud-actions {
+        top: calc(0.75rem + var(--safe-top, env(safe-area-inset-top, 0px)));
+        bottom: auto;
+        right: calc(0.75rem + var(--safe-right, env(safe-area-inset-right, 0px)));
+    }
+    .icon-button,
+    .icon-btn {
+        width: 44px;
+        height: 44px;
+    }
+    .touch-controls {
+        height: min(42%, 38dvh);
+    }
 }

--- a/labs/videogame/index.html
+++ b/labs/videogame/index.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <title>Videogame | Diogo Paulino</title>
     <meta name="description" content="Emulador de jogos clássicos no navegador. Jogue Sonic e outros títulos retrô.">
     <link rel="canonical" href="https://diogopaulino.com.br/labs/videogame/">
@@ -25,7 +25,7 @@
 
 
 
-    <link rel="stylesheet" href="/labs/shared.css?v=7">
+    <link rel="stylesheet" href="/labs/shared.css?v=8">
     <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="mobile.css">
     <script src="/labs/videogame/lib/nostalgist.umd.js" defer></script>

--- a/labs/winamp/index.html
+++ b/labs/winamp/index.html
@@ -26,7 +26,7 @@
     <meta name="twitter:title" content="Winamp JS | Diogo Paulino">
     <meta name="twitter:description" content="Player retrô 100% vanilla: playlist, equalizador, visualizador e músicas chiptune sintetizadas no navegador.">
     <meta name="twitter:image" content="https://diogopaulino.com.br/assets/img/diogo.jpeg">
-    <link rel="stylesheet" href="/labs/shared.css?v=7">
+    <link rel="stylesheet" href="/labs/shared.css?v=8">
     <link rel="stylesheet" href="style.css?v=5">
     <script type="application/ld+json">
     {

--- a/labs/winamp/style.css
+++ b/labs/winamp/style.css
@@ -1536,3 +1536,9 @@ noscript {
         transition: none !important;
     }
 }
+/* --- lab-responsive-pass --- */
+@media (max-width: 760px) {
+    header[data-lab-header] .back-link { min-height: 44px; min-width: 44px; }
+    .task-button { width: auto; flex: 1 1 0; min-width: 0; }
+    .system-tray { flex-shrink: 0; }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 🎯 Objetivo

Fazer **todos** os labs (jogos, ferramentas, simulações e áudio) funcionarem bem no celular/tablet, e deixar isso obrigatório no `AGENTS.md` para os próximos.

## ✨ O que mudou

- `AGENTS.md`: seção **Responsivo (obrigatório)** — viewport, safe-area, overflow, toque ≥ 44px, HUD, landscape, alvos de teste (375 / 390 / landscape curto)
- Template de PR: passo de teste + checklist de responsivo
- Home, galeria e `shared.css`: `viewport-fit=cover`, safe-area, filtros 44px, theme toggle 44px
- Jogos 3D: HUD/ações fora da zona de toque, overlays com safe-area, landscape curto, botões 44px
- Jogos 2D: escala em landscape (Snake/Tetris), canvas do Neon Invaders sem acumular DPR, Jungle Run com subir/descer no toque, Santos Games escala &lt; 1×
- Ferramentas e áudio: overflow (Paint, Image Optimizer, Pomodoro, Image Editor, Calculator, Partitura, Piano, etc.)

## 🧪 Como testar

1. Na raiz do repo: `python3 -m http.server 8000`
2. Abrir [http://localhost:8000/](http://localhost:8000/) (home) e [http://localhost:8000/labs/](http://localhost:8000/labs/) (galeria)
3. Abrir o lab ou a página alterada e confirmar que CSS, JS e o voltar funcionam
4. Responsivo: DevTools em **375×667**, **390×844** e landscape curto (~667×375) — sem overflow horizontal, HUD/controles utilizáveis, alvos ≥ 44px
5. Amostrar pelo menos um de cada família: 3D (Noctiluca / Honor Front), 2D (Jungle Run / Snake), ferramenta (Pomodoro / Paint), áudio (Piano / Winamp)

## ✅ Checklist

- [x] Links conferidos: pasta do lab ↔ card da galeria ↔ README ↔ sitemap (e corrigidos se quebravam)
- [x] README atualizado (linha na tabela + URL + contagem no badge/texto) — obrigatório em lab novo, renomeado ou removido
- [x] SEO consistente: title, description, canonical, author, robots, OG, Twitter, JSON-LD (e contagem nos metas da galeria)
- [x] Testado via HTTP na raiz, não via `file://`
- [x] Responsivo: 375px / 390px / landscape — overflow, HUD, toque, safe-area (`viewport-fit=cover`)
- [x] Nada fora do escopo foi quebrado

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ffe19-947a-78ec-bbd4-a2fe734f5508?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ffe19-947a-78ec-bbd4-a2fe734f5508&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

