### PR TITLE
🧪 Eyra — voo 3D pelos picos flutuantes em three.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 Mais de 20 anos em tecnologia, entre liderança, código hands-on e design UI/UX.
 
 [![Website](https://img.shields.io/badge/Website-diogopaulino.com.br-3B82F6?style=flat-square&logo=googlechrome&logoColor=white)](https://diogopaulino.com.br/)
-[![Labs](https://img.shields.io/badge/Labs-46_experimentos-8B5CF6?style=flat-square&logo=stackblitz&logoColor=white)](https://diogopaulino.com.br/labs/)
+[![Labs](https://img.shields.io/badge/Labs-47_experimentos-8B5CF6?style=flat-square&logo=stackblitz&logoColor=white)](https://diogopaulino.com.br/labs/)
 [![GitHub](https://img.shields.io/badge/GitHub-diogopaulino-181717?style=flat-square&logo=github&logoColor=white)](https://github.com/diogopaulino)
 [![LinkedIn](https://img.shields.io/badge/LinkedIn-Diogo_Paulino-0A66C2?style=flat-square)](https://br.linkedin.com/in/diogopaulino)
 [![Spotify](https://img.shields.io/badge/Spotify-Artist-1DB954?style=flat-square&logo=spotify&logoColor=white)](https://open.spotify.com/intl-pt/artist/0ue2WfDQ1P4XR2vXdSIrYQ)
@@ -32,12 +32,13 @@ Gosto de construir coisas — de time e produto até interface e código. Nessa 
 
 > *Abre, experimenta, quebra, reconstrói. Esse é o espírito.*
 
-Um laboratório aberto com **46 experimentos** que rodam direto no navegador — HTML, CSS e JavaScript puro, sem instalar nada. Catálogo completo em [diogopaulino.com.br/labs](https://diogopaulino.com.br/labs/).
+Um laboratório aberto com **47 experimentos** que rodam direto no navegador — HTML, CSS e JavaScript puro, sem instalar nada. Catálogo completo em [diogopaulino.com.br/labs](https://diogopaulino.com.br/labs/).
 
 ### 🪐 Mundos 3D
 
 | Projeto | O que é? |
 | :--- | :--- |
+| ✧ **[Eyra](https://diogopaulino.com.br/labs/eyra/)** | Voo numa fera alada pelos picos flutuantes — sementes de luz, cachoeiras no céu e a Yva |
 | 🪸 **[Nereida](https://diogopaulino.com.br/labs/nereida/)** | Voo da arraia-manta num recife bioluminescente — anéis de luz, pérolas e o templo náutilo |
 | ◎ **[Riftball](https://diogopaulino.com.br/labs/riftball/)** | Duelo 1v1 no rift — hovers, bola de éter e gol online com código de sala |
 | 🪼 **[Noctiluca](https://diogopaulino.com.br/labs/noctiluca/)** | Medusa de luz no abismo — pulse no ritmo, atravesse anéis de ruína e desça a cidade submersa |

--- a/index.html
+++ b/index.html
@@ -157,7 +157,7 @@
       </nav>
       <div class="labs-easter-egg" id="labs-easter-egg">
         <a href="/labs/" class="labs-badge"
-          aria-label="Labs de Diogo Paulino: 46 experimentos de jogos, código, música e IA">
+          aria-label="Labs de Diogo Paulino: 47 experimentos de jogos, código, música e IA">
           <span class="labs-text">labs</span>
           <svg class="labs-sparkles" width="14" height="14" viewBox="0 0 24 24" fill="currentColor" stroke="none">
             <path d="M12 2L14.4 9.6L22 12L14.4 14.4L12 22L9.6 14.4L2 12L9.6 9.6L12 2Z" />

--- a/labs/eyra/index.html
+++ b/labs/eyra/index.html
@@ -1,0 +1,286 @@
+<!DOCTYPE html>
+<html lang="pt-br" data-theme="dark">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport"
+        content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover">
+    <meta name="theme-color" content="#041820">
+    <title>Eyra — voo nos ares | Diogo Paulino</title>
+    <meta name="description"
+        content="Voe numa fera alada pelos picos flutuantes de Eyra em three.js: floresta bioluminescente, cachoeiras no céu e o vínculo com a Yva.">
+    <link rel="canonical" href="https://diogopaulino.com.br/labs/eyra/">
+    <meta name="author" content="Diogo Paulino">
+    <meta name="robots" content="index, follow">
+    <link rel="icon" href="/favicon.ico" sizes="any">
+    <meta property="og:image" content="https://diogopaulino.com.br/assets/img/diogo.jpeg">
+    <meta property="og:image:alt" content="Diogo Paulino">
+    <meta property="og:locale" content="pt_BR">
+    <meta name="twitter:image" content="https://diogopaulino.com.br/assets/img/diogo.jpeg">
+
+    <meta property="og:type" content="website">
+    <meta property="og:site_name" content="Diogo Paulino · Labs">
+    <meta property="og:url" content="https://diogopaulino.com.br/labs/eyra/">
+    <meta property="og:title" content="Eyra — voo nos ares | Diogo Paulino">
+    <meta property="og:description"
+        content="Picos flutuantes, uma fera alada e a árvore-mãe. three.js, ACES e o céu de um mundo vivo.">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Eyra | Diogo Paulino">
+    <meta name="twitter:description" content="Voo 3D pelos picos flutuantes de Eyra. Colete sementes de luz e volte à Yva.">
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;600;700;800&family=Outfit:wght@400;500;600;700;800&display=swap"
+        rel="stylesheet">
+    <link rel="stylesheet" href="/labs/shared.css?v=7">
+    <link rel="stylesheet" href="style.css">
+
+    <script type="importmap">
+    {
+        "imports": {
+            "three": "https://cdn.jsdelivr.net/npm/three@0.185.1/build/three.module.js",
+            "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.185.1/examples/jsm/"
+        }
+    }
+    </script>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@graph": [
+        {
+          "@type": "WebApplication",
+          "name": "Eyra",
+          "url": "https://diogopaulino.com.br/labs/eyra/",
+          "description": "Voe numa fera alada pelos picos flutuantes de Eyra em three.js: floresta bioluminescente, cachoeiras no céu e o vínculo com a Yva.",
+          "applicationCategory": "GameApplication",
+          "operatingSystem": "Any",
+          "inLanguage": "pt-BR",
+          "isAccessibleForFree": true,
+          "author": {
+            "@type": "Person",
+            "name": "Diogo Paulino",
+            "url": "https://diogopaulino.com.br/"
+          },
+          "image": "https://diogopaulino.com.br/assets/img/diogo.jpeg"
+        },
+        {
+          "@type": "BreadcrumbList",
+          "itemListElement": [
+            {
+              "@type": "ListItem",
+              "position": 1,
+              "name": "Diogo Paulino",
+              "item": "https://diogopaulino.com.br/"
+            },
+            {
+              "@type": "ListItem",
+              "position": 2,
+              "name": "Labs",
+              "item": "https://diogopaulino.com.br/labs/"
+            },
+            {
+              "@type": "ListItem",
+              "position": 3,
+              "name": "Eyra",
+              "item": "https://diogopaulino.com.br/labs/eyra/"
+            }
+          ]
+        }
+      ]
+    }
+    </script>
+</head>
+
+<body>
+    <main class="game-shell">
+        <header data-lab-header data-title="Eyra" data-back-label="Labs">
+            <template data-slot="logo">
+                <div class="app-logo">
+                    <span class="brand-mark" aria-hidden="true">✧</span>
+                    <span>Eyra</span>
+                </div>
+            </template>
+        </header>
+
+        <section class="stage" aria-label="Mundo flutuante em 3D">
+            <canvas id="scene" aria-label="Picos flutuantes de Eyra com uma fera alada em voo"></canvas>
+            <div class="vignette" aria-hidden="true"></div>
+        </section>
+
+        <div id="hud" class="hud" hidden>
+            <div class="hud-top">
+                <div class="panel alt-panel">
+                    <span class="hud-label">Altitude</span>
+                    <strong id="altValue" class="mono">056 m</strong>
+                    <span id="zoneValue" class="hud-tag">Picos de Helion</span>
+                </div>
+                <div class="panel quest-panel">
+                    <span class="hud-label" id="questTag">O vínculo adormecido</span>
+                    <p id="objective" class="objective">Colete as oito sementes e volte à Yva.</p>
+                    <div class="boost-meter" title="Impulso">
+                        <i id="boostFill"></i>
+                    </div>
+                    <span id="speedValue" class="hud-tag mono">00 kn</span>
+                </div>
+                <div class="panel score-panel">
+                    <span class="hud-label">Sementes</span>
+                    <div id="seedPips" class="pips" aria-label="Sementes coletadas"></div>
+                    <strong id="seedValue" class="mono">00 / 8</strong>
+                    <div class="score-row">
+                        <span>Combo</span>
+                        <strong id="comboValue" class="mono">1×</strong>
+                    </div>
+                    <div class="score-row">
+                        <span>Canto</span>
+                        <strong id="scoreValue" class="mono">0</strong>
+                    </div>
+                </div>
+            </div>
+
+            <p id="message" class="message" role="status" aria-live="polite" data-show="false"></p>
+
+            <div class="hud-actions">
+                <button id="soundButton" class="icon-button" type="button" aria-pressed="true"
+                    title="Som (M)" aria-label="Alternar som">♪</button>
+                <button id="pauseButton" class="icon-button" type="button" title="Pausar (P)"
+                    aria-label="Pausar">II</button>
+                <span id="fpsCounter" class="fps mono">—</span>
+            </div>
+
+            <div id="touchControls" class="touch-controls" hidden>
+                <div id="moveStick" class="stick" aria-label="Voar">
+                    <i id="moveKnob"></i>
+                    <span>voar</span>
+                </div>
+                <div class="touch-buttons">
+                    <button type="button" id="btnRoll" class="pad" aria-label="Pirueta">GIRO</button>
+                    <button type="button" id="btnBoost" class="pad pad-magic" aria-label="Impulso">ÍMPETO</button>
+                </div>
+            </div>
+        </div>
+
+        <div id="loadingOverlay" class="overlay loading-overlay">
+            <div class="loading-card">
+                <span class="star-loader" aria-hidden="true">✧</span>
+                <h1>Eyra</h1>
+                <p id="loadingText">Os picos acordam…</p>
+                <div class="loading-bar"><i id="loadingFill"></i></div>
+            </div>
+        </div>
+
+        <div id="menuOverlay" class="overlay menu-overlay" hidden>
+            <div class="overlay-card menu-card">
+                <header class="menu-head">
+                    <p class="eyebrow"><i></i> three.js · picos · bioluminescência</p>
+                    <h1>Ey<span>ra</span></h1>
+                    <p class="lede">Você é o piloto da ira, a fera alada dos picos flutuantes.
+                        Deslize entre montanhas no céu, atravesse anéis de névoa, colete as oito
+                        sementes de luz e devolva o canto à Yva, a árvore-mãe.</p>
+                </header>
+
+                <div class="menu-grid">
+                    <section class="menu-section">
+                        <h2>Como voar</h2>
+                        <div class="keys">
+                            <span><kbd>W</kbd><kbd>A</kbd><kbd>S</kbd><kbd>D</kbd> guiar · acelerar</span>
+                            <span><kbd>Shift</kbd> subir · <kbd>Ctrl</kbd> descer</span>
+                            <span><kbd>Espaço</kbd> impulso · <kbd>Q</kbd> <kbd>E</kbd> pirueta</span>
+                            <span>Mouse arrasta a câmera</span>
+                            <span><kbd>P</kbd> pausa · <kbd>M</kbd> som</span>
+                        </div>
+                    </section>
+                    <section class="menu-section">
+                        <h2>Ajustes</h2>
+                        <div class="settings-grid">
+                            <label class="field">
+                                <span>Qualidade</span>
+                                <select id="qualitySelect">
+                                    <option value="auto">Automática</option>
+                                    <option value="low">Leve</option>
+                                    <option value="medium">Equilibrada</option>
+                                    <option value="high">Cinemática</option>
+                                </select>
+                            </label>
+                            <label class="field">
+                                <span>Volume <b id="volumeValue">70</b></span>
+                                <input id="volumeSlider" type="range" min="0" max="100" step="1" value="70">
+                            </label>
+                        </div>
+                        <p class="section-note">Melhor canto: <b id="bestScore" class="mono">—</b></p>
+                    </section>
+                </div>
+
+                <footer class="menu-foot">
+                    <button id="startButton" class="primary-button" type="button">
+                        <span>Entrar no céu</span>
+                        <i aria-hidden="true">→</i>
+                    </button>
+                </footer>
+            </div>
+        </div>
+
+        <div id="pauseOverlay" class="overlay" hidden>
+            <div class="overlay-card compact-card">
+                <p class="eyebrow"><i></i> Os picos esperam</p>
+                <h2>O vento<br>está em pausa.</h2>
+                <div class="card-actions">
+                    <button id="resumeButton" class="primary-button" type="button">
+                        <span>Continuar</span><i aria-hidden="true">→</i>
+                    </button>
+                    <button id="pauseMenuButton" class="ghost-button" type="button">Voltar ao início</button>
+                </div>
+            </div>
+        </div>
+
+        <div id="victoryOverlay" class="overlay" hidden>
+            <div class="overlay-card compact-card victory-card">
+                <p class="eyebrow"><i></i> O vínculo acendeu</p>
+                <h2>A Yva<br>canta de novo.</h2>
+                <p class="lede">As oito sementes voltaram para o coração da árvore. Os picos
+                    brilham e a ira planeia em paz.</p>
+                <div id="victoryStats" class="stats"></div>
+                <div class="card-actions">
+                    <button id="replayButton" class="primary-button" type="button">
+                        <span>Voar outra vez</span><i aria-hidden="true">↻</i>
+                    </button>
+                    <button id="victoryMenuButton" class="ghost-button" type="button">Voltar ao início</button>
+                </div>
+            </div>
+        </div>
+
+        <div id="errorOverlay" class="overlay" hidden>
+            <div class="overlay-card compact-card">
+                <p class="eyebrow eyebrow--danger"><i></i> WebGL indisponível</p>
+                <h2>O céu não<br>pôde abrir.</h2>
+                <p class="lede" id="errorText">Este laboratório precisa de WebGL. Tente um navegador
+                    atualizado ou reative a aceleração de hardware.</p>
+            </div>
+        </div>
+
+        <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
+    </main>
+
+    <script src="/labs/shared.js?v=7" defer></script>
+    <script>
+        (function () {
+            function hasGpu() {
+                try {
+                    var c = document.createElement('canvas');
+                    return !!(c.getContext('webgl2') || c.getContext('webgl'));
+                } catch (e) { return false; }
+            }
+            if (!hasGpu()) {
+                document.addEventListener('DOMContentLoaded', function () {
+                    var err = document.getElementById('errorOverlay');
+                    var load = document.getElementById('loadingOverlay');
+                    if (load) load.hidden = true;
+                    if (err) err.hidden = false;
+                });
+            }
+        })();
+    </script>
+    <script type="module" src="src/main.js"></script>
+</body>
+
+</html>

--- a/labs/eyra/src/audio.js
+++ b/labs/eyra/src/audio.js
@@ -1,0 +1,160 @@
+/**
+ * Pad em ré menor pentatônico, vento nas asas e sinos de semente.
+ * Só Web Audio — nenhum sample externo.
+ */
+
+export class EyraAudio {
+    constructor() {
+        this.ctx = null;
+        this.enabled = true;
+        this.volume = 0.7;
+        this.master = null;
+        this.started = false;
+        this.step = 0;
+        this.acc = 0;
+        this.bpm = 64;
+    }
+
+    init() {
+        if (this.ctx) {
+            if (this.ctx.state === 'suspended') this.ctx.resume();
+            this.started = true;
+            return;
+        }
+        const Ctx = window.AudioContext || window.webkitAudioContext;
+        if (!Ctx) return;
+        this.ctx = new Ctx();
+        this.master = this.ctx.createGain();
+        this.master.gain.value = this.enabled ? this.volume : 0;
+        this.master.connect(this.ctx.destination);
+
+        this.music = this.ctx.createGain();
+        this.music.gain.value = 0.36;
+        this.music.connect(this.master);
+
+        const noiseBuf = this.ctx.createBuffer(1, this.ctx.sampleRate * 2, this.ctx.sampleRate);
+        const data = noiseBuf.getChannelData(0);
+        for (let i = 0; i < data.length; i++) data[i] = Math.random() * 2 - 1;
+        const wind = this.ctx.createBufferSource();
+        wind.buffer = noiseBuf;
+        wind.loop = true;
+        const bp = this.ctx.createBiquadFilter();
+        bp.type = 'bandpass';
+        bp.frequency.value = 380;
+        bp.Q.value = 0.4;
+        this.windGain = this.ctx.createGain();
+        this.windGain.gain.value = 0.04;
+        wind.connect(bp);
+        bp.connect(this.windGain);
+        this.windGain.connect(this.master);
+        wind.start();
+
+        this.whoosh = this.ctx.createOscillator();
+        this.whoosh.type = 'sawtooth';
+        this.whoosh.frequency.value = 42;
+        this.whooshGain = this.ctx.createGain();
+        this.whooshGain.gain.value = 0;
+        const lp = this.ctx.createBiquadFilter();
+        lp.type = 'lowpass';
+        lp.frequency.value = 220;
+        this.whoosh.connect(lp);
+        lp.connect(this.whooshGain);
+        this.whooshGain.connect(this.master);
+        this.whoosh.start();
+
+        this._pad();
+        this.started = true;
+    }
+
+    _osc(type, freq, dest, gain = 0.06) {
+        const o = this.ctx.createOscillator();
+        o.type = type;
+        o.frequency.value = freq;
+        const g = this.ctx.createGain();
+        g.gain.value = gain;
+        o.connect(g);
+        g.connect(dest);
+        o.start();
+        return { o, g };
+    }
+
+    _pad() {
+        const filter = this.ctx.createBiquadFilter();
+        filter.type = 'lowpass';
+        filter.frequency.value = 520;
+        filter.Q.value = 0.55;
+        filter.connect(this.music);
+        this._osc('sine', 146.83, filter, 0.07);
+        this._osc('sine', 174.61, filter, 0.045);
+        this._osc('triangle', 220.0, filter, 0.03);
+        this._osc('sine', 329.63, filter, 0.02);
+    }
+
+    setVolume(v) {
+        this.volume = v;
+        if (this.master) this.master.gain.value = this.enabled ? v : 0;
+    }
+
+    setEnabled(on) {
+        this.enabled = on;
+        if (this.master) this.master.gain.value = on ? this.volume : 0;
+        if (on) this.init();
+    }
+
+    setFlight(speed01, boosting) {
+        if (!this.windGain || !this.whooshGain) return;
+        const t = this.ctx.currentTime;
+        this.windGain.gain.setTargetAtTime(0.03 + speed01 * 0.05, t, 0.12);
+        this.whooshGain.gain.setTargetAtTime(boosting ? 0.045 : speed01 * 0.018, t, 0.08);
+        this.whoosh.frequency.setTargetAtTime(36 + speed01 * 40, t, 0.1);
+    }
+
+    blip(freq, dur, type = 'sine', gain = 0.12) {
+        if (!this.ctx || !this.enabled || !this.started) return;
+        const t = this.ctx.currentTime;
+        const o = this.ctx.createOscillator();
+        const g = this.ctx.createGain();
+        o.type = type;
+        o.frequency.setValueAtTime(freq, t);
+        o.frequency.exponentialRampToValueAtTime(Math.max(40, freq * 0.62), t + dur);
+        g.gain.setValueAtTime(gain, t);
+        g.gain.exponentialRampToValueAtTime(0.001, t + dur);
+        o.connect(g);
+        g.connect(this.master);
+        o.start(t);
+        o.stop(t + dur + 0.02);
+    }
+
+    seed(combo = 1) {
+        const base = 392 * Math.pow(2, (combo % 8) / 12);
+        this.blip(base, 0.28, 'sine', 0.12);
+        this.blip(base * 1.5, 0.36, 'triangle', 0.06);
+    }
+
+    ring(combo = 1) {
+        this.blip(523 * Math.pow(2, (combo % 5) / 12), 0.18, 'sine', 0.08);
+    }
+
+    hit() {
+        this.blip(90, 0.22, 'sawtooth', 0.08);
+        this.blip(60, 0.3, 'square', 0.04);
+    }
+
+    victory() {
+        [392, 494, 587, 740].forEach((f, i) => {
+            setTimeout(() => this.blip(f, 0.45, 'sine', 0.1), i * 160);
+        });
+    }
+
+    tick(dt) {
+        if (!this.ctx || !this.enabled || !this.started) return;
+        this.acc += dt;
+        const step = 60 / this.bpm;
+        if (this.acc < step) return;
+        this.acc -= step;
+        const scale = [146.83, 174.61, 196, 220, 261.63, 293.66];
+        const note = scale[this.step % scale.length];
+        if (this.step % 4 === 0) this.blip(note * 2, 0.4, 'sine', 0.035);
+        this.step++;
+    }
+}

--- a/labs/eyra/src/config.js
+++ b/labs/eyra/src/config.js
@@ -1,0 +1,135 @@
+/**
+ * Eyra — escala do mundo, física do voo e presets de qualidade.
+ *
+ * Unidades ≈ metros. A ira (fera alada) planeia sempre para a frente;
+ * o piloto só escolhe o vetor e o impulso. Arcade, não Navier–Stokes.
+ *
+ * Fórmulas:
+ *   vAlvo  = cruise * (1 + W * 0.9 − S * 0.55) + boost * BOOST_MUL
+ *   v'     = v + (vAlvo − v) * (1 − exp(−DRAG * dt))
+ *   yaw'   = yaw − (mouseX + A/D) * YAW * (0.5 + v / vmax) * dt
+ *   pitch' = clamp(pitch + (mouseY + R/F) * PITCH * dt, −0.82, 0.58)
+ *   roll   = damp(roll, −bank * MAX_BANK, 7, dt)
+ *   fwd    = (sin(yaw) cos(pitch), sin(pitch), cos(yaw) cos(pitch))
+ *   pos   += fwd * v * dt
+ *   se |pos − pico| < raio: empurra na normal e v *= HIT_SLOW
+ *   combo  += 1 ao atravessar anel; decai se dtGap > COMBO_WINDOW
+ *   score  += semente * 400 * combo + anel * 80 * combo
+ */
+
+export const STORAGE_KEY = 'eyra-v1';
+
+export const WORLD = {
+    radius: 260,
+    canopy: 4,
+    ceiling: 210,
+    fogNear: 40,
+    fogFar: 420
+};
+
+export const PHYS = {
+    cruise: 28,
+    maxSpeed: 78,
+    boostMul: 1.9,
+    boostCost: 0.34,
+    boostRegen: 0.18,
+    drag: 2.4,
+    yaw: 1.35,
+    pitch: 1.15,
+    maxBank: 0.78,
+    minPitch: -0.82,
+    maxPitch: 0.58,
+    radius: 2.4,
+    invuln: 1.05,
+    hitSlow: 0.48,
+    comboWindow: 3.2,
+    rollDuration: 0.78
+};
+
+export const CAMERA = {
+    dist: 14.5,
+    height: 4.2,
+    look: 9.5,
+    fov: 58,
+    fovBoost: 16,
+    mouse: 0.0026
+};
+
+export const SEEDS = 8;
+
+export const QUALITY = {
+    low: {
+        antialias: false,
+        pixelRatio: 1,
+        bloom: false,
+        shadows: false,
+        trees: 90,
+        plants: 40,
+        clouds: 10,
+        spores: 80,
+        peaks: 8
+    },
+    medium: {
+        antialias: true,
+        pixelRatio: 1.35,
+        bloom: true,
+        shadows: true,
+        trees: 180,
+        plants: 90,
+        clouds: 16,
+        spores: 140,
+        peaks: 11
+    },
+    high: {
+        antialias: true,
+        pixelRatio: 1.7,
+        bloom: true,
+        shadows: true,
+        trees: 280,
+        plants: 140,
+        clouds: 22,
+        spores: 220,
+        peaks: 13
+    }
+};
+
+export const PALETTE = {
+    abyss: 0x041820,
+    fog: 0x1a4a52,
+    lumen: 0x5ef0d8,
+    gold: 0xffd27a,
+    moss: 0x2f6b3a,
+    leaf: 0x1f8a4a,
+    rock: 0x6a7a6e,
+    magenta: 0xd46ad0,
+    water: 0x1a8a9a
+};
+
+export const ZONES = [
+    { y: 0, name: 'Canópia de jade' },
+    { y: 48, name: 'Picos de Helion' },
+    { y: 96, name: 'Mar de nuvens' },
+    { y: 150, name: 'Céu de Eyra' }
+];
+
+export function loadSettings() {
+    try {
+        return {
+            quality: 'auto',
+            volume: 70,
+            muted: false,
+            best: 0,
+            ...JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}')
+        };
+    } catch {
+        return { quality: 'auto', volume: 70, muted: false, best: 0 };
+    }
+}
+
+export function saveSettings(s) {
+    try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(s));
+    } catch {
+        /* private mode */
+    }
+}

--- a/labs/eyra/src/effects.js
+++ b/labs/eyra/src/effects.js
@@ -1,0 +1,169 @@
+/**
+ * Esporos bioluminescentes, rastro da ira e explosões de semente.
+ */
+
+import * as THREE from 'three';
+import { glowSprite } from './textures.js';
+import { WORLD } from './config.js';
+import { hash } from './utils.js';
+
+export class Effects {
+    constructor(scene, quality) {
+        this.scene = scene;
+        this.quality = quality;
+        this.bursts = [];
+        this.trail = [];
+        this._spores(quality.spores);
+        this._trail(28);
+        this._godrays();
+    }
+
+    _spores(count) {
+        const geo = new THREE.BufferGeometry();
+        const pos = new Float32Array(count * 3);
+        const phase = new Float32Array(count);
+        for (let i = 0; i < count; i++) {
+            const a = hash(i * 3.1) * Math.PI * 2;
+            const r = hash(i * 7.7) * WORLD.radius * 0.9;
+            pos[i * 3] = Math.cos(a) * r;
+            pos[i * 3 + 1] = 6 + hash(i * 2.2) * 140;
+            pos[i * 3 + 2] = Math.sin(a) * r;
+            phase[i] = hash(i) * Math.PI * 2;
+        }
+        geo.setAttribute('position', new THREE.BufferAttribute(pos, 3));
+        this.sporePhase = phase;
+        this.spores = new THREE.Points(
+            geo,
+            new THREE.PointsMaterial({
+                map: glowSprite('#7af0d8'),
+                color: 0xaef8e8,
+                size: 1.15,
+                transparent: true,
+                opacity: 0.85,
+                depthWrite: false,
+                blending: THREE.AdditiveBlending
+            })
+        );
+        this.scene.add(this.spores);
+    }
+
+    _trail(n) {
+        const mat = new THREE.SpriteMaterial({
+            map: glowSprite('#5ef0d8'),
+            transparent: true,
+            depthWrite: false,
+            blending: THREE.AdditiveBlending
+        });
+        for (let i = 0; i < n; i++) {
+            const s = new THREE.Sprite(mat.clone());
+            s.visible = false;
+            s.scale.setScalar(0.8);
+            this.scene.add(s);
+            this.trail.push({ mesh: s, life: 0 });
+        }
+        this.trailIndex = 0;
+    }
+
+    _godrays() {
+        const mat = new THREE.MeshBasicMaterial({
+            color: 0xffe8b0,
+            transparent: true,
+            opacity: 0.045,
+            depthWrite: false,
+            side: THREE.DoubleSide
+        });
+        this.rays = [];
+        for (let i = 0; i < 5; i++) {
+            const cone = new THREE.Mesh(new THREE.ConeGeometry(18, 90, 8, 1, true), mat.clone());
+            cone.position.set((i - 2) * 28, 80, -40 + i * 12);
+            cone.rotation.x = Math.PI;
+            cone.rotation.z = 0.18;
+            this.scene.add(cone);
+            this.rays.push(cone);
+        }
+    }
+
+    sparkle(position) {
+        const p = this.trail[this.trailIndex % this.trail.length];
+        this.trailIndex++;
+        p.mesh.position.copy(position);
+        p.mesh.position.x += (Math.random() - 0.5) * 0.6;
+        p.mesh.position.y += (Math.random() - 0.5) * 0.4;
+        p.mesh.visible = true;
+        p.mesh.material.opacity = 0.9;
+        p.mesh.scale.setScalar(0.6 + Math.random() * 0.8);
+        p.life = 0.55;
+    }
+
+    burst(position, color = 0x7af0d8) {
+        const geo = new THREE.BufferGeometry();
+        const n = 28;
+        const pos = new Float32Array(n * 3);
+        const vel = [];
+        for (let i = 0; i < n; i++) {
+            pos[i * 3] = position.x;
+            pos[i * 3 + 1] = position.y;
+            pos[i * 3 + 2] = position.z;
+            const dir = new THREE.Vector3().randomDirection().multiplyScalar(8 + Math.random() * 10);
+            vel.push(dir);
+        }
+        geo.setAttribute('position', new THREE.BufferAttribute(pos, 3));
+        const pts = new THREE.Points(
+            geo,
+            new THREE.PointsMaterial({
+                color,
+                size: 0.55,
+                transparent: true,
+                opacity: 1,
+                depthWrite: false,
+                blending: THREE.AdditiveBlending
+            })
+        );
+        this.scene.add(pts);
+        this.bursts.push({ pts, vel, life: 0.7 });
+    }
+
+    update(dt, follow) {
+        const t = performance.now() * 0.001;
+        const attr = this.spores.geometry.getAttribute('position');
+        for (let i = 0; i < this.sporePhase.length; i++) {
+            attr.array[i * 3 + 1] += Math.sin(t * 0.6 + this.sporePhase[i]) * 0.015;
+        }
+        attr.needsUpdate = true;
+
+        if (follow) {
+            this.sparkle(follow);
+        }
+        for (const p of this.trail) {
+            if (p.life <= 0) {
+                p.mesh.visible = false;
+                continue;
+            }
+            p.life -= dt;
+            p.mesh.material.opacity = Math.max(0, p.life * 1.5);
+            p.mesh.scale.multiplyScalar(0.96);
+        }
+        for (let i = this.bursts.length - 1; i >= 0; i--) {
+            const b = this.bursts[i];
+            b.life -= dt;
+            const a = b.pts.geometry.getAttribute('position');
+            for (let k = 0; k < b.vel.length; k++) {
+                a.array[k * 3] += b.vel[k].x * dt;
+                a.array[k * 3 + 1] += b.vel[k].y * dt;
+                a.array[k * 3 + 2] += b.vel[k].z * dt;
+                b.vel[k].y -= 4 * dt;
+            }
+            a.needsUpdate = true;
+            b.pts.material.opacity = Math.max(0, b.life * 1.4);
+            if (b.life <= 0) {
+                this.scene.remove(b.pts);
+                b.pts.geometry.dispose();
+                this.bursts.splice(i, 1);
+            }
+        }
+        for (const ray of this.rays) {
+            ray.rotation.y += dt * 0.02;
+            ray.material.opacity = 0.035 + Math.sin(t * 0.4 + ray.position.x) * 0.015;
+        }
+    }
+}

--- a/labs/eyra/src/hud.js
+++ b/labs/eyra/src/hud.js
@@ -1,0 +1,156 @@
+/**
+ * HUD, menus e overlays. Sem lógica 3D aqui.
+ */
+
+import { SEEDS } from './config.js';
+import { formatTime, formatScore } from './utils.js';
+
+const $ = (id) => document.getElementById(id);
+
+export class Hud {
+    constructor() {
+        this.el = {
+            hud: $('hud'),
+            alt: $('altValue'),
+            zone: $('zoneValue'),
+            boost: $('boostFill'),
+            speed: $('speedValue'),
+            seeds: $('seedValue'),
+            combo: $('comboValue'),
+            score: $('scoreValue'),
+            fps: $('fpsCounter'),
+            message: $('message'),
+            objective: $('objective'),
+            questTag: $('questTag'),
+            seedPips: $('seedPips'),
+            touch: $('touchControls'),
+            soundButton: $('soundButton'),
+            pauseButton: $('pauseButton'),
+            loading: $('loadingOverlay'),
+            loadingFill: $('loadingFill'),
+            loadingText: $('loadingText'),
+            menu: $('menuOverlay'),
+            pause: $('pauseOverlay'),
+            victory: $('victoryOverlay'),
+            error: $('errorOverlay'),
+            errorText: $('errorText'),
+            qualitySelect: $('qualitySelect'),
+            volumeSlider: $('volumeSlider'),
+            volumeValue: $('volumeValue'),
+            bestScore: $('bestScore'),
+            victoryStats: $('victoryStats'),
+            startButton: $('startButton'),
+            resumeButton: $('resumeButton'),
+            pauseMenuButton: $('pauseMenuButton'),
+            replayButton: $('replayButton'),
+            victoryMenuButton: $('victoryMenuButton')
+        };
+        this.msgTimer = 0;
+        this.buildPips(SEEDS);
+    }
+
+    buildPips(n) {
+        this.el.seedPips.innerHTML = '';
+        for (let i = 0; i < n; i++) {
+            this.el.seedPips.appendChild(document.createElement('i'));
+        }
+    }
+
+    setLoading(p, text) {
+        if (text) this.el.loadingText.textContent = text;
+        this.el.loadingFill.style.width = `${Math.round(p * 100)}%`;
+    }
+
+    hideLoading() {
+        this.el.loading.hidden = true;
+    }
+
+    fail(message) {
+        this.el.errorText.textContent = message;
+        this.el.error.hidden = false;
+        this.el.loading.hidden = true;
+    }
+
+    showMenu() {
+        this.el.menu.hidden = false;
+        this.el.pause.hidden = true;
+        this.el.victory.hidden = true;
+        this.el.hud.hidden = true;
+    }
+
+    showPlay() {
+        this.el.menu.hidden = true;
+        this.el.pause.hidden = true;
+        this.el.victory.hidden = true;
+        this.el.hud.hidden = false;
+    }
+
+    showPause() {
+        this.el.pause.hidden = false;
+    }
+
+    hidePause() {
+        this.el.pause.hidden = true;
+    }
+
+    showVictory({ seeds, rings, score, seconds }) {
+        this.el.victory.hidden = false;
+        this.el.victoryStats.innerHTML = `
+            <div><dt>Sementes</dt><dd>${seeds}/${SEEDS}</dd></div>
+            <div><dt>Anéis</dt><dd>${rings}</dd></div>
+            <div><dt>Canto</dt><dd>${formatScore(score)}</dd></div>
+            <div><dt>Tempo</dt><dd>${formatTime(seconds)}</dd></div>`;
+    }
+
+    setFlight({ alt, zone, speed, boost }) {
+        this.el.alt.textContent = `${String(Math.round(alt)).padStart(3, '0')} m`;
+        this.el.zone.textContent = zone;
+        this.el.speed.textContent = `${String(Math.round(speed)).padStart(2, '0')} kn`;
+        this.el.boost.style.width = `${Math.round(boost * 100)}%`;
+    }
+
+    setScore({ seeds, combo, score }) {
+        this.el.seeds.textContent = `${String(seeds).padStart(2, '0')} / ${SEEDS}`;
+        this.el.combo.textContent = `${combo}×`;
+        this.el.score.textContent = formatScore(score);
+        [...this.el.seedPips.children].forEach((pip, i) => {
+            pip.classList.toggle('on', i < seeds);
+        });
+        if (seeds === 0) {
+            this.el.questTag.textContent = 'O vínculo adormecido';
+            this.el.objective.textContent = 'Colete as oito sementes e volte à Yva.';
+        } else if (seeds < SEEDS) {
+            this.el.questTag.textContent = 'As sementes acordam';
+            this.el.objective.textContent = `Ainda faltam ${SEEDS - seeds} sementes nos picos.`;
+        } else {
+            this.el.questTag.textContent = 'A Yva chama';
+            this.el.objective.textContent = 'Voe até o coração da árvore-mãe.';
+        }
+    }
+
+    say(text, ms = 2800) {
+        this.el.message.textContent = text;
+        this.el.message.dataset.show = 'true';
+        clearTimeout(this.msgTimer);
+        this.msgTimer = setTimeout(() => {
+            this.el.message.dataset.show = 'false';
+        }, ms);
+    }
+
+    setBest(score) {
+        this.el.bestScore.textContent = score ? formatScore(score) : '—';
+    }
+
+    setSound(on) {
+        this.el.soundButton.setAttribute('aria-pressed', on ? 'true' : 'false');
+        this.el.soundButton.textContent = on ? '♪' : '×';
+    }
+
+    setFps(n) {
+        this.el.fps.textContent = n ? `${n}` : '—';
+    }
+
+    setTouchVisible(on) {
+        this.el.touch.hidden = !on;
+    }
+}

--- a/labs/eyra/src/input.js
+++ b/labs/eyra/src/input.js
@@ -1,0 +1,153 @@
+/**
+ * Teclado, mouse e stick virtual.
+ * axis.x = banco, axis.y = arfagem, axis.z = aceleração (W = −1).
+ */
+
+export class Input {
+    constructor(canvas) {
+        this.canvas = canvas;
+        this.keys = new Set();
+        this.axis = { x: 0, y: 0, z: 0 };
+        this.look = { dx: 0, dy: 0 };
+        this.boostHeld = false;
+        this.rollLeft = false;
+        this.rollRight = false;
+        this.dragging = false;
+        this.pointers = new Map();
+        this.stick = { x: 0, y: 0 };
+        this.listeners = new Map();
+        this._bind();
+    }
+
+    on(name, fn) {
+        if (!this.listeners.has(name)) this.listeners.set(name, new Set());
+        this.listeners.get(name).add(fn);
+    }
+
+    emit(name) {
+        this.listeners.get(name)?.forEach((fn) => fn());
+    }
+
+    consumeRoll() {
+        if (this.rollLeft) { this.rollLeft = false; return -1; }
+        if (this.rollRight) { this.rollRight = false; return 1; }
+        return 0;
+    }
+
+    _bind() {
+        window.addEventListener('keydown', (e) => {
+            if (e.repeat) return;
+            if (e.code === 'KeyP' || e.code === 'Escape') this.emit('pause');
+            if (e.code === 'KeyM') this.emit('mute');
+            if (e.code === 'KeyC') this.emit('camera');
+            if (e.code === 'KeyQ') this.rollLeft = true;
+            if (e.code === 'KeyE') this.rollRight = true;
+            if (e.code === 'Space') {
+                this.boostHeld = true;
+                e.preventDefault();
+            }
+            this.keys.add(e.code);
+        }, { passive: false });
+
+        window.addEventListener('keyup', (e) => {
+            this.keys.delete(e.code);
+            if (e.code === 'Space') this.boostHeld = false;
+        });
+        window.addEventListener('blur', () => {
+            this.keys.clear();
+            this.stick.x = this.stick.y = 0;
+            this.boostHeld = false;
+        });
+
+        const el = this.canvas;
+        el.addEventListener('pointerdown', (e) => {
+            el.setPointerCapture(e.pointerId);
+            this.pointers.set(e.pointerId, { x: e.clientX, y: e.clientY });
+            if (this.pointers.size === 1) {
+                this.dragging = true;
+                el.classList.add('is-dragging');
+            }
+        });
+        el.addEventListener('pointermove', (e) => {
+            const prev = this.pointers.get(e.pointerId);
+            if (!prev) return;
+            this.look.dx += e.clientX - prev.x;
+            this.look.dy += e.clientY - prev.y;
+            this.pointers.set(e.pointerId, { x: e.clientX, y: e.clientY });
+        });
+        const up = (e) => {
+            this.pointers.delete(e.pointerId);
+            if (this.pointers.size === 0) {
+                this.dragging = false;
+                el.classList.remove('is-dragging');
+            }
+        };
+        el.addEventListener('pointerup', up);
+        el.addEventListener('pointercancel', up);
+        el.addEventListener('contextmenu', (e) => e.preventDefault());
+    }
+
+    bindTouch({ stick, knob, boost, roll }) {
+        if (!stick) return;
+        const setKnob = (x, y) => {
+            knob.style.transform = `translate(${x * 28}px, ${y * 28}px)`;
+        };
+        const onMove = (e) => {
+            const r = stick.getBoundingClientRect();
+            const cx = r.left + r.width / 2;
+            const cy = r.top + r.height / 2;
+            const p = e.touches ? e.touches[0] : e;
+            let x = (p.clientX - cx) / (r.width * 0.42);
+            let y = (p.clientY - cy) / (r.height * 0.42);
+            const mag = Math.hypot(x, y) || 1;
+            if (mag > 1) { x /= mag; y /= mag; }
+            this.stick.x = x;
+            this.stick.y = y;
+            setKnob(x, y);
+        };
+        const end = () => {
+            this.stick.x = this.stick.y = 0;
+            setKnob(0, 0);
+        };
+        stick.addEventListener('pointerdown', (e) => {
+            stick.setPointerCapture(e.pointerId);
+            onMove(e);
+        });
+        stick.addEventListener('pointermove', (e) => {
+            if (e.pressure === 0 && e.buttons === 0) return;
+            onMove(e);
+        });
+        stick.addEventListener('pointerup', end);
+        stick.addEventListener('pointercancel', end);
+
+        const hold = (btn, onDown, onUp) => {
+            if (!btn) return;
+            btn.addEventListener('pointerdown', (e) => { e.preventDefault(); onDown(); });
+            btn.addEventListener('pointerup', onUp);
+            btn.addEventListener('pointerleave', onUp);
+            btn.addEventListener('pointercancel', onUp);
+        };
+        hold(boost, () => { this.boostHeld = true; }, () => { this.boostHeld = false; });
+        hold(roll, () => { this.rollRight = true; }, () => {});
+    }
+
+    sample() {
+        let x = this.stick.x;
+        let z = this.stick.y;
+        if (this.keys.has('KeyA') || this.keys.has('ArrowLeft')) x -= 1;
+        if (this.keys.has('KeyD') || this.keys.has('ArrowRight')) x += 1;
+        if (this.keys.has('KeyW') || this.keys.has('ArrowUp')) z -= 1;
+        if (this.keys.has('KeyS') || this.keys.has('ArrowDown')) z += 1;
+        let y = 0;
+        if (this.keys.has('ShiftLeft') || this.keys.has('ShiftRight') || this.keys.has('KeyR')) y += 1;
+        if (this.keys.has('ControlLeft') || this.keys.has('ControlRight') || this.keys.has('KeyF')) y -= 1;
+        const mag = Math.hypot(x, z) || 1;
+        this.axis.x = x / (mag > 1 ? mag : 1);
+        this.axis.z = z / (mag > 1 ? mag : 1);
+        this.axis.y = y;
+        if (this.keys.has('Space')) this.boostHeld = true;
+        const look = { dx: this.look.dx, dy: this.look.dy };
+        this.look.dx = this.look.dy = 0;
+        return look;
+    }
+}

--- a/labs/eyra/src/main.js
+++ b/labs/eyra/src/main.js
@@ -129,7 +129,7 @@ class Eyra {
         this.renderer.setSize(innerWidth, innerHeight);
         this.renderer.outputColorSpace = THREE.SRGBColorSpace;
         this.renderer.toneMapping = THREE.ACESFilmicToneMapping;
-        this.renderer.toneMappingExposure = 1.08;
+        this.renderer.toneMappingExposure = 1.18;
         this.renderer.shadowMap.enabled = this.quality.shadows;
         this.renderer.shadowMap.type = THREE.PCFSoftShadowMap;
 
@@ -328,8 +328,8 @@ class Eyra {
             this.audio.tick(dt);
         } else {
             const t = now * 0.00008;
-            this.camera.position.set(Math.cos(t) * 90, 62 + Math.sin(t * 0.7) * 10, Math.sin(t) * 90);
-            this.camera.lookAt(0, 48, 0);
+            this.camera.position.set(Math.cos(t) * 56, 48 + Math.sin(t * 0.7) * 8, Math.sin(t) * 56);
+            this.camera.lookAt(0, 42, 0);
             this.camera.fov = 52;
             this.camera.updateProjectionMatrix();
             this.input.look.dx = this.input.look.dy = 0;

--- a/labs/eyra/src/main.js
+++ b/labs/eyra/src/main.js
@@ -1,0 +1,368 @@
+/**
+ * Eyra — laço principal: renderer, pós-processamento, voo e o vínculo com a Yva.
+ */
+
+import * as THREE from 'three';
+import { World } from './world.js';
+import { Player } from './player.js';
+import { Effects } from './effects.js';
+import { Input } from './input.js';
+import { Hud } from './hud.js';
+import { EyraAudio } from './audio.js';
+import { tickShaders } from './shaders.js';
+import {
+    QUALITY, PHYS, SEEDS, ZONES, loadSettings, saveSettings
+} from './config.js';
+import { detectMobile, detectSoftwareGL, zoneAt, clamp } from './utils.js';
+
+function pickQuality(mode, renderer) {
+    if (QUALITY[mode]) return QUALITY[mode];
+    const mobile = detectMobile() || innerWidth < 800;
+    if (detectSoftwareGL(renderer) || mobile) return QUALITY.low;
+    if (devicePixelRatio >= 2 && innerWidth >= 1400) return QUALITY.high;
+    return QUALITY.medium;
+}
+
+class Eyra {
+    constructor() {
+        this.canvas = document.getElementById('scene');
+        this.hud = new Hud();
+        this.audio = new EyraAudio();
+        this.input = new Input(this.canvas);
+        this.state = 'boot';
+        this.settings = loadSettings();
+        this.bindUi();
+        this.boot();
+    }
+
+    bindUi() {
+        const h = this.hud.el;
+        h.qualitySelect.value = this.settings.quality;
+        h.volumeSlider.value = this.settings.volume;
+        h.volumeValue.textContent = this.settings.volume;
+        this.hud.setBest(this.settings.best);
+        this.hud.setSound(!this.settings.muted);
+
+        h.startButton.addEventListener('click', () => this.start());
+        h.resumeButton.addEventListener('click', () => this.resume());
+        h.pauseMenuButton.addEventListener('click', () => this.enterMenu());
+        h.replayButton.addEventListener('click', () => this.start());
+        h.victoryMenuButton.addEventListener('click', () => this.enterMenu());
+        h.pauseButton.addEventListener('click', () => {
+            if (this.state === 'play') this.pause();
+            else if (this.state === 'pause') this.resume();
+        });
+        h.soundButton.addEventListener('click', () => this.toggleMute());
+        h.qualitySelect.addEventListener('change', () => {
+            this.settings.quality = h.qualitySelect.value;
+            saveSettings(this.settings);
+        });
+        h.volumeSlider.addEventListener('input', () => {
+            this.settings.volume = Number(h.volumeSlider.value);
+            h.volumeValue.textContent = this.settings.volume;
+            this.audio.setVolume(this.settings.volume / 100);
+            saveSettings(this.settings);
+        });
+
+        this.input.on('pause', () => {
+            if (this.state === 'play') this.pause();
+            else if (this.state === 'pause') this.resume();
+        });
+        this.input.on('mute', () => this.toggleMute());
+
+        this.input.bindTouch({
+            stick: document.getElementById('moveStick'),
+            knob: document.getElementById('moveKnob'),
+            boost: document.getElementById('btnBoost'),
+            roll: document.getElementById('btnRoll')
+        });
+
+        window.addEventListener('resize', () => this.resize());
+        document.addEventListener('visibilitychange', () => {
+            if (document.hidden && this.state === 'play') this.pause();
+        });
+    }
+
+    async boot() {
+        this.hud.setLoading(0.08, 'Abrindo o céu…');
+        try {
+            await this.setupRenderer();
+        } catch (err) {
+            this.hud.fail(err?.message || 'Falha ao iniciar o WebGL.');
+            return;
+        }
+
+        this.hud.setLoading(0.32, 'Erguendo os picos…');
+        this.world = new World(this.scene, this.quality);
+
+        this.hud.setLoading(0.58, 'Chamando a ira…');
+        this.player = new Player(this.scene, this.camera);
+        this.effects = new Effects(this.scene, this.quality);
+
+        this.hud.setLoading(0.82, 'Acendendo o sol…');
+        await this.setupBloom();
+
+        this.renderer.compile(this.scene, this.camera);
+        this.render();
+        this.hud.setLoading(1, 'Pronto');
+        setTimeout(() => {
+            this.hud.hideLoading();
+            this.enterMenu();
+            this.last = performance.now();
+            this.fpsAcc = 0;
+            this.fpsFrames = 0;
+            this.renderer.setAnimationLoop((now) => this.frame(now));
+        }, 280);
+    }
+
+    async setupRenderer() {
+        this.renderer = new THREE.WebGLRenderer({
+            canvas: this.canvas,
+            antialias: true,
+            powerPreference: 'high-performance',
+            stencil: false
+        });
+        if (!this.renderer.getContext()) {
+            throw new Error('WebGL indisponível neste navegador.');
+        }
+        this.quality = pickQuality(this.settings.quality, this.renderer);
+        this.renderer.setPixelRatio(Math.min(devicePixelRatio, this.quality.pixelRatio));
+        this.renderer.setSize(innerWidth, innerHeight);
+        this.renderer.outputColorSpace = THREE.SRGBColorSpace;
+        this.renderer.toneMapping = THREE.ACESFilmicToneMapping;
+        this.renderer.toneMappingExposure = 1.08;
+        this.renderer.shadowMap.enabled = this.quality.shadows;
+        this.renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+
+        this.scene = new THREE.Scene();
+        this.camera = new THREE.PerspectiveCamera(58, innerWidth / innerHeight, 0.35, 1400);
+
+        const hemi = new THREE.HemisphereLight(0xffe2b0, 0x1a4a38, 0.72);
+        this.scene.add(hemi);
+
+        this.sun = new THREE.DirectionalLight(0xffe8c0, 1.55);
+        this.sun.position.set(80, 90, 40);
+        this.sun.castShadow = this.quality.shadows;
+        if (this.quality.shadows) {
+            this.sun.shadow.mapSize.set(2048, 2048);
+            this.sun.shadow.camera.near = 10;
+            this.sun.shadow.camera.far = 320;
+            this.sun.shadow.camera.left = -140;
+            this.sun.shadow.camera.right = 140;
+            this.sun.shadow.camera.top = 140;
+            this.sun.shadow.camera.bottom = -140;
+            this.sun.shadow.bias = -0.00035;
+        }
+        this.scene.add(this.sun);
+        this.scene.add(new THREE.AmbientLight(0x4a7080, 0.32));
+        const fill = new THREE.DirectionalLight(0x88c8e0, 0.4);
+        fill.position.set(-50, 30, -40);
+        this.scene.add(fill);
+        const bio = new THREE.PointLight(0x5ef0d8, 1.2, 80, 1.4);
+        bio.position.set(0, 52, 0);
+        this.scene.add(bio);
+    }
+
+    async setupBloom() {
+        if (!this.quality.bloom) return;
+        try {
+            const [{ EffectComposer }, { RenderPass }, { UnrealBloomPass }, { OutputPass }] = await Promise.all([
+                import('three/addons/postprocessing/EffectComposer.js'),
+                import('three/addons/postprocessing/RenderPass.js'),
+                import('three/addons/postprocessing/UnrealBloomPass.js'),
+                import('three/addons/postprocessing/OutputPass.js')
+            ]);
+            const composer = new EffectComposer(this.renderer);
+            composer.setPixelRatio(this.renderer.getPixelRatio());
+            composer.setSize(innerWidth, innerHeight);
+            composer.addPass(new RenderPass(this.scene, this.camera));
+            composer.addPass(new UnrealBloomPass(
+                new THREE.Vector2(innerWidth, innerHeight),
+                0.32,
+                0.48,
+                0.78
+            ));
+            composer.addPass(new OutputPass());
+            this.composer = composer;
+        } catch {
+            this.composer = null;
+        }
+    }
+
+    start() {
+        this.audio.init();
+        this.audio.setVolume(this.settings.volume / 100);
+        this.audio.setEnabled(!this.settings.muted);
+        this.seeds = 0;
+        this.rings = 0;
+        this.combo = 1;
+        this.comboTimer = 0;
+        this.score = 0;
+        this.playTime = 0;
+        this.won = false;
+        this.player.reset();
+        this.world.resetPickups();
+        this.hud.setScore({ seeds: 0, combo: 1, score: 0 });
+        this.hud.setTouchVisible(matchMedia('(pointer: coarse)').matches);
+        this.hud.showPlay();
+        this.hud.say('Voe até as sementes de luz. Espaço é o impulso.');
+        this.state = 'play';
+        document.body.dataset.state = 'play';
+    }
+
+    enterMenu() {
+        this.state = 'menu';
+        document.body.dataset.state = 'menu';
+        this.hud.showMenu();
+    }
+
+    pause() {
+        if (this.state !== 'play') return;
+        this.state = 'pause';
+        this.hud.showPause();
+    }
+
+    resume() {
+        if (this.state !== 'pause') return;
+        this.state = 'play';
+        this.hud.hidePause();
+        this.last = performance.now();
+    }
+
+    toggleMute() {
+        this.settings.muted = !this.settings.muted;
+        this.audio.setEnabled(!this.settings.muted);
+        this.hud.setSound(!this.settings.muted);
+        saveSettings(this.settings);
+    }
+
+    collectSeed(seed) {
+        seed.userData.taken = true;
+        seed.visible = false;
+        this.seeds++;
+        this.combo = Math.min(12, this.combo + 1);
+        this.comboTimer = PHYS.comboWindow;
+        this.score += 400 * this.combo;
+        this.effects.burst(seed.position.clone());
+        this.audio.seed(this.combo);
+        this.hud.setScore({ seeds: this.seeds, combo: this.combo, score: this.score });
+        this.hud.say(this.seeds >= SEEDS
+            ? 'As oito sementes cantam. Volte à Yva.'
+            : `Semente ${this.seeds} de ${SEEDS}.`);
+        this.sun.intensity = 1.55 - (this.seeds / SEEDS) * 0.35;
+    }
+
+    collectRing(ring) {
+        ring.userData.taken = true;
+        this.rings++;
+        this.combo = Math.min(12, this.combo + 1);
+        this.comboTimer = PHYS.comboWindow;
+        this.score += 80 * this.combo;
+        this.audio.ring(this.combo);
+        this.hud.setScore({ seeds: this.seeds, combo: this.combo, score: this.score });
+        this.player.boost = clamp(this.player.boost + 0.12, 0, 1);
+    }
+
+    win() {
+        this.won = true;
+        this.audio.victory();
+        this.effects.burst(this.world.yvaPos.clone(), 0xffe08a);
+        if (!this.settings.best || this.score > this.settings.best) {
+            this.settings.best = this.score;
+            saveSettings(this.settings);
+            this.hud.setBest(this.settings.best);
+        }
+        setTimeout(() => {
+            this.state = 'victory';
+            this.hud.showVictory({
+                seeds: this.seeds,
+                rings: this.rings,
+                score: this.score,
+                seconds: this.playTime
+            });
+        }, 1400);
+    }
+
+    frame(now) {
+        const dt = Math.min(0.033, (now - this.last) / 1000) || 0.016;
+        this.last = now;
+
+        const look = this.input.sample();
+        const playing = this.state === 'play';
+        const dusk = 0.18 + (this.seeds / SEEDS) * 0.55;
+
+        if (playing) {
+            this.playTime += dt;
+            this.comboTimer -= dt;
+            if (this.comboTimer <= 0) this.combo = 1;
+
+            const boosting = this.input.boostHeld;
+            const roll = this.input.consumeRoll();
+            if (roll) this.player.startRoll(roll);
+
+            const hit = this.player.update(dt, this.input, look, this.world, boosting);
+            if (hit) this.audio.hit();
+
+            const pos = this.player.pos;
+            for (const seed of this.world.seeds) {
+                if (seed.userData.taken) continue;
+                if (pos.distanceTo(seed.position) < 4.2) this.collectSeed(seed);
+            }
+            for (const ring of this.world.rings) {
+                if (ring.userData.taken) continue;
+                if (pos.distanceTo(ring.position) < 3.4) this.collectRing(ring);
+            }
+
+            if (this.seeds >= SEEDS && !this.won && this.world.yvaPos) {
+                if (pos.distanceTo(this.world.yvaPos) < 14) this.win();
+            }
+
+            const zone = zoneAt(pos.y, ZONES);
+            this.hud.setFlight({
+                alt: pos.y,
+                zone: zone.name,
+                speed: this.player.speed * 1.8,
+                boost: this.player.boost
+            });
+            this.hud.setScore({ seeds: this.seeds, combo: this.combo, score: this.score });
+            this.audio.setFlight(this.player.speed / PHYS.maxSpeed, boosting);
+            this.audio.tick(dt);
+        } else {
+            const t = now * 0.00008;
+            this.camera.position.set(Math.cos(t) * 90, 62 + Math.sin(t * 0.7) * 10, Math.sin(t) * 90);
+            this.camera.lookAt(0, 48, 0);
+            this.camera.fov = 52;
+            this.camera.updateProjectionMatrix();
+            this.input.look.dx = this.input.look.dy = 0;
+        }
+
+        this.world.update(dt, dusk);
+        this.effects.update(dt, playing ? this.player.pos : null);
+        tickShaders(this.scene, now * 0.001);
+        this.render();
+
+        this.fpsAcc += dt;
+        this.fpsFrames++;
+        if (this.fpsAcc >= 0.5) {
+            this.hud.setFps(Math.round(this.fpsFrames / this.fpsAcc));
+            this.fpsAcc = 0;
+            this.fpsFrames = 0;
+        }
+    }
+
+    render() {
+        if (this.composer) this.composer.render();
+        else this.renderer.render(this.scene, this.camera);
+    }
+
+    resize() {
+        const w = innerWidth;
+        const h = innerHeight;
+        this.camera.aspect = w / h;
+        this.camera.updateProjectionMatrix();
+        this.renderer.setSize(w, h);
+        this.composer?.setSize(w, h);
+    }
+}
+
+new Eyra();

--- a/labs/eyra/src/main.js
+++ b/labs/eyra/src/main.js
@@ -87,32 +87,31 @@ class Eyra {
         this.hud.setLoading(0.08, 'Abrindo o céu…');
         try {
             await this.setupRenderer();
+            this.hud.setLoading(0.32, 'Erguendo os picos…');
+            this.world = new World(this.scene, this.quality);
+
+            this.hud.setLoading(0.58, 'Chamando a ira…');
+            this.player = new Player(this.scene, this.camera);
+            this.effects = new Effects(this.scene, this.quality);
+
+            this.hud.setLoading(0.82, 'Acendendo o sol…');
+            await this.setupBloom();
+
+            this.renderer.compile(this.scene, this.camera);
+            this.render();
+            this.hud.setLoading(1, 'Pronto');
+            setTimeout(() => {
+                this.hud.hideLoading();
+                this.enterMenu();
+                this.last = performance.now();
+                this.fpsAcc = 0;
+                this.fpsFrames = 0;
+                this.renderer.setAnimationLoop((now) => this.frame(now));
+            }, 280);
         } catch (err) {
+            console.error(err);
             this.hud.fail(err?.message || 'Falha ao iniciar o WebGL.');
-            return;
         }
-
-        this.hud.setLoading(0.32, 'Erguendo os picos…');
-        this.world = new World(this.scene, this.quality);
-
-        this.hud.setLoading(0.58, 'Chamando a ira…');
-        this.player = new Player(this.scene, this.camera);
-        this.effects = new Effects(this.scene, this.quality);
-
-        this.hud.setLoading(0.82, 'Acendendo o sol…');
-        await this.setupBloom();
-
-        this.renderer.compile(this.scene, this.camera);
-        this.render();
-        this.hud.setLoading(1, 'Pronto');
-        setTimeout(() => {
-            this.hud.hideLoading();
-            this.enterMenu();
-            this.last = performance.now();
-            this.fpsAcc = 0;
-            this.fpsFrames = 0;
-            this.renderer.setAnimationLoop((now) => this.frame(now));
-        }, 280);
     }
 
     async setupRenderer() {

--- a/labs/eyra/src/models.js
+++ b/labs/eyra/src/models.js
@@ -1,0 +1,391 @@
+/**
+ * Modelos nativos: a ira (fera alada), a Yva (árvore-mãe), picos,
+ * helicoidais e o piloto. Sem GLTF — só geometria Three.js.
+ */
+
+import * as THREE from 'three';
+import {
+    rockTexture, mossTexture, barkTexture, leafTexture, wingTexture, glowSprite
+} from './textures.js';
+import { applyRockMoss, applyLeafSway, waterfallMaterial } from './shaders.js';
+
+const geo = {
+    sphere: new THREE.SphereGeometry(1, 22, 16),
+    sphereLo: new THREE.SphereGeometry(1, 12, 10),
+    sphereHi: new THREE.SphereGeometry(1, 28, 20),
+    box: new THREE.BoxGeometry(1, 1, 1),
+    cyl: new THREE.CylinderGeometry(1, 1, 1, 12),
+    cylLo: new THREE.CylinderGeometry(1, 1, 1, 8),
+    cone: new THREE.ConeGeometry(1, 1, 12),
+    coneLo: new THREE.ConeGeometry(1, 1, 8),
+    torus: new THREE.TorusGeometry(1, 0.18, 10, 28),
+    plane: new THREE.PlaneGeometry(1, 1, 1, 1),
+    icosa: new THREE.IcosahedronGeometry(1, 1)
+};
+
+export function std(color, {
+    map = null,
+    roughness = 0.72,
+    metalness = 0.04,
+    emissive = 0x000000,
+    em = 0,
+    transparent = false,
+    opacity = 1,
+    side = THREE.FrontSide,
+    flat = false
+} = {}) {
+    return new THREE.MeshStandardMaterial({
+        color,
+        map,
+        roughness,
+        metalness,
+        emissive,
+        emissiveIntensity: em,
+        transparent,
+        opacity,
+        side,
+        flatShading: flat
+    });
+}
+
+function mesh(geometry, material, { pos, scale, rot, cast = true, receive = true } = {}) {
+    const m = new THREE.Mesh(geometry, material);
+    if (pos) m.position.set(...pos);
+    if (scale) m.scale.set(...scale);
+    if (rot) m.rotation.set(...rot);
+    m.castShadow = cast;
+    m.receiveShadow = receive;
+    return m;
+}
+
+let MAT = null;
+
+export function materials() {
+    if (MAT) return MAT;
+    const rock = applyRockMoss(std(0x7a8a7e, { map: rockTexture(), roughness: 0.88, flat: true }));
+    const moss = std(0x2a8a48, { map: mossTexture(), roughness: 0.92 });
+    const bark = std(0x5a3a28, { map: barkTexture(), roughness: 0.9 });
+    const leaf = applyLeafSway(std(0x1f9a4a, { map: leafTexture(), roughness: 0.7, side: THREE.DoubleSide }));
+    const leafDark = applyLeafSway(std(0x0e6a38, { map: leafTexture(), roughness: 0.75, side: THREE.DoubleSide }));
+    const wing = std(0x1a4a58, {
+        map: wingTexture(),
+        roughness: 0.45,
+        metalness: 0.08,
+        side: THREE.DoubleSide,
+        transparent: true,
+        opacity: 0.92
+    });
+    MAT = {
+        rock, moss, bark, leaf, leafDark, wing,
+        skin: std(0x1c3a48, { roughness: 0.42, metalness: 0.12 }),
+        belly: std(0x2a6a68, { roughness: 0.5, emissive: 0x0a3a38, em: 0.15 }),
+        stripe: std(0x5ef0d8, { roughness: 0.3, emissive: 0x2ad4c0, em: 0.85 }),
+        eye: std(0xffe08a, { roughness: 0.15, emissive: 0xffc040, em: 1.4 }),
+        rider: std(0x3a8a9a, { roughness: 0.55 }),
+        cloth: std(0x6a3a28, { roughness: 0.8 }),
+        gold: std(0xe8c060, { roughness: 0.35, metalness: 0.4, emissive: 0xa08030, em: 0.2 }),
+        seed: std(0x7af0d8, { roughness: 0.2, emissive: 0x3ae0c0, em: 1.2 }),
+        magenta: std(0xd46ad0, { roughness: 0.4, emissive: 0xa040a0, em: 0.7 }),
+        water: std(0x1a8aaa, { roughness: 0.12, metalness: 0.35, transparent: true, opacity: 0.78 }),
+        cloud: std(0xf4f0e8, { roughness: 1, transparent: true, opacity: 0.55 }),
+        vine: std(0x1a6a38, { roughness: 0.85 })
+    };
+    return MAT;
+}
+
+export function createIra() {
+    const m = materials();
+    const g = new THREE.Group();
+    g.name = 'ira';
+
+    const body = mesh(geo.sphereHi, m.skin, { scale: [1.15, 0.85, 2.4] });
+    const belly = mesh(geo.sphere, m.belly, { scale: [0.85, 0.55, 1.9], pos: [0, -0.28, 0.1] });
+    g.add(body, belly);
+
+    for (let i = 0; i < 5; i++) {
+        const z = -1.6 + i * 0.7;
+        g.add(mesh(geo.box, m.stripe, {
+            scale: [1.7, 0.06, 0.12],
+            pos: [0, 0.15, z],
+            cast: false
+        }));
+    }
+
+    const neck = new THREE.Group();
+    neck.position.set(0, 0.15, 1.9);
+    for (let i = 0; i < 5; i++) {
+        const s = 0.38 - i * 0.04;
+        neck.add(mesh(geo.sphere, m.skin, {
+            scale: [s, s * 0.85, s * 1.15],
+            pos: [0, i * 0.12, i * 0.38]
+        }));
+    }
+    g.add(neck);
+
+    const head = new THREE.Group();
+    head.position.set(0, 0.62, 3.85);
+    head.add(mesh(geo.sphereHi, m.skin, { scale: [0.42, 0.32, 0.72] }));
+    head.add(mesh(geo.cone, m.skin, { scale: [0.18, 0.7, 0.22], pos: [0, -0.05, 0.72], rot: [Math.PI / 2, 0, 0] }));
+    head.add(mesh(geo.sphere, m.eye, { scale: [0.09, 0.09, 0.09], pos: [0.22, 0.08, 0.28], cast: false }));
+    head.add(mesh(geo.sphere, m.eye, { scale: [0.09, 0.09, 0.09], pos: [-0.22, 0.08, 0.28], cast: false }));
+    const crest = mesh(geo.cone, m.stripe, { scale: [0.08, 0.55, 0.18], pos: [0, 0.38, -0.1], rot: [0.4, 0, 0] });
+    head.add(crest);
+    for (let i = 0; i < 4; i++) {
+        const a = (i - 1.5) * 0.18;
+        head.add(mesh(geo.cylLo, m.stripe, {
+            scale: [0.025, 0.55, 0.025],
+            pos: [a, 0.42, -0.15 - i * 0.04],
+            rot: [0.5, 0, a]
+        }));
+    }
+    g.add(head);
+
+    const makeWing = (side) => {
+        const wing = new THREE.Group();
+        const bone = mesh(geo.cyl, m.skin, {
+            scale: [0.07, 3.6, 0.07],
+            pos: [side * 2.0, 0.2, 0.2],
+            rot: [0, 0, side * -1.05]
+        });
+        const membrane = mesh(
+            new THREE.PlaneGeometry(4.4, 2.6, 6, 4),
+            m.wing,
+            {
+                pos: [side * 2.5, -0.15, -0.15],
+                rot: [0.15, 0, side * -0.15],
+                scale: [side, 1, 1],
+                cast: false
+            }
+        );
+        const tip = mesh(geo.cone, m.skin, {
+            scale: [0.12, 0.7, 0.18],
+            pos: [side * 4.15, 0.55, 0.05],
+            rot: [0, 0, side * -1.2]
+        });
+        wing.add(bone, membrane, tip);
+        wing.userData.side = side;
+        return wing;
+    };
+    const left = makeWing(1);
+    const right = makeWing(-1);
+    g.add(left, right);
+
+    const tail = new THREE.Group();
+    tail.position.set(0, 0.1, -2.2);
+    for (let i = 0; i < 7; i++) {
+        const s = 0.32 - i * 0.035;
+        tail.add(mesh(geo.sphereLo, m.skin, {
+            scale: [s * 0.7, s * 0.55, s * 1.3],
+            pos: [0, -i * 0.04, -i * 0.48]
+        }));
+    }
+    const fin = mesh(new THREE.PlaneGeometry(1.6, 0.9), m.wing, {
+        pos: [0, 0.05, -3.4],
+        rot: [0.2, 0, 0],
+        cast: false
+    });
+    tail.add(fin);
+    g.add(tail);
+
+    const rider = createRider();
+    rider.position.set(0, 0.95, 0.85);
+    rider.rotation.x = 0.15;
+    g.add(rider);
+
+    const glow = new THREE.PointLight(0x5ef0d8, 1.4, 18, 2);
+    glow.position.set(0, 0.2, 0.4);
+    g.add(glow);
+
+    g.userData = { left, right, tail, head, neck, glow, rider };
+    g.scale.setScalar(1.15);
+    return g;
+}
+
+function createRider() {
+    const m = materials();
+    const g = new THREE.Group();
+    g.add(mesh(geo.sphere, m.rider, { scale: [0.16, 0.22, 0.14], pos: [0, 0.28, 0] }));
+    g.add(mesh(geo.sphere, m.rider, { scale: [0.12, 0.12, 0.12], pos: [0, 0.52, 0.02] }));
+    g.add(mesh(geo.cylLo, m.cloth, { scale: [0.13, 0.28, 0.13], pos: [0, 0.12, 0] }));
+    g.add(mesh(geo.cylLo, m.rider, { scale: [0.04, 0.22, 0.04], pos: [0.12, 0.22, 0.05], rot: [0.6, 0, -0.4] }));
+    g.add(mesh(geo.cylLo, m.rider, { scale: [0.04, 0.22, 0.04], pos: [-0.12, 0.22, 0.05], rot: [0.6, 0, 0.4] }));
+    const braid = mesh(geo.cylLo, m.gold, {
+        scale: [0.018, 0.55, 0.018],
+        pos: [0, 0.28, -0.18],
+        rot: [0.9, 0, 0]
+    });
+    g.add(braid);
+    return g;
+}
+
+export function createYva() {
+    const m = materials();
+    const g = new THREE.Group();
+    g.name = 'yva';
+    g.add(mesh(geo.cyl, m.bark, { scale: [2.8, 22, 2.8], pos: [0, 11, 0] }));
+    g.add(mesh(geo.sphereHi, m.bark, { scale: [3.4, 4.2, 3.4], pos: [0, 2.2, 0] }));
+    for (let i = 0; i < 6; i++) {
+        const a = (i / 6) * Math.PI * 2;
+        g.add(mesh(geo.cylLo, m.bark, {
+            scale: [0.55, 8, 0.55],
+            pos: [Math.cos(a) * 4.5, 18, Math.sin(a) * 4.5],
+            rot: [0.7, a, 0]
+        }));
+        g.add(mesh(geo.sphere, m.leaf, {
+            scale: [4.2, 2.4, 4.2],
+            pos: [Math.cos(a) * 7.5, 22, Math.sin(a) * 7.5]
+        }));
+    }
+    g.add(mesh(geo.sphereHi, m.leafDark, { scale: [10, 5.5, 10], pos: [0, 24, 0] }));
+    g.add(mesh(geo.sphere, m.leaf, { scale: [7.5, 4, 7.5], pos: [0, 27, 0] }));
+    const heart = mesh(geo.icosa, m.seed, { scale: [1.4, 1.8, 1.4], pos: [0, 14, 0], cast: false });
+    const light = new THREE.PointLight(0x7af0d8, 3.2, 48, 1.6);
+    light.position.set(0, 14, 0);
+    g.add(heart, light);
+    g.userData.heart = heart;
+    return g;
+}
+
+export function createSpiralPlant(rng = Math.random) {
+    const m = materials();
+    const g = new THREE.Group();
+    const h = 2.2 + rng() * 2.4;
+    const turns = 4 + Math.floor(rng() * 3);
+    const pts = [];
+    for (let i = 0; i <= 28; i++) {
+        const t = i / 28;
+        const a = t * turns * Math.PI * 2;
+        pts.push(new THREE.Vector3(Math.cos(a) * t * 0.55, t * h, Math.sin(a) * t * 0.55));
+    }
+    const curve = new THREE.CatmullRomCurve3(pts);
+    const tube = new THREE.TubeGeometry(curve, 40, 0.045, 5, false);
+    const stem = new THREE.Mesh(tube, m.magenta);
+    stem.castShadow = true;
+    g.add(stem);
+    const cup = mesh(geo.sphere, m.magenta, { scale: [0.42, 0.22, 0.42], pos: [pts[28].x, pts[28].y, pts[28].z] });
+    g.add(cup);
+    return g;
+}
+
+export function createCanopyTree(rng = Math.random) {
+    const m = materials();
+    const g = new THREE.Group();
+    const h = 8 + rng() * 10;
+    const r = 0.35 + rng() * 0.35;
+    g.add(mesh(geo.cylLo, m.bark, { scale: [r, h, r], pos: [0, h * 0.5, 0] }));
+    const layers = 2 + Math.floor(rng() * 2);
+    for (let i = 0; i < layers; i++) {
+        const s = 3.2 - i * 0.55 + rng() * 0.6;
+        g.add(mesh(geo.sphereLo, i % 2 ? m.leaf : m.leafDark, {
+            scale: [s, s * 0.55, s],
+            pos: [(rng() - 0.5) * 0.8, h - 0.4 - i * 1.5, (rng() - 0.5) * 0.8]
+        }));
+    }
+    return g;
+}
+
+export function createPeakTree(rng = Math.random) {
+    const m = materials();
+    const g = new THREE.Group();
+    const h = 2.4 + rng() * 2.2;
+    g.add(mesh(geo.cylLo, m.bark, { scale: [0.12, h, 0.12], pos: [0, h * 0.5, 0] }));
+    g.add(mesh(geo.coneLo, m.leaf, { scale: [1.1, 2.2, 1.1], pos: [0, h + 0.4, 0] }));
+    g.add(mesh(geo.coneLo, m.leafDark, { scale: [0.75, 1.4, 0.75], pos: [0, h + 1.1, 0] }));
+    return g;
+}
+
+export function createMountain(rng, size = 1) {
+    const m = materials();
+    const g = new THREE.Group();
+    const h = 18 * size;
+    const r = 8 * size;
+    const rock = mesh(geo.cone, m.rock, { scale: [r, h, r * 0.92], pos: [0, h * 0.15, 0], rot: [0, rng() * 6, 0.08] });
+    const cap = mesh(geo.sphere, m.moss, { scale: [r * 0.92, r * 0.38, r * 0.92], pos: [0, h * 0.52, 0] });
+    const hang = mesh(geo.cone, m.rock, {
+        scale: [r * 0.72, h * 0.85, r * 0.68],
+        pos: [0, -h * 0.28, 0],
+        rot: [Math.PI, rng() * 2, 0.12]
+    });
+    g.add(rock, cap, hang);
+    const nVines = 3 + Math.floor(rng() * 4);
+    for (let i = 0; i < nVines; i++) {
+        const a = rng() * Math.PI * 2;
+        const vr = r * (0.4 + rng() * 0.4);
+        g.add(mesh(geo.cylLo, m.vine, {
+            scale: [0.06, 6 + rng() * 8, 0.06],
+            pos: [Math.cos(a) * vr, -2 - rng() * 4, Math.sin(a) * vr]
+        }));
+    }
+    g.userData.radius = r;
+    g.userData.height = h;
+    return g;
+}
+
+export function createWaterfall(height = 22, width = 2.4) {
+    const m = materials();
+    const mat = waterfallMaterial();
+    const plane = new THREE.Mesh(new THREE.PlaneGeometry(width, height, 1, 12), mat);
+    plane.position.y = -height * 0.35;
+    plane.castShadow = false;
+    plane.receiveShadow = false;
+    const splash = mesh(geo.sphereLo, std(0xd8f8fc, { transparent: true, opacity: 0.35, roughness: 0.2 }), {
+        scale: [width * 0.7, 0.4, width * 0.7],
+        pos: [0, -height * 0.7, 0],
+        cast: false
+    });
+    const g = new THREE.Group();
+    g.add(plane, splash);
+    return g;
+}
+
+export function createSeed() {
+    const m = materials();
+    const g = new THREE.Group();
+    const core = mesh(geo.icosa, m.seed, { scale: [0.55, 0.7, 0.55], cast: false });
+    const halo = new THREE.Sprite(new THREE.SpriteMaterial({
+        map: glowSprite('#7af0d8'),
+        color: 0xffffff,
+        transparent: true,
+        depthWrite: false,
+        blending: THREE.AdditiveBlending
+    }));
+    halo.scale.set(3.2, 3.2, 1);
+    const light = new THREE.PointLight(0x7af0d8, 1.6, 16, 2);
+    g.add(core, halo, light);
+    g.userData.core = core;
+    return g;
+}
+
+export function createRing() {
+    const m = materials();
+    const ring = mesh(geo.torus, m.stripe, { scale: [2.6, 2.6, 2.6], rot: [Math.PI / 2, 0, 0], cast: false });
+    ring.material = std(0x7af0d8, {
+        roughness: 0.25,
+        emissive: 0x3ae0c8,
+        em: 0.95,
+        transparent: true,
+        opacity: 0.85
+    });
+    const g = new THREE.Group();
+    g.add(ring);
+    const glow = new THREE.PointLight(0x5ef0d8, 1.1, 12, 2);
+    g.add(glow);
+    return g;
+}
+
+export function createCloud(rng = Math.random) {
+    const m = materials();
+    const g = new THREE.Group();
+    const n = 3 + Math.floor(rng() * 3);
+    for (let i = 0; i < n; i++) {
+        g.add(mesh(geo.sphereLo, m.cloud, {
+            scale: [4 + rng() * 5, 1.6 + rng() * 1.4, 3.5 + rng() * 4],
+            pos: [(rng() - 0.5) * 6, (rng() - 0.5) * 1.2, (rng() - 0.5) * 5],
+            cast: false,
+            receive: false
+        }));
+    }
+    return g;
+}
+
+export { geo, mesh };

--- a/labs/eyra/src/player.js
+++ b/labs/eyra/src/player.js
@@ -1,0 +1,174 @@
+/**
+ * Voo da ira em terceira pessoa. A câmera persegue com inércia;
+ * o roll segue o banco; as asas batem com a velocidade.
+ *
+ * flap = sin(t * (2.1 + speed * 0.06)) * 0.42
+ */
+
+import * as THREE from 'three';
+import { PHYS, CAMERA, WORLD } from './config.js';
+import { clamp, damp } from './utils.js';
+import { createIra } from './models.js';
+
+export class Player {
+    constructor(scene, camera) {
+        this.scene = scene;
+        this.camera = camera;
+        this.mesh = createIra();
+        scene.add(this.mesh);
+
+        this.pos = new THREE.Vector3(0, 56, 42);
+        this.yaw = Math.PI;
+        this.pitch = 0.08;
+        this.roll = 0;
+        this.speed = PHYS.cruise * 0.7;
+        this.boost = 1;
+        this.spin = 0;
+        this.spinDir = 0;
+        this.invuln = 0;
+        this.forward = new THREE.Vector3(0, 0, -1);
+        this.vel = new THREE.Vector3();
+
+        this._q = new THREE.Quaternion();
+        this._e = new THREE.Euler();
+        this._cam = new THREE.Vector3();
+        this._look = new THREE.Vector3();
+        this._right = new THREE.Vector3();
+        this._up = new THREE.Vector3(0, 1, 0);
+        this._desiredCam = new THREE.Vector3();
+
+        this.reset();
+    }
+
+    reset() {
+        this.pos.set(0, 56, 42);
+        this.yaw = Math.PI;
+        this.pitch = 0.08;
+        this.roll = 0;
+        this.speed = PHYS.cruise * 0.55;
+        this.boost = 1;
+        this.spin = 0;
+        this.invuln = 0;
+        this.mesh.visible = true;
+        this.mesh.position.copy(this.pos);
+        this.syncForward();
+        this.camera.position.set(this.pos.x, this.pos.y + 8, this.pos.z + 22);
+        this.camera.lookAt(this.pos);
+    }
+
+    startRoll(dir) {
+        if (this.spin > 0) return false;
+        this.spin = PHYS.rollDuration;
+        this.spinDir = dir < 0 ? -1 : 1;
+        this.invuln = Math.max(this.invuln, PHYS.rollDuration * 0.8);
+        return true;
+    }
+
+    hit() {
+        this.invuln = PHYS.invuln;
+        this.speed *= PHYS.hitSlow;
+        this.boost = Math.max(0, this.boost - 0.2);
+    }
+
+    syncForward() {
+        const cp = Math.cos(this.pitch);
+        this.forward.set(
+            Math.sin(this.yaw) * cp,
+            Math.sin(this.pitch),
+            Math.cos(this.yaw) * cp
+        );
+    }
+
+    update(dt, input, look, world, boosting) {
+        this.yaw -= look.dx * CAMERA.mouse;
+        this.pitch = clamp(this.pitch - look.dy * CAMERA.mouse * 0.85, PHYS.minPitch, PHYS.maxPitch);
+
+        const throttle = -input.axis.z;
+        const bank = input.axis.x;
+        const climb = input.axis.y;
+
+        this.yaw -= bank * PHYS.yaw * (0.5 + this.speed / PHYS.maxSpeed) * dt;
+        this.pitch = clamp(
+            this.pitch + climb * PHYS.pitch * dt,
+            PHYS.minPitch,
+            PHYS.maxPitch
+        );
+
+        const cruise = PHYS.cruise * (1 + Math.max(0, throttle) * 0.9 - Math.max(0, -throttle) * 0.55);
+        const target = cruise * (boosting && this.boost > 0.04 ? PHYS.boostMul : 1);
+        this.speed += (target - this.speed) * (1 - Math.exp(-PHYS.drag * dt));
+        this.speed = clamp(this.speed, 8, PHYS.maxSpeed);
+
+        if (boosting && this.boost > 0) {
+            this.boost = Math.max(0, this.boost - PHYS.boostCost * dt);
+        } else {
+            this.boost = Math.min(1, this.boost + PHYS.boostRegen * dt);
+        }
+
+        this.roll = damp(this.roll, -bank * PHYS.maxBank, 7, dt);
+
+        if (this.spin > 0) {
+            this.spin = Math.max(0, this.spin - dt);
+            this.roll += this.spinDir * Math.PI * 2 * (dt / PHYS.rollDuration);
+        }
+
+        this.syncForward();
+        this.pos.addScaledVector(this.forward, this.speed * dt);
+
+        const ground = world.groundHeight(this.pos.x, this.pos.z) + 3.2;
+        if (this.pos.y < ground) {
+            this.pos.y = ground;
+            this.pitch = Math.max(this.pitch, 0.12);
+            this.speed *= 0.92;
+        }
+        this.pos.y = clamp(this.pos.y, WORLD.canopy + 2.5, WORLD.ceiling);
+
+        const hit = world.collide(this.pos, PHYS.radius);
+        if (hit && this.invuln <= 0) this.hit();
+
+        this.invuln = Math.max(0, this.invuln - dt);
+        this.mesh.position.copy(this.pos);
+
+        this._e.set(this.pitch, this.yaw, this.roll, 'YXZ');
+        this.mesh.quaternion.setFromEuler(this._e);
+
+        const flap = Math.sin(performance.now() * 0.001 * (2.1 + this.speed * 0.06)) * 0.42;
+        const ud = this.mesh.userData;
+        if (ud.left && ud.right) {
+            ud.left.rotation.z = 0.08 + flap;
+            ud.right.rotation.z = -0.08 - flap;
+            ud.tail.rotation.x = flap * 0.22;
+            ud.head.rotation.x = this.pitch * 0.15;
+        }
+        if (ud.glow) {
+            ud.glow.intensity = 1.1 + this.boost * 2.2 + (boosting ? 1.4 : 0);
+        }
+        if (this.invuln > 0) {
+            this.mesh.visible = Math.sin(this.invuln * 28) > 0;
+        } else {
+            this.mesh.visible = true;
+        }
+
+        this.updateCamera(dt, boosting);
+        this.vel.copy(this.forward).multiplyScalar(this.speed);
+        return hit;
+    }
+
+    updateCamera(dt, boosting) {
+        this._right.set(Math.cos(this.yaw), 0, -Math.sin(this.yaw));
+        const back = CAMERA.dist + this.speed * 0.04;
+        this._desiredCam.set(
+            this.pos.x - this.forward.x * back + this._right.x * this.roll * 2.2,
+            this.pos.y + CAMERA.height - this.pitch * 4,
+            this.pos.z - this.forward.z * back + this._right.z * this.roll * 2.2
+        );
+        this.camera.position.lerp(this._desiredCam, 1 - Math.exp(-5.2 * dt));
+        this._look.copy(this.pos).addScaledVector(this.forward, CAMERA.look);
+        this._look.y += 1.2;
+        this.camera.lookAt(this._look);
+
+        const fovT = CAMERA.fov + (boosting ? CAMERA.fovBoost : this.speed / PHYS.maxSpeed * 8);
+        this.camera.fov = damp(this.camera.fov, fovT, 4, dt);
+        this.camera.updateProjectionMatrix();
+    }
+}

--- a/labs/eyra/src/shaders.js
+++ b/labs/eyra/src/shaders.js
@@ -3,6 +3,8 @@
  * Injetados em MeshStandardMaterial via onBeforeCompile quando preciso.
  */
 
+import * as THREE from 'three';
+
 const WATER_KEY = 'eyra-water-v1';
 const ROCK_KEY = 'eyra-rock-v1';
 const LEAF_KEY = 'eyra-leaf-v1';

--- a/labs/eyra/src/shaders.js
+++ b/labs/eyra/src/shaders.js
@@ -1,0 +1,145 @@
+/**
+ * Shaders do mundo: água, queda, musgo no rochedo e o céu de Eyra.
+ * Injetados em MeshStandardMaterial via onBeforeCompile quando preciso.
+ */
+
+const WATER_KEY = 'eyra-water-v1';
+const ROCK_KEY = 'eyra-rock-v1';
+const LEAF_KEY = 'eyra-leaf-v1';
+
+export function applyWater(material) {
+    material.onBeforeCompile = (shader) => {
+        shader.uniforms.uTime = { value: 0 };
+        shader.vertexShader = shader.vertexShader
+            .replace(
+                '#include <common>',
+                `#include <common>\nuniform float uTime;\nvarying vec3 vWorldPos;`
+            )
+            .replace(
+                '#include <begin_vertex>',
+                `#include <begin_vertex>
+                transformed.z += sin(position.x * 0.18 + uTime * 1.1) * 0.12
+                               + cos(position.y * 0.22 + uTime * 0.9) * 0.1;`
+            )
+            .replace(
+                '#include <worldpos_vertex>',
+                `#include <worldpos_vertex>\nvWorldPos = (modelMatrix * vec4(transformed, 1.0)).xyz;`
+            );
+        shader.fragmentShader = shader.fragmentShader
+            .replace(
+                '#include <common>',
+                `#include <common>
+                uniform float uTime;
+                varying vec3 vWorldPos;`
+            )
+            .replace(
+                '#include <emissivemap_fragment>',
+                `#include <emissivemap_fragment>
+                float spark = step(0.97, fract(sin(dot(vWorldPos.xz * 0.35, vec2(12.9898, 78.233)) + uTime) * 43758.5453));
+                float fres = pow(1.0 - max(dot(normalize(vNormal), normalize(vViewPosition)), 0.0), 2.4);
+                totalEmissiveRadiance += vec3(0.35, 0.85, 0.8) * spark * 0.65;
+                totalEmissiveRadiance += vec3(0.2, 0.55, 0.5) * fres * 0.25;`
+            );
+        material.userData.shader = shader;
+    };
+    material.customProgramCacheKey = () => WATER_KEY;
+    return material;
+}
+
+export function applyRockMoss(material, strength = 0.55) {
+    material.onBeforeCompile = (shader) => {
+        shader.uniforms.uMoss = { value: strength };
+        shader.vertexShader = shader.vertexShader.replace(
+            '#include <common>',
+            `#include <common>\nvarying vec3 vWorldN;\nvarying vec3 vWorldP;`
+        ).replace(
+            '#include <worldpos_vertex>',
+            `#include <worldpos_vertex>
+            vWorldP = (modelMatrix * vec4(transformed, 1.0)).xyz;
+            vWorldN = normalize(mat3(modelMatrix) * normal);`
+        );
+        shader.fragmentShader = shader.fragmentShader.replace(
+            '#include <common>',
+            `#include <common>
+            uniform float uMoss;
+            varying vec3 vWorldN;
+            varying vec3 vWorldP;`
+        ).replace(
+            '#include <color_fragment>',
+            `#include <color_fragment>
+            float up = smoothstep(0.18, 0.72, vWorldN.y);
+            vec3 moss = vec3(0.12, 0.42, 0.18);
+            diffuseColor.rgb = mix(diffuseColor.rgb, moss, up * uMoss);
+            float vein = sin(vWorldP.y * 0.35 + vWorldP.x * 0.12) * 0.5 + 0.5;
+            diffuseColor.rgb = mix(diffuseColor.rgb, vec3(0.08, 0.22, 0.16), vein * 0.12 * up);`
+        );
+        material.userData.shader = shader;
+    };
+    material.customProgramCacheKey = () => ROCK_KEY;
+    return material;
+}
+
+export function waterfallMaterial() {
+    const mat = new THREE.ShaderMaterial({
+        uniforms: {
+            uTime: { value: 0 }
+        },
+        transparent: true,
+        depthWrite: false,
+        side: THREE.DoubleSide,
+        vertexShader: /* glsl */ `
+            varying vec2 vUv;
+            void main() {
+                vUv = uv;
+                gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+            }
+        `,
+        fragmentShader: /* glsl */ `
+            uniform float uTime;
+            varying vec2 vUv;
+            void main() {
+                float yv = vUv.y + uTime * 0.55;
+                float band = abs(sin(yv * 28.0 + sin(vUv.x * 12.0 + uTime) * 1.4));
+                float edge = smoothstep(0.0, 0.12, vUv.x) * smoothstep(1.0, 0.88, vUv.x);
+                float mist = smoothstep(0.0, 0.15, vUv.y) * smoothstep(1.0, 0.75, vUv.y);
+                vec3 col = mix(vec3(0.55, 0.85, 0.92), vec3(0.9, 0.98, 1.0), band);
+                float alpha = edge * mist * (0.28 + band * 0.45);
+                gl_FragColor = vec4(col, alpha);
+            }
+        `
+    });
+    mat.userData.shader = mat;
+    return mat;
+}
+
+export function applyLeafSway(material) {
+    material.onBeforeCompile = (shader) => {
+        shader.uniforms.uTime = { value: 0 };
+        shader.vertexShader = shader.vertexShader.replace(
+            '#include <common>',
+            `#include <common>\nuniform float uTime;`
+        ).replace(
+            '#include <begin_vertex>',
+            `#include <begin_vertex>
+            float sway = sin(uTime * 0.7 + position.x * 0.4 + position.z * 0.3) * 0.08;
+            transformed.x += sway * position.y * 0.15;
+            transformed.z += cos(uTime * 0.55 + position.y) * 0.05 * position.y * 0.1;`
+        );
+        material.userData.shader = shader;
+    };
+    material.customProgramCacheKey = () => LEAF_KEY;
+    return material;
+}
+
+export function tickShaders(root, time) {
+    root.traverse((obj) => {
+        const mats = Array.isArray(obj.material) ? obj.material : [obj.material];
+        for (const m of mats) {
+            if (!m) continue;
+            if (m.uniforms?.uTime) m.uniforms.uTime.value = time;
+            if (m.userData?.shader?.uniforms?.uTime) {
+                m.userData.shader.uniforms.uTime.value = time;
+            }
+        }
+    });
+}

--- a/labs/eyra/src/sky.js
+++ b/labs/eyra/src/sky.js
@@ -1,0 +1,127 @@
+/**
+ * Céu de Eyra: zênite teal, horizonte ouro-verde, duas luas e o sol
+ * baixo — o “magic hour” permanente de um mundo de picos flutuantes.
+ */
+
+import * as THREE from 'three';
+
+const skyVert = /* glsl */ `
+varying vec3 vDir;
+void main() {
+    vDir = position;
+    gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+}`;
+
+const skyFrag = /* glsl */ `
+varying vec3 vDir;
+uniform vec3 uZenith;
+uniform vec3 uMid;
+uniform vec3 uHorizon;
+uniform vec3 uSunColor;
+uniform vec3 uSunDir;
+uniform float uDusk;
+
+void main() {
+    vec3 dir = normalize(vDir);
+    float h = dir.y * 0.5 + 0.5;
+    vec3 col = mix(uHorizon, uMid, smoothstep(0.22, 0.52, h));
+    col = mix(col, uZenith, smoothstep(0.5, 0.95, h));
+
+    float sun = pow(max(dot(dir, normalize(uSunDir)), 0.0), 48.0);
+    float glow = pow(max(dot(dir, normalize(uSunDir)), 0.0), 5.0);
+    col += uSunColor * sun * 1.35;
+    col += uSunColor * glow * 0.28;
+
+    float band = exp(-pow((h - 0.38) * 7.5, 2.0));
+    col += vec3(1.0, 0.55, 0.28) * band * 0.22 * (1.0 - uDusk * 0.4);
+
+    // véu magenta nas alturas — o céu “alienígena”
+    float veil = smoothstep(0.62, 0.95, h);
+    col = mix(col, vec3(0.42, 0.18, 0.48), veil * 0.18 * uDusk);
+
+    gl_FragColor = vec4(col, 1.0);
+}`;
+
+export function createSky() {
+    const geo = new THREE.SphereGeometry(780, 40, 24);
+    const mat = new THREE.ShaderMaterial({
+        uniforms: {
+            uZenith: { value: new THREE.Color('#143a62') },
+            uMid: { value: new THREE.Color('#3a8a9a') },
+            uHorizon: { value: new THREE.Color('#e8c878') },
+            uSunColor: { value: new THREE.Color('#fff1b8') },
+            uSunDir: { value: new THREE.Vector3(0.62, 0.18, 0.55).normalize() },
+            uDusk: { value: 0.22 }
+        },
+        vertexShader: skyVert,
+        fragmentShader: skyFrag,
+        side: THREE.BackSide,
+        depthWrite: false
+    });
+    const group = new THREE.Group();
+    group.name = 'sky';
+    const dome = new THREE.Mesh(geo, mat);
+    dome.frustumCulled = false;
+    group.add(dome);
+
+    const sunDir = mat.uniforms.uSunDir.value;
+    const sun = new THREE.Mesh(
+        new THREE.SphereGeometry(18, 28, 18),
+        new THREE.MeshBasicMaterial({ color: 0xfff4c4 })
+    );
+    sun.position.copy(sunDir).multiplyScalar(520);
+    const corona = new THREE.Mesh(
+        new THREE.SphereGeometry(32, 20, 14),
+        new THREE.MeshBasicMaterial({
+            color: 0xffc070,
+            transparent: true,
+            opacity: 0.22,
+            depthWrite: false
+        })
+    );
+    sun.add(corona);
+    group.add(sun);
+
+    const moonA = new THREE.Mesh(
+        new THREE.SphereGeometry(22, 24, 16),
+        new THREE.MeshBasicMaterial({ color: 0xc8d8e8 })
+    );
+    moonA.position.set(-280, 210, -340);
+    const moonB = new THREE.Mesh(
+        new THREE.SphereGeometry(10, 18, 12),
+        new THREE.MeshBasicMaterial({ color: 0xf0d8c0 })
+    );
+    moonB.position.set(-240, 180, -380);
+    group.add(moonA, moonB);
+
+    const n = 1400;
+    const pos = new Float32Array(n * 3);
+    for (let i = 0; i < n; i++) {
+        const a = Math.random() * Math.PI * 2;
+        const h = Math.random() * 0.55 + 0.35;
+        const r = 620;
+        pos[i * 3] = Math.cos(a) * Math.cos(h * Math.PI) * r;
+        pos[i * 3 + 1] = Math.sin(h * Math.PI) * r * 0.55;
+        pos[i * 3 + 2] = Math.sin(a) * Math.cos(h * Math.PI) * r;
+    }
+    const stars = new THREE.BufferGeometry();
+    stars.setAttribute('position', new THREE.BufferAttribute(pos, 3));
+    group.add(new THREE.Points(
+        stars,
+        new THREE.PointsMaterial({
+            color: 0xe8f4ff,
+            size: 1.4,
+            transparent: true,
+            opacity: 0.55,
+            depthWrite: false
+        })
+    ));
+
+    group.userData.mat = mat;
+    return group;
+}
+
+export function setSkyDusk(sky, t) {
+    const mat = sky?.userData?.mat;
+    if (mat) mat.uniforms.uDusk.value = t;
+}

--- a/labs/eyra/src/textures.js
+++ b/labs/eyra/src/textures.js
@@ -1,0 +1,207 @@
+/**
+ * Texturas procedurais — o lab não usa PNG externos.
+ * Ruído, musgo, casca, membrana de asa e rampa de musgo úmido.
+ */
+
+import * as THREE from 'three';
+
+const cache = new Map();
+
+function canvas(w, h = w) {
+    const el = document.createElement('canvas');
+    el.width = w;
+    el.height = h;
+    return el;
+}
+
+function toTexture(el, { nearest = false, repeat = [1, 1], colorSpace = true } = {}) {
+    const tex = new THREE.CanvasTexture(el);
+    tex.colorSpace = colorSpace && !nearest ? THREE.SRGBColorSpace : THREE.NoColorSpace;
+    tex.wrapS = tex.wrapT = THREE.RepeatWrapping;
+    tex.repeat.set(repeat[0], repeat[1]);
+    tex.anisotropy = nearest ? 1 : 8;
+    if (nearest) {
+        tex.minFilter = tex.magFilter = THREE.NearestFilter;
+        tex.generateMipmaps = false;
+    }
+    tex.needsUpdate = true;
+    return tex;
+}
+
+function cached(key, factory) {
+    if (!cache.has(key)) cache.set(key, factory());
+    return cache.get(key);
+}
+
+function noise2(x, y) {
+    const n = Math.sin(x * 127.1 + y * 311.7) * 43758.5453;
+    return n - Math.floor(n);
+}
+
+function fbm(x, y) {
+    let v = 0;
+    let a = 0.5;
+    let f = 1;
+    for (let i = 0; i < 5; i++) {
+        v += a * noise2(x * f, y * f);
+        f *= 2.03;
+        a *= 0.5;
+    }
+    return v;
+}
+
+export function rockTexture() {
+    return cached('rock', () => {
+        const s = 256;
+        const el = canvas(s);
+        const ctx = el.getContext('2d');
+        const img = ctx.createImageData(s, s);
+        for (let y = 0; y < s; y++) {
+            for (let x = 0; x < s; x++) {
+                const n = fbm(x * 0.035, y * 0.035);
+                const crack = Math.abs(Math.sin(x * 0.08 + n * 6) * Math.cos(y * 0.07));
+                const g = 78 + n * 55 + crack * 18;
+                const i = (y * s + x) * 4;
+                img.data[i] = g * 0.82;
+                img.data[i + 1] = g * 0.92;
+                img.data[i + 2] = g * 0.78;
+                img.data[i + 3] = 255;
+            }
+        }
+        ctx.putImageData(img, 0, 0);
+        return toTexture(el, { repeat: [4, 4] });
+    });
+}
+
+export function mossTexture() {
+    return cached('moss', () => {
+        const s = 256;
+        const el = canvas(s);
+        const ctx = el.getContext('2d');
+        const img = ctx.createImageData(s, s);
+        for (let y = 0; y < s; y++) {
+            for (let x = 0; x < s; x++) {
+                const n = fbm(x * 0.05, y * 0.05);
+                const speck = noise2(x * 0.4, y * 0.4);
+                const i = (y * s + x) * 4;
+                img.data[i] = 18 + n * 40 + speck * 20;
+                img.data[i + 1] = 70 + n * 90 + speck * 30;
+                img.data[i + 2] = 28 + n * 35;
+                img.data[i + 3] = 255;
+            }
+        }
+        ctx.putImageData(img, 0, 0);
+        return toTexture(el, { repeat: [6, 6] });
+    });
+}
+
+export function barkTexture() {
+    return cached('bark', () => {
+        const s = 128;
+        const el = canvas(s);
+        const ctx = el.getContext('2d');
+        const img = ctx.createImageData(s, s);
+        for (let y = 0; y < s; y++) {
+            for (let x = 0; x < s; x++) {
+                const n = fbm(x * 0.18, y * 0.04);
+                const i = (y * s + x) * 4;
+                const g = 48 + n * 40;
+                img.data[i] = g * 0.7;
+                img.data[i + 1] = g * 0.48;
+                img.data[i + 2] = g * 0.32;
+                img.data[i + 3] = 255;
+            }
+        }
+        ctx.putImageData(img, 0, 0);
+        return toTexture(el, { repeat: [2, 4] });
+    });
+}
+
+export function leafTexture() {
+    return cached('leaf', () => {
+        const s = 128;
+        const el = canvas(s);
+        const ctx = el.getContext('2d');
+        const g = ctx.createRadialGradient(64, 64, 8, 64, 64, 64);
+        g.addColorStop(0, '#3ecf6a');
+        g.addColorStop(0.55, '#1a8a48');
+        g.addColorStop(1, '#0a4a28');
+        ctx.fillStyle = g;
+        ctx.fillRect(0, 0, s, s);
+        ctx.strokeStyle = 'rgba(20, 80, 40, 0.35)';
+        for (let i = 0; i < 12; i++) {
+            ctx.beginPath();
+            ctx.moveTo(64, 8);
+            ctx.quadraticCurveTo(40 + i * 4, 70, 20 + i * 8, 120);
+            ctx.stroke();
+        }
+        return toTexture(el);
+    });
+}
+
+export function wingTexture() {
+    return cached('wing', () => {
+        const el = canvas(256, 128);
+        const ctx = el.getContext('2d');
+        const g = ctx.createLinearGradient(0, 0, 256, 128);
+        g.addColorStop(0, '#143a48');
+        g.addColorStop(0.4, '#1a5a62');
+        g.addColorStop(0.7, '#0e2a38');
+        g.addColorStop(1, '#082028');
+        ctx.fillStyle = g;
+        ctx.fillRect(0, 0, 256, 128);
+        ctx.strokeStyle = 'rgba(94, 240, 216, 0.28)';
+        ctx.lineWidth = 2;
+        for (let i = 0; i < 9; i++) {
+            ctx.beginPath();
+            ctx.moveTo(12, 8);
+            ctx.quadraticCurveTo(80 + i * 14, 40 + i * 6, 240, 20 + i * 12);
+            ctx.stroke();
+        }
+        ctx.fillStyle = 'rgba(94, 240, 216, 0.12)';
+        for (let i = 0; i < 18; i++) {
+            ctx.beginPath();
+            ctx.ellipse(30 + (i % 6) * 38, 24 + Math.floor(i / 6) * 36, 10, 16, 0.3, 0, Math.PI * 2);
+            ctx.fill();
+        }
+        return toTexture(el);
+    });
+}
+
+export function waterTexture() {
+    return cached('water', () => {
+        const s = 256;
+        const el = canvas(s);
+        const ctx = el.getContext('2d');
+        const img = ctx.createImageData(s, s);
+        for (let y = 0; y < s; y++) {
+            for (let x = 0; x < s; x++) {
+                const n = fbm(x * 0.04, y * 0.04);
+                const i = (y * s + x) * 4;
+                img.data[i] = 20 + n * 30;
+                img.data[i + 1] = 90 + n * 70;
+                img.data[i + 2] = 110 + n * 80;
+                img.data[i + 3] = 255;
+            }
+        }
+        ctx.putImageData(img, 0, 0);
+        return toTexture(el, { repeat: [8, 8] });
+    });
+}
+
+export function glowSprite(color = '#5ef0d8') {
+    return cached(`glow:${color}`, () => {
+        const el = canvas(64);
+        const ctx = el.getContext('2d');
+        const g = ctx.createRadialGradient(32, 32, 0, 32, 32, 32);
+        g.addColorStop(0, '#ffffff');
+        g.addColorStop(0.2, color);
+        g.addColorStop(0.55, color + '88');
+        g.addColorStop(1, 'rgba(0,0,0,0)');
+        ctx.fillStyle = g;
+        ctx.fillRect(0, 0, 64, 64);
+        const tex = toTexture(el, { colorSpace: false });
+        tex.wrapS = tex.wrapT = THREE.ClampToEdgeWrapping;
+        return tex;
+    });
+}

--- a/labs/eyra/src/utils.js
+++ b/labs/eyra/src/utils.js
@@ -1,0 +1,67 @@
+/** Utilitários numéricos e detecção de dispositivo. */
+
+export const clamp = (v, min, max) => (v < min ? min : v > max ? max : v);
+export const lerp = (a, b, t) => a + (b - a) * t;
+export const damp = (current, target, lambda, dt) =>
+    lerp(current, target, 1 - Math.exp(-lambda * dt));
+
+export const randRange = (min, max) => min + Math.random() * (max - min);
+export const pick = (arr) => arr[Math.floor(Math.random() * arr.length)];
+
+export function hash(n) {
+    n = (n | 0) * 374761393 + 668265263;
+    n = (n ^ (n >>> 13)) * 1274126177;
+    return ((n ^ (n >>> 16)) >>> 0) / 4294967296;
+}
+
+export function mulberry32(seed) {
+    let a = seed | 0;
+    return () => {
+        a |= 0;
+        a = (a + 0x6d2b79f5) | 0;
+        let t = Math.imul(a ^ (a >>> 15), 1 | a);
+        t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+        return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+    };
+}
+
+export function formatTime(seconds) {
+    const s = Math.max(0, Math.floor(seconds));
+    const m = Math.floor(s / 60);
+    const r = s % 60;
+    return `${m}:${r.toString().padStart(2, '0')}`;
+}
+
+export function formatScore(n) {
+    return Math.floor(n).toLocaleString('pt-BR');
+}
+
+export function detectMobile() {
+    if (typeof navigator === 'undefined') return false;
+    const coarse = window.matchMedia?.('(pointer: coarse)')?.matches;
+    const narrow = Math.min(window.innerWidth, window.innerHeight) < 760;
+    return Boolean(coarse && narrow) || /Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
+}
+
+export function detectSoftwareGL(renderer) {
+    try {
+        const gl = renderer?.getContext?.() || (() => {
+            const c = document.createElement('canvas');
+            return c.getContext('webgl2') || c.getContext('webgl');
+        })();
+        if (!gl) return true;
+        const info = gl.getExtension('WEBGL_debug_renderer_info');
+        const name = info ? String(gl.getParameter(info.UNMASKED_RENDERER_WEBGL) || '') : '';
+        return /swiftshader|llvmpipe|softpipe|microsoft basic render|\bcpu\b/i.test(name);
+    } catch {
+        return true;
+    }
+}
+
+export function zoneAt(y, zones) {
+    let z = zones[0];
+    for (let i = 0; i < zones.length; i++) {
+        if (y >= zones[i].y) z = zones[i];
+    }
+    return z;
+}

--- a/labs/eyra/src/world.js
+++ b/labs/eyra/src/world.js
@@ -1,0 +1,307 @@
+/**
+ * Eyra: picos flutuantes, canópia, a Yva e os anéis de névoa.
+ * Colisores esféricos por pico — o voo empurra na normal.
+ */
+
+import * as THREE from 'three';
+import { WORLD, SEEDS } from './config.js';
+import { hash, mulberry32 } from './utils.js';
+import { createSky } from './sky.js';
+import { applyWater } from './shaders.js';
+import { waterTexture, mossTexture } from './textures.js';
+import {
+    materials, createIra, createYva, createMountain, createCanopyTree,
+    createPeakTree, createSpiralPlant, createWaterfall, createSeed,
+    createRing, createCloud, std, geo, mesh
+} from './models.js';
+
+const LANDMARKS = [
+    { x: 0, y: 38, z: 0, size: 1.55, yva: true, fall: false },
+    { x: 72, y: 62, z: -48, size: 1.15, seed: 0, fall: true },
+    { x: -80, y: 54, z: -28, size: 1.05, seed: 1, fall: true },
+    { x: 48, y: 88, z: 64, size: 0.95, seed: 2, fall: false },
+    { x: -56, y: 78, z: 70, size: 1.2, seed: 3, fall: true },
+    { x: 110, y: 50, z: 18, size: 0.88, seed: 4, fall: false },
+    { x: -108, y: 46, z: 12, size: 0.92, seed: 5, fall: true },
+    { x: 22, y: 118, z: -92, size: 0.78, seed: 6, fall: false },
+    { x: -30, y: 102, z: 108, size: 0.85, seed: 7, fall: true },
+    { x: 86, y: 36, z: 96, size: 0.7, fall: false },
+    { x: -92, y: 34, z: -88, size: 0.74, fall: false },
+    { x: 0, y: 28, z: -120, size: 0.82, fall: true },
+    { x: 130, y: 70, z: -70, size: 0.62, fall: false }
+];
+
+export class World {
+    constructor(scene, quality) {
+        this.scene = scene;
+        this.quality = quality;
+        this.root = new THREE.Group();
+        this.root.name = 'eyra';
+        scene.add(this.root);
+
+        this.colliders = [];
+        this.seeds = [];
+        this.rings = [];
+        this.clouds = [];
+        this.clock = 0;
+
+        this.sky = createSky();
+        scene.add(this.sky);
+
+        this._floor();
+        this._peaks();
+        this._jungle();
+        this._rings();
+        this._clouds();
+        this._fog(scene);
+    }
+
+    _floor() {
+        const m = materials();
+        const ground = mesh(
+            new THREE.CircleGeometry(WORLD.radius * 1.35, 64),
+            std(0x145828, { map: mossTexture(), roughness: 0.95 }),
+            { rot: [-Math.PI / 2, 0, 0], pos: [0, 0, 0], cast: false }
+        );
+        this.root.add(ground);
+
+        const lakeMat = applyWater(std(0x1a7a8a, {
+            map: waterTexture(),
+            roughness: 0.12,
+            metalness: 0.28,
+            transparent: true,
+            opacity: 0.82
+        }));
+        this.lake = mesh(new THREE.CircleGeometry(38, 48), lakeMat, {
+            rot: [-Math.PI / 2, 0, 0],
+            pos: [18, 0.4, 24],
+            cast: false
+        });
+        this.root.add(this.lake);
+
+        const mist = mesh(
+            new THREE.CircleGeometry(WORLD.radius * 0.9, 32),
+            std(0xc8e8d8, { transparent: true, opacity: 0.08, roughness: 1 }),
+            { rot: [-Math.PI / 2, 0, 0], pos: [0, 14, 0], cast: false, receive: false }
+        );
+        this.root.add(mist);
+    }
+
+    _peaks() {
+        const rng = mulberry32(42);
+        const count = Math.min(LANDMARKS.length, this.quality.peaks + 2);
+        for (let i = 0; i < count; i++) {
+            const L = LANDMARKS[i];
+            const peak = createMountain(rng, L.size);
+            peak.position.set(L.x, L.y, L.z);
+            peak.rotation.y = rng() * Math.PI * 2;
+            this.root.add(peak);
+
+            const r = 8 * L.size;
+            const h = 18 * L.size;
+            this.colliders.push({
+                x: L.x,
+                y: L.y + h * 0.1,
+                z: L.z,
+                r: r * 0.85,
+                top: L.y + h * 0.55
+            });
+
+            if (L.yva) {
+                const yva = createYva();
+                yva.position.set(L.x, L.y + h * 0.48, L.z);
+                this.root.add(yva);
+                this.yva = yva;
+                this.yvaPos = new THREE.Vector3(L.x, L.y + h * 0.48 + 14, L.z);
+            }
+
+            const trees = 3 + Math.floor(rng() * 4);
+            for (let t = 0; t < trees; t++) {
+                const a = rng() * Math.PI * 2;
+                const d = rng() * r * 0.55;
+                const tree = createPeakTree(rng);
+                tree.position.set(
+                    L.x + Math.cos(a) * d,
+                    L.y + h * 0.5,
+                    L.z + Math.sin(a) * d
+                );
+                tree.scale.setScalar(0.7 + rng() * 0.5);
+                this.root.add(tree);
+            }
+
+            if (L.fall) {
+                const fall = createWaterfall(h * 1.15, 1.6 + rng() * 1.2);
+                const a = rng() * Math.PI * 2;
+                fall.position.set(
+                    L.x + Math.cos(a) * r * 0.55,
+                    L.y + h * 0.2,
+                    L.z + Math.sin(a) * r * 0.55
+                );
+                fall.lookAt(L.x, L.y, L.z);
+                this.root.add(fall);
+            }
+
+            if (Number.isInteger(L.seed) && L.seed < SEEDS) {
+                const seed = createSeed();
+                seed.position.set(L.x, L.y + h * 0.62 + 2.4, L.z);
+                seed.userData.taken = false;
+                seed.userData.index = L.seed;
+                this.root.add(seed);
+                this.seeds.push(seed);
+            }
+        }
+    }
+
+    _jungle() {
+        const rng = mulberry32(99);
+        const n = this.quality.trees;
+        for (let i = 0; i < n; i++) {
+            const a = hash(i * 17.2) * Math.PI * 2;
+            const d = 22 + hash(i * 9.1) * (WORLD.radius * 0.85);
+            if (d < 28) continue;
+            const tree = createCanopyTree(rng);
+            tree.position.set(Math.cos(a) * d, 0, Math.sin(a) * d);
+            tree.rotation.y = rng() * 6;
+            tree.scale.setScalar(0.7 + rng() * 0.7);
+            this.root.add(tree);
+        }
+        const plants = this.quality.plants;
+        for (let i = 0; i < plants; i++) {
+            const a = hash(i * 23.7) * Math.PI * 2;
+            const d = 8 + hash(i * 4.4) * 90;
+            const p = createSpiralPlant(rng);
+            const peak = LANDMARKS[i % 6];
+            if (i % 3 === 0) {
+                p.position.set(peak.x + (rng() - 0.5) * 10, peak.y + 10, peak.z + (rng() - 0.5) * 10);
+            } else {
+                p.position.set(Math.cos(a) * d, 0.2, Math.sin(a) * d);
+            }
+            p.scale.setScalar(0.8 + rng() * 0.8);
+            this.root.add(p);
+        }
+    }
+
+    _rings() {
+        const path = [
+            [40, 58, -20],
+            [64, 70, 8],
+            [50, 92, 48],
+            [8, 100, 70],
+            [-42, 86, 62],
+            [-70, 64, 24],
+            [-48, 72, -36],
+            [6, 110, -70],
+            [38, 96, -80],
+            [90, 58, -30],
+            [20, 48, 20],
+            [-20, 130, 20]
+        ];
+        for (const [x, y, z] of path) {
+            const ring = createRing();
+            ring.position.set(x, y, z);
+            ring.lookAt(0, y, 0);
+            ring.userData.taken = false;
+            this.root.add(ring);
+            this.rings.push(ring);
+        }
+    }
+
+    _clouds() {
+        const rng = mulberry32(7);
+        for (let i = 0; i < this.quality.clouds; i++) {
+            const c = createCloud(rng);
+            const a = rng() * Math.PI * 2;
+            const d = 40 + rng() * 180;
+            c.position.set(Math.cos(a) * d, 30 + rng() * 90, Math.sin(a) * d);
+            c.userData.drift = (rng() - 0.5) * 1.6;
+            this.root.add(c);
+            this.clouds.push(c);
+        }
+    }
+
+    _fog(scene) {
+        scene.fog = new THREE.Fog(0x1a4a52, WORLD.fogNear, WORLD.fogFar);
+        scene.background = new THREE.Color(0x143a48);
+    }
+
+    groundHeight(x, z) {
+        let h = WORLD.canopy;
+        for (const c of this.colliders) {
+            const d = Math.hypot(x - c.x, z - c.z);
+            const reach = c.r * 1.55;
+            if (d < reach) {
+                const k = 1 - d / reach;
+                h = Math.max(h, c.top * (k * k) + 1.2);
+            }
+        }
+        return h;
+    }
+
+    collide(pos, radius) {
+        let hit = null;
+        for (const c of this.colliders) {
+            const dx = pos.x - c.x;
+            const dy = pos.y - c.y;
+            const dz = pos.z - c.z;
+            const d = Math.hypot(dx, dy, dz);
+            const min = c.r + radius;
+            if (d < min && d > 0.001) {
+                const k = min / d;
+                pos.x = c.x + dx * k;
+                pos.y = c.y + dy * k;
+                pos.z = c.z + dz * k;
+                hit = { nx: dx / d, ny: dy / d, nz: dz / d };
+            }
+        }
+        const radial = Math.hypot(pos.x, pos.z);
+        if (radial > WORLD.radius) {
+            const k = WORLD.radius / radial;
+            pos.x *= k;
+            pos.z *= k;
+        }
+        return hit;
+    }
+
+    update(dt, dusk) {
+        this.clock += dt;
+        const t = this.clock;
+        for (const seed of this.seeds) {
+            if (seed.userData.taken) continue;
+            seed.rotation.y += dt * 1.4;
+            seed.position.y += Math.sin(t * 2.2 + seed.userData.index) * 0.006;
+            if (seed.userData.core) seed.userData.core.rotation.x += dt * 0.8;
+        }
+        for (const ring of this.rings) {
+            if (ring.userData.taken) {
+                ring.rotation.z += dt * 4;
+                continue;
+            }
+            ring.rotation.z += dt * 0.8;
+        }
+        for (const c of this.clouds) {
+            c.position.x += c.userData.drift * dt;
+            c.position.z += Math.sin(t * 0.05 + c.position.x * 0.01) * 0.4 * dt;
+        }
+        if (this.yva?.userData.heart) {
+            this.yva.userData.heart.rotation.y += dt * 0.6;
+            this.yva.userData.heart.scale.setScalar(1 + Math.sin(t * 1.6) * 0.06);
+        }
+        if (this.sky?.userData.mat) {
+            this.sky.userData.mat.uniforms.uDusk.value = dusk;
+        }
+    }
+
+    resetPickups() {
+        for (const seed of this.seeds) {
+            seed.visible = true;
+            seed.userData.taken = false;
+        }
+        for (const ring of this.rings) {
+            ring.visible = true;
+            ring.userData.taken = false;
+            ring.scale.setScalar(1);
+        }
+    }
+}
+
+export { createIra };

--- a/labs/eyra/style.css
+++ b/labs/eyra/style.css
@@ -439,8 +439,8 @@ button {
     place-items: center;
     padding: calc(5.5rem + var(--safe-top)) 1.2rem calc(1.4rem + var(--safe-bottom));
     background:
-        radial-gradient(ellipse at 50% 20%, oklch(38% 0.1 185 / 0.32), transparent 50%),
-        color-mix(in oklab, var(--dusk-deep) 72%, transparent);
+        radial-gradient(ellipse at 50% 20%, oklch(38% 0.1 185 / 0.22), transparent 52%),
+        color-mix(in oklab, var(--dusk-deep) 42%, transparent);
     backdrop-filter: blur(10px);
     -webkit-backdrop-filter: blur(10px);
 }

--- a/labs/eyra/style.css
+++ b/labs/eyra/style.css
@@ -1,0 +1,704 @@
+/* ================================================================
+   Eyra — voo nos ares
+   Paleta: teal de canópia, ouro do sol baixo, ciano bioluminescente.
+   ================================================================ */
+
+:root {
+    --dusk: oklch(14% 0.04 200);
+    --dusk-deep: oklch(9% 0.035 200);
+    --cyan: oklch(82% 0.13 185);
+    --gold: oklch(84% 0.14 90);
+    --gold-deep: oklch(68% 0.12 78);
+    --moss: oklch(52% 0.12 150);
+    --magenta: oklch(70% 0.16 330);
+    --ink: oklch(16% 0.04 200);
+
+    --text: oklch(97% 0.02 90);
+    --text-soft: oklch(88% 0.03 180);
+    --text-dim: oklch(70% 0.04 180);
+
+    --panel: color-mix(in oklab, oklch(16% 0.05 200) 58%, transparent);
+    --panel-strong: color-mix(in oklab, oklch(11% 0.05 200) 84%, transparent);
+    --line: color-mix(in oklab, var(--cyan) 34%, transparent);
+    --line-soft: color-mix(in oklab, var(--gold) 16%, transparent);
+
+    --radius: 18px;
+    --radius-lg: 28px;
+    --blur: 22px;
+
+    --safe-top: env(safe-area-inset-top, 0px);
+    --safe-bottom: env(safe-area-inset-bottom, 0px);
+    --safe-left: env(safe-area-inset-left, 0px);
+    --safe-right: env(safe-area-inset-right, 0px);
+
+    --ease: cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+*, *::before, *::after {
+    box-sizing: border-box;
+    -webkit-tap-highlight-color: transparent;
+}
+
+html, body {
+    margin: 0;
+    width: 100%;
+    height: 100%;
+    overflow: clip;
+    overscroll-behavior: none;
+    background: var(--dusk-deep);
+}
+
+body {
+    min-height: 100dvh;
+    padding: 0 !important;
+    display: block !important;
+    color: var(--text);
+    font-family: 'Outfit', system-ui, -apple-system, 'Segoe UI', sans-serif;
+    user-select: none;
+    -webkit-user-select: none;
+    touch-action: none;
+}
+
+button, input, select {
+    font: inherit;
+    color: inherit;
+}
+
+button {
+    background: none;
+    border: 0;
+    cursor: pointer;
+}
+
+.mono {
+    font-variant-numeric: tabular-nums;
+    font-feature-settings: 'tnum' 1;
+}
+
+:focus-visible {
+    outline: 2px solid var(--cyan);
+    outline-offset: 3px;
+}
+
+.game-shell {
+    position: fixed;
+    inset: 0;
+    overflow: hidden;
+    background:
+        radial-gradient(120% 80% at 50% 0%, oklch(28% 0.08 190) 0%, var(--dusk-deep) 70%);
+}
+
+.stage {
+    position: absolute;
+    inset: 0;
+}
+
+#scene {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    display: block;
+    cursor: grab;
+    touch-action: none;
+}
+
+#scene.is-dragging {
+    cursor: grabbing;
+}
+
+.vignette {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background:
+        radial-gradient(ellipse at 50% 46%, transparent 48%, oklch(10% 0.04 200 / 0.48) 100%),
+        linear-gradient(to top, oklch(12% 0.05 160 / 0.28), transparent 30%);
+    z-index: 2;
+}
+
+.game-shell > header {
+    position: absolute;
+    top: calc(0.85rem + var(--safe-top));
+    left: calc(1rem + var(--safe-left));
+    right: calc(1rem + var(--safe-right));
+    z-index: 40;
+    margin: 0;
+    padding: 0;
+    max-width: none;
+    width: auto;
+    pointer-events: none;
+    gap: 0.55rem;
+}
+
+.game-shell > header > * {
+    pointer-events: auto;
+}
+
+.game-shell > header .back-link {
+    background: var(--panel-strong);
+    backdrop-filter: blur(var(--blur));
+    -webkit-backdrop-filter: blur(var(--blur));
+    border-color: var(--line);
+    color: var(--text-soft);
+    box-shadow: 0 10px 30px rgba(4, 24, 32, 0.4);
+}
+
+.game-shell > header .back-link:hover {
+    color: var(--cyan);
+    border-color: var(--cyan);
+}
+
+.game-shell > header .app-logo {
+    font-family: 'Cinzel', Georgia, serif;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    font-size: 1.15rem;
+    color: var(--gold);
+    text-shadow: 0 2px 18px rgba(4, 20, 28, 0.65);
+}
+
+.brand-mark {
+    display: inline-block;
+    margin-right: 0.35rem;
+    color: var(--cyan);
+    animation: twinkle 2.4s ease-in-out infinite;
+}
+
+@keyframes twinkle {
+    0%, 100% { opacity: 1; transform: scale(1) rotate(0deg); }
+    50% { opacity: 0.55; transform: scale(1.18) rotate(18deg); }
+}
+
+.lab-foot {
+    position: absolute;
+    bottom: calc(0.4rem + var(--safe-bottom));
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 8;
+    pointer-events: none;
+    opacity: 0.45;
+}
+
+.lab-foot a {
+    pointer-events: auto;
+}
+
+.hud {
+    position: absolute;
+    inset: 0;
+    z-index: 12;
+    pointer-events: none;
+}
+
+.hud-top {
+    position: absolute;
+    top: calc(4.4rem + var(--safe-top));
+    left: calc(1rem + var(--safe-left));
+    right: calc(1rem + var(--safe-right));
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    gap: 0.7rem;
+    align-items: stretch;
+}
+
+.panel {
+    pointer-events: auto;
+    background: var(--panel);
+    backdrop-filter: blur(var(--blur));
+    -webkit-backdrop-filter: blur(var(--blur));
+    border: 1px solid var(--line);
+    border-radius: var(--radius);
+    padding: 0.7rem 0.9rem;
+    box-shadow: 0 12px 36px rgba(4, 20, 28, 0.32);
+}
+
+.hud-label {
+    display: block;
+    font-size: 0.68rem;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--text-dim);
+    font-weight: 800;
+}
+
+.alt-panel .mono, .score-panel .mono {
+    display: block;
+    margin-top: 0.15rem;
+    font-size: 1.15rem;
+    color: var(--cyan);
+    font-family: 'Cinzel', Georgia, serif;
+}
+
+.hud-tag {
+    display: block;
+    margin-top: 0.2rem;
+    font-size: 0.78rem;
+    color: var(--gold);
+    letter-spacing: 0.04em;
+}
+
+.boost-meter {
+    margin-top: 0.55rem;
+    height: 0.38rem;
+    border-radius: 999px;
+    background: color-mix(in oklab, white 10%, transparent);
+    overflow: hidden;
+}
+
+.boost-meter i {
+    display: block;
+    height: 100%;
+    width: 100%;
+    border-radius: inherit;
+    background: linear-gradient(90deg, var(--moss), var(--cyan), var(--gold));
+    transition: width 0.18s linear;
+}
+
+.pips {
+    display: flex;
+    gap: 0.28rem;
+    margin: 0.4rem 0 0.15rem;
+}
+
+.pips i {
+    width: 0.72rem;
+    height: 0.72rem;
+    border-radius: 50%;
+    background: color-mix(in oklab, var(--text) 14%, transparent);
+    box-shadow: inset 0 0 0 1px var(--line-soft);
+    transition: background 0.35s var(--ease), box-shadow 0.35s var(--ease), transform 0.35s var(--ease);
+}
+
+.pips i.on {
+    background: radial-gradient(circle at 35% 30%, #fff8e8, var(--cyan));
+    box-shadow: 0 0 12px color-mix(in oklab, var(--cyan) 70%, transparent);
+    transform: scale(1.08);
+}
+
+.objective {
+    margin: 0.25rem 0 0;
+    font-size: 0.95rem;
+    color: var(--text-soft);
+    line-height: 1.35;
+}
+
+.score-row {
+    display: flex;
+    justify-content: space-between;
+    gap: 0.8rem;
+    margin-top: 0.25rem;
+    font-size: 0.82rem;
+    color: var(--text-dim);
+}
+
+.score-row .mono {
+    font-size: 0.95rem;
+    margin: 0;
+    color: var(--gold);
+}
+
+.message {
+    position: absolute;
+    left: 50%;
+    bottom: calc(7.2rem + var(--safe-bottom));
+    transform: translateX(-50%) translateY(8px);
+    margin: 0;
+    padding: 0.65rem 1.1rem;
+    max-width: min(28rem, 86vw);
+    text-align: center;
+    background: var(--panel-strong);
+    border: 1px solid var(--line);
+    border-radius: 999px;
+    font-weight: 700;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.35s var(--ease), transform 0.35s var(--ease);
+}
+
+.message[data-show="true"] {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0);
+}
+
+.hud-actions {
+    position: absolute;
+    bottom: calc(1.4rem + var(--safe-bottom));
+    right: calc(1rem + var(--safe-right));
+    display: flex;
+    gap: 0.45rem;
+    align-items: center;
+    pointer-events: auto;
+    z-index: 15;
+}
+
+.fps {
+    font-size: 0.72rem;
+    color: var(--text-dim);
+    min-width: 2rem;
+}
+
+.icon-button {
+    width: 2.5rem;
+    height: 2.5rem;
+    border-radius: 50%;
+    background: var(--panel-strong);
+    border: 1px solid var(--line);
+    color: var(--cyan);
+    font-weight: 800;
+    backdrop-filter: blur(var(--blur));
+    -webkit-backdrop-filter: blur(var(--blur));
+}
+
+.icon-button:hover {
+    border-color: var(--cyan);
+    transform: translateY(-1px);
+}
+
+.icon-button[aria-pressed="false"] {
+    color: var(--text-dim);
+}
+
+.touch-controls {
+    position: absolute;
+    inset: auto calc(1rem + var(--safe-right)) calc(1.2rem + var(--safe-bottom)) calc(1rem + var(--safe-left));
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-end;
+    pointer-events: none;
+    z-index: 14;
+}
+
+.stick {
+    position: relative;
+    width: 7.2rem;
+    height: 7.2rem;
+    border-radius: 50%;
+    background: color-mix(in oklab, oklch(14% 0.04 200) 50%, transparent);
+    border: 1px solid var(--line);
+    pointer-events: auto;
+    touch-action: none;
+}
+
+.stick i {
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    width: 2.5rem;
+    height: 2.5rem;
+    margin: -1.25rem 0 0 -1.25rem;
+    border-radius: 50%;
+    background: radial-gradient(circle at 35% 30%, #e8fff8, var(--cyan));
+    box-shadow: 0 8px 18px rgba(4, 24, 32, 0.4);
+}
+
+.stick span {
+    position: absolute;
+    bottom: -1.35rem;
+    left: 50%;
+    transform: translateX(-50%);
+    font-size: 0.68rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--text-dim);
+    font-weight: 800;
+}
+
+.touch-buttons {
+    display: flex;
+    gap: 0.55rem;
+    pointer-events: auto;
+}
+
+.pad {
+    width: 3.6rem;
+    height: 3.6rem;
+    border-radius: 50%;
+    background: var(--panel-strong);
+    border: 1px solid var(--line);
+    color: var(--text);
+    font-weight: 800;
+    font-size: 0.72rem;
+    letter-spacing: 0.06em;
+}
+
+.pad-magic {
+    width: 4.3rem;
+    height: 4.3rem;
+    background: radial-gradient(circle at 35% 30%, #e8fff4, #1a8a78);
+    color: #041820;
+    border-color: color-mix(in oklab, var(--cyan) 50%, white);
+    box-shadow: 0 0 24px color-mix(in oklab, var(--cyan) 55%, transparent);
+}
+
+.overlay {
+    position: absolute;
+    inset: 0;
+    z-index: 30;
+    display: grid;
+    place-items: center;
+    padding: calc(5.5rem + var(--safe-top)) 1.2rem calc(1.4rem + var(--safe-bottom));
+    background:
+        radial-gradient(ellipse at 50% 20%, oklch(38% 0.1 185 / 0.32), transparent 50%),
+        color-mix(in oklab, var(--dusk-deep) 72%, transparent);
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+}
+
+.overlay[hidden] {
+    display: none !important;
+}
+
+.overlay-card, .loading-card {
+    width: min(52rem, 100%);
+    background: color-mix(in oklab, oklch(14% 0.05 200) 82%, transparent);
+    border: 1px solid var(--line);
+    border-radius: var(--radius-lg);
+    padding: 1.6rem 1.7rem 1.4rem;
+    box-shadow:
+        0 30px 80px rgba(4, 16, 24, 0.5),
+        inset 0 1px 0 color-mix(in oklab, white 14%, transparent);
+}
+
+.loading-card {
+    width: min(26rem, 100%);
+    text-align: center;
+}
+
+.loading-card h1, .menu-head h1, .compact-card h2 {
+    font-family: 'Cinzel', Georgia, serif;
+    font-weight: 800;
+    letter-spacing: 0.04em;
+    font-size: clamp(2.1rem, 5vw, 3.4rem);
+    line-height: 0.95;
+    margin: 0.2rem 0 0.55rem;
+    background: linear-gradient(180deg, #fff8e0 10%, var(--gold) 45%, var(--cyan) 100%);
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+}
+
+.menu-head h1 span {
+    color: var(--cyan);
+    background: none;
+    -webkit-text-fill-color: var(--cyan);
+}
+
+.star-loader {
+    display: inline-block;
+    font-size: 2rem;
+    color: var(--cyan);
+    animation: twinkle 1.2s ease-in-out infinite;
+}
+
+.loading-bar {
+    margin-top: 1.1rem;
+    height: 0.42rem;
+    border-radius: 999px;
+    background: color-mix(in oklab, white 10%, transparent);
+    overflow: hidden;
+}
+
+.loading-bar i {
+    display: block;
+    height: 100%;
+    width: 8%;
+    border-radius: inherit;
+    background: linear-gradient(90deg, var(--moss), var(--cyan), var(--gold));
+    transition: width 0.35s var(--ease);
+}
+
+.eyebrow {
+    display: flex;
+    align-items: center;
+    gap: 0.55rem;
+    margin: 0;
+    font-size: 0.72rem;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    font-weight: 800;
+    color: var(--gold);
+}
+
+.eyebrow i {
+    width: 1.6rem;
+    height: 2px;
+    background: linear-gradient(90deg, var(--gold), transparent);
+}
+
+.lede {
+    margin: 0;
+    color: var(--text-soft);
+    line-height: 1.5;
+    max-width: 38rem;
+}
+
+.menu-grid {
+    display: grid;
+    grid-template-columns: 1.15fr 0.85fr;
+    gap: 1.2rem;
+    margin: 1.4rem 0 1.2rem;
+}
+
+.menu-section h2 {
+    margin: 0 0 0.6rem;
+    font-size: 0.72rem;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--text-dim);
+}
+
+.keys {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    color: var(--text-soft);
+    font-size: 0.92rem;
+}
+
+kbd {
+    display: inline-block;
+    min-width: 1.4rem;
+    padding: 0.08rem 0.38rem;
+    margin-right: 0.15rem;
+    border-radius: 0.4rem;
+    border: 1px solid var(--line);
+    background: color-mix(in oklab, white 8%, transparent);
+    font-family: inherit;
+    font-size: 0.78rem;
+    font-weight: 800;
+    text-align: center;
+}
+
+.settings-grid {
+    display: grid;
+    gap: 0.85rem;
+}
+
+.field {
+    display: grid;
+    gap: 0.35rem;
+    font-size: 0.88rem;
+    color: var(--text-soft);
+}
+
+.field select, .field input[type="range"] {
+    width: 100%;
+}
+
+.field select {
+    appearance: none;
+    padding: 0.55rem 0.7rem;
+    border-radius: 0.7rem;
+    border: 1px solid var(--line);
+    background: color-mix(in oklab, black 22%, transparent);
+}
+
+.section-note {
+    margin: 0.85rem 0 0;
+    font-size: 0.82rem;
+    color: var(--text-dim);
+}
+
+.menu-foot, .card-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.7rem;
+}
+
+.primary-button, .ghost-button {
+    pointer-events: auto;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.55rem;
+    padding: 0.85rem 1.25rem;
+    border-radius: 999px;
+    font-weight: 800;
+    transition: transform 0.2s var(--ease), box-shadow 0.2s var(--ease);
+}
+
+.primary-button {
+    background: linear-gradient(180deg, #e8fff4, #3ad4b8);
+    color: #041820;
+    box-shadow: 0 10px 28px color-mix(in oklab, var(--cyan) 40%, transparent);
+}
+
+.primary-button:hover {
+    transform: translateY(-2px);
+}
+
+.ghost-button {
+    border: 1px solid var(--line);
+    color: var(--text-soft);
+    background: color-mix(in oklab, white 6%, transparent);
+}
+
+.compact-card {
+    width: min(28rem, 100%);
+}
+
+.compact-card h2 {
+    font-size: clamp(1.8rem, 4vw, 2.6rem);
+}
+
+.stats {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.55rem;
+    margin: 1rem 0 1.2rem;
+}
+
+.stats div {
+    padding: 0.65rem 0.75rem;
+    border-radius: 0.9rem;
+    border: 1px solid var(--line-soft);
+    background: color-mix(in oklab, white 5%, transparent);
+}
+
+.stats dt {
+    font-size: 0.68rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--text-dim);
+}
+
+.stats dd {
+    margin: 0.15rem 0 0;
+    font-family: 'Cinzel', Georgia, serif;
+    font-size: 1.2rem;
+    color: var(--cyan);
+}
+
+.eyebrow--danger {
+    color: oklch(78% 0.16 20);
+}
+
+@media (max-width: 820px) {
+    .hud-top {
+        grid-template-columns: 1fr 1fr;
+    }
+
+    .quest-panel {
+        grid-column: 1 / -1;
+    }
+
+    .hud-actions {
+        top: calc(0.85rem + var(--safe-top));
+        right: calc(1rem + var(--safe-right));
+        bottom: auto;
+    }
+
+    .menu-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .message {
+        bottom: calc(10.5rem + var(--safe-bottom));
+    }
+}
+
+@media (pointer: fine) {
+    .touch-controls {
+        display: none !important;
+    }
+}

--- a/labs/index.html
+++ b/labs/index.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Labs — Diogo Paulino | Jogos 3D, código, música e IA</title>
-  <meta name="description" content="46 experimentos de Diogo Paulino: jogos 3D, ferramentas, música e inteligência artificial em HTML, CSS e JavaScript puro.">
+  <meta name="description" content="47 experimentos de Diogo Paulino: jogos 3D, ferramentas, música e inteligência artificial em HTML, CSS e JavaScript puro.">
   <meta name="author" content="Diogo Paulino">
   <meta name="robots" content="index, follow">
   <meta name="theme-color" content="#fafbfc">
@@ -16,14 +16,14 @@
   <meta property="og:site_name" content="Diogo Paulino · Labs">
   <meta property="og:title" content="Labs — Diogo Paulino | Jogos 3D, código, música e IA">
   <meta property="og:description"
-    content="46 laboratórios de Diogo Paulino: mundos 3D, jogos, ferramentas, música e IA em HTML, CSS e JavaScript puro.">
+    content="47 laboratórios de Diogo Paulino: mundos 3D, jogos, ferramentas, música e IA em HTML, CSS e JavaScript puro.">
   <meta property="og:url" content="https://diogopaulino.com.br/labs/">
   <meta property="og:image" content="https://diogopaulino.com.br/assets/img/diogo.jpeg">
   <meta property="og:image:alt" content="Diogo Paulino">
   <meta property="og:locale" content="pt_BR">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Labs — Diogo Paulino | Jogos 3D, código, música e IA">
-  <meta name="twitter:description" content="46 experimentos de Diogo Paulino: jogos, código, música e inteligência artificial.">
+  <meta name="twitter:description" content="47 experimentos de Diogo Paulino: jogos, código, música e inteligência artificial.">
   <meta name="twitter:image" content="https://diogopaulino.com.br/assets/img/diogo.jpeg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -39,7 +39,7 @@
         "@id": "https://diogopaulino.com.br/labs/#page",
         "name": "Labs — Diogo Paulino",
         "url": "https://diogopaulino.com.br/labs/",
-        "description": "46 experimentos de Diogo Paulino: jogos 3D, ferramentas, música e inteligência artificial em HTML, CSS e JavaScript puro.",
+        "description": "47 experimentos de Diogo Paulino: jogos 3D, ferramentas, música e inteligência artificial em HTML, CSS e JavaScript puro.",
         "inLanguage": "pt-BR",
         "isPartOf": {
           "@id": "https://diogopaulino.com.br/#website"
@@ -47,7 +47,7 @@
         "creator": {
           "@id": "https://diogopaulino.com.br/#person"
         },
-        "numberOfItems": 46,
+        "numberOfItems": 47,
         "mainEntity": {
           "@id": "https://diogopaulino.com.br/labs/#list"
         }
@@ -56,281 +56,287 @@
         "@type": "ItemList",
         "@id": "https://diogopaulino.com.br/labs/#list",
         "name": "Labs de Diogo Paulino",
-        "numberOfItems": 46,
+        "numberOfItems": 47,
         "itemListElement": [
           {
             "@type": "ListItem",
             "position": 1,
+            "url": "https://diogopaulino.com.br/labs/eyra/",
+            "name": "Eyra"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
             "url": "https://diogopaulino.com.br/labs/nereida/",
             "name": "Nereida"
           },
           {
             "@type": "ListItem",
-            "position": 2,
+            "position": 3,
             "url": "https://diogopaulino.com.br/labs/riftball/",
             "name": "Riftball"
           },
           {
             "@type": "ListItem",
-            "position": 3,
+            "position": 4,
             "url": "https://diogopaulino.com.br/labs/noctiluca/",
             "name": "Noctiluca"
           },
           {
             "@type": "ListItem",
-            "position": 4,
+            "position": 5,
             "url": "https://diogopaulino.com.br/labs/ilha-do-ambar/",
             "name": "Ilha do Âmbar"
           },
           {
             "@type": "ListItem",
-            "position": 5,
+            "position": 6,
             "url": "https://diogopaulino.com.br/labs/silkline/",
             "name": "Silkline"
           },
           {
             "@type": "ListItem",
-            "position": 6,
+            "position": 7,
             "url": "https://diogopaulino.com.br/labs/vector-fighter/",
             "name": "Vector Fighter"
           },
           {
             "@type": "ListItem",
-            "position": 7,
+            "position": 8,
             "url": "https://diogopaulino.com.br/labs/lumina/",
             "name": "Lúmina"
           },
           {
             "@type": "ListItem",
-            "position": 8,
+            "position": 9,
             "url": "https://diogopaulino.com.br/labs/honor-front/",
             "name": "Honor Front"
           },
           {
             "@type": "ListItem",
-            "position": 9,
+            "position": 10,
             "url": "https://diogopaulino.com.br/labs/safari-dourado/",
             "name": "Safari Dourado"
           },
           {
             "@type": "ListItem",
-            "position": 10,
+            "position": 11,
             "url": "https://diogopaulino.com.br/labs/aurelia/",
             "name": "Aurelia Festival"
           },
           {
             "@type": "ListItem",
-            "position": 11,
+            "position": 12,
             "url": "https://diogopaulino.com.br/labs/grao/",
             "name": "Grão"
           },
           {
             "@type": "ListItem",
-            "position": 12,
+            "position": 13,
             "url": "https://diogopaulino.com.br/labs/armilla/",
             "name": "Armilla"
           },
           {
             "@type": "ListItem",
-            "position": 13,
+            "position": 14,
             "url": "https://diogopaulino.com.br/labs/orbis/",
             "name": "Orbis"
           },
           {
             "@type": "ListItem",
-            "position": 14,
+            "position": 15,
             "url": "https://diogopaulino.com.br/labs/aetherion/",
             "name": "Aetherion"
           },
           {
             "@type": "ListItem",
-            "position": 15,
+            "position": 16,
             "url": "https://diogopaulino.com.br/labs/neon-rider/",
             "name": "Neon Rider"
           },
           {
             "@type": "ListItem",
-            "position": 16,
+            "position": 17,
             "url": "https://diogopaulino.com.br/labs/toaster-64/",
             "name": "Torradeira 64"
           },
           {
             "@type": "ListItem",
-            "position": 17,
+            "position": 18,
             "url": "https://diogopaulino.com.br/labs/river-knight/",
             "name": "River Knight"
           },
           {
             "@type": "ListItem",
-            "position": 18,
+            "position": 19,
             "url": "https://diogopaulino.com.br/labs/jornada-do-anel/",
             "name": "A Jornada do Anel"
           },
           {
             "@type": "ListItem",
-            "position": 19,
+            "position": 20,
             "url": "https://diogopaulino.com.br/labs/pandemonium/",
             "name": "Pandemônio"
           },
           {
             "@type": "ListItem",
-            "position": 20,
+            "position": 21,
             "url": "https://diogopaulino.com.br/labs/beige-box/",
             "name": "Beige Box"
           },
           {
             "@type": "ListItem",
-            "position": 21,
+            "position": 22,
             "url": "https://diogopaulino.com.br/labs/f1-racing/",
             "name": "F1 Grand Prix"
           },
           {
             "@type": "ListItem",
-            "position": 22,
+            "position": 23,
             "url": "https://diogopaulino.com.br/labs/santos-games/",
             "name": "Santos Games"
           },
           {
             "@type": "ListItem",
-            "position": 23,
+            "position": 24,
             "url": "https://diogopaulino.com.br/labs/ravi-123/",
             "name": "Ravi 1·2·3"
           },
           {
             "@type": "ListItem",
-            "position": 24,
+            "position": 25,
             "url": "https://diogopaulino.com.br/labs/rock-kombat/",
             "name": "Rock Kombat"
           },
           {
             "@type": "ListItem",
-            "position": 25,
+            "position": 26,
             "url": "https://diogopaulino.com.br/labs/videogame/",
             "name": "Videogame"
           },
           {
             "@type": "ListItem",
-            "position": 26,
+            "position": 27,
             "url": "https://diogopaulino.com.br/labs/lander/",
             "name": "Lunar Lander"
           },
           {
             "@type": "ListItem",
-            "position": 27,
+            "position": 28,
             "url": "https://diogopaulino.com.br/labs/jungle-run/",
             "name": "Jungle Run"
           },
           {
             "@type": "ListItem",
-            "position": 28,
+            "position": 29,
             "url": "https://diogopaulino.com.br/labs/space-shooter/",
             "name": "Neon Invaders"
           },
           {
             "@type": "ListItem",
-            "position": 29,
+            "position": 30,
             "url": "https://diogopaulino.com.br/labs/tetris/",
             "name": "Tetris 90s"
           },
           {
             "@type": "ListItem",
-            "position": 30,
+            "position": 31,
             "url": "https://diogopaulino.com.br/labs/snake/",
             "name": "Retro Snake"
           },
           {
             "@type": "ListItem",
-            "position": 31,
+            "position": 32,
             "url": "https://diogopaulino.com.br/labs/minesweeper/",
             "name": "Campo Minado 95"
           },
           {
             "@type": "ListItem",
-            "position": 32,
+            "position": 33,
             "url": "https://diogopaulino.com.br/labs/tamagotchi/",
             "name": "RakuRaku Dinokun"
           },
           {
             "@type": "ListItem",
-            "position": 33,
+            "position": 34,
             "url": "https://diogopaulino.com.br/labs/cyberos/",
             "name": "CyberOS Terminal"
           },
           {
             "@type": "ListItem",
-            "position": 34,
+            "position": 35,
             "url": "https://diogopaulino.com.br/labs/matrix/",
             "name": "Matrix"
           },
           {
             "@type": "ListItem",
-            "position": 35,
+            "position": 36,
             "url": "https://diogopaulino.com.br/labs/aurora-flow/",
             "name": "Aurora Flow"
           },
           {
             "@type": "ListItem",
-            "position": 36,
+            "position": 37,
             "url": "https://diogopaulino.com.br/labs/paint/",
             "name": "Paint Lab"
           },
           {
             "@type": "ListItem",
-            "position": 37,
+            "position": 38,
             "url": "https://diogopaulino.com.br/labs/gravity/",
             "name": "Gravity"
           },
           {
             "@type": "ListItem",
-            "position": 38,
+            "position": 39,
             "url": "https://diogopaulino.com.br/labs/image-optimizer/",
             "name": "Image Optimizer"
           },
           {
             "@type": "ListItem",
-            "position": 39,
+            "position": 40,
             "url": "https://diogopaulino.com.br/labs/image-editor/",
             "name": "Image Editor"
           },
           {
             "@type": "ListItem",
-            "position": 40,
+            "position": 41,
             "url": "https://diogopaulino.com.br/labs/pomodoro/",
             "name": "Pomodoro"
           },
           {
             "@type": "ListItem",
-            "position": 41,
+            "position": 42,
             "url": "https://diogopaulino.com.br/labs/english-duo/",
             "name": "Talk"
           },
           {
             "@type": "ListItem",
-            "position": 42,
+            "position": 43,
             "url": "https://diogopaulino.com.br/labs/calculator/",
             "name": "Calculator"
           },
           {
             "@type": "ListItem",
-            "position": 43,
+            "position": 44,
             "url": "https://diogopaulino.com.br/labs/partitura/",
             "name": "Partitura: Maestro Quest"
           },
           {
             "@type": "ListItem",
-            "position": 44,
+            "position": 45,
             "url": "https://diogopaulino.com.br/labs/piano/",
             "name": "Piano"
           },
           {
             "@type": "ListItem",
-            "position": 45,
+            "position": 46,
             "url": "https://diogopaulino.com.br/labs/winamp/",
             "name": "Winamp JS"
           },
           {
             "@type": "ListItem",
-            "position": 46,
+            "position": 47,
             "url": "https://diogopaulino.com.br/labs/pulsar/",
             "name": "Pulsar"
           }
@@ -376,6 +382,28 @@
     </div>
 
     <div class="projects-grid">
+      <a href="/labs/eyra/" class="project-card" data-groups="game,creative">
+        <div class="project-icon">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+            stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M4 14c3-6 6.5-9 8-9s5 3 8 9" />
+            <path d="M3 15.5c2.5 2.2 5.2 3.2 9 3.2s6.5-1 9-3.2" opacity="0.55" />
+            <path d="M12 5.2c-1.2 2.4-1.4 4.8 0 7.2 1.4-2.4 1.2-4.8 0-7.2z" />
+            <path d="M8.2 11.5c.6-2.6 1.8-4.2 3.8-5.2" opacity="0.7" />
+            <path d="M15.8 11.5c-.6-2.6-1.8-4.2-3.8-5.2" opacity="0.7" />
+            <circle cx="12" cy="6.2" r="0.7" fill="currentColor" stroke="none" />
+          </svg>
+        </div>
+        <div class="project-content">
+          <h2>Eyra</h2>
+          <p>Voo 3D numa fera alada pelos picos flutuantes: floresta bioluminescente, cachoeiras no céu e a Yva</p>
+          <div class="project-tags">
+            <span class="tag">three.js</span>
+            <span class="tag">Voo</span>
+            <span class="tag">Mundo</span>
+          </div>
+        </div>
+      </a>
       <a href="/labs/nereida/" class="project-card" data-groups="game,creative">
         <div class="project-icon">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -61,6 +61,12 @@
     <priority>0.7</priority>
   </url>
   <url>
+    <loc>https://diogopaulino.com.br/labs/eyra/</loc>
+    <lastmod>2026-08-14</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
     <loc>https://diogopaulino.com.br/labs/f1-racing/</loc>
     <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 🎯 Objetivo

Novo lab **Eyra**: voo em terceira pessoa numa fera alada pelos picos flutuantes, no espírito de um mundo tipo Avatar — floresta bioluminescente, cachoeiras no céu e o vínculo com a Yva.

## ✨ O que mudou

- Lab `labs/eyra/` em three.js (ES modules, sem build): ira alada, picos, Yva, sementes e anéis de névoa
- Voo com inércia (W/A/S/D, impulso, pirueta), HUD, som Web Audio e qualidade auto/leve/cinemática
- Catálogo: card na galeria, linha no README, `sitemap.xml` e contagem **49 experimentos** (merge com `master`: Eyra + Lavandula + Guerreiro)
- SEO do lab: title, description, canonical, author, OG, Twitter, JSON-LD (WebApplication + BreadcrumbList)

## 🧪 Como testar

1. Na raiz do repo: `python3 -m http.server 8000`
2. Abrir [http://localhost:8000/](http://localhost:8000/) (home) e [http://localhost:8000/labs/](http://localhost:8000/labs/) (galeria)
3. Abrir [http://localhost:8000/labs/eyra/](http://localhost:8000/labs/eyra/) — Entrar no céu, voar, coletar sementes e voltar à Yva
4. Conferir pasta ↔ card da galeria ↔ README ↔ `sitemap.xml` ↔ canonical/OG

## ✅ Checklist

- [x] Links conferidos: pasta do lab ↔ card da galeria ↔ README ↔ sitemap (e corrigidos se quebravam)
- [x] README atualizado (linha na tabela + URL + contagem no badge/texto) — obrigatório em lab novo, renomeado ou removido
- [x] SEO consistente: title, description, canonical, author, robots, OG, Twitter, JSON-LD (e contagem nos metas da galeria)
- [x] Testado via HTTP na raiz, não via `file://`
- [x] Nada fora do escopo foi quebrado

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ffe20-71d6-728d-a69b-cb83e809cdf0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ffe20-71d6-728d-a69b-cb83e809cdf0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

