### PR TITLE
🧪 Rastro Vermelho — faroeste 3D de galope sem fim

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 Mais de 20 anos em tecnologia, entre liderança, código hands-on e design UI/UX.
 
 [![Website](https://img.shields.io/badge/Website-diogopaulino.com.br-3B82F6?style=flat-square&logo=googlechrome&logoColor=white)](https://diogopaulino.com.br/)
-[![Labs](https://img.shields.io/badge/Labs-57_experimentos-8B5CF6?style=flat-square&logo=stackblitz&logoColor=white)](https://diogopaulino.com.br/labs/)
+[![Labs](https://img.shields.io/badge/Labs-58_experimentos-8B5CF6?style=flat-square&logo=stackblitz&logoColor=white)](https://diogopaulino.com.br/labs/)
 [![GitHub](https://img.shields.io/badge/GitHub-diogopaulino-181717?style=flat-square&logo=github&logoColor=white)](https://github.com/diogopaulino)
 [![LinkedIn](https://img.shields.io/badge/LinkedIn-Diogo_Paulino-0A66C2?style=flat-square)](https://br.linkedin.com/in/diogopaulino)
 [![Spotify](https://img.shields.io/badge/Spotify-Artist-1DB954?style=flat-square&logo=spotify&logoColor=white)](https://open.spotify.com/intl-pt/artist/0ue2WfDQ1P4XR2vXdSIrYQ)
@@ -32,12 +32,13 @@ Gosto de construir coisas — de time e produto até interface e código. Nessa 
 
 > *Abre, experimenta, quebra, reconstrói. Esse é o espírito.*
 
-Um laboratório aberto com **57 experimentos** que rodam direto no navegador — HTML, CSS e JavaScript puro, sem instalar nada. Catálogo completo em [diogopaulino.com.br/labs](https://diogopaulino.com.br/labs/).
+Um laboratório aberto com **58 experimentos** que rodam direto no navegador — HTML, CSS e JavaScript puro, sem instalar nada. Catálogo completo em [diogopaulino.com.br/labs](https://diogopaulino.com.br/labs/).
 
 ### 🪐 Mundos 3D
 
 | Projeto | O que é? |
 | :--- | :--- |
+| 🐎 **[Rastro Vermelho](https://diogopaulino.com.br/labs/rastro-vermelho/)** | Faroeste 3D — galope sem parar por serras, cânions e pradarias; o cavalo não cansa |
 | 🟡 **[Tatu Bola](https://diogopaulino.com.br/labs/tatu-bola/)** | Platformer 3D estilo PS1 — pule, role e colete cristais na ilha low-poly |
 | ★ **[Cúpola 64](https://diogopaulino.com.br/labs/cupola-64/)** | Platformer 3D no espírito Super Mario 64 — Nico, câmera Lakitu, pulo triplo e sete estrelas |
 | 🏮 **[A Menina da Lanterna](https://diogopaulino.com.br/labs/menina-da-lanterna/)** | Conto 3D — Clara carrega a última chama, acende Vale-da-Bruma e traz o primeiro sol |

--- a/index.html
+++ b/index.html
@@ -157,7 +157,7 @@
       </nav>
       <div class="labs-easter-egg" id="labs-easter-egg">
         <a href="/labs/" class="labs-badge"
-          aria-label="Labs de Diogo Paulino: 57 experimentos de jogos, código, música e IA">
+          aria-label="Labs de Diogo Paulino: 58 experimentos de jogos, código, música e IA">
           <span class="labs-text">labs</span>
           <svg class="labs-sparkles" width="14" height="14" viewBox="0 0 24 24" fill="currentColor" stroke="none">
             <path d="M12 2L14.4 9.6L22 12L14.4 14.4L12 22L9.6 14.4L2 12L9.6 9.6L12 2Z" />

--- a/labs/index.html
+++ b/labs/index.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <title>Labs — Diogo Paulino | Jogos 3D, código, música e IA</title>
-  <meta name="description" content="57 experimentos de Diogo Paulino: jogos 3D, ferramentas, música e inteligência artificial em HTML, CSS e JavaScript puro.">
+  <meta name="description" content="58 experimentos de Diogo Paulino: jogos 3D, ferramentas, música e inteligência artificial em HTML, CSS e JavaScript puro.">
   <meta name="author" content="Diogo Paulino">
   <meta name="robots" content="index, follow">
   <meta name="theme-color" content="#fafbfc">
@@ -16,14 +16,14 @@
   <meta property="og:site_name" content="Diogo Paulino · Labs">
   <meta property="og:title" content="Labs — Diogo Paulino | Jogos 3D, código, música e IA">
   <meta property="og:description"
-    content="57 laboratórios de Diogo Paulino: mundos 3D, jogos, ferramentas, música e IA em HTML, CSS e JavaScript puro.">
+    content="58 laboratórios de Diogo Paulino: mundos 3D, jogos, ferramentas, música e IA em HTML, CSS e JavaScript puro.">
   <meta property="og:url" content="https://diogopaulino.com.br/labs/">
   <meta property="og:image" content="https://diogopaulino.com.br/assets/img/diogo.jpeg">
   <meta property="og:image:alt" content="Diogo Paulino">
   <meta property="og:locale" content="pt_BR">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Labs — Diogo Paulino | Jogos 3D, código, música e IA">
-  <meta name="twitter:description" content="57 experimentos de Diogo Paulino: jogos, código, música e inteligência artificial.">
+  <meta name="twitter:description" content="58 experimentos de Diogo Paulino: jogos, código, música e inteligência artificial.">
   <meta name="twitter:image" content="https://diogopaulino.com.br/assets/img/diogo.jpeg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -39,7 +39,7 @@
         "@id": "https://diogopaulino.com.br/labs/#page",
         "name": "Labs — Diogo Paulino",
         "url": "https://diogopaulino.com.br/labs/",
-        "description": "57 experimentos de Diogo Paulino: jogos 3D, ferramentas, música e inteligência artificial em HTML, CSS e JavaScript puro.",
+        "description": "58 experimentos de Diogo Paulino: jogos 3D, ferramentas, música e inteligência artificial em HTML, CSS e JavaScript puro.",
         "inLanguage": "pt-BR",
         "isPartOf": {
           "@id": "https://diogopaulino.com.br/#website"
@@ -47,7 +47,7 @@
         "creator": {
           "@id": "https://diogopaulino.com.br/#person"
         },
-        "numberOfItems": 57,
+        "numberOfItems": 58,
         "mainEntity": {
           "@id": "https://diogopaulino.com.br/labs/#list"
         }
@@ -56,7 +56,7 @@
         "@type": "ItemList",
         "@id": "https://diogopaulino.com.br/labs/#list",
         "name": "Labs de Diogo Paulino",
-        "numberOfItems": 57,
+        "numberOfItems": 58,
                                         "itemListElement": [
           {
             "@type": "ListItem",
@@ -399,6 +399,12 @@
             "position": 57,
             "url": "https://diogopaulino.com.br/labs/amora/",
             "name": "Amora"
+          },
+          {
+            "@type": "ListItem",
+            "position": 58,
+            "url": "https://diogopaulino.com.br/labs/rastro-vermelho/",
+            "name": "Rastro Vermelho"
           }
         ]
       },
@@ -442,6 +448,27 @@
     </div>
 
     <div class="projects-grid">
+      <a href="/labs/rastro-vermelho/" class="project-card" data-groups="game,creative">
+        <div class="project-icon">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+            stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M3 19l5.2-8.2 3.1 4.4 3.4-6.6L21 19H3z" opacity="0.7" />
+            <path d="M5.5 14.2c2.4-1.6 4.2-1.8 6.2-.4 1.4 1 2.6.8 4.2-.2" />
+            <path d="M8.2 12.4c.2-1.6 1.2-2.6 2.6-2.8" />
+            <circle cx="11.2" cy="8.6" r="1.1" />
+            <path d="M12.2 8.2c1.2.1 2.2.8 2.6 1.8" opacity="0.8" />
+          </svg>
+        </div>
+        <div class="project-content">
+          <h2>Rastro Vermelho</h2>
+          <p>Faroeste 3D em three.js: galope sem parar por serras, cânions e pradarias — o cavalo não cansa</p>
+          <div class="project-tags">
+            <span class="tag">three.js</span>
+            <span class="tag">Mundo aberto</span>
+            <span class="tag">Faroeste</span>
+          </div>
+        </div>
+      </a>
       <a href="/labs/tatu-bola/" class="project-card" data-groups="game,creative">
         <div class="project-icon">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"

--- a/labs/rastro-vermelho/index.html
+++ b/labs/rastro-vermelho/index.html
@@ -1,0 +1,290 @@
+<!DOCTYPE html>
+<html lang="pt-br" data-theme="dark">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport"
+        content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover">
+    <meta name="theme-color" content="#1a0e08">
+    <title>Rastro Vermelho — galope sem fim pelo faroeste | Diogo Paulino</title>
+    <meta name="description"
+        content="Mundo aberto 3D em three.js: galope sem parar por serras, cânions e pradarias no espírito do faroeste. O cavalo não cansa — o oeste não acaba.">
+    <link rel="canonical" href="https://diogopaulino.com.br/labs/rastro-vermelho/">
+    <meta name="author" content="Diogo Paulino">
+    <meta name="robots" content="index, follow">
+    <link rel="icon" href="/favicon.ico" sizes="any">
+    <meta property="og:image" content="https://diogopaulino.com.br/assets/img/diogo.jpeg">
+    <meta property="og:image:alt" content="Diogo Paulino">
+    <meta property="og:locale" content="pt_BR">
+    <meta name="twitter:image" content="https://diogopaulino.com.br/assets/img/diogo.jpeg">
+
+    <meta property="og:type" content="website">
+    <meta property="og:site_name" content="Diogo Paulino · Labs">
+    <meta property="og:url" content="https://diogopaulino.com.br/labs/rastro-vermelho/">
+    <meta property="og:title" content="Rastro Vermelho — galope sem fim pelo faroeste | Diogo Paulino">
+    <meta property="og:description"
+        content="Mundo aberto 3D em three.js: galope sem parar por serras, cânions e pradarias no espírito do faroeste.">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Rastro Vermelho | Diogo Paulino">
+    <meta name="twitter:description" content="Cavalo, montanhas e faroeste infinito no navegador. three.js.">
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;600;700;800&family=Outfit:wght@300;400;500;600;700&display=swap"
+        rel="stylesheet">
+    <link rel="stylesheet" href="/labs/shared.css?v=8">
+    <link rel="stylesheet" href="style.css?v=1">
+
+    <script type="importmap">
+    {
+        "imports": {
+            "three": "https://cdn.jsdelivr.net/npm/three@0.185.1/build/three.module.js",
+            "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.185.1/examples/jsm/"
+        }
+    }
+    </script>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@graph": [
+        {
+          "@type": "WebApplication",
+          "name": "Rastro Vermelho",
+          "url": "https://diogopaulino.com.br/labs/rastro-vermelho/",
+          "description": "Mundo aberto 3D em three.js: galope sem parar por serras, cânions e pradarias no espírito do faroeste. O cavalo não cansa — o oeste não acaba.",
+          "applicationCategory": "GameApplication",
+          "operatingSystem": "Any",
+          "inLanguage": "pt-BR",
+          "isAccessibleForFree": true,
+          "author": {
+            "@type": "Person",
+            "name": "Diogo Paulino",
+            "url": "https://diogopaulino.com.br/"
+          },
+          "image": "https://diogopaulino.com.br/assets/img/diogo.jpeg"
+        },
+        {
+          "@type": "BreadcrumbList",
+          "itemListElement": [
+            {
+              "@type": "ListItem",
+              "position": 1,
+              "name": "Diogo Paulino",
+              "item": "https://diogopaulino.com.br/"
+            },
+            {
+              "@type": "ListItem",
+              "position": 2,
+              "name": "Labs",
+              "item": "https://diogopaulino.com.br/labs/"
+            },
+            {
+              "@type": "ListItem",
+              "position": 3,
+              "name": "Rastro Vermelho",
+              "item": "https://diogopaulino.com.br/labs/rastro-vermelho/"
+            }
+          ]
+        }
+      ]
+    }
+    </script>
+</head>
+
+<body>
+    <main class="game-shell">
+        <header data-lab-header data-title="Rastro Vermelho" data-back-label="Labs">
+            <template data-slot="logo">
+                <div class="app-logo">
+                    <span class="brand-mark" aria-hidden="true">★</span>
+                    <span>Rastro Vermelho</span>
+                </div>
+            </template>
+        </header>
+
+        <canvas id="scene" aria-label="Faroeste 3D em mundo aberto, a cavalo pelas montanhas"></canvas>
+        <div id="vignette" class="vignette" aria-hidden="true"></div>
+
+        <div id="hud" class="hud" hidden>
+            <div class="hud-top">
+                <div class="panel compass-panel">
+                    <div class="compass" aria-label="Bússola">
+                        <div id="compassRose" class="compass-rose">
+                            <span class="n">N</span>
+                            <span class="e">L</span>
+                            <span class="s">S</span>
+                            <span class="w">O</span>
+                        </div>
+                        <i class="compass-needle" aria-hidden="true"></i>
+                    </div>
+                    <div class="region-block">
+                        <span class="hud-label">Território</span>
+                        <strong id="regionName">Pradaria Dourada</strong>
+                        <span id="biomeLabel" class="meta">pradaria</span>
+                    </div>
+                </div>
+                <div class="panel gait-panel">
+                    <span class="hud-label">Marcha</span>
+                    <div class="speed-row">
+                        <strong id="gaitValue">galope</strong>
+                        <span class="mono"><b id="speedValue">40</b> km/h</span>
+                    </div>
+                    <span id="cruiseHint" class="meta">galope livre</span>
+                </div>
+                <div class="panel trail-panel">
+                    <span class="hud-label">Rastro</span>
+                    <div class="speed-row">
+                        <strong id="distanceValue" class="mono">0 m</strong>
+                        <span id="hourLabel">manhã</span>
+                    </div>
+                    <span id="clockValue" class="mono meta">4:00</span>
+                    · <span id="markCount" class="mono meta">0/6</span>
+                    <div id="markPips" class="mark-pips" aria-label="Marcos encontrados"></div>
+                </div>
+            </div>
+
+            <p id="message" class="message" role="status" aria-live="polite" data-show="false"></p>
+            <p id="prompt" class="prompt">W galope · A D curva · Espaço espora · G livre</p>
+
+            <div class="hud-actions">
+                <button id="soundButton" class="icon-button" type="button" aria-pressed="true"
+                    title="Som (M)" aria-label="Alternar som">♪</button>
+                <button id="pauseButton" class="icon-button" type="button" title="Pausar (P)"
+                    aria-label="Pausar">II</button>
+                <span id="fpsCounter" class="fps mono">—</span>
+            </div>
+
+            <div id="touchControls" class="touch-controls" hidden>
+                <div id="moveStick" class="stick" aria-label="Galopar">
+                    <i id="moveKnob"></i>
+                    <span>rédea</span>
+                </div>
+                <div id="lookZone" class="look-zone" aria-label="Olhar"></div>
+                <div class="touch-buttons">
+                    <button type="button" id="btnSpur" class="pad pad-spur">espora</button>
+                </div>
+            </div>
+        </div>
+
+        <div id="loadingOverlay" class="overlay loading-overlay">
+            <div class="loading-card">
+                <span class="sun-loader" aria-hidden="true"></span>
+                <h1>Rastro Vermelho</h1>
+                <p id="loadingText">O oeste acorda…</p>
+                <div class="loading-bar"><i id="loadingFill"></i></div>
+            </div>
+        </div>
+
+        <div id="menuOverlay" class="overlay menu-overlay" hidden>
+            <div class="overlay-card menu-card">
+                <header class="menu-head">
+                    <p class="eyebrow"><i></i> three.js · mundo aberto · faroeste</p>
+                    <h1>Rastro <span>Vermelho</span></h1>
+                    <p class="lede">O cavalo já está em galope e não para. Serras, cânions, rios e povoados
+                        nascem na frente — um oeste procedural que não acaba. Espore, cruze a pradaria,
+                        ache a fogueira. O sol faz o dia inteiro.</p>
+                </header>
+
+                <div class="menu-grid">
+                    <section class="menu-section">
+                        <h2>O oeste</h2>
+                        <ul class="species-preview">
+                            <li>Pradaria dourada</li>
+                            <li>Serras e pinheiros</li>
+                            <li>Cânions de pedra</li>
+                            <li>Mesas e cactos</li>
+                            <li>Rios e cachoeiras</li>
+                            <li>Povoados de madeira</li>
+                        </ul>
+                    </section>
+
+                    <section class="menu-section">
+                        <h2>Comandos</h2>
+                        <div class="keys">
+                            <span><kbd>W</kbd><kbd>A</kbd><kbd>S</kbd><kbd>D</kbd> rédea e curva</span>
+                            <span><kbd>Espaço</kbd> espora · <kbd>Shift</kbd> disparada</span>
+                            <span><kbd>G</kbd> galope livre (não para)</span>
+                            <span><kbd>C</kbd> câmera · <kbd>P</kbd> pausa · <kbd>M</kbd> som</span>
+                            <span>mouse olha · roda aproxima</span>
+                        </div>
+                    </section>
+
+                    <section class="menu-section">
+                        <h2>Ajustes</h2>
+                        <div class="settings-grid">
+                            <label class="field">
+                                <span>Qualidade</span>
+                                <select id="qualitySelect">
+                                    <option value="auto">Automática</option>
+                                    <option value="low">Performance</option>
+                                    <option value="medium">Equilibrada</option>
+                                    <option value="high">Cinemática</option>
+                                </select>
+                            </label>
+                            <label class="field">
+                                <span>Volume <b id="volumeValue">70</b></span>
+                                <input id="volumeSlider" type="range" min="0" max="100" step="1" value="70">
+                            </label>
+                        </div>
+                        <p class="section-note">Maior rastro: <b id="bestScore" class="mono">—</b></p>
+                    </section>
+                </div>
+
+                <footer class="menu-foot">
+                    <button id="startButton" class="primary-button" type="button">
+                        <span>Montar e galopar</span>
+                        <i aria-hidden="true">→</i>
+                    </button>
+                </footer>
+            </div>
+        </div>
+
+        <div id="pauseOverlay" class="overlay" hidden>
+            <div class="overlay-card compact-card">
+                <p class="eyebrow"><i></i> O cavalo espera</p>
+                <h2>A trilha<br>está pausada.</h2>
+                <div class="card-actions">
+                    <button id="resumeButton" class="primary-button" type="button">
+                        <span>Continuar</span><i aria-hidden="true">→</i>
+                    </button>
+                    <button id="pauseMenuButton" class="ghost-button" type="button">Voltar ao acampamento</button>
+                </div>
+            </div>
+        </div>
+
+        <div id="errorOverlay" class="overlay" hidden>
+            <div class="overlay-card compact-card">
+                <p class="eyebrow eyebrow--danger"><i></i> WebGL indisponível</p>
+                <h2>O oeste não<br>pôde abrir.</h2>
+                <p class="lede" id="errorText">Este laboratório precisa de WebGL. Tente um navegador
+                    atualizado ou reative a aceleração de hardware.</p>
+            </div>
+        </div>
+
+        <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
+    </main>
+
+    <script src="/labs/shared.js?v=6" defer></script>
+    <script>
+        (function () {
+            function hasGpu() {
+                try {
+                    var c = document.createElement('canvas');
+                    return !!(c.getContext('webgl2') || c.getContext('webgl'));
+                } catch (e) { return false; }
+            }
+            if (!hasGpu()) {
+                document.addEventListener('DOMContentLoaded', function () {
+                    var err = document.getElementById('errorOverlay');
+                    var load = document.getElementById('loadingOverlay');
+                    if (load) load.hidden = true;
+                    if (err) err.hidden = false;
+                });
+            }
+        })();
+    </script>
+    <script type="module" src="src/main.js"></script>
+</body>
+
+</html>

--- a/labs/rastro-vermelho/src/audio.js
+++ b/labs/rastro-vermelho/src/audio.js
@@ -1,0 +1,192 @@
+/**
+ * Trilha original: drone de cordas, vento da pradaria, gaita pentatônica e cascos.
+ */
+
+import { clamp } from './utils.js';
+
+export class GameAudio {
+    constructor() {
+        this.ctx = null;
+        this.master = null;
+        this.muted = false;
+        this.volume = 0.7;
+        this._enabled = false;
+        this._t = 0;
+        this._step = 0;
+        this._hoof = 0;
+    }
+
+    async unlock() {
+        if (this.ctx) {
+            if (this.ctx.state === 'suspended') await this.ctx.resume();
+            return;
+        }
+        const Ctx = window.AudioContext || window.webkitAudioContext;
+        if (!Ctx) return;
+        this.ctx = new Ctx();
+        this.master = this.ctx.createGain();
+        this.master.gain.value = this.muted ? 0 : this.volume;
+        this.master.connect(this.ctx.destination);
+
+        this.filter = this.ctx.createBiquadFilter();
+        this.filter.type = 'lowpass';
+        this.filter.frequency.value = 1200;
+        this.filter.connect(this.master);
+
+        this.delay = this.ctx.createDelay();
+        this.delay.delayTime.value = 0.38;
+        const fb = this.ctx.createGain();
+        fb.gain.value = 0.22;
+        this.filter.connect(this.delay);
+        this.delay.connect(fb);
+        fb.connect(this.delay);
+        this.delay.connect(this.master);
+
+        this._startDrone();
+        this._startWind();
+        this._enabled = true;
+    }
+
+    setMuted(muted) {
+        this.muted = muted;
+        if (this.master && this.ctx) {
+            this.master.gain.setTargetAtTime(muted ? 0 : this.volume, this.ctx.currentTime, 0.05);
+        }
+    }
+
+    setVolume(v) {
+        this.volume = clamp(v, 0, 1);
+        if (!this.muted && this.master && this.ctx) {
+            this.master.gain.setTargetAtTime(this.volume, this.ctx.currentTime, 0.05);
+        }
+    }
+
+    _startDrone() {
+        const o1 = this.ctx.createOscillator();
+        const o2 = this.ctx.createOscillator();
+        o1.type = 'sine';
+        o2.type = 'triangle';
+        o1.frequency.value = 73;
+        o2.frequency.value = 110;
+        const g = this.ctx.createGain();
+        g.gain.value = 0.04;
+        o1.connect(g);
+        o2.connect(g);
+        g.connect(this.filter);
+        o1.start();
+        o2.start();
+        this.drone = { o1, o2, g };
+    }
+
+    _startWind() {
+        const buf = this.ctx.createBuffer(1, this.ctx.sampleRate * 2, this.ctx.sampleRate);
+        const data = buf.getChannelData(0);
+        for (let i = 0; i < data.length; i++) data[i] = Math.random() * 2 - 1;
+        const src = this.ctx.createBufferSource();
+        src.buffer = buf;
+        src.loop = true;
+        const bp = this.ctx.createBiquadFilter();
+        bp.type = 'bandpass';
+        bp.frequency.value = 620;
+        bp.Q.value = 0.55;
+        const g = this.ctx.createGain();
+        g.gain.value = 0.028;
+        src.connect(bp);
+        bp.connect(g);
+        g.connect(this.master);
+        src.start();
+        this.wind = { src, g, bp };
+    }
+
+    update(dt, speed) {
+        if (!this._enabled) return;
+        this._t += dt;
+        this._step += dt * (0.42 + Math.min(0.35, Math.abs(speed) * 0.012));
+        if (this._step >= 1) {
+            this._step -= 1;
+            this._pluck();
+        }
+        if (this.wind) {
+            this.wind.g.gain.setTargetAtTime(
+                0.022 + Math.min(0.045, Math.abs(speed) * 0.0018),
+                this.ctx.currentTime,
+                0.2
+            );
+        }
+        if (Math.random() < dt * 0.06) this._harmonica();
+    }
+
+    _pluck() {
+        const scale = [0, 2, 3, 5, 7, 10, 12];
+        const n = scale[Math.floor(Math.random() * scale.length)];
+        const f = 146.8 * (2 ** (n / 12));
+        const osc = this.ctx.createOscillator();
+        osc.type = 'triangle';
+        osc.frequency.value = f;
+        const g = this.ctx.createGain();
+        g.gain.value = 0.038;
+        g.gain.exponentialRampToValueAtTime(0.001, this.ctx.currentTime + 1.35);
+        osc.connect(g);
+        g.connect(this.filter);
+        osc.start();
+        osc.stop(this.ctx.currentTime + 1.4);
+    }
+
+    _harmonica() {
+        const scale = [0, 3, 5, 7, 10];
+        const n = scale[Math.floor(Math.random() * scale.length)];
+        const f = 392 * (2 ** (n / 12));
+        const osc = this.ctx.createOscillator();
+        osc.type = 'square';
+        osc.frequency.value = f;
+        const bp = this.ctx.createBiquadFilter();
+        bp.type = 'bandpass';
+        bp.frequency.value = f;
+        bp.Q.value = 6;
+        const g = this.ctx.createGain();
+        g.gain.value = 0.018;
+        g.gain.exponentialRampToValueAtTime(0.001, this.ctx.currentTime + 0.7);
+        osc.connect(bp);
+        bp.connect(g);
+        g.connect(this.master);
+        osc.start();
+        osc.stop(this.ctx.currentTime + 0.75);
+    }
+
+    hoof(inWater) {
+        if (!this._enabled) return;
+        const t = this.ctx.currentTime;
+        const buf = this.ctx.createBuffer(1, 800, this.ctx.sampleRate);
+        const data = buf.getChannelData(0);
+        for (let i = 0; i < data.length; i++) {
+            data[i] = (Math.random() * 2 - 1) * (1 - i / data.length);
+        }
+        const src = this.ctx.createBufferSource();
+        src.buffer = buf;
+        const bp = this.ctx.createBiquadFilter();
+        bp.type = 'bandpass';
+        bp.frequency.value = inWater ? 380 : 180;
+        bp.Q.value = 0.8;
+        const g = this.ctx.createGain();
+        g.gain.value = inWater ? 0.05 : 0.07;
+        src.connect(bp);
+        bp.connect(g);
+        g.connect(this.master);
+        src.start(t);
+    }
+
+    spur() {
+        if (!this._enabled) return;
+        const osc = this.ctx.createOscillator();
+        osc.type = 'sawtooth';
+        osc.frequency.setValueAtTime(180, this.ctx.currentTime);
+        osc.frequency.exponentialRampToValueAtTime(90, this.ctx.currentTime + 0.18);
+        const g = this.ctx.createGain();
+        g.gain.value = 0.04;
+        g.gain.exponentialRampToValueAtTime(0.001, this.ctx.currentTime + 0.2);
+        osc.connect(g);
+        g.connect(this.master);
+        osc.start();
+        osc.stop(this.ctx.currentTime + 0.22);
+    }
+}

--- a/labs/rastro-vermelho/src/config.js
+++ b/labs/rastro-vermelho/src/config.js
@@ -1,0 +1,221 @@
+/**
+ * Rastro Vermelho — constantes do mundo aberto, do cavalo e da qualidade.
+ *
+ * O cavalo não cansa: o galope de cruzeiro é o estado padrão.
+ * O terreno é infinito (chunks) e a altura vem de fBm + vales de rio.
+ */
+
+export const STORAGE_KEY = 'rastro-vermelho:v1';
+
+/** Tamanho de um chunk no plano XZ (unidades de jogo ≈ metros). */
+export const CHUNK_SIZE = 96;
+
+/** Nível d’água. Vales abaixo disso viram rio ou lago. */
+export const WATER_Y = 3.35;
+
+export const HORSE = {
+    /** Velocidade mínima com o galope livre ligado — o cavalo não para. */
+    cruise: 11.4,
+    walk: 3.6,
+    trot: 7.1,
+    canter: 12.2,
+    gallop: 19.8,
+    spur: 24.5,
+    accel: 11,
+    brake: 14,
+    friction: 1.15,
+    turn: 1.48,
+    radius: 1.15,
+    height: 1.55,
+    /** Inclinação máxima que o cavalo sobe sem perder impulso. */
+    maxClimb: 0.72,
+    spurBoost: 4.2,
+    spurTime: 1.35
+};
+
+export const CAMERA = {
+    chaseDist: 8.6,
+    chaseHeight: 3.35,
+    chaseLook: 1.35,
+    cineDist: 14.5,
+    cineHeight: 4.8,
+    riderHeight: 2.05,
+    chaseFov: 58,
+    cineFov: 52,
+    riderFov: 68,
+    pitchMin: -0.42,
+    pitchMax: 0.62,
+    defaultPitch: 0.12
+};
+
+export const DAY_LENGTH = 480;
+
+export const QUALITY = {
+    low: {
+        id: 'low',
+        label: 'Performance',
+        pixelRatio: 1,
+        antialias: false,
+        shadows: false,
+        shadowSize: 1024,
+        bloom: false,
+        chunkRadius: 1,
+        terrainSegments: 18,
+        grass: 900,
+        trees: 8,
+        rocks: 6,
+        wildlife: 4,
+        birds: 5,
+        drawDistance: 280,
+        fogDensity: 0.0064
+    },
+    medium: {
+        id: 'medium',
+        label: 'Equilibrada',
+        pixelRatio: 1.25,
+        antialias: true,
+        shadows: true,
+        shadowSize: 1536,
+        bloom: true,
+        chunkRadius: 2,
+        terrainSegments: 26,
+        grass: 2400,
+        trees: 14,
+        rocks: 10,
+        wildlife: 8,
+        birds: 9,
+        drawDistance: 420,
+        fogDensity: 0.0044
+    },
+    high: {
+        id: 'high',
+        label: 'Cinemática',
+        pixelRatio: 1.55,
+        antialias: true,
+        shadows: true,
+        shadowSize: 2048,
+        bloom: true,
+        chunkRadius: 2,
+        terrainSegments: 34,
+        grass: 4200,
+        trees: 20,
+        rocks: 14,
+        wildlife: 12,
+        birds: 14,
+        drawDistance: 560,
+        fogDensity: 0.0034
+    }
+};
+
+/**
+ * Ciclo de um dia. `at` ∈ [0, 1] — 0 é o fim da madrugada.
+ * sunDir aponta PARA o sol (o shader usa o mesmo vetor do Safari Dourado).
+ */
+export const SKY_STOPS = [
+    {
+        at: 0,
+        zenith: [0.05, 0.07, 0.16],
+        horizon: [0.42, 0.22, 0.18],
+        ground: [0.12, 0.08, 0.06],
+        sun: [1.0, 0.55, 0.28],
+        sunDir: [-0.72, 0.08, -0.42],
+        fog: [0.18, 0.12, 0.10],
+        light: [1.0, 0.62, 0.38],
+        lightIntensity: 0.55,
+        ambient: [0.16, 0.14, 0.18]
+    },
+    {
+        at: 0.12,
+        zenith: [0.22, 0.38, 0.72],
+        horizon: [1.0, 0.58, 0.28],
+        ground: [0.38, 0.18, 0.10],
+        sun: [1.0, 0.72, 0.38],
+        sunDir: [-0.62, 0.28, -0.52],
+        fog: [0.72, 0.48, 0.32],
+        light: [1.0, 0.82, 0.55],
+        lightIntensity: 1.55,
+        ambient: [0.38, 0.28, 0.24]
+    },
+    {
+        at: 0.38,
+        zenith: [0.28, 0.52, 0.88],
+        horizon: [0.72, 0.82, 0.92],
+        ground: [0.42, 0.32, 0.22],
+        sun: [1.0, 0.96, 0.82],
+        sunDir: [0.18, 0.82, -0.42],
+        fog: [0.62, 0.72, 0.82],
+        light: [1.0, 0.98, 0.92],
+        lightIntensity: 2.15,
+        ambient: [0.48, 0.46, 0.44]
+    },
+    {
+        at: 0.62,
+        zenith: [0.22, 0.42, 0.78],
+        horizon: [0.96, 0.68, 0.38],
+        ground: [0.40, 0.24, 0.14],
+        sun: [1.0, 0.82, 0.42],
+        sunDir: [0.62, 0.42, -0.48],
+        fog: [0.78, 0.58, 0.36],
+        light: [1.0, 0.88, 0.62],
+        lightIntensity: 1.92,
+        ambient: [0.42, 0.36, 0.30]
+    },
+    {
+        at: 0.78,
+        zenith: [0.14, 0.18, 0.42],
+        horizon: [1.0, 0.42, 0.16],
+        ground: [0.32, 0.14, 0.08],
+        sun: [1.0, 0.52, 0.22],
+        sunDir: [0.78, 0.16, -0.42],
+        fog: [0.62, 0.32, 0.16],
+        light: [1.0, 0.58, 0.28],
+        lightIntensity: 1.35,
+        ambient: [0.32, 0.22, 0.20]
+    },
+    {
+        at: 0.92,
+        zenith: [0.04, 0.05, 0.12],
+        horizon: [0.22, 0.14, 0.18],
+        ground: [0.08, 0.06, 0.05],
+        sun: [0.72, 0.78, 1.0],
+        sunDir: [0.55, -0.08, -0.62],
+        fog: [0.10, 0.08, 0.12],
+        light: [0.62, 0.70, 0.92],
+        lightIntensity: 0.38,
+        ambient: [0.12, 0.12, 0.18]
+    },
+    {
+        at: 1,
+        zenith: [0.05, 0.07, 0.16],
+        horizon: [0.42, 0.22, 0.18],
+        ground: [0.12, 0.08, 0.06],
+        sun: [1.0, 0.55, 0.28],
+        sunDir: [-0.72, 0.08, -0.42],
+        fog: [0.18, 0.12, 0.10],
+        light: [1.0, 0.62, 0.38],
+        lightIntensity: 0.55,
+        ambient: [0.16, 0.14, 0.18]
+    }
+];
+
+export const REGION_PREFIX = [
+    'Serra', 'Vale', 'Mesa', 'Cânion', 'Pradaria', 'Passo', 'Riacho', 'Morro',
+    'Alto', 'Baixada', 'Garganta', 'Chapada'
+];
+
+export const REGION_SUFFIX = [
+    'do Corvo', 'Rubra', 'da Poeira', 'do Oeste', 'Dourada', 'dos Ossos',
+    'do Trovão', 'Silenciosa', 'do Mustangue', 'da Lua', 'do Cobre',
+    'dos Ventos', 'do Sal', 'Encarnada', 'do Relâmpago'
+];
+
+export const LANDMARKS = {
+    town: { id: 'town', label: 'Povoado' },
+    camp: { id: 'camp', label: 'Fogueira' },
+    arch: { id: 'arch', label: 'Arco de pedra' },
+    wagon: { id: 'wagon', label: 'Carroça' },
+    herd: { id: 'herd', label: 'Manada' },
+    falls: { id: 'falls', label: 'Cachoeira' }
+};
+
+export const LANDMARK_ORDER = ['town', 'camp', 'arch', 'wagon', 'herd', 'falls'];

--- a/labs/rastro-vermelho/src/config.js
+++ b/labs/rastro-vermelho/src/config.js
@@ -66,8 +66,8 @@ export const QUALITY = {
         rocks: 6,
         wildlife: 4,
         birds: 5,
-        drawDistance: 280,
-        fogDensity: 0.0064
+        drawDistance: 360,
+        fogDensity: 0.0048
     },
     medium: {
         id: 'medium',
@@ -85,7 +85,7 @@ export const QUALITY = {
         wildlife: 8,
         birds: 9,
         drawDistance: 420,
-        fogDensity: 0.0044
+        fogDensity: 0.0032
     },
     high: {
         id: 'high',
@@ -103,7 +103,7 @@ export const QUALITY = {
         wildlife: 12,
         birds: 14,
         drawDistance: 560,
-        fogDensity: 0.0034
+        fogDensity: 0.0024
     }
 };
 

--- a/labs/rastro-vermelho/src/effects.js
+++ b/labs/rastro-vermelho/src/effects.js
@@ -1,0 +1,72 @@
+/**
+ * Poeira dos cascos e spray quando o cavalo cruza o rio.
+ */
+
+import * as THREE from 'three';
+import { WATER_Y } from './config.js';
+
+export class Dust {
+    constructor(scene, quality) {
+        const n = quality.id === 'low' ? 80 : quality.id === 'high' ? 220 : 140;
+        this.count = n;
+        const geo = new THREE.BufferGeometry();
+        const pos = new Float32Array(n * 3);
+        const vel = new Float32Array(n * 3);
+        const life = new Float32Array(n);
+        for (let i = 0; i < n; i++) {
+            pos[i * 3 + 1] = -20;
+            life[i] = 0;
+        }
+        geo.setAttribute('position', new THREE.BufferAttribute(pos, 3));
+        this.pos = pos;
+        this.vel = vel;
+        this.life = life;
+        this.cursor = 0;
+
+        const mat = new THREE.PointsMaterial({
+            color: 0xc4a070,
+            size: 0.28,
+            transparent: true,
+            opacity: 0.45,
+            depthWrite: false,
+            sizeAttenuation: true
+        });
+        this.points = new THREE.Points(geo, mat);
+        this.points.frustumCulled = false;
+        scene.add(this.points);
+        this.geo = geo;
+    }
+
+    burst(x, y, z, speed, inWater) {
+        const n = inWater ? 6 : speed > 14 ? 4 : 2;
+        for (let k = 0; k < n; k++) {
+            const i = this.cursor % this.count;
+            this.cursor++;
+            this.pos[i * 3] = x + (Math.random() - 0.5) * 0.6;
+            this.pos[i * 3 + 1] = y + 0.15;
+            this.pos[i * 3 + 2] = z + (Math.random() - 0.5) * 0.6;
+            this.vel[i * 3] = (Math.random() - 0.5) * 1.4;
+            this.vel[i * 3 + 1] = 1.2 + Math.random() * 2.2;
+            this.vel[i * 3 + 2] = (Math.random() - 0.5) * 1.4;
+            this.life[i] = inWater ? 0.55 : 0.7 + Math.random() * 0.4;
+        }
+        this.points.material.color.set(inWater ? 0xb8d0d0 : 0xc4a070);
+    }
+
+    update(dt) {
+        const pos = this.pos;
+        const vel = this.vel;
+        const life = this.life;
+        for (let i = 0; i < this.count; i++) {
+            if (life[i] <= 0) continue;
+            life[i] -= dt;
+            pos[i * 3] += vel[i * 3] * dt;
+            pos[i * 3 + 1] += vel[i * 3 + 1] * dt;
+            pos[i * 3 + 2] += vel[i * 3 + 2] * dt;
+            vel[i * 3 + 1] -= 6 * dt;
+            if (pos[i * 3 + 1] < WATER_Y - 2) life[i] = 0;
+            if (life[i] <= 0) pos[i * 3 + 1] = -40;
+        }
+        this.geo.attributes.position.needsUpdate = true;
+    }
+}

--- a/labs/rastro-vermelho/src/horse.js
+++ b/labs/rastro-vermelho/src/horse.js
@@ -17,7 +17,6 @@ import * as THREE from 'three';
 import { HORSE } from './config.js';
 import { clamp, damp, wrapPi, lerp } from './utils.js';
 import { std } from './models.js';
-import { hideTexture } from './textures.js';
 
 function enableShadows(root) {
     root.traverse((c) => {
@@ -30,11 +29,9 @@ function enableShadows(root) {
 
 export function buildHorse() {
     const root = new THREE.Group();
-    const coat = new THREE.MeshStandardMaterial({
-        map: hideTexture(), color: 0xb86a32, roughness: 0.68
-    });
+    const coat = std(0xc47838, 0.62);
     const dark = std(0x1a120c, 0.78);
-    const cream = std(0xd8c8a8, 0.7);
+    const cream = std(0xe8dcc4, 0.65);
     const leather = std(0x4a2412, 0.7);
     const cloth = std(0x6a1c14, 0.75);
     const skin = std(0xc4a07a, 0.65);

--- a/labs/rastro-vermelho/src/horse.js
+++ b/labs/rastro-vermelho/src/horse.js
@@ -1,0 +1,314 @@
+/**
+ * Cavalo + cavaleiro.
+ *
+ * Física arcade:
+ *   v' = v + throttle * accel * dt
+ *   yaw' = yaw − steer * turn * (v / cruise) * dt
+ *   y = heightAt(x, z)
+ *
+ * Galope livre: a velocidade nunca cai abaixo de HORSE.cruise (ou walk se
+ * o jogador segura S). O cavalo não cansa — “sem parar” é a regra.
+ *
+ * Marcha (gait) pela velocidade: passo → trote → galope → disparada.
+ * Pernas em diagonal (trote): FL+HR vs FR+HL, fase = distance * 2.4.
+ */
+
+import * as THREE from 'three';
+import { HORSE } from './config.js';
+import { clamp, damp, wrapPi, lerp } from './utils.js';
+import { std } from './models.js';
+import { hideTexture } from './textures.js';
+
+function enableShadows(root) {
+    root.traverse((c) => {
+        if (c.isMesh) {
+            c.castShadow = true;
+            c.receiveShadow = true;
+        }
+    });
+}
+
+export function buildHorse() {
+    const root = new THREE.Group();
+    const coat = new THREE.MeshStandardMaterial({
+        map: hideTexture(), color: 0x5a3018, roughness: 0.72
+    });
+    const dark = std(0x1a120c, 0.78);
+    const cream = std(0xd8c8a8, 0.7);
+    const leather = std(0x4a2412, 0.7);
+    const cloth = std(0x6a1c14, 0.75);
+    const skin = std(0xc4a07a, 0.65);
+    const hat = std(0x2a2018, 0.8);
+
+    const body = new THREE.Mesh(new THREE.SphereGeometry(0.52, 10, 8), coat);
+    body.scale.set(1.05, 0.92, 1.85);
+    body.position.set(0, 1.18, 0);
+    root.add(body);
+
+    const chest = new THREE.Mesh(new THREE.SphereGeometry(0.4, 8, 8), coat);
+    chest.position.set(0, 1.16, 0.68);
+    root.add(chest);
+
+    const rump = new THREE.Mesh(new THREE.SphereGeometry(0.38, 8, 8), coat);
+    rump.position.set(0, 1.2, -0.72);
+    root.add(rump);
+
+    const neck = new THREE.Mesh(new THREE.CylinderGeometry(0.16, 0.26, 0.78, 8), coat);
+    neck.position.set(0, 1.58, 0.92);
+    neck.rotation.x = 0.62;
+    root.add(neck);
+
+    const headG = new THREE.Group();
+    headG.position.set(0, 2.02, 1.28);
+    const head = new THREE.Mesh(new THREE.SphereGeometry(0.2, 8, 8), coat);
+    head.scale.set(0.72, 0.78, 1.4);
+    headG.add(head);
+    const muzzle = new THREE.Mesh(new THREE.SphereGeometry(0.11, 6, 6), cream);
+    muzzle.position.set(0, -0.04, 0.28);
+    muzzle.scale.set(0.75, 0.65, 1.15);
+    headG.add(muzzle);
+    for (const sx of [-1, 1]) {
+        const ear = new THREE.Mesh(new THREE.ConeGeometry(0.05, 0.16, 4), coat);
+        ear.position.set(sx * 0.1, 0.2, -0.04);
+        ear.rotation.z = sx * 0.25;
+        headG.add(ear);
+        const eye = new THREE.Mesh(new THREE.SphereGeometry(0.03, 6, 6), dark);
+        eye.position.set(sx * 0.1, 0.04, 0.12);
+        headG.add(eye);
+    }
+    root.add(headG);
+
+    const mane = new THREE.Mesh(new THREE.BoxGeometry(0.06, 0.55, 0.7), dark);
+    mane.position.set(0, 1.72, 0.72);
+    mane.rotation.x = 0.5;
+    root.add(mane);
+
+    const tail = new THREE.Mesh(new THREE.CylinderGeometry(0.04, 0.08, 0.95, 6), dark);
+    tail.position.set(0, 1.05, -1.15);
+    tail.rotation.x = 0.45;
+    root.add(tail);
+
+    const legs = [];
+    const spots = [
+        { x: 0.22, z: 0.55, name: 'fl' },
+        { x: -0.22, z: 0.55, name: 'fr' },
+        { x: 0.22, z: -0.55, name: 'hl' },
+        { x: -0.22, z: -0.55, name: 'hr' }
+    ];
+    for (const s of spots) {
+        const hip = new THREE.Group();
+        hip.position.set(s.x, 1.05, s.z);
+        const thigh = new THREE.Mesh(new THREE.CylinderGeometry(0.08, 0.1, 0.52, 6), coat);
+        thigh.position.y = -0.22;
+        hip.add(thigh);
+        const shinG = new THREE.Group();
+        shinG.position.y = -0.48;
+        const shin = new THREE.Mesh(new THREE.CylinderGeometry(0.055, 0.07, 0.48, 6), coat);
+        shin.position.y = -0.2;
+        shinG.add(shin);
+        const hoof = new THREE.Mesh(new THREE.BoxGeometry(0.1, 0.08, 0.14), dark);
+        hoof.position.y = -0.46;
+        shinG.add(hoof);
+        hip.add(shinG);
+        root.add(hip);
+        legs.push({ hip, shin: shinG, name: s.name });
+    }
+
+    const saddle = new THREE.Mesh(new THREE.BoxGeometry(0.55, 0.12, 0.7), leather);
+    saddle.position.set(0, 1.58, 0.02);
+    root.add(saddle);
+
+    const rider = new THREE.Group();
+    rider.position.set(0, 1.62, 0.02);
+    const hips = new THREE.Mesh(new THREE.BoxGeometry(0.38, 0.18, 0.28), cloth);
+    hips.position.y = 0.22;
+    rider.add(hips);
+    const torso = new THREE.Mesh(new THREE.BoxGeometry(0.4, 0.48, 0.28), cloth);
+    torso.position.y = 0.52;
+    rider.add(torso);
+    const poncho = new THREE.Mesh(new THREE.ConeGeometry(0.42, 0.55, 6, 1, true), std(0x8a3a18, 0.8));
+    poncho.position.y = 0.42;
+    rider.add(poncho);
+    const headR = new THREE.Mesh(new THREE.SphereGeometry(0.14, 8, 8), skin);
+    headR.position.y = 0.88;
+    rider.add(headR);
+    const brim = new THREE.Mesh(new THREE.CylinderGeometry(0.28, 0.28, 0.03, 10), hat);
+    brim.position.y = 0.98;
+    rider.add(brim);
+    const crown = new THREE.Mesh(new THREE.CylinderGeometry(0.12, 0.14, 0.16, 8), hat);
+    crown.position.y = 1.08;
+    rider.add(crown);
+    for (const sx of [-1, 1]) {
+        const arm = new THREE.Mesh(new THREE.CylinderGeometry(0.05, 0.06, 0.42, 6), cloth);
+        arm.position.set(sx * 0.28, 0.48, 0.12);
+        arm.rotation.x = 0.85;
+        arm.rotation.z = -sx * 0.25;
+        rider.add(arm);
+        const boot = new THREE.Mesh(new THREE.BoxGeometry(0.1, 0.22, 0.18), dark);
+        boot.position.set(sx * 0.16, 0.02, 0.12);
+        rider.add(boot);
+    }
+    root.add(rider);
+
+    enableShadows(root);
+    return { root, parts: { legs, neck, head: headG, tail, rider, mane } };
+}
+
+function gaitName(speed) {
+    if (speed < 5) return 'passo';
+    if (speed < 9.5) return 'trote';
+    if (speed < 16.5) return 'galope';
+    return 'disparada';
+}
+
+export class Horse {
+    constructor(scene, world) {
+        this.world = world;
+        const built = buildHorse();
+        this.mesh = built.root;
+        this.parts = built.parts;
+        scene.add(this.mesh);
+        this.x = 0;
+        this.z = 0;
+        this.y = 0;
+        this.yaw = 0;
+        this.speed = HORSE.cruise;
+        this.pitch = 0;
+        this.roll = 0;
+        this.phase = 0;
+        this.spurT = 0;
+        this.cruise = true;
+        this.distance = 0;
+        this.air = 0;
+        this.hoofTimer = 0;
+        this.gait = 'galope';
+        this.inWater = false;
+    }
+
+    reset(spawn) {
+        this.x = spawn.x;
+        this.z = spawn.z;
+        this.yaw = spawn.yaw;
+        this.speed = HORSE.cruise;
+        this.pitch = 0;
+        this.roll = 0;
+        this.phase = 0;
+        this.spurT = 0;
+        this.distance = 0;
+        this.y = this.world.heightAt(this.x, this.z);
+        this.sync();
+    }
+
+    get forward() {
+        return { x: Math.sin(this.yaw), z: Math.cos(this.yaw) };
+    }
+
+    toggleCruise() {
+        this.cruise = !this.cruise;
+        return this.cruise;
+    }
+
+    update(dt, input) {
+        const steer = input.move.x;
+        const throttle = input.move.z;
+        const sprint = input.move.sprint;
+
+        const spurred = input.consumeSpur();
+        if (spurred) this.spurT = HORSE.spurTime;
+
+        this.spurT = Math.max(0, this.spurT - dt);
+
+        let target;
+        if (this.spurT > 0 || sprint) {
+            target = this.spurT > 0 ? HORSE.spur : HORSE.gallop;
+        } else if (throttle > 0.12) {
+            target = lerp(HORSE.canter, HORSE.gallop, clamp(throttle, 0, 1));
+        } else if (throttle < -0.12) {
+            const brake = clamp(-throttle, 0, 1);
+            target = this.cruise
+                ? lerp(HORSE.cruise, HORSE.walk, brake)
+                : lerp(HORSE.walk, 0, brake);
+        } else {
+            target = this.cruise ? HORSE.cruise : HORSE.walk;
+        }
+
+        const rate = target > this.speed ? HORSE.accel : HORSE.brake;
+        this.speed = damp(this.speed, target, rate * 0.22, dt);
+        if (this.cruise) this.speed = Math.max(this.speed, HORSE.walk * 0.92);
+
+        const f = this.forward;
+        const look = 2.4;
+        const aheadY = this.world.heightAt(this.x + f.x * look, this.z + f.z * look);
+        const slope = (aheadY - this.y) / look;
+        if (slope > HORSE.maxClimb) this.speed *= 1 - clamp((slope - HORSE.maxClimb) * 1.6, 0, 0.55) * dt * 8;
+
+        const turnScale = clamp(Math.abs(this.speed) / 7, 0.28, 1.15);
+        this.yaw -= steer * HORSE.turn * turnScale * dt;
+        this.yaw = wrapPi(this.yaw);
+
+        const f2 = this.forward;
+        let x = this.x + f2.x * this.speed * dt;
+        let z = this.z + f2.z * this.speed * dt;
+        const hit = this.world.collide(x, z, HORSE.radius);
+        x = hit.x;
+        z = hit.z;
+
+        const ground = this.world.heightAt(x, z);
+        this.inWater = ground < this.world.waterY + 0.35;
+        if (this.inWater) this.speed = Math.min(this.speed, HORSE.trot * 1.05);
+
+        const dist = Math.hypot(x - this.x, z - this.z);
+        this.distance += dist;
+        this.x = x;
+        this.z = z;
+        this.y = ground;
+        this.gait = gaitName(this.speed);
+
+        const right = this.world.heightAt(
+            x + Math.cos(this.yaw) * 1.4,
+            z - Math.sin(this.yaw) * 1.4
+        );
+        this.pitch = damp(this.pitch, clamp((this.y - aheadY) * 0.16, -0.28, 0.28), 7, dt);
+        this.roll = damp(this.roll, clamp((this.y - right) * 0.1 - steer * 0.14, -0.22, 0.22), 8, dt);
+
+        this.phase += this.speed * dt * 2.35;
+        this.animate(dt, steer);
+        this.sync();
+
+        this.hoofTimer += this.speed * dt;
+        const stride = this.speed > 14 ? 1.35 : this.speed > 8 ? 1.7 : 2.15;
+        const hoof = this.hoofTimer > stride;
+        if (hoof) this.hoofTimer = 0;
+        return { hoof, spur: spurred };
+    }
+
+    animate(dt, steer) {
+        const amp = clamp(this.speed / HORSE.gallop, 0.12, 1) * 0.72;
+        const g = Math.sin(this.phase);
+        const g2 = Math.sin(this.phase + Math.PI);
+        const legs = this.parts.legs;
+        legs[0].hip.rotation.x = g * amp;
+        legs[3].hip.rotation.x = g * amp * 0.92;
+        legs[1].hip.rotation.x = g2 * amp;
+        legs[2].hip.rotation.x = g2 * amp * 0.92;
+        legs[0].shin.rotation.x = Math.max(0, -g) * amp * 0.7;
+        legs[3].shin.rotation.x = Math.max(0, -g) * amp * 0.6;
+        legs[1].shin.rotation.x = Math.max(0, -g2) * amp * 0.7;
+        legs[2].shin.rotation.x = Math.max(0, -g2) * amp * 0.6;
+
+        this.parts.neck.rotation.x = 0.62 - amp * 0.12 + Math.sin(this.phase * 0.5) * 0.04;
+        this.parts.head.rotation.x = Math.sin(this.phase * 0.5) * 0.05;
+        this.parts.tail.rotation.x = 0.45 + Math.sin(this.phase * 0.8) * 0.18;
+        this.parts.tail.rotation.z = steer * 0.25 + Math.sin(this.phase) * 0.08;
+        this.parts.rider.rotation.z = -steer * 0.12;
+        this.parts.rider.rotation.x = -this.pitch * 0.4 + Math.sin(this.phase) * 0.03;
+    }
+
+    sync() {
+        this.mesh.position.set(this.x, this.y, this.z);
+        this.mesh.rotation.order = 'YXZ';
+        this.mesh.rotation.y = this.yaw;
+        this.mesh.rotation.x = this.pitch;
+        this.mesh.rotation.z = this.roll;
+    }
+}

--- a/labs/rastro-vermelho/src/horse.js
+++ b/labs/rastro-vermelho/src/horse.js
@@ -31,7 +31,7 @@ function enableShadows(root) {
 export function buildHorse() {
     const root = new THREE.Group();
     const coat = new THREE.MeshStandardMaterial({
-        map: hideTexture(), color: 0x5a3018, roughness: 0.72
+        map: hideTexture(), color: 0xb86a32, roughness: 0.68
     });
     const dark = std(0x1a120c, 0.78);
     const cream = std(0xd8c8a8, 0.7);

--- a/labs/rastro-vermelho/src/hud.js
+++ b/labs/rastro-vermelho/src/hud.js
@@ -1,0 +1,148 @@
+/**
+ * HUD, bússola, menus e overlays — tudo que é DOM.
+ */
+
+import { LANDMARK_ORDER, LANDMARKS } from './config.js';
+import { formatKm, formatClock, hourLabel } from './utils.js';
+
+const $ = (id) => document.getElementById(id);
+
+export function statsBlock(rows) {
+    return rows.map(([k, v]) => `<div><span>${k}</span><strong class="mono">${v}</strong></div>`).join('');
+}
+
+const BIOME_LABEL = {
+    prairie: 'pradaria',
+    desert: 'deserto',
+    mesa: 'mesa',
+    canyon: 'cânion',
+    pine: 'pinheiros',
+    alpine: 'cume',
+    riparian: 'rio'
+};
+
+export class Hud {
+    constructor() {
+        this.el = {
+            hud: $('hud'),
+            gait: $('gaitValue'),
+            speed: $('speedValue'),
+            region: $('regionName'),
+            biome: $('biomeLabel'),
+            distance: $('distanceValue'),
+            hour: $('hourLabel'),
+            clock: $('clockValue'),
+            fps: $('fpsCounter'),
+            compassRose: $('compassRose'),
+            message: $('message'),
+            prompt: $('prompt'),
+            marks: $('markPips'),
+            markCount: $('markCount'),
+            cruiseHint: $('cruiseHint'),
+            soundButton: $('soundButton'),
+            pauseButton: $('pauseButton'),
+            loading: $('loadingOverlay'),
+            loadingFill: $('loadingFill'),
+            loadingText: $('loadingText'),
+            menu: $('menuOverlay'),
+            pause: $('pauseOverlay'),
+            error: $('errorOverlay'),
+            errorText: $('errorText'),
+            qualitySelect: $('qualitySelect'),
+            volumeSlider: $('volumeSlider'),
+            volumeValue: $('volumeValue'),
+            bestScore: $('bestScore'),
+            touch: $('touchControls')
+        };
+        this.messageTimer = 0;
+        this.buildMarks();
+    }
+
+    buildMarks() {
+        this.el.marks.innerHTML = LANDMARK_ORDER.map((id) => {
+            const s = LANDMARKS[id];
+            return `<i data-id="${id}" title="${s.label}"></i>`;
+        }).join('');
+    }
+
+    setState(state) {
+        document.body.dataset.state = state;
+    }
+
+    setLoading(progress, text) {
+        if (text) this.el.loadingText.textContent = text;
+        this.el.loadingFill.style.width = `${Math.round(progress * 100)}%`;
+    }
+
+    hideLoading() {
+        this.el.loading.hidden = true;
+    }
+
+    showError(message) {
+        if (message) this.el.errorText.textContent = message;
+        this.el.error.hidden = false;
+        this.el.loading.hidden = true;
+    }
+
+    showHud(v) {
+        this.el.hud.hidden = !v;
+    }
+
+    showMenu(v) {
+        this.el.menu.hidden = !v;
+    }
+
+    showPause(v) {
+        this.el.pause.hidden = !v;
+    }
+
+    setMuted(muted) {
+        this.el.soundButton.setAttribute('aria-pressed', muted ? 'false' : 'true');
+        this.el.soundButton.textContent = muted ? '♭' : '♪';
+    }
+
+    setSettings({ quality, volume, best }) {
+        this.el.qualitySelect.value = quality;
+        this.el.volumeSlider.value = String(volume);
+        this.el.volumeValue.textContent = String(volume);
+        this.el.bestScore.textContent = best ? formatKm(best) : '—';
+    }
+
+    setPlay({ gait, speed, region, biome, distance, hour, yaw, cruise, marks }) {
+        this.el.gait.textContent = gait;
+        this.el.speed.textContent = `${Math.round(speed * 3.6)}`;
+        this.el.region.textContent = region;
+        this.el.biome.textContent = BIOME_LABEL[biome] || biome;
+        this.el.distance.textContent = formatKm(distance);
+        this.el.hour.textContent = hourLabel(hour);
+        this.el.clock.textContent = formatClock(hour);
+        this.el.compassRose.style.transform = `rotate(${-yaw * (180 / Math.PI)}deg)`;
+        this.el.cruiseHint.textContent = cruise ? 'galope livre' : 'passo livre';
+        const n = marks?.size || 0;
+        this.el.markCount.textContent = `${n}/${LANDMARK_ORDER.length}`;
+        this.el.marks.querySelectorAll('i').forEach((pip) => {
+            pip.dataset.on = marks?.has(pip.dataset.id) ? 'true' : 'false';
+        });
+    }
+
+    setFps(fps) {
+        this.el.fps.textContent = `${fps} fps`;
+    }
+
+    say(text, seconds = 3.2) {
+        this.el.message.textContent = text;
+        this.el.message.dataset.show = 'true';
+        this.messageTimer = seconds;
+    }
+
+    showTouch(v) {
+        this.el.touch.hidden = !v;
+    }
+
+    tick(dt) {
+        if (this.messageTimer > 0) {
+            this.messageTimer -= dt;
+            if (this.messageTimer <= 0) this.el.message.dataset.show = 'false';
+        }
+    }
+}

--- a/labs/rastro-vermelho/src/input.js
+++ b/labs/rastro-vermelho/src/input.js
@@ -1,0 +1,214 @@
+/**
+ * Teclado, mouse (pointer lock), toque e atalhos.
+ *
+ * Frente do cavalo segue W/stick-cima. O galope livre ignora soltar W.
+ */
+
+import { clamp } from './utils.js';
+
+const MOVE = {
+    KeyW: 'forward',
+    ArrowUp: 'forward',
+    KeyS: 'back',
+    ArrowDown: 'back',
+    KeyA: 'left',
+    ArrowLeft: 'left',
+    KeyD: 'right',
+    ArrowRight: 'right',
+    ShiftLeft: 'sprint',
+    ShiftRight: 'sprint'
+};
+
+const ACTIONS = {
+    KeyP: 'pause',
+    Escape: 'pause',
+    KeyM: 'mute',
+    KeyC: 'camera',
+    Space: 'spur',
+    KeyG: 'cruise',
+    Enter: 'confirm'
+};
+
+export class Input {
+    constructor(canvas) {
+        this.canvas = canvas;
+        this.keys = new Set();
+        this.lookX = 0;
+        this.lookY = 0;
+        this.zoomDelta = 0;
+        this.locked = false;
+        this.enabled = true;
+        this.listeners = new Map();
+        this.touchMove = { x: 0, y: 0 };
+        this.touchLook = { x: 0, y: 0 };
+        this.spurPressed = false;
+        this._bind();
+    }
+
+    on(action, handler) {
+        if (!this.listeners.has(action)) this.listeners.set(action, new Set());
+        this.listeners.get(action).add(handler);
+        return () => this.listeners.get(action).delete(handler);
+    }
+
+    emit(action, payload) {
+        this.listeners.get(action)?.forEach((fn) => fn(payload));
+    }
+
+    consumeLook() {
+        const x = this.lookX + this.touchLook.x;
+        const y = this.lookY + this.touchLook.y;
+        this.lookX = 0;
+        this.lookY = 0;
+        this.touchLook.x = 0;
+        this.touchLook.y = 0;
+        return { x, y };
+    }
+
+    consumeZoom() {
+        const z = this.zoomDelta;
+        this.zoomDelta = 0;
+        return z;
+    }
+
+    consumeSpur() {
+        const v = this.spurPressed;
+        this.spurPressed = false;
+        return v;
+    }
+
+    get move() {
+        const f = this.keys.has('forward') ? 1 : 0;
+        const b = this.keys.has('back') ? 1 : 0;
+        const r = this.keys.has('right') ? 1 : 0;
+        const l = this.keys.has('left') ? 1 : 0;
+        return {
+            x: clamp(r - l + this.touchMove.x, -1, 1),
+            z: clamp(f - b + this.touchMove.y, -1, 1),
+            sprint: this.keys.has('sprint')
+        };
+    }
+
+    requestLock() {
+        if (this.locked) return;
+        const result = this.canvas.requestPointerLock?.();
+        if (result && typeof result.catch === 'function') result.catch(() => {});
+    }
+
+    exitLock() {
+        if (document.pointerLockElement) document.exitPointerLock?.();
+    }
+
+    bindTouch({ stick, knob, look, spur }) {
+        const setFromTouch = (el, ev, target) => {
+            const t = ev.changedTouches[0];
+            if (!t) return;
+            const r = el.getBoundingClientRect();
+            const x = (t.clientX - r.left) / r.width * 2 - 1;
+            const y = (t.clientY - r.top) / r.height * 2 - 1;
+            target.x = clamp(x, -1, 1);
+            target.y = clamp(-y, -1, 1);
+        };
+
+        if (stick) {
+            const onMove = (ev) => {
+                ev.preventDefault();
+                setFromTouch(stick, ev, this.touchMove);
+                if (knob) {
+                    knob.style.transform = `translate(${this.touchMove.x * 18}px, ${-this.touchMove.y * 18}px)`;
+                }
+            };
+            const clear = () => {
+                this.touchMove.x = 0;
+                this.touchMove.y = 0;
+                if (knob) knob.style.transform = '';
+            };
+            stick.addEventListener('touchstart', onMove, { passive: false });
+            stick.addEventListener('touchmove', onMove, { passive: false });
+            stick.addEventListener('touchend', clear);
+            stick.addEventListener('touchcancel', clear);
+        }
+
+        if (look) {
+            let lx = 0;
+            let ly = 0;
+            look.addEventListener('touchstart', (ev) => {
+                const t = ev.changedTouches[0];
+                lx = t.clientX;
+                ly = t.clientY;
+            }, { passive: true });
+            look.addEventListener('touchmove', (ev) => {
+                const t = ev.changedTouches[0];
+                this.touchLook.x += t.clientX - lx;
+                this.touchLook.y += t.clientY - ly;
+                lx = t.clientX;
+                ly = t.clientY;
+            }, { passive: true });
+        }
+
+        if (spur) {
+            spur.addEventListener('touchstart', (ev) => {
+                ev.preventDefault();
+                this.spurPressed = true;
+            }, { passive: false });
+        }
+    }
+
+    _bind() {
+        this._onKeyDown = (e) => {
+            if (!this.enabled) return;
+            const action = ACTIONS[e.code];
+            if (action) {
+                if (action === 'confirm' && document.activeElement?.tagName === 'BUTTON') return;
+                if (action === 'spur') {
+                    if (!e.repeat) this.spurPressed = true;
+                } else {
+                    this.emit(action);
+                }
+                if (action !== 'confirm') e.preventDefault();
+            }
+            const key = MOVE[e.code];
+            if (!key) return;
+            e.preventDefault();
+            this.keys.add(key);
+        };
+
+        this._onKeyUp = (e) => {
+            const key = MOVE[e.code];
+            if (key) this.keys.delete(key);
+        };
+
+        this._onMouseMove = (e) => {
+            if (!this.enabled) return;
+            if (this.locked) {
+                this.lookX += e.movementX;
+                this.lookY += e.movementY;
+            }
+        };
+
+        this._onMouseDown = (e) => {
+            if (!this.enabled) return;
+            if (e.button === 0) this.emit('pointerdown');
+        };
+
+        this._onWheel = (e) => {
+            if (!this.enabled) return;
+            this.zoomDelta += Math.sign(e.deltaY);
+            e.preventDefault();
+        };
+
+        this._onLock = () => {
+            this.locked = document.pointerLockElement === this.canvas;
+        };
+
+        this._onContext = (e) => e.preventDefault();
+
+        window.addEventListener('keydown', this._onKeyDown);
+        window.addEventListener('keyup', this._onKeyUp);
+        window.addEventListener('mousemove', this._onMouseMove);
+        this.canvas.addEventListener('mousedown', this._onMouseDown);
+        this.canvas.addEventListener('wheel', this._onWheel, { passive: false });
+        this.canvas.addEventListener('contextmenu', this._onContext);
+        document.addEventListener('pointerlockchange', this._onLock);
+    }
+}

--- a/labs/rastro-vermelho/src/main.js
+++ b/labs/rastro-vermelho/src/main.js
@@ -30,7 +30,7 @@ class Game {
         this.state = 'loading';
         this.time = 0;
         this.elapsed = 0;
-        this.hour = 0.18;
+        this.hour = 0.72;
         this.cameraMode = 0;
         this.lookYaw = 0;
         this.lookPitch = CAMERA.defaultPitch;
@@ -226,7 +226,7 @@ class Game {
         this.audio.setVolume(this.settings.volume / 100);
         this.player.reset(this.spawn);
         this.elapsed = 0;
-        this.hour = 0.18;
+        this.hour = 0.72;
         this.marks = new Set();
         this.lastRegion = '';
         this.lookYaw = this.player.yaw;
@@ -299,7 +299,7 @@ class Game {
 
         if (this.state === 'play') {
             this.elapsed += dt;
-            this.hour = wrap01(0.18 + this.elapsed / DAY_LENGTH);
+            this.hour = wrap01(0.72 + this.elapsed / DAY_LENGTH);
             this.tickPlay(dt);
         } else {
             this.idleCamera(dt);

--- a/labs/rastro-vermelho/src/main.js
+++ b/labs/rastro-vermelho/src/main.js
@@ -1,0 +1,473 @@
+/**
+ * Rastro Vermelho — laço principal, câmera de perseguição e ciclo do dia.
+ *
+ * Câmera 0: chase atrás do cavalo
+ * Câmera 1: cinematográfica (mais longe, FOV fechado)
+ * Câmera 2: sobre o ombro do cavaleiro
+ */
+
+import * as THREE from 'three';
+import { QUALITY, STORAGE_KEY, CAMERA, DAY_LENGTH, CHUNK_SIZE } from './config.js';
+import { clamp, damp, detectMobile, detectSoftwareGL, rendererIsSoftware, wrap01 } from './utils.js';
+import { Input } from './input.js';
+import { GameAudio } from './audio.js';
+import { Hud } from './hud.js';
+import { createSky, createSkyUniforms, sampleSkyPalette, applySkyPalette, createLights } from './sky.js';
+import { World } from './world.js';
+import { Horse } from './horse.js';
+import { Wildlife } from './wildlife.js';
+import { Dust } from './effects.js';
+
+const LOOK = new THREE.Vector3();
+const CAM = new THREE.Vector3();
+const FWD = new THREE.Vector3();
+
+class Game {
+    constructor() {
+        this.hud = new Hud();
+        this.canvas = document.getElementById('scene');
+        this.settings = this.loadSettings();
+        this.state = 'loading';
+        this.time = 0;
+        this.elapsed = 0;
+        this.hour = 0.18;
+        this.cameraMode = 0;
+        this.lookYaw = 0;
+        this.lookPitch = CAMERA.defaultPitch;
+        this.camDist = CAMERA.chaseDist;
+        this.fpsAccum = 0;
+        this.fpsFrames = 0;
+        this.hudAccum = 0;
+        this.fpsLowTime = 0;
+        this.adapted = false;
+        this.lastRegion = '';
+        this.marks = new Set();
+    }
+
+    loadSettings() {
+        const fallback = { quality: 'auto', volume: 70, muted: false, best: 0 };
+        try {
+            const raw = localStorage.getItem(STORAGE_KEY);
+            return raw ? { ...fallback, ...JSON.parse(raw) } : fallback;
+        } catch (err) {
+            return fallback;
+        }
+    }
+
+    saveSettings() {
+        try {
+            localStorage.setItem(STORAGE_KEY, JSON.stringify(this.settings));
+        } catch (err) { /* privado */ }
+    }
+
+    resolveQuality() {
+        const choice = this.settings.quality;
+        if (choice !== 'auto' && QUALITY[choice]) return QUALITY[choice];
+        if (detectMobile() || detectSoftwareGL()) return QUALITY.low;
+        const big = Math.min(window.innerWidth, window.innerHeight) >= 900;
+        return big ? QUALITY.high : QUALITY.medium;
+    }
+
+    async init() {
+        this.hud.setLoading(0.08, 'Abrindo a trilha de terra…');
+        this.quality = this.resolveQuality();
+        this.mobile = detectMobile() || Boolean(window.matchMedia?.('(pointer: coarse)')?.matches);
+
+        try {
+            this.renderer = new THREE.WebGLRenderer({
+                canvas: this.canvas,
+                antialias: this.quality.antialias,
+                powerPreference: 'high-performance',
+                alpha: false
+            });
+        } catch (err) {
+            this.hud.showError('WebGL não pôde iniciar neste navegador.');
+            return;
+        }
+
+        this.renderer.setPixelRatio(Math.min(window.devicePixelRatio, this.quality.pixelRatio));
+        this.renderer.setSize(window.innerWidth, window.innerHeight);
+        this.renderer.outputColorSpace = THREE.SRGBColorSpace;
+        this.renderer.toneMapping = THREE.ACESFilmicToneMapping;
+        this.renderer.toneMappingExposure = 1.08;
+        this.renderer.shadowMap.enabled = this.quality.shadows;
+        this.renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+        this.renderer.setClearColor(0x1a0e08, 1);
+
+        if (rendererIsSoftware(this.renderer) && this.settings.quality === 'auto') {
+            this.quality = QUALITY.low;
+            this.renderer.shadowMap.enabled = false;
+            this.renderer.setPixelRatio(1);
+        }
+
+        this.scene = new THREE.Scene();
+        this.scene.fog = new THREE.FogExp2(0xc89a62, this.quality.fogDensity);
+
+        this.camera = new THREE.PerspectiveCamera(
+            CAMERA.chaseFov,
+            window.innerWidth / window.innerHeight,
+            0.15,
+            this.quality.drawDistance * 4
+        );
+        this.skyUniforms = createSkyUniforms();
+        this.sky = createSky(this.skyUniforms);
+        this.scene.add(this.sky);
+        this.lights = createLights(this.scene, this.quality);
+
+        this.hud.setLoading(0.32, 'Erguendo as serras…');
+        this.world = new World(this.scene, this.quality);
+        this.spawn = this.world.findSpawn();
+        this.world.loadChunk(Math.floor(this.spawn.x / CHUNK_SIZE), Math.floor(this.spawn.z / CHUNK_SIZE));
+
+        this.hud.setLoading(0.58, 'Apertando a sela…');
+        this.player = new Horse(this.scene, this.world);
+        this.player.reset(this.spawn);
+        this.wildlife = new Wildlife(this.scene, this.world, this.quality);
+        this.dust = new Dust(this.scene, this.quality);
+
+        this.hud.setLoading(0.82, 'O vento chega do oeste…');
+        this.input = new Input(this.canvas);
+        this.audio = new GameAudio();
+        this.audio.volume = this.settings.volume / 100;
+        this.audio.muted = this.settings.muted;
+
+        this.input.bindTouch({
+            stick: document.getElementById('moveStick'),
+            knob: document.getElementById('moveKnob'),
+            look: document.getElementById('lookZone'),
+            spur: document.getElementById('btnSpur')
+        });
+
+        this.composer = null;
+        if (this.quality.bloom) {
+            try {
+                const [{ EffectComposer }, { RenderPass }, { UnrealBloomPass }, { OutputPass }] = await Promise.all([
+                    import('three/addons/postprocessing/EffectComposer.js'),
+                    import('three/addons/postprocessing/RenderPass.js'),
+                    import('three/addons/postprocessing/UnrealBloomPass.js'),
+                    import('three/addons/postprocessing/OutputPass.js')
+                ]);
+                const composer = new EffectComposer(this.renderer);
+                composer.addPass(new RenderPass(this.scene, this.camera));
+                const bloom = new UnrealBloomPass(
+                    new THREE.Vector2(window.innerWidth, window.innerHeight),
+                    0.18, 0.55, 0.84
+                );
+                composer.addPass(bloom);
+                composer.addPass(new OutputPass());
+                this.composer = composer;
+                this.bloom = bloom;
+            } catch (err) {
+                this.composer = null;
+            }
+        }
+
+        this.bindUi();
+        this.hud.setSettings({
+            quality: this.settings.quality,
+            volume: this.settings.volume,
+            best: this.settings.best
+        });
+        this.hud.setMuted(this.settings.muted);
+        this.hud.showTouch(this.mobile);
+        this.hud.hideLoading();
+        this.hud.showMenu(true);
+        this.state = 'menu';
+        this.hud.setState('menu');
+
+        window.addEventListener('resize', () => this.resize());
+        this.clock = new THREE.Clock();
+        this.renderer.setAnimationLoop(() => this.frame());
+    }
+
+    bindUi() {
+        const h = this.hud.el;
+        h.startButton = document.getElementById('startButton');
+        h.resumeButton = document.getElementById('resumeButton');
+        h.pauseMenuButton = document.getElementById('pauseMenuButton');
+
+        h.startButton.addEventListener('click', () => this.start());
+        h.resumeButton.addEventListener('click', () => this.resume());
+        h.pauseMenuButton.addEventListener('click', () => this.toMenu());
+        h.soundButton.addEventListener('click', () => this.toggleMute());
+        h.pauseButton.addEventListener('click', () => this.togglePause());
+        h.qualitySelect.addEventListener('change', () => {
+            this.settings.quality = h.qualitySelect.value;
+            this.saveSettings();
+        });
+        h.volumeSlider.addEventListener('input', () => {
+            this.settings.volume = Number(h.volumeSlider.value);
+            h.volumeValue.textContent = String(this.settings.volume);
+            this.audio.setVolume(this.settings.volume / 100);
+            this.saveSettings();
+        });
+
+        this.input.on('pause', () => this.togglePause());
+        this.input.on('mute', () => this.toggleMute());
+        this.input.on('camera', () => {
+            if (this.state === 'play') this.cameraMode = (this.cameraMode + 1) % 3;
+        });
+        this.input.on('cruise', () => {
+            if (this.state !== 'play') return;
+            const on = this.player.toggleCruise();
+            this.hud.say(on ? 'Galope livre — o cavalo não para.' : 'Rédea curta — o passo fica com você.', 2.8);
+        });
+        this.input.on('pointerdown', () => {
+            if (this.state === 'play') this.input.requestLock();
+        });
+        this.canvas.addEventListener('click', () => {
+            if (this.state === 'play') this.input.requestLock();
+        });
+    }
+
+    async start() {
+        await this.audio.unlock();
+        this.audio.setMuted(this.settings.muted);
+        this.audio.setVolume(this.settings.volume / 100);
+        this.player.reset(this.spawn);
+        this.elapsed = 0;
+        this.hour = 0.18;
+        this.marks = new Set();
+        this.lastRegion = '';
+        this.lookYaw = this.player.yaw;
+        this.lookPitch = CAMERA.defaultPitch;
+        this.hud.showMenu(false);
+        this.hud.showPause(false);
+        this.hud.showHud(true);
+        this.state = 'play';
+        this.hud.setState('play');
+        this.input.enabled = true;
+        this.input.requestLock();
+        const region = this.world.currentRegion(this.player.x, this.player.z);
+        this.hud.say(`${region.name}. O cavalo já galopa — o oeste não acaba.`, 4.6);
+        this.lastRegion = region.name;
+    }
+
+    toMenu() {
+        this.input.exitLock();
+        this.settings.best = Math.max(this.settings.best, this.player.distance);
+        this.saveSettings();
+        this.hud.showPause(false);
+        this.hud.showHud(false);
+        this.hud.showMenu(true);
+        this.state = 'menu';
+        this.hud.setState('menu');
+        this.hud.setSettings({
+            quality: this.settings.quality,
+            volume: this.settings.volume,
+            best: this.settings.best
+        });
+    }
+
+    togglePause() {
+        if (this.state === 'play') {
+            this.state = 'pause';
+            this.hud.setState('pause');
+            this.hud.showPause(true);
+            this.input.exitLock();
+        } else if (this.state === 'pause') {
+            this.resume();
+        }
+    }
+
+    resume() {
+        this.hud.showPause(false);
+        this.state = 'play';
+        this.hud.setState('play');
+        this.input.requestLock();
+    }
+
+    toggleMute() {
+        this.settings.muted = !this.settings.muted;
+        this.audio.setMuted(this.settings.muted);
+        this.hud.setMuted(this.settings.muted);
+        this.saveSettings();
+    }
+
+    resize() {
+        const w = window.innerWidth;
+        const h = window.innerHeight;
+        this.camera.aspect = w / h;
+        this.camera.updateProjectionMatrix();
+        this.renderer.setSize(w, h);
+        this.composer?.setSize(w, h);
+    }
+
+    frame() {
+        const dt = Math.min(0.05, this.clock.getDelta());
+        this.time += dt;
+
+        if (this.state === 'play') {
+            this.elapsed += dt;
+            this.hour = wrap01(0.18 + this.elapsed / DAY_LENGTH);
+            this.tickPlay(dt);
+        } else {
+            this.idleCamera(dt);
+        }
+
+        this.applySky();
+        this.sky.position.copy(this.camera.position);
+        if (this.sky.material.uniforms.uTime) this.sky.material.uniforms.uTime.value = this.time;
+        this.world.update(dt, this.time, this.player);
+        this.dust.update(dt);
+
+        if (this.composer) this.composer.render();
+        else this.renderer.render(this.scene, this.camera);
+
+        this.fpsAccum += dt;
+        this.fpsFrames += 1;
+        if (this.fpsAccum >= 0.5) {
+            const fps = Math.round(this.fpsFrames / this.fpsAccum);
+            this.hud.setFps(fps);
+            this.adaptIfNeeded(fps, this.fpsAccum);
+            this.fpsAccum = 0;
+            this.fpsFrames = 0;
+        }
+        this.hud.tick(dt);
+    }
+
+    tickPlay(dt) {
+        const result = this.player.update(dt, this.input);
+        const nearHerd = this.wildlife.update(dt, this.player, this.time);
+        this.updateCamera(dt);
+
+        this.audio.update(dt, this.player.speed);
+        if (result.hoof) {
+            this.audio.hoof(this.player.inWater);
+            this.dust.burst(this.player.x, this.player.y, this.player.z, this.player.speed, this.player.inWater);
+        }
+        if (result.spur) this.audio.spur();
+
+        const region = this.world.currentRegion(this.player.x, this.player.z);
+        if (region.name !== this.lastRegion) {
+            this.lastRegion = region.name;
+            this.hud.say(region.name, 2.6);
+        }
+
+        const mark = this.world.nearestLandmark(this.player.x, this.player.z, 16);
+        if (mark && !this.marks.has(mark.id)) {
+            this.marks.add(mark.id);
+            this.hud.say(`${mark.label} — ${region.name}`, 3.2);
+        }
+        if (nearHerd && !this.marks.has('herd')) {
+            this.marks.add('herd');
+            this.hud.say('Manada na pradaria.', 2.8);
+        }
+
+        this.hudAccum += dt;
+        if (this.hudAccum > 0.12) {
+            this.hudAccum = 0;
+            this.hud.setPlay({
+                gait: this.player.gait,
+                speed: this.player.speed,
+                region: region.name,
+                biome: region.biome,
+                distance: this.player.distance,
+                hour: this.hour,
+                yaw: this.lookYaw,
+                cruise: this.player.cruise,
+                marks: this.marks
+            });
+        }
+
+        if (this.player.distance > this.settings.best) {
+            this.settings.best = this.player.distance;
+        }
+    }
+
+    adaptIfNeeded(fps, dt) {
+        if (this.adapted || this.settings.quality !== 'auto') return;
+        if (fps < 26) this.fpsLowTime += dt;
+        else this.fpsLowTime = 0;
+        if (this.fpsLowTime < 2.2) return;
+        this.adapted = true;
+        this.renderer.setPixelRatio(1);
+        this.renderer.shadowMap.enabled = false;
+        this.composer = null;
+        if (this.world.grass) this.world.grass.count = Math.min(this.world.grass.count, 700);
+        this.hud.say('Qualidade reduzida para manter o galope fluido.', 3.4);
+    }
+
+    updateCamera(dt) {
+        const look = this.input.consumeLook();
+        this.lookYaw -= look.x * 0.0022;
+        this.lookPitch = clamp(this.lookPitch - look.y * 0.0018, CAMERA.pitchMin, CAMERA.pitchMax);
+        this.camDist = clamp(this.camDist + this.input.consumeZoom() * 0.45, 5.5, 22);
+
+        if (this.cameraMode === 0 && Math.hypot(this.input.move.x, this.input.move.z) > 0.12) {
+            this.lookYaw = damp(this.lookYaw, this.player.yaw, 1.6, dt);
+        }
+
+        const fovTarget = this.cameraMode === 1 ? CAMERA.cineFov
+            : this.cameraMode === 2 ? CAMERA.riderFov
+                : CAMERA.chaseFov;
+        this.camera.fov = damp(this.camera.fov, fovTarget, 8, dt);
+        this.camera.updateProjectionMatrix();
+
+        FWD.set(Math.sin(this.lookYaw), 0, Math.cos(this.lookYaw));
+        const origin = this.player.mesh.position;
+
+        if (this.cameraMode === 2) {
+            CAM.copy(origin).addScaledVector(FWD, 0.35);
+            CAM.y = origin.y + CAMERA.riderHeight;
+            LOOK.copy(origin).addScaledVector(FWD, 14);
+            LOOK.y = origin.y + 1.5 + Math.sin(this.lookPitch) * 4;
+        } else if (this.cameraMode === 1) {
+            const dist = this.camDist * 1.45;
+            CAM.copy(origin).addScaledVector(FWD, -dist);
+            CAM.y = origin.y + CAMERA.cineHeight + Math.sin(this.lookPitch) * 3;
+            LOOK.copy(origin);
+            LOOK.y = origin.y + 1.1;
+        } else {
+            CAM.copy(origin).addScaledVector(FWD, -this.camDist);
+            CAM.y = origin.y + CAMERA.chaseHeight + Math.sin(this.lookPitch) * 2.4;
+            LOOK.copy(origin);
+            LOOK.y = origin.y + CAMERA.chaseLook;
+        }
+
+        const ground = this.world.heightAt(CAM.x, CAM.z);
+        CAM.y = Math.max(CAM.y, ground + 1.35);
+
+        this.camera.position.lerp(CAM, 1 - Math.exp(-6.5 * dt));
+        this.camera.lookAt(LOOK);
+
+        this.lights.dir.target.position.copy(origin);
+        this.lights.dir.position.copy(origin).addScaledVector(this.skyUniforms.uSunDir.value, 96);
+    }
+
+    idleCamera(dt) {
+        const t = this.time * 0.07;
+        const s = this.spawn;
+        CAM.set(s.x + Math.cos(t) * 28, s.y + 11 + Math.sin(t * 0.6) * 2.5, s.z + 18 + Math.sin(t) * 16);
+        LOOK.set(s.x, s.y + 1.8, s.z);
+        this.camera.position.lerp(CAM, 1 - Math.exp(-1.4 * dt));
+        this.camera.lookAt(LOOK);
+        this.camera.fov = damp(this.camera.fov, 52, 3, dt);
+        this.camera.updateProjectionMatrix();
+        this.lights.dir.target.position.set(s.x, s.y, s.z);
+        this.lights.dir.position.set(s.x + 70, s.y + 48, s.z - 50);
+    }
+
+    applySky() {
+        const pal = sampleSkyPalette(this.state === 'play' ? this.hour : 0.72);
+        applySkyPalette(this.skyUniforms, pal);
+        this.scene.fog.color.copy(pal.fog);
+        this.lights.dir.color.copy(pal.light);
+        this.lights.dir.intensity = pal.lightIntensity;
+        this.lights.hemi.color.copy(pal.horizon);
+        this.lights.hemi.groundColor.copy(pal.ground);
+        this.lights.amb.color.copy(pal.ambient);
+        const night = pal.lightIntensity < 0.8 ? 0.22 : 0;
+        this.renderer.toneMappingExposure = 1.1 - night * 0.15;
+        if (this.bloom) this.bloom.strength = 0.16 + (this.hour > 0.7 && this.hour < 0.88 ? 0.16 : 0);
+        if (this.world.water?.material) {
+            this.world.water.material.color.set(0x1a3a3a).lerp(pal.horizon, 0.25);
+        }
+    }
+}
+
+const game = new Game();
+game.init().catch((err) => {
+    console.error(err);
+    game.hud.showError('Algo falhou ao abrir o oeste.');
+});

--- a/labs/rastro-vermelho/src/models.js
+++ b/labs/rastro-vermelho/src/models.js
@@ -1,0 +1,321 @@
+/**
+ * Modelos do faroeste: pinheiro, algodoeiro, cacto, rocha, cabana, saloon,
+ * carroça, fogueira, arco de pedra, veado. Tudo em primitivas — nenhum GLB.
+ */
+
+import * as THREE from 'three';
+import { barkTexture, canopyTexture, rockTexture, woodTexture, hideTexture } from './textures.js';
+
+const matCache = new Map();
+
+function mat(key, factory) {
+    if (!matCache.has(key)) matCache.set(key, factory());
+    return matCache.get(key);
+}
+
+export function std(color, roughness = 0.82, metalness = 0.04, extra = {}) {
+    return mat(`std:${color}:${roughness}:${metalness}:${JSON.stringify(extra)}`, () =>
+        new THREE.MeshStandardMaterial({ color, roughness, metalness, ...extra }));
+}
+
+function enableShadows(root) {
+    root.traverse((c) => {
+        if (c.isMesh) {
+            c.castShadow = true;
+            c.receiveShadow = true;
+        }
+    });
+}
+
+export function buildPine(rng = Math.random) {
+    const group = new THREE.Group();
+    const bark = new THREE.MeshStandardMaterial({
+        map: barkTexture(), color: 0x4a3828, roughness: 0.94
+    });
+    const needle = new THREE.MeshStandardMaterial({
+        map: canopyTexture(), color: 0x2a4a28, roughness: 0.82
+    });
+    const h = 7.5 + rng() * 5.5;
+    const trunk = new THREE.Mesh(new THREE.CylinderGeometry(0.16, 0.32, h, 7), bark);
+    trunk.position.y = h * 0.5;
+    group.add(trunk);
+    const layers = 4 + Math.floor(rng() * 2);
+    for (let i = 0; i < layers; i++) {
+        const t = i / layers;
+        const cone = new THREE.Mesh(
+            new THREE.ConeGeometry(1.8 - t * 1.15, 2.4 - t * 0.4, 7),
+            needle
+        );
+        cone.position.y = h * 0.38 + t * h * 0.55;
+        group.add(cone);
+    }
+    enableShadows(group);
+    return group;
+}
+
+export function buildCottonwood(rng = Math.random) {
+    const group = new THREE.Group();
+    const bark = new THREE.MeshStandardMaterial({
+        map: barkTexture(), color: 0x6a5840, roughness: 0.92
+    });
+    const leaf = new THREE.MeshStandardMaterial({
+        map: canopyTexture(), color: 0x6a8a38, roughness: 0.78
+    });
+    const h = 6.2 + rng() * 3.8;
+    const trunk = new THREE.Mesh(new THREE.CylinderGeometry(0.22, 0.38, h, 8), bark);
+    trunk.position.y = h * 0.5;
+    group.add(trunk);
+    const canopy = new THREE.Mesh(new THREE.SphereGeometry(2.1 + rng() * 0.7, 8, 6), leaf);
+    canopy.position.y = h * 0.88;
+    canopy.scale.set(1.35, 0.85, 1.2);
+    group.add(canopy);
+    const canopy2 = canopy.clone();
+    canopy2.position.set(0.7, h * 0.78, -0.4);
+    canopy2.scale.setScalar(0.7);
+    group.add(canopy2);
+    enableShadows(group);
+    return group;
+}
+
+export function buildCactus(rng = Math.random) {
+    const group = new THREE.Group();
+    const green = std(0x3a6a38, 0.7);
+    const h = 2.4 + rng() * 2.2;
+    const stem = new THREE.Mesh(new THREE.CylinderGeometry(0.22, 0.26, h, 8), green);
+    stem.position.y = h * 0.5;
+    group.add(stem);
+    const cap = new THREE.Mesh(new THREE.SphereGeometry(0.22, 8, 6), green);
+    cap.position.y = h;
+    group.add(cap);
+    if (rng() > 0.25) {
+        const arm = new THREE.Mesh(new THREE.CylinderGeometry(0.12, 0.14, 0.9, 6), green);
+        arm.rotation.z = Math.PI / 2;
+        arm.position.set(0.45, h * 0.55, 0);
+        group.add(arm);
+        const up = new THREE.Mesh(new THREE.CylinderGeometry(0.12, 0.12, 0.7, 6), green);
+        up.position.set(0.85, h * 0.55 + 0.28, 0);
+        group.add(up);
+    }
+    if (rng() > 0.55) {
+        const arm = new THREE.Mesh(new THREE.CylinderGeometry(0.1, 0.12, 0.7, 6), green);
+        arm.rotation.z = -Math.PI / 2;
+        arm.position.set(-0.35, h * 0.42, 0);
+        group.add(arm);
+        const up = new THREE.Mesh(new THREE.CylinderGeometry(0.1, 0.1, 0.5, 6), green);
+        up.position.set(-0.7, h * 0.42 + 0.2, 0);
+        group.add(up);
+    }
+    enableShadows(group);
+    return group;
+}
+
+export function buildRock(rng = Math.random) {
+    const group = new THREE.Group();
+    const matRock = new THREE.MeshStandardMaterial({
+        map: rockTexture(), color: 0xb07048, roughness: 0.92, flatShading: true
+    });
+    const n = 2 + Math.floor(rng() * 3);
+    for (let i = 0; i < n; i++) {
+        const m = new THREE.Mesh(new THREE.DodecahedronGeometry(0.55 + rng() * 0.9, 0), matRock);
+        m.position.set((rng() - 0.5) * 1.4, 0.25 + rng() * 0.2, (rng() - 0.5) * 1.4);
+        m.rotation.set(rng() * 1, rng() * 2, rng() * 1);
+        m.scale.set(0.8 + rng() * 0.8, 0.45 + rng() * 0.55, 0.8 + rng() * 0.7);
+        group.add(m);
+    }
+    enableShadows(group);
+    return group;
+}
+
+export function buildCabin() {
+    const group = new THREE.Group();
+    const wood = new THREE.MeshStandardMaterial({
+        map: woodTexture(), color: 0x8a5a32, roughness: 0.88
+    });
+    const dark = std(0x2a1a10, 0.9);
+    const body = new THREE.Mesh(new THREE.BoxGeometry(4.2, 2.4, 3.4), wood);
+    body.position.y = 1.2;
+    group.add(body);
+    const roof = new THREE.Mesh(new THREE.ConeGeometry(3.4, 1.6, 4), dark);
+    roof.position.y = 3.15;
+    roof.rotation.y = Math.PI / 4;
+    group.add(roof);
+    const door = new THREE.Mesh(new THREE.BoxGeometry(0.7, 1.4, 0.08), dark);
+    door.position.set(0, 0.7, 1.72);
+    group.add(door);
+    const porch = new THREE.Mesh(new THREE.BoxGeometry(4.4, 0.12, 1.1), wood);
+    porch.position.set(0, 0.12, 2.1);
+    group.add(porch);
+    enableShadows(group);
+    return group;
+}
+
+export function buildSaloon() {
+    const group = new THREE.Group();
+    const wood = new THREE.MeshStandardMaterial({
+        map: woodTexture(), color: 0x9a6840, roughness: 0.86
+    });
+    const paint = std(0x6a2a1a, 0.7);
+    const dark = std(0x1a120c, 0.9);
+    const body = new THREE.Mesh(new THREE.BoxGeometry(6.4, 3.4, 4.2), wood);
+    body.position.y = 1.7;
+    group.add(body);
+    const falseFront = new THREE.Mesh(new THREE.BoxGeometry(6.8, 2.2, 0.18), paint);
+    falseFront.position.set(0, 4.2, 2.15);
+    group.add(falseFront);
+    const roof = new THREE.Mesh(new THREE.BoxGeometry(6.5, 0.16, 4.4), dark);
+    roof.position.set(0, 3.5, 0);
+    roof.rotation.x = -0.08;
+    group.add(roof);
+    const door = new THREE.Mesh(new THREE.BoxGeometry(1.1, 1.8, 0.1), dark);
+    door.position.set(0, 0.9, 2.16);
+    group.add(door);
+    const rail = new THREE.Mesh(new THREE.BoxGeometry(6.6, 0.08, 0.08), std(0xc4a060, 0.4, 0.4));
+    rail.position.set(0, 1.15, 2.55);
+    group.add(rail);
+    enableShadows(group);
+    return group;
+}
+
+export function buildWagon() {
+    const group = new THREE.Group();
+    const wood = new THREE.MeshStandardMaterial({
+        map: woodTexture(), color: 0x7a4a28, roughness: 0.88
+    });
+    const iron = std(0x2a2420, 0.5, 0.4);
+    const bed = new THREE.Mesh(new THREE.BoxGeometry(1.6, 0.7, 3.2), wood);
+    bed.position.y = 0.95;
+    group.add(bed);
+    const canvas = new THREE.Mesh(
+        new THREE.CylinderGeometry(0.85, 0.85, 2.6, 8, 1, true, 0, Math.PI),
+        std(0xe8d8b8, 0.92)
+    );
+    canvas.rotation.z = Math.PI / 2;
+    canvas.position.y = 1.7;
+    group.add(canvas);
+    for (const z of [-1.05, 1.05]) {
+        for (const x of [-0.85, 0.85]) {
+            const w = new THREE.Mesh(new THREE.TorusGeometry(0.42, 0.08, 6, 12), iron);
+            w.position.set(x, 0.42, z);
+            w.rotation.y = Math.PI / 2;
+            group.add(w);
+        }
+    }
+    enableShadows(group);
+    return group;
+}
+
+export function buildCampfire() {
+    const group = new THREE.Group();
+    const logMat = new THREE.MeshStandardMaterial({
+        map: woodTexture(), color: 0x4a3020, roughness: 0.9
+    });
+    for (let i = 0; i < 5; i++) {
+        const log = new THREE.Mesh(new THREE.CylinderGeometry(0.08, 0.1, 1.1, 6), logMat);
+        log.rotation.z = Math.PI / 2;
+        log.rotation.y = (i / 5) * Math.PI;
+        log.position.y = 0.08;
+        group.add(log);
+    }
+    const flame = new THREE.Mesh(
+        new THREE.ConeGeometry(0.22, 0.7, 5),
+        new THREE.MeshStandardMaterial({
+            color: 0xff6a20, emissive: 0xff4010, emissiveIntensity: 1.4, roughness: 0.4
+        })
+    );
+    flame.position.y = 0.45;
+    flame.name = 'flame';
+    group.add(flame);
+    const light = new THREE.PointLight(0xff6a28, 1.6, 14, 1.6);
+    light.position.y = 0.7;
+    group.add(light);
+    enableShadows(group);
+    return group;
+}
+
+export function buildArch() {
+    const group = new THREE.Group();
+    const matRock = new THREE.MeshStandardMaterial({
+        map: rockTexture(), color: 0xc45a32, roughness: 0.9, flatShading: true
+    });
+    const left = new THREE.Mesh(new THREE.BoxGeometry(2.2, 9, 2.4), matRock);
+    left.position.set(-3.2, 4.5, 0);
+    const right = left.clone();
+    right.position.x = 3.2;
+    const top = new THREE.Mesh(new THREE.BoxGeometry(8.6, 2.4, 2.8), matRock);
+    top.position.set(0, 10.2, 0);
+    top.rotation.z = 0.08;
+    group.add(left, right, top);
+    enableShadows(group);
+    return group;
+}
+
+export function buildDeer() {
+    const group = new THREE.Group();
+    const hide = new THREE.MeshStandardMaterial({
+        map: hideTexture(), color: 0x8a5a32, roughness: 0.78
+    });
+    const dark = std(0x2a1a10, 0.8);
+    const body = new THREE.Mesh(new THREE.SphereGeometry(0.38, 8, 6), hide);
+    body.scale.set(0.85, 0.7, 1.55);
+    body.position.y = 0.85;
+    group.add(body);
+    const neck = new THREE.Mesh(new THREE.CylinderGeometry(0.1, 0.14, 0.45, 6), hide);
+    neck.position.set(0, 1.15, 0.42);
+    neck.rotation.x = 0.5;
+    group.add(neck);
+    const head = new THREE.Mesh(new THREE.SphereGeometry(0.16, 6, 6), hide);
+    head.scale.set(0.7, 0.7, 1.2);
+    head.position.set(0, 1.38, 0.62);
+    group.add(head);
+    for (const sx of [-1, 1]) {
+        const ant = new THREE.Mesh(new THREE.CylinderGeometry(0.015, 0.02, 0.35, 4), dark);
+        ant.position.set(sx * 0.08, 1.58, 0.55);
+        ant.rotation.z = sx * 0.35;
+        group.add(ant);
+    }
+    const legs = [];
+    const spots = [[-0.12, 0.28], [0.12, 0.28], [-0.12, -0.28], [0.12, -0.28]];
+    for (const [x, z] of spots) {
+        const leg = new THREE.Mesh(new THREE.CylinderGeometry(0.04, 0.05, 0.7, 5), hide);
+        leg.position.set(x, 0.35, z);
+        group.add(leg);
+        legs.push(leg);
+    }
+    enableShadows(group);
+    group.userData.legs = legs;
+    return group;
+}
+
+export function grassBladeGeometry() {
+    const geo = new THREE.PlaneGeometry(0.12, 0.55, 1, 2);
+    geo.translate(0, 0.275, 0);
+    return geo;
+}
+
+export function grassMaterial() {
+    const matGrass = new THREE.MeshStandardMaterial({
+        color: 0xc4a04a,
+        roughness: 0.92,
+        side: THREE.DoubleSide,
+        vertexColors: false
+    });
+    matGrass.onBeforeCompile = (shader) => {
+        shader.uniforms.uTime = { value: 0 };
+        shader.vertexShader = `uniform float uTime;\n${shader.vertexShader}`;
+        shader.vertexShader = shader.vertexShader.replace(
+            '#include <begin_vertex>',
+            `#include <begin_vertex>
+             transformed.x += sin(uTime * 1.35 + transformed.y * 4.0 + position.z) * 0.14 * transformed.y;`
+        );
+        matGrass.userData.shader = shader;
+    };
+    return matGrass;
+}
+
+export function disposeUnique(root) {
+    root.traverse((c) => {
+        if (c.isMesh && c.geometry && c.geometry.userData?.unique) {
+            c.geometry.dispose();
+        }
+    });
+}

--- a/labs/rastro-vermelho/src/sky.js
+++ b/labs/rastro-vermelho/src/sky.js
@@ -1,0 +1,223 @@
+/**
+ * Céu cinematográfico: gradiente, disco solar, halo, nuvens em fBm e estrelas.
+ * O mesmo `sfSky(dir)` pinta o horizonte do faroeste o dia inteiro.
+ */
+
+import * as THREE from 'three';
+import { SKY_STOPS } from './config.js';
+
+export const SKY_GLSL = /* glsl */ `
+uniform vec3 uZenith;
+uniform vec3 uHorizon;
+uniform vec3 uGround;
+uniform vec3 uSunColor;
+uniform vec3 uSunDir;
+uniform float uSunPower;
+
+vec3 sfSky(vec3 dir) {
+    float h = dir.y;
+    float t = clamp(h * 1.15 + 0.08, 0.0, 1.0);
+    vec3 col = mix(uHorizon, uZenith, pow(t, 0.55));
+    col = mix(uGround, col, smoothstep(-0.12, 0.04, h));
+
+    float sd = max(dot(normalize(dir), uSunDir), 0.0);
+    col += uSunColor * pow(sd, 3.0) * 0.18;
+    col += uSunColor * pow(sd, 28.0) * 0.45;
+    col += uSunColor * pow(sd, 220.0) * 0.85;
+    col += uSunColor * smoothstep(0.9992, 0.99982, sd) * uSunPower;
+    return col;
+}
+`;
+
+export const NOISE_GLSL = /* glsl */ `
+float sfHash(vec2 p) {
+    p = fract(p * vec2(123.34, 456.21));
+    p += dot(p, p + 45.32);
+    return fract(p.x * p.y);
+}
+
+float sfValueNoise(vec2 p) {
+    vec2 i = floor(p);
+    vec2 f = fract(p);
+    f = f * f * (3.0 - 2.0 * f);
+    float a = sfHash(i);
+    float b = sfHash(i + vec2(1.0, 0.0));
+    float c = sfHash(i + vec2(0.0, 1.0));
+    float d = sfHash(i + vec2(1.0, 1.0));
+    return mix(mix(a, b, f.x), mix(c, d, f.x), f.y);
+}
+
+float sfFbm(vec2 p) {
+    float v = 0.0;
+    float amp = 0.5;
+    for (int i = 0; i < 5; i++) {
+        v += amp * sfValueNoise(p);
+        p = p * 2.03 + 17.3;
+        amp *= 0.5;
+    }
+    return v;
+}
+`;
+
+export function createSkyUniforms() {
+    const stop = SKY_STOPS[2];
+    return {
+        uZenith: { value: new THREE.Color().fromArray(stop.zenith) },
+        uHorizon: { value: new THREE.Color().fromArray(stop.horizon) },
+        uGround: { value: new THREE.Color().fromArray(stop.ground) },
+        uSunColor: { value: new THREE.Color().fromArray(stop.sun) },
+        uSunDir: { value: new THREE.Vector3().fromArray(stop.sunDir).normalize() },
+        uSunPower: { value: 26 }
+    };
+}
+
+const tmpA = new THREE.Color();
+const tmpB = new THREE.Color();
+const tmpVA = new THREE.Vector3();
+const tmpVB = new THREE.Vector3();
+
+const paletteOut = {
+    zenith: new THREE.Color(),
+    horizon: new THREE.Color(),
+    ground: new THREE.Color(),
+    sun: new THREE.Color(),
+    fog: new THREE.Color(),
+    light: new THREE.Color(),
+    ambient: new THREE.Color(),
+    sunDir: new THREE.Vector3(),
+    lightIntensity: 2
+};
+
+export function sampleSkyPalette(progress) {
+    const p = Math.max(0, Math.min(1, progress));
+    let a = SKY_STOPS[0];
+    let b = SKY_STOPS[SKY_STOPS.length - 1];
+    for (let i = 0; i < SKY_STOPS.length - 1; i++) {
+        if (p >= SKY_STOPS[i].at && p <= SKY_STOPS[i + 1].at) {
+            a = SKY_STOPS[i];
+            b = SKY_STOPS[i + 1];
+            break;
+        }
+    }
+    const t = Math.max(0, Math.min(1, (p - a.at) / Math.max(1e-5, b.at - a.at)));
+    const lerpColor = (key, out) => {
+        tmpA.fromArray(a[key]);
+        tmpB.fromArray(b[key]);
+        out.copy(tmpA).lerp(tmpB, t);
+    };
+    lerpColor('zenith', paletteOut.zenith);
+    lerpColor('horizon', paletteOut.horizon);
+    lerpColor('ground', paletteOut.ground);
+    lerpColor('sun', paletteOut.sun);
+    lerpColor('fog', paletteOut.fog);
+    lerpColor('light', paletteOut.light);
+    lerpColor('ambient', paletteOut.ambient);
+    tmpVA.fromArray(a.sunDir);
+    tmpVB.fromArray(b.sunDir);
+    paletteOut.sunDir.copy(tmpVA).lerp(tmpVB, t).normalize();
+    paletteOut.lightIntensity = a.lightIntensity + (b.lightIntensity - a.lightIntensity) * t;
+    return paletteOut;
+}
+
+export function applySkyPalette(uniforms, palette) {
+    uniforms.uZenith.value.copy(palette.zenith);
+    uniforms.uHorizon.value.copy(palette.horizon);
+    uniforms.uGround.value.copy(palette.ground);
+    uniforms.uSunColor.value.copy(palette.sun);
+    uniforms.uSunDir.value.copy(palette.sunDir);
+}
+
+export function createSky(uniforms) {
+    const material = new THREE.ShaderMaterial({
+        side: THREE.BackSide,
+        depthWrite: false,
+        fog: false,
+        uniforms: {
+            ...uniforms,
+            uTime: { value: 0 },
+            uCloud: { value: 0.52 }
+        },
+        vertexShader: /* glsl */ `
+            varying vec3 vDir;
+            void main() {
+                vDir = position;
+                vec4 mvPosition = modelViewMatrix * vec4(position, 1.0);
+                gl_Position = projectionMatrix * mvPosition;
+                gl_Position.z = gl_Position.w;
+            }
+        `,
+        fragmentShader: /* glsl */ `
+            varying vec3 vDir;
+            uniform float uTime;
+            uniform float uCloud;
+            ${SKY_GLSL}
+            ${NOISE_GLSL}
+            void main() {
+                vec3 dir = normalize(vDir);
+                vec3 col = sfSky(dir);
+
+                float up = max(dir.y, 0.02);
+                vec2 cp = dir.xz / up;
+                vec2 drift = vec2(uTime * 0.0048, uTime * 0.0016);
+                float clouds = sfFbm(cp * 0.42 + drift);
+                float wisps = sfFbm(cp * 1.05 + drift * 1.3 + 9.1);
+                clouds = smoothstep(0.42, 0.90, clouds) * uCloud;
+                clouds += smoothstep(0.58, 0.96, wisps) * uCloud * 0.32;
+                clouds *= smoothstep(0.0, 0.16, dir.y);
+                clouds = clamp(clouds, 0.0, 1.0);
+
+                float sunFacing = max(dot(dir, uSunDir), 0.0);
+                vec3 cloudLit = mix(uHorizon * 0.9, uSunColor, pow(sunFacing, 1.6) * 0.85);
+                vec3 cloudShadow = mix(uZenith * 0.65, uHorizon * 0.4, 0.45);
+                vec3 cloudCol = mix(cloudShadow, cloudLit, clamp(clouds * 1.5, 0.0, 1.0));
+                col = mix(col, cloudCol, clouds * 0.82);
+
+                float night = clamp(1.0 - length(uHorizon) * 0.85, 0.0, 1.0);
+                float stars = step(0.9978, sfHash(floor(dir.xz * 380.0 / max(dir.y, 0.22))));
+                col += vec3(1.0, 0.92, 0.78) * stars * night * smoothstep(0.12, 0.55, dir.y);
+
+                gl_FragColor = vec4(col, 1.0);
+                #include <tonemapping_fragment>
+                #include <colorspace_fragment>
+            }
+        `
+    });
+
+    const mesh = new THREE.Mesh(new THREE.SphereGeometry(1, 48, 32), material);
+    mesh.scale.setScalar(4800);
+    mesh.frustumCulled = false;
+    mesh.renderOrder = -1000;
+    mesh.name = 'sky';
+    return mesh;
+}
+
+export function createLights(scene, quality) {
+    const group = new THREE.Group();
+    scene.add(group);
+
+    const amb = new THREE.AmbientLight(0xc8a070, 0.42);
+    group.add(amb);
+
+    const hemi = new THREE.HemisphereLight(0xffd8a0, 0x6a4428, 0.85);
+    group.add(hemi);
+
+    const dir = new THREE.DirectionalLight(0xffe0a0, 2.05);
+    dir.position.set(80, 42, -64);
+    dir.castShadow = quality.shadows;
+    if (quality.shadows) {
+        dir.shadow.mapSize.set(quality.shadowSize, quality.shadowSize);
+        const s = 78;
+        dir.shadow.camera.left = -s;
+        dir.shadow.camera.right = s;
+        dir.shadow.camera.top = s;
+        dir.shadow.camera.bottom = -s;
+        dir.shadow.camera.near = 8;
+        dir.shadow.camera.far = 260;
+        dir.shadow.bias = -0.0007;
+        dir.shadow.normalBias = 0.04;
+    }
+    group.add(dir);
+    group.add(dir.target);
+
+    return { group, dir, hemi, amb };
+}

--- a/labs/rastro-vermelho/src/textures.js
+++ b/labs/rastro-vermelho/src/textures.js
@@ -1,0 +1,170 @@
+/**
+ * Texturas procedurais em canvas — o lab não usa PNG externos.
+ */
+
+import * as THREE from 'three';
+
+const cache = new Map();
+
+function canvas(size, height = size) {
+    const el = document.createElement('canvas');
+    el.width = size;
+    el.height = height;
+    return el;
+}
+
+function toTexture(el, { repeat = [1, 1], srgb = true, aniso = 4 } = {}) {
+    const tex = new THREE.CanvasTexture(el);
+    tex.wrapS = tex.wrapT = THREE.RepeatWrapping;
+    tex.repeat.set(repeat[0], repeat[1]);
+    tex.anisotropy = aniso;
+    if (srgb) tex.colorSpace = THREE.SRGBColorSpace;
+    tex.needsUpdate = true;
+    return tex;
+}
+
+function cached(key, factory) {
+    if (!cache.has(key)) cache.set(key, factory());
+    return cache.get(key);
+}
+
+function noise2(x, y, seed = 0) {
+    const n = Math.sin(x * 127.1 + y * 311.7 + seed * 74.7) * 43758.5453;
+    return n - Math.floor(n);
+}
+
+function grain(ctx, w, h, amount, seed = 0) {
+    const img = ctx.getImageData(0, 0, w, h);
+    const data = img.data;
+    for (let i = 0, p = 0; i < data.length; i += 4, p++) {
+        const x = p % w;
+        const y = (p / w) | 0;
+        const n = (noise2(x, y, seed) - 0.5) * amount;
+        data[i] = Math.max(0, Math.min(255, data[i] + n));
+        data[i + 1] = Math.max(0, Math.min(255, data[i + 1] + n));
+        data[i + 2] = Math.max(0, Math.min(255, data[i + 2] + n));
+    }
+    ctx.putImageData(img, 0, 0);
+}
+
+export function dirtTexture() {
+    return cached('dirt', () => {
+        const size = 512;
+        const el = canvas(size);
+        const ctx = el.getContext('2d');
+        ctx.fillStyle = '#a87848';
+        ctx.fillRect(0, 0, size, size);
+        for (let i = 0; i < 220; i++) {
+            const x = noise2(i, 2.1) * size;
+            const y = noise2(i, 8.4) * size;
+            const r = 16 + noise2(i, 3.3) * 80;
+            const grd = ctx.createRadialGradient(x, y, 0, x, y, r);
+            const warm = noise2(i, 11) > 0.5;
+            grd.addColorStop(0, warm ? 'rgba(140, 62, 28, 0.38)' : 'rgba(72, 96, 40, 0.22)');
+            grd.addColorStop(1, 'rgba(168, 120, 72, 0)');
+            ctx.fillStyle = grd;
+            ctx.beginPath();
+            ctx.arc(x, y, r, 0, Math.PI * 2);
+            ctx.fill();
+        }
+        ctx.strokeStyle = 'rgba(80, 48, 22, 0.14)';
+        ctx.lineWidth = 1;
+        for (let i = 0; i < 380; i++) {
+            const x = noise2(i, 21) * size;
+            const y = noise2(i, 44) * size;
+            ctx.beginPath();
+            ctx.moveTo(x, y);
+            ctx.lineTo(x + (noise2(i, 7) - 0.5) * 16, y + 8 + noise2(i, 9) * 12);
+            ctx.stroke();
+        }
+        grain(ctx, size, size, 28, 4);
+        return toTexture(el, { repeat: [18, 18] });
+    });
+}
+
+export function barkTexture() {
+    return cached('bark', () => {
+        const size = 256;
+        const el = canvas(size);
+        const ctx = el.getContext('2d');
+        ctx.fillStyle = '#4a3220';
+        ctx.fillRect(0, 0, size, size);
+        for (let x = 0; x < size; x += 4) {
+            ctx.strokeStyle = `rgba(20, 12, 8, ${0.15 + noise2(x, 2) * 0.35})`;
+            ctx.beginPath();
+            ctx.moveTo(x + noise2(x, 1) * 3, 0);
+            ctx.lineTo(x + noise2(x, 3) * 6, size);
+            ctx.stroke();
+        }
+        grain(ctx, size, size, 22, 8);
+        return toTexture(el, { repeat: [1, 2] });
+    });
+}
+
+export function rockTexture() {
+    return cached('rock', () => {
+        const size = 256;
+        const el = canvas(size);
+        const ctx = el.getContext('2d');
+        ctx.fillStyle = '#8a5a3a';
+        ctx.fillRect(0, 0, size, size);
+        for (let i = 0; i < 80; i++) {
+            ctx.fillStyle = `rgba(${90 + noise2(i, 1) * 80}, ${50 + noise2(i, 2) * 40}, ${30 + noise2(i, 3) * 20}, 0.35)`;
+            ctx.beginPath();
+            ctx.ellipse(
+                noise2(i, 4) * size, noise2(i, 5) * size,
+                8 + noise2(i, 6) * 28, 6 + noise2(i, 7) * 18,
+                noise2(i, 8) * 6, 0, Math.PI * 2
+            );
+            ctx.fill();
+        }
+        grain(ctx, size, size, 36, 12);
+        return toTexture(el, { repeat: [2, 2] });
+    });
+}
+
+export function woodTexture() {
+    return cached('wood', () => {
+        const size = 256;
+        const el = canvas(size);
+        const ctx = el.getContext('2d');
+        ctx.fillStyle = '#6a4428';
+        ctx.fillRect(0, 0, size, size);
+        for (let y = 0; y < size; y += 7) {
+            ctx.fillStyle = `rgba(40, 22, 10, ${0.12 + noise2(y, 2) * 0.25})`;
+            ctx.fillRect(0, y, size, 3 + noise2(y, 3) * 3);
+        }
+        grain(ctx, size, size, 18, 5);
+        return toTexture(el, { repeat: [2, 2] });
+    });
+}
+
+export function canopyTexture() {
+    return cached('canopy', () => {
+        const size = 256;
+        const el = canvas(size);
+        const ctx = el.getContext('2d');
+        ctx.fillStyle = '#3a5a28';
+        ctx.fillRect(0, 0, size, size);
+        for (let i = 0; i < 120; i++) {
+            ctx.fillStyle = `rgba(${40 + noise2(i, 1) * 50}, ${80 + noise2(i, 2) * 70}, ${20 + noise2(i, 3) * 20}, 0.45)`;
+            ctx.beginPath();
+            ctx.arc(noise2(i, 4) * size, noise2(i, 5) * size, 8 + noise2(i, 6) * 18, 0, Math.PI * 2);
+            ctx.fill();
+        }
+        grain(ctx, size, size, 20, 2);
+        return toTexture(el);
+    });
+}
+
+export function hideTexture() {
+    return cached('hide', () => {
+        const size = 128;
+        const el = canvas(size);
+        const ctx = el.getContext('2d');
+        ctx.fillStyle = '#6a3c1e';
+        ctx.fillRect(0, 0, size, size);
+        grain(ctx, size, size, 40, 9);
+        return toTexture(el);
+    });
+}

--- a/labs/rastro-vermelho/src/utils.js
+++ b/labs/rastro-vermelho/src/utils.js
@@ -1,0 +1,145 @@
+/** Utilitários numéricos, ruído e detecção de dispositivo. */
+
+export const clamp = (v, min, max) => (v < min ? min : v > max ? max : v);
+export const lerp = (a, b, t) => a + (b - a) * t;
+export const damp = (current, target, lambda, dt) =>
+    lerp(current, target, 1 - Math.exp(-lambda * dt));
+
+export const smoothstep = (edge0, edge1, x) => {
+    const t = clamp((x - edge0) / (edge1 - edge0), 0, 1);
+    return t * t * (3 - 2 * t);
+};
+
+export const wrapPi = (a) => {
+    let v = a;
+    while (v > Math.PI) v -= Math.PI * 2;
+    while (v < -Math.PI) v += Math.PI * 2;
+    return v;
+};
+
+export const wrap01 = (t) => {
+    let v = t % 1;
+    if (v < 0) v += 1;
+    return v;
+};
+
+export function formatTime(seconds) {
+    const s = Math.max(0, Math.floor(seconds));
+    const m = Math.floor(s / 60);
+    return `${m}:${String(s % 60).padStart(2, '0')}`;
+}
+
+/** Relógio de 24h a partir de progresso do dia ∈ [0, 1]. */
+export function formatClock(dayT) {
+    const totalMin = Math.floor(((dayT % 1) + 1) % 1 * 24 * 60);
+    const h = Math.floor(totalMin / 60) % 24;
+    const m = totalMin % 60;
+    return `${h}:${String(m).padStart(2, '0')}`;
+}
+
+export function formatKm(meters) {
+    if (meters < 1000) return `${Math.round(meters)} m`;
+    return `${(meters / 1000).toFixed(meters < 10000 ? 2 : 1)} km`;
+}
+
+/** Hash 2D determinístico em [0, 1). */
+export function hash2(x, y, seed = 0) {
+    const n = Math.sin(x * 127.1 + y * 311.7 + seed * 74.7) * 43758.5453;
+    return n - Math.floor(n);
+}
+
+export function valueNoise(x, y, seed = 0) {
+    const x0 = Math.floor(x);
+    const y0 = Math.floor(y);
+    const fx = x - x0;
+    const fy = y - y0;
+    const sx = fx * fx * (3 - 2 * fx);
+    const sy = fy * fy * (3 - 2 * fy);
+    const a = hash2(x0, y0, seed);
+    const b = hash2(x0 + 1, y0, seed);
+    const c = hash2(x0, y0 + 1, seed);
+    const d = hash2(x0 + 1, y0 + 1, seed);
+    return lerp(lerp(a, b, sx), lerp(c, d, sx), sy);
+}
+
+export function fbm(x, y, seed = 0, octaves = 4) {
+    let sum = 0;
+    let amp = 0.5;
+    let freq = 1;
+    for (let i = 0; i < octaves; i++) {
+        sum += valueNoise(x * freq, y * freq, seed + i * 19) * amp;
+        amp *= 0.5;
+        freq *= 2.03;
+    }
+    return sum;
+}
+
+/** Ruído de crista: 1 − |2n − 1|, bom para serras e cânions. */
+export function ridged(x, y, seed = 0, octaves = 4) {
+    let sum = 0;
+    let amp = 0.5;
+    let freq = 1;
+    for (let i = 0; i < octaves; i++) {
+        const n = 1 - Math.abs(valueNoise(x * freq, y * freq, seed + i * 19) * 2 - 1);
+        sum += n * amp;
+        amp *= 0.5;
+        freq *= 2.07;
+    }
+    return sum;
+}
+
+export function seeded(seed) {
+    let s = seed >>> 0;
+    return () => {
+        s = (s * 1664525 + 1013904223) >>> 0;
+        return s / 4294967296;
+    };
+}
+
+export function detectMobile() {
+    if (typeof navigator === 'undefined') return false;
+    const coarse = window.matchMedia?.('(pointer: coarse)')?.matches;
+    const narrow = Math.min(window.innerWidth, window.innerHeight) < 760;
+    return Boolean(coarse && narrow) || /Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
+}
+
+const SOFTWARE_GL = /swiftshader|llvmpipe|softpipe|microsoft basic render|\bcpu\b|software/i;
+
+export function isSoftwareGLName(name) {
+    return SOFTWARE_GL.test(String(name || ''));
+}
+
+export function detectSoftwareGL() {
+    try {
+        const canvas = document.createElement('canvas');
+        const gl = canvas.getContext('webgl2') || canvas.getContext('webgl');
+        if (!gl) return true;
+        const info = gl.getExtension('WEBGL_debug_renderer_info');
+        const name = info ? String(gl.getParameter(info.UNMASKED_RENDERER_WEBGL) || '') : '';
+        return isSoftwareGLName(name);
+    } catch (err) {
+        return true;
+    }
+}
+
+export function rendererIsSoftware(renderer) {
+    try {
+        const gl = renderer.getContext();
+        const info = gl.getExtension('WEBGL_debug_renderer_info');
+        const name = info ? String(gl.getParameter(info.UNMASKED_RENDERER_WEBGL) || '') : '';
+        return isSoftwareGLName(name);
+    } catch (err) {
+        return false;
+    }
+}
+
+export function hourLabel(t) {
+    if (t < 0.08) return 'madrugada';
+    if (t < 0.16) return 'alvorada';
+    if (t < 0.32) return 'manhã';
+    if (t < 0.55) return 'meio-dia';
+    if (t < 0.70) return 'tarde';
+    if (t < 0.84) return 'hora dourada';
+    if (t < 0.93) return 'crepúsculo';
+    return 'noite';
+}

--- a/labs/rastro-vermelho/src/wildlife.js
+++ b/labs/rastro-vermelho/src/wildlife.js
@@ -1,0 +1,107 @@
+/**
+ * Vida selvagem: veados que pastam e fogem, águias em círculos altos.
+ */
+
+import * as THREE from 'three';
+import { buildDeer } from './models.js';
+import { heightAt, biomeAt } from './world.js';
+import { WATER_Y } from './config.js';
+import { hash2, wrapPi } from './utils.js';
+
+export class Wildlife {
+    constructor(scene, world, quality) {
+        this.scene = scene;
+        this.world = world;
+        this.group = new THREE.Group();
+        scene.add(this.group);
+        this.deer = [];
+        this.birds = [];
+        this.herdAnnounced = false;
+
+        const n = quality.wildlife;
+        for (let i = 0; i < n; i++) {
+            const mesh = buildDeer();
+            const a = hash2(i, 2, 8) * Math.PI * 2;
+            const r = 30 + hash2(i, 5, 9) * 90;
+            mesh.position.set(Math.cos(a) * r, 0, Math.sin(a) * r);
+            this.group.add(mesh);
+            this.deer.push({
+                mesh,
+                x: mesh.position.x,
+                z: mesh.position.z,
+                yaw: a,
+                speed: 1.4 + hash2(i, 7, 3) * 1.2,
+                phase: hash2(i, 1, 4) * 10,
+                flee: 0
+            });
+        }
+
+        const birdGeo = new THREE.ConeGeometry(0.14, 0.7, 4);
+        const birdMat = new THREE.MeshStandardMaterial({
+            color: 0x2a2218, roughness: 0.7, flatShading: true
+        });
+        for (let i = 0; i < quality.birds; i++) {
+            const m = new THREE.Mesh(birdGeo, birdMat);
+            m.rotation.x = Math.PI;
+            const g = new THREE.Group();
+            g.add(m);
+            this.group.add(g);
+            this.birds.push({
+                mesh: g,
+                radius: 18 + hash2(i, 3, 11) * 28,
+                height: 16 + hash2(i, 6, 12) * 14,
+                speed: 0.22 + hash2(i, 8, 13) * 0.18,
+                offset: hash2(i, 4, 14) * Math.PI * 2
+            });
+        }
+    }
+
+    update(dt, player, time) {
+        let nearHerd = false;
+        for (const d of this.deer) {
+            const dist = Math.hypot(d.x - player.x, d.z - player.z);
+            if (dist < 22) nearHerd = true;
+            if (dist > 220) {
+                const a = Math.atan2(player.x - d.x, player.z - d.z) + Math.PI;
+                d.x = player.x + Math.sin(a) * 90;
+                d.z = player.z + Math.cos(a) * 90;
+            }
+            if (dist < 16) d.flee = 2.8;
+            d.flee = Math.max(0, d.flee - dt);
+
+            const targetSpeed = d.flee > 0 ? 9.5 : d.speed;
+            const turn = d.flee > 0
+                ? Math.atan2(d.x - player.x, d.z - player.z)
+                : d.yaw + Math.sin(time * 0.3 + d.phase) * 0.4;
+            d.yaw = wrapPi(d.yaw + wrapPi(turn - d.yaw) * dt * (d.flee > 0 ? 3.2 : 0.8));
+            d.x += Math.sin(d.yaw) * targetSpeed * dt;
+            d.z += Math.cos(d.yaw) * targetSpeed * dt;
+            let y = heightAt(d.x, d.z);
+            if (y < WATER_Y + 0.4) {
+                d.yaw += 0.8;
+                y = WATER_Y + 0.4;
+            }
+            d.phase += targetSpeed * dt * 4;
+            const gait = Math.sin(d.phase);
+            const legs = d.mesh.userData.legs || [];
+            if (legs[0]) legs[0].rotation.x = gait * 0.55;
+            if (legs[1]) legs[1].rotation.x = -gait * 0.55;
+            if (legs[2]) legs[2].rotation.x = -gait * 0.55;
+            if (legs[3]) legs[3].rotation.x = gait * 0.55;
+            d.mesh.position.set(d.x, y, d.z);
+            d.mesh.rotation.y = d.yaw;
+        }
+
+        for (const b of this.birds) {
+            const t = time * b.speed + b.offset;
+            const x = player.x + Math.cos(t) * b.radius;
+            const z = player.z + Math.sin(t) * b.radius;
+            const y = heightAt(player.x, player.z) + b.height + Math.sin(t * 2) * 1.4;
+            b.mesh.position.set(x, y, z);
+            b.mesh.rotation.y = -t + Math.PI / 2;
+            b.mesh.children[0].rotation.z = Math.sin(time * 8 + b.offset) * 0.35;
+        }
+
+        return nearHerd && biomeAt(player.x, player.z) === 'prairie';
+    }
+}

--- a/labs/rastro-vermelho/src/world.js
+++ b/labs/rastro-vermelho/src/world.js
@@ -4,12 +4,13 @@
  * Altura h(x, z):
  *   continent = fBm(x·0.00105, z·0.00105) ^ 1.55           → serras longas
  *   ridge     = ridged(x·0.0022, z·0.0022) ^ 2.1            → cristas
- *   hills     = (fBm(x·0.008, z·0.008) − 0.45) · 8
- *   detail    = (fBm(x·0.034, z·0.034) − 0.5) · 1.7
+ *   hills     = (fBm(x·0.0065, z·0.0065) − 0.38) · 14
+ *   rolling   = fBm(x·0.0026, z·0.0026) ^ 1.25 · 20         → lombadas
+ *   detail    = (fBm(x·0.034, z·0.034) − 0.5) · 2.1
  *   river     = |sin(warpX·0.004) · cos(warpZ·0.003)|        → talvegue
  *   carve     = (1 − smoothstep(0.02, 0.16, river))^2 · 15
  *   canyon    = −(1 − |2n−1|)^3 · 20 · máscara árida
- *   h         = continent·58 + ridge·continent·36 + hills + detail + canyon − carve
+ *   h         = continent·72 + ridge·continent·42 + hills + rolling + detail + canyon − carve
  *   mesa      = achata 14 < h < 32 onde arid > 0.62
  *
  * Bioma: alpine / pine / prairie / desert / mesa / canyon / riparian.
@@ -31,11 +32,12 @@ export function aridAt(x, z) {
 }
 
 export function heightAt(x, z) {
-    const continent = Math.pow(fbm(x * 0.00105, z * 0.00105, 1, 5), 1.55);
+    const continent = Math.pow(fbm(x * 0.00105, z * 0.00105, 1, 5), 1.22);
     const ridge = Math.pow(ridged(x * 0.0022, z * 0.0022, 11, 4), 2.1);
-    const mountains = continent * 58 + ridge * continent * 36;
-    const hills = (fbm(x * 0.008, z * 0.008, 3, 4) - 0.45) * 8;
-    const detail = (fbm(x * 0.034, z * 0.034, 9, 3) - 0.5) * 1.7;
+    const mountains = continent * 72 + ridge * continent * 42;
+    const hills = (fbm(x * 0.0065, z * 0.0065, 3, 5) - 0.38) * 14;
+    const rolling = Math.pow(fbm(x * 0.0026, z * 0.0026, 15, 4), 1.25) * 20;
+    const detail = (fbm(x * 0.034, z * 0.034, 9, 3) - 0.5) * 2.1;
 
     const warpX = x + (fbm(x * 0.002, z * 0.002, 21, 3) - 0.5) * 180;
     const warpZ = z + (fbm(x * 0.002, z * 0.002, 27, 3) - 0.5) * 180;
@@ -47,7 +49,7 @@ export function heightAt(x, z) {
     const nCan = ridged(x * 0.0062, z * 0.0062, 33, 3);
     const canyon = -Math.pow(nCan, 3) * 20 * canyonMask;
 
-    let h = mountains + hills + detail + canyon - carve;
+    let h = mountains + hills + rolling + detail + canyon - carve;
     if (arid > 0.62 && h > 14 && h < 32) {
         h = lerp(h, 18 + (h - 18) * 0.18, smoothstep(0.62, 0.8, arid));
     }
@@ -155,6 +157,7 @@ export class World {
         });
 
         this.addWater();
+        this.addHorizon();
         this.scatterGrass();
     }
 
@@ -172,6 +175,48 @@ export class World {
         this.water.position.y = WATER_Y;
         this.water.receiveShadow = true;
         this.group.add(this.water);
+    }
+
+    /**
+     * Silhuetas de serra no horizonte — acompanham o cavalo para o oeste
+     * nunca parecer uma mesa infinita.
+     */
+    addHorizon() {
+        this.peaks = [];
+        const rock = new THREE.MeshStandardMaterial({
+            color: 0x6a3a28,
+            roughness: 0.96,
+            flatShading: true
+        });
+        const snow = new THREE.MeshStandardMaterial({
+            color: 0xd8d0c4,
+            roughness: 0.88,
+            flatShading: true
+        });
+        for (let i = 0; i < 16; i++) {
+            const g = new THREE.Group();
+            const n = 2 + (i % 3);
+            for (let k = 0; k < n; k++) {
+                const h = 28 + hash2(i, k, 4) * 48;
+                const r = 10 + hash2(i, k, 8) * 16;
+                const cone = new THREE.Mesh(new THREE.ConeGeometry(r, h, 5), k === 0 && h > 52 ? snow : rock);
+                cone.position.set((k - 1) * r * 1.1, h * 0.5, (hash2(i, k, 2) - 0.5) * 12);
+                cone.rotation.y = hash2(i, k, 11) * 6;
+                g.add(cone);
+            }
+            g.traverse((c) => {
+                if (c.isMesh) {
+                    c.castShadow = false;
+                    c.receiveShadow = false;
+                }
+            });
+            this.group.add(g);
+            this.peaks.push({
+                group: g,
+                angle: (i / 16) * Math.PI * 2,
+                dist: 260 + hash2(i, 1, 19) * 90
+            });
+        }
     }
 
     scatterGrass() {
@@ -416,6 +461,7 @@ export class World {
         this.water.position.x = player.x;
         this.water.position.z = player.z;
         this.refreshGrass(player.x, player.z);
+        this.updateHorizon(player);
 
         if (this.grassMat.userData.shader) {
             this.grassMat.userData.shader.uniforms.uTime.value = time;
@@ -427,6 +473,17 @@ export class World {
                 c.rotation.y += dt * 2.4;
             }
         });
+    }
+
+    updateHorizon(player) {
+        if (!this.peaks) return;
+        for (const p of this.peaks) {
+            const x = player.x + Math.cos(p.angle) * p.dist;
+            const z = player.z + Math.sin(p.angle) * p.dist;
+            const y = heightAt(x, z);
+            p.group.position.set(x, Math.max(y - 6, 2), z);
+            p.group.rotation.y = p.angle;
+        }
     }
 
     collide(x, z, radius) {
@@ -466,15 +523,22 @@ export class World {
     }
 
     findSpawn() {
-        for (let i = 0; i < 80; i++) {
+        for (let i = 0; i < 100; i++) {
             const a = hash2(i, 4, 5) * Math.PI * 2;
-            const r = 20 + hash2(i, 9, 6) * 80;
+            const r = 18 + hash2(i, 9, 6) * 90;
             const x = Math.cos(a) * r;
             const z = Math.sin(a) * r;
             const y = heightAt(x, z);
             const b = biomeAt(x, z, y);
-            const slope = Math.abs(heightAt(x + 3, z) - y);
-            if (y > WATER_Y + 1.5 && y < 22 && slope < 2.5 && (b === 'prairie' || b === 'desert')) {
+            const slope = Math.abs(heightAt(x + 4, z) - y) + Math.abs(heightAt(x, z + 4) - y);
+            const horizon = Math.max(
+                heightAt(x + 80, z),
+                heightAt(x - 80, z),
+                heightAt(x, z + 80),
+                heightAt(x, z - 80)
+            );
+            if (y > WATER_Y + 1.8 && y < 26 && slope < 5 && horizon > y + 10
+                && (b === 'prairie' || b === 'desert' || b === 'mesa')) {
                 return { x, z, yaw: a + Math.PI, y };
             }
         }

--- a/labs/rastro-vermelho/src/world.js
+++ b/labs/rastro-vermelho/src/world.js
@@ -1,0 +1,483 @@
+/**
+ * Mundo infinito em chunks.
+ *
+ * Altura h(x, z):
+ *   continent = fBm(x·0.00105, z·0.00105) ^ 1.55           → serras longas
+ *   ridge     = ridged(x·0.0022, z·0.0022) ^ 2.1            → cristas
+ *   hills     = (fBm(x·0.008, z·0.008) − 0.45) · 8
+ *   detail    = (fBm(x·0.034, z·0.034) − 0.5) · 1.7
+ *   river     = |sin(warpX·0.004) · cos(warpZ·0.003)|        → talvegue
+ *   carve     = (1 − smoothstep(0.02, 0.16, river))^2 · 15
+ *   canyon    = −(1 − |2n−1|)^3 · 20 · máscara árida
+ *   h         = continent·58 + ridge·continent·36 + hills + detail + canyon − carve
+ *   mesa      = achata 14 < h < 32 onde arid > 0.62
+ *
+ * Bioma: alpine / pine / prairie / desert / mesa / canyon / riparian.
+ * Água: plano em WATER_Y; o terreno abaixo vira rio.
+ */
+
+import * as THREE from 'three';
+import { CHUNK_SIZE, WATER_Y, REGION_PREFIX, REGION_SUFFIX } from './config.js';
+import { fbm, ridged, hash2, seeded, smoothstep, lerp } from './utils.js';
+import { dirtTexture } from './textures.js';
+import {
+    buildPine, buildCottonwood, buildCactus, buildRock, buildCabin,
+    buildSaloon, buildWagon, buildCampfire, buildArch,
+    grassBladeGeometry, grassMaterial, disposeUnique
+} from './models.js';
+
+export function aridAt(x, z) {
+    return fbm(x * 0.00092, z * 0.00092, 7, 4);
+}
+
+export function heightAt(x, z) {
+    const continent = Math.pow(fbm(x * 0.00105, z * 0.00105, 1, 5), 1.55);
+    const ridge = Math.pow(ridged(x * 0.0022, z * 0.0022, 11, 4), 2.1);
+    const mountains = continent * 58 + ridge * continent * 36;
+    const hills = (fbm(x * 0.008, z * 0.008, 3, 4) - 0.45) * 8;
+    const detail = (fbm(x * 0.034, z * 0.034, 9, 3) - 0.5) * 1.7;
+
+    const warpX = x + (fbm(x * 0.002, z * 0.002, 21, 3) - 0.5) * 180;
+    const warpZ = z + (fbm(x * 0.002, z * 0.002, 27, 3) - 0.5) * 180;
+    const river = Math.abs(Math.sin(warpX * 0.0042) * Math.cos(warpZ * 0.0031));
+    const carve = Math.pow(1 - smoothstep(0.02, 0.16, river), 2) * 15;
+
+    const arid = aridAt(x, z);
+    const canyonMask = smoothstep(0.55, 0.82, arid) * smoothstep(0.32, 0.7, ridge);
+    const nCan = ridged(x * 0.0062, z * 0.0062, 33, 3);
+    const canyon = -Math.pow(nCan, 3) * 20 * canyonMask;
+
+    let h = mountains + hills + detail + canyon - carve;
+    if (arid > 0.62 && h > 14 && h < 32) {
+        h = lerp(h, 18 + (h - 18) * 0.18, smoothstep(0.62, 0.8, arid));
+    }
+    return h;
+}
+
+export function biomeAt(x, z, h = heightAt(x, z)) {
+    const arid = aridAt(x, z);
+    const moist = 1 - arid;
+    if (h < WATER_Y + 1.6) return 'riparian';
+    if (h > 48) return 'alpine';
+    const canyonDeep = h < 12 && arid > 0.55 && ridged(x * 0.0062, z * 0.0062, 33, 3) > 0.55;
+    if (canyonDeep) return 'canyon';
+    if (h > 30 && moist > 0.42) return 'pine';
+    if (arid > 0.6) return h > 18 ? 'mesa' : 'desert';
+    return 'prairie';
+}
+
+export function regionName(cx, cz) {
+    const a = Math.floor(hash2(cx, cz, 41) * REGION_PREFIX.length);
+    const b = Math.floor(hash2(cx, cz, 73) * REGION_SUFFIX.length);
+    return `${REGION_PREFIX[a]} ${REGION_SUFFIX[b]}`;
+}
+
+const GOLD = new THREE.Color(0xd2b05a);
+const GREEN = new THREE.Color(0x5a7a32);
+const DIRT = new THREE.Color(0xa86a38);
+const REDROCK = new THREE.Color(0xb24a28);
+const SAND = new THREE.Color(0xc4a06a);
+const STONE = new THREE.Color(0x8a8078);
+const SNOW = new THREE.Color(0xe8e4dc);
+const WET = new THREE.Color(0x4a5a38);
+const tmpC = new THREE.Color();
+
+function vertexColor(x, z, y) {
+    const biome = biomeAt(x, z, y);
+    const n = fbm(x * 0.04, z * 0.04, 9, 3);
+    switch (biome) {
+        case 'riparian':
+            tmpC.copy(WET).lerp(DIRT, n * 0.4);
+            break;
+        case 'alpine':
+            tmpC.copy(STONE).lerp(SNOW, smoothstep(46, 58, y));
+            break;
+        case 'pine':
+            tmpC.copy(DIRT).lerp(GREEN, 0.45 + n * 0.2);
+            break;
+        case 'desert':
+            tmpC.copy(SAND).lerp(DIRT, n * 0.35);
+            break;
+        case 'mesa':
+        case 'canyon':
+            tmpC.copy(REDROCK).lerp(SAND, n * 0.35);
+            break;
+        default:
+            tmpC.copy(GOLD).lerp(n > 0.58 ? GREEN : DIRT, n > 0.58 ? 0.45 : n * 0.4);
+    }
+    tmpC.offsetHSL(0, 0, (hash2(x, z, 2) - 0.5) * 0.06);
+    return tmpC;
+}
+
+function makeTerrainGeometry(cx, cz, segs) {
+    const size = CHUNK_SIZE;
+    const geo = new THREE.PlaneGeometry(size, size, segs, segs);
+    geo.rotateX(-Math.PI / 2);
+    const pos = geo.attributes.position;
+    const colors = new Float32Array(pos.count * 3);
+    const ox = (cx + 0.5) * size;
+    const oz = (cz + 0.5) * size;
+    for (let i = 0; i < pos.count; i++) {
+        const x = pos.getX(i) + ox;
+        const z = pos.getZ(i) + oz;
+        const y = heightAt(x, z);
+        pos.setY(i, y);
+        const c = vertexColor(x, z, y);
+        colors[i * 3] = c.r;
+        colors[i * 3 + 1] = c.g;
+        colors[i * 3 + 2] = c.b;
+    }
+    geo.setAttribute('color', new THREE.Float32BufferAttribute(colors, 3));
+    geo.computeVertexNormals();
+    geo.userData.unique = true;
+    return geo;
+}
+
+export class World {
+    constructor(scene, quality) {
+        this.scene = scene;
+        this.quality = quality;
+        this.group = new THREE.Group();
+        scene.add(this.group);
+        this.chunks = new Map();
+        this.colliders = [];
+        this.waterY = WATER_Y;
+        this.heightAt = heightAt;
+        this.biomeAt = biomeAt;
+        this.landmarks = [];
+        this.discovered = new Set();
+
+        this.terrainMat = new THREE.MeshStandardMaterial({
+            map: dirtTexture(),
+            vertexColors: true,
+            roughness: 0.94,
+            metalness: 0
+        });
+
+        this.addWater();
+        this.scatterGrass();
+    }
+
+    addWater() {
+        const geo = new THREE.PlaneGeometry(1400, 1400, 1, 1);
+        geo.rotateX(-Math.PI / 2);
+        const mat = new THREE.MeshStandardMaterial({
+            color: 0x2a4a48,
+            roughness: 0.18,
+            metalness: 0.22,
+            transparent: true,
+            opacity: 0.82
+        });
+        this.water = new THREE.Mesh(geo, mat);
+        this.water.position.y = WATER_Y;
+        this.water.receiveShadow = true;
+        this.group.add(this.water);
+    }
+
+    scatterGrass() {
+        const count = this.quality.grass;
+        const geo = grassBladeGeometry();
+        this.grassMat = grassMaterial();
+        const mesh = new THREE.InstancedMesh(geo, this.grassMat, count);
+        mesh.instanceMatrix.setUsage(THREE.DynamicDrawUsage);
+        mesh.castShadow = false;
+        mesh.receiveShadow = true;
+        mesh.frustumCulled = false;
+        this.group.add(mesh);
+        this.grass = mesh;
+        this._grassOrigin = { x: 99999, z: 99999 };
+        this._dummy = new THREE.Object3D();
+    }
+
+    refreshGrass(px, pz) {
+        if (Math.hypot(px - this._grassOrigin.x, pz - this._grassOrigin.z) < 10) return;
+        this._grassOrigin = { x: px, z: pz };
+        const rng = seeded(((px * 13) | 0) * 73856093 ^ ((pz * 17) | 0) * 19349663);
+        const dummy = this._dummy;
+        const count = this.grass.count;
+        const radius = 42;
+        let placed = 0;
+        for (let i = 0; i < count * 3 && placed < count; i++) {
+            const a = rng() * Math.PI * 2;
+            const r = Math.sqrt(rng()) * radius;
+            const x = px + Math.cos(a) * r;
+            const z = pz + Math.sin(a) * r;
+            const y = heightAt(x, z);
+            const biome = biomeAt(x, z, y);
+            if (biome === 'desert' || biome === 'alpine' || y < WATER_Y + 0.4) continue;
+            dummy.position.set(x, y, z);
+            dummy.rotation.y = rng() * Math.PI;
+            dummy.scale.setScalar(0.65 + rng() * 1.15);
+            dummy.updateMatrix();
+            this.grass.setMatrixAt(placed, dummy.matrix);
+            placed++;
+        }
+        for (let i = placed; i < count; i++) {
+            dummy.position.set(0, -40, 0);
+            dummy.scale.setScalar(0);
+            dummy.updateMatrix();
+            this.grass.setMatrixAt(i, dummy.matrix);
+        }
+        this.grass.instanceMatrix.needsUpdate = true;
+        this.grass.count = Math.max(1, placed);
+    }
+
+    loadChunk(cx, cz) {
+        const key = `${cx},${cz}`;
+        if (this.chunks.has(key)) return;
+        const chunk = new THREE.Group();
+        chunk.position.set((cx + 0.5) * CHUNK_SIZE, 0, (cz + 0.5) * CHUNK_SIZE);
+
+        const geo = makeTerrainGeometry(cx, cz, this.quality.terrainSegments);
+        const mesh = new THREE.Mesh(geo, this.terrainMat);
+        mesh.receiveShadow = true;
+        mesh.castShadow = false;
+        mesh.position.set(-(cx + 0.5) * CHUNK_SIZE, 0, -(cz + 0.5) * CHUNK_SIZE);
+        chunk.add(mesh);
+
+        const colliders = [];
+        const marks = this.scatterProps(cx, cz, chunk, colliders);
+        this.group.add(chunk);
+        this.chunks.set(key, { group: chunk, colliders, marks, cx, cz });
+        this.colliders.push(...colliders);
+        for (const m of marks) this.landmarks.push(m);
+    }
+
+    scatterProps(cx, cz, chunk, colliders) {
+        const rng = seeded(((cx + 4096) * 73856093) ^ ((cz + 4096) * 19349663));
+        const ox = (cx + 0.5) * CHUNK_SIZE;
+        const oz = (cz + 0.5) * CHUNK_SIZE;
+        const marks = [];
+        const trees = this.quality.trees;
+        const rocks = this.quality.rocks;
+
+        const centerBiome = biomeAt(ox, oz);
+        const roll = hash2(cx, cz, 91);
+
+        if (roll < 0.042 && (centerBiome === 'prairie' || centerBiome === 'desert')) {
+            this.placeTown(ox, oz, chunk, colliders, rng);
+            marks.push({ id: 'town', x: ox, z: oz, label: 'Povoado' });
+        } else if (roll < 0.078) {
+            const camp = buildCampfire();
+            const y = heightAt(ox + 4, oz - 3);
+            camp.position.set(4, y, -3);
+            chunk.add(camp);
+            marks.push({ id: 'camp', x: ox + 4, z: oz - 3, label: 'Fogueira' });
+        } else if (roll < 0.11 && (centerBiome === 'mesa' || centerBiome === 'canyon' || centerBiome === 'desert')) {
+            const arch = buildArch();
+            const y = heightAt(ox, oz);
+            arch.position.set(0, y, 0);
+            arch.rotation.y = rng() * Math.PI;
+            chunk.add(arch);
+            colliders.push({ x: ox - 3.2, z: oz, r: 2.2 });
+            colliders.push({ x: ox + 3.2, z: oz, r: 2.2 });
+            marks.push({ id: 'arch', x: ox, z: oz, label: 'Arco de pedra' });
+        } else if (roll < 0.145) {
+            const wagon = buildWagon();
+            const y = heightAt(ox - 6, oz + 8);
+            wagon.position.set(-6, y, 8);
+            wagon.rotation.y = rng() * 6;
+            chunk.add(wagon);
+            colliders.push({ x: ox - 6, z: oz + 8, r: 1.8 });
+            marks.push({ id: 'wagon', x: ox - 6, z: oz + 8, label: 'Carroça' });
+        }
+
+        for (let i = 0; i < trees; i++) {
+            const lx = (rng() - 0.5) * (CHUNK_SIZE - 8);
+            const lz = (rng() - 0.5) * (CHUNK_SIZE - 8);
+            const x = ox + lx;
+            const z = oz + lz;
+            const y = heightAt(x, z);
+            if (y < WATER_Y + 0.5) continue;
+            const biome = biomeAt(x, z, y);
+            let prop = null;
+            let radius = 0.7;
+            if (biome === 'pine' || biome === 'alpine') {
+                if (rng() > 0.15) prop = buildPine(rng);
+                radius = 0.85;
+            } else if (biome === 'riparian') {
+                prop = buildCottonwood(rng);
+                radius = 0.9;
+            } else if (biome === 'desert' || biome === 'mesa') {
+                prop = buildCactus(rng);
+                radius = 0.45;
+            } else if (biome === 'prairie') {
+                if (rng() > 0.55) prop = buildCottonwood(rng);
+                radius = 0.8;
+            } else if (biome === 'canyon' && rng() > 0.7) {
+                prop = buildCactus(rng);
+                radius = 0.4;
+            }
+            if (!prop) continue;
+            const s = 0.75 + rng() * 0.55;
+            prop.scale.setScalar(s);
+            prop.position.set(lx, y, lz);
+            prop.rotation.y = rng() * Math.PI * 2;
+            chunk.add(prop);
+            colliders.push({ x, z, r: radius * s });
+        }
+
+        for (let i = 0; i < rocks; i++) {
+            const lx = (rng() - 0.5) * (CHUNK_SIZE - 6);
+            const lz = (rng() - 0.5) * (CHUNK_SIZE - 6);
+            const x = ox + lx;
+            const z = oz + lz;
+            const y = heightAt(x, z);
+            if (y < WATER_Y + 0.2) continue;
+            const rock = buildRock(rng);
+            const s = 0.7 + rng() * 1.4;
+            rock.scale.setScalar(s);
+            rock.position.set(lx, y, lz);
+            rock.rotation.y = rng() * 6;
+            chunk.add(rock);
+            colliders.push({ x, z, r: 1.1 * s });
+        }
+
+        if (centerBiome === 'riparian' || centerBiome === 'pine') {
+            const y0 = heightAt(ox, oz);
+            const y1 = heightAt(ox + 8, oz);
+            if (y0 > WATER_Y + 8 && y1 < WATER_Y + 2.5) {
+                marks.push({ id: 'falls', x: ox, z: oz, label: 'Cachoeira' });
+                const spray = new THREE.Points(
+                    this.makeSprayGeo(),
+                    new THREE.PointsMaterial({
+                        color: 0xd8e8e8, size: 0.18, transparent: true, opacity: 0.45, depthWrite: false
+                    })
+                );
+                spray.position.set(0, WATER_Y + 4, 0);
+                chunk.add(spray);
+            }
+        }
+
+        return marks;
+    }
+
+    makeSprayGeo() {
+        const n = 40;
+        const pos = new Float32Array(n * 3);
+        for (let i = 0; i < n; i++) {
+            pos[i * 3] = (Math.random() - 0.5) * 4;
+            pos[i * 3 + 1] = Math.random() * 6;
+            pos[i * 3 + 2] = (Math.random() - 0.5) * 3;
+        }
+        const geo = new THREE.BufferGeometry();
+        geo.setAttribute('position', new THREE.BufferAttribute(pos, 3));
+        geo.userData.unique = true;
+        return geo;
+    }
+
+    placeTown(ox, oz, chunk, colliders, rng) {
+        const saloon = buildSaloon();
+        const sy = heightAt(ox, oz);
+        saloon.position.set(0, sy, 0);
+        chunk.add(saloon);
+        colliders.push({ x: ox, z: oz, r: 3.6 });
+        for (let i = 0; i < 3; i++) {
+            const cabin = buildCabin();
+            const lx = (i - 1) * 9 + (rng() - 0.5) * 2;
+            const lz = 10 + (rng() - 0.5) * 4;
+            const y = heightAt(ox + lx, oz + lz);
+            cabin.position.set(lx, y, lz);
+            cabin.rotation.y = rng() * 0.4 - 0.2 + Math.PI;
+            chunk.add(cabin);
+            colliders.push({ x: ox + lx, z: oz + lz, r: 2.4 });
+        }
+    }
+
+    unloadChunk(key) {
+        const chunk = this.chunks.get(key);
+        if (!chunk) return;
+        this.group.remove(chunk.group);
+        disposeUnique(chunk.group);
+        chunk.group.traverse((c) => {
+            if (c.isMesh && c.geometry?.userData?.unique) c.geometry.dispose();
+        });
+        this.colliders = this.colliders.filter((c) => !chunk.colliders.includes(c));
+        this.landmarks = this.landmarks.filter((m) => !chunk.marks.includes(m));
+        this.chunks.delete(key);
+    }
+
+    update(dt, time, player) {
+        const pcx = Math.floor(player.x / CHUNK_SIZE);
+        const pcz = Math.floor(player.z / CHUNK_SIZE);
+        const r = this.quality.chunkRadius;
+        const needed = new Set();
+        for (let dz = -r; dz <= r; dz++) {
+            for (let dx = -r; dx <= r; dx++) {
+                const key = `${pcx + dx},${pcz + dz}`;
+                needed.add(key);
+                this.loadChunk(pcx + dx, pcz + dz);
+            }
+        }
+        for (const key of [...this.chunks.keys()]) {
+            if (!needed.has(key)) this.unloadChunk(key);
+        }
+
+        this.water.position.x = player.x;
+        this.water.position.z = player.z;
+        this.refreshGrass(player.x, player.z);
+
+        if (this.grassMat.userData.shader) {
+            this.grassMat.userData.shader.uniforms.uTime.value = time;
+        }
+
+        this.group.traverse((c) => {
+            if (c.name === 'flame') {
+                c.scale.y = 0.85 + Math.sin(time * 9 + c.id) * 0.18;
+                c.rotation.y += dt * 2.4;
+            }
+        });
+    }
+
+    collide(x, z, radius) {
+        let ox = x;
+        let oz = z;
+        for (const c of this.colliders) {
+            const dx = ox - c.x;
+            const dz = oz - c.z;
+            const d = Math.hypot(dx, dz);
+            const min = radius + c.r;
+            if (d < min && d > 1e-4) {
+                const push = (min - d) / d;
+                ox += dx * push;
+                oz += dz * push;
+            }
+        }
+        return { x: ox, z: oz };
+    }
+
+    nearestLandmark(x, z, maxDist = 18) {
+        let best = null;
+        let bestD = maxDist;
+        for (const m of this.landmarks) {
+            const d = Math.hypot(m.x - x, m.z - z);
+            if (d < bestD) {
+                best = m;
+                bestD = d;
+            }
+        }
+        return best;
+    }
+
+    currentRegion(x, z) {
+        const cx = Math.floor(x / CHUNK_SIZE);
+        const cz = Math.floor(z / CHUNK_SIZE);
+        return { name: regionName(cx, cz), cx, cz, biome: biomeAt(x, z) };
+    }
+
+    findSpawn() {
+        for (let i = 0; i < 80; i++) {
+            const a = hash2(i, 4, 5) * Math.PI * 2;
+            const r = 20 + hash2(i, 9, 6) * 80;
+            const x = Math.cos(a) * r;
+            const z = Math.sin(a) * r;
+            const y = heightAt(x, z);
+            const b = biomeAt(x, z, y);
+            const slope = Math.abs(heightAt(x + 3, z) - y);
+            if (y > WATER_Y + 1.5 && y < 22 && slope < 2.5 && (b === 'prairie' || b === 'desert')) {
+                return { x, z, yaw: a + Math.PI, y };
+            }
+        }
+        return { x: 8, z: 24, yaw: 0.4, y: heightAt(8, 24) };
+    }
+}

--- a/labs/rastro-vermelho/src/world.js
+++ b/labs/rastro-vermelho/src/world.js
@@ -2,7 +2,7 @@
  * Mundo infinito em chunks.
  *
  * Altura h(x, z):
- *   continent = fBm(x·0.00105, z·0.00105) ^ 1.55           → serras longas
+ *   continent = fBm(x·0.00105, z·0.00105) ^ 1.22           → serras longas
  *   ridge     = ridged(x·0.0022, z·0.0022) ^ 2.1            → cristas
  *   hills     = (fBm(x·0.0065, z·0.0065) − 0.38) · 14
  *   rolling   = fBm(x·0.0026, z·0.0026) ^ 1.25 · 20         → lombadas
@@ -35,8 +35,8 @@ export function heightAt(x, z) {
     const continent = Math.pow(fbm(x * 0.00105, z * 0.00105, 1, 5), 1.22);
     const ridge = Math.pow(ridged(x * 0.0022, z * 0.0022, 11, 4), 2.1);
     const mountains = continent * 72 + ridge * continent * 42;
-    const hills = (fbm(x * 0.0065, z * 0.0065, 3, 5) - 0.38) * 14;
-    const rolling = Math.pow(fbm(x * 0.0026, z * 0.0026, 15, 4), 1.25) * 20;
+    const hills = (fbm(x * 0.0065, z * 0.0065, 3, 5) - 0.32) * 18;
+    const rolling = Math.pow(fbm(x * 0.0026, z * 0.0026, 15, 4), 1.12) * 26;
     const detail = (fbm(x * 0.034, z * 0.034, 9, 3) - 0.5) * 2.1;
 
     const warpX = x + (fbm(x * 0.002, z * 0.002, 21, 3) - 0.5) * 180;

--- a/labs/rastro-vermelho/style.css
+++ b/labs/rastro-vermelho/style.css
@@ -1,0 +1,670 @@
+/* ================================================================
+   Rastro Vermelho — interface
+   Paleta: ferrugem, ocre, poeira, ouro velho, sangue de pôr do sol.
+   ================================================================ */
+
+:root {
+    --ink: oklch(14% 0.04 48);
+    --ink-deep: oklch(8% 0.03 42);
+    --parchment: oklch(92% 0.04 88);
+    --gold: oklch(76% 0.15 72);
+    --gold-deep: oklch(58% 0.14 58);
+    --dust: oklch(70% 0.08 68);
+    --ember: oklch(58% 0.19 38);
+    --blood: oklch(48% 0.18 28);
+
+    --text: oklch(96% 0.02 88);
+    --text-soft: oklch(82% 0.03 80);
+    --text-dim: oklch(64% 0.03 72);
+
+    --panel: color-mix(in oklab, oklch(16% 0.04 48) 64%, transparent);
+    --panel-strong: color-mix(in oklab, oklch(11% 0.04 42) 84%, transparent);
+    --line: color-mix(in oklab, var(--gold) 30%, transparent);
+    --line-soft: color-mix(in oklab, var(--parchment) 12%, transparent);
+
+    --radius: 14px;
+    --radius-lg: 22px;
+    --blur: 20px;
+    --safe-top: env(safe-area-inset-top, 0px);
+    --safe-bottom: env(safe-area-inset-bottom, 0px);
+    --safe-left: env(safe-area-inset-left, 0px);
+    --safe-right: env(safe-area-inset-right, 0px);
+    --ease: cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+*, *::before, *::after {
+    box-sizing: border-box;
+    -webkit-tap-highlight-color: transparent;
+}
+
+html, body {
+    margin: 0;
+    width: 100%;
+    height: 100%;
+    overflow: clip;
+    overscroll-behavior: none;
+    background: var(--ink-deep);
+}
+
+body {
+    min-height: 100dvh;
+    color: var(--text);
+    font-family: 'Outfit', system-ui, sans-serif;
+    user-select: none;
+    touch-action: none;
+}
+
+button, input, select { font: inherit; color: inherit; }
+button { background: none; border: 0; cursor: pointer; }
+
+.mono {
+    font-variant-numeric: tabular-nums;
+    font-feature-settings: 'tnum' 1;
+}
+
+:focus-visible {
+    outline: 2px solid var(--gold);
+    outline-offset: 3px;
+}
+
+.game-shell {
+    position: fixed;
+    inset: 0;
+    overflow: hidden;
+    background: radial-gradient(120% 90% at 50% 0%, oklch(26% 0.08 48) 0%, var(--ink-deep) 70%);
+}
+
+#scene {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    display: block;
+    touch-action: none;
+}
+
+.app-logo {
+    display: flex;
+    align-items: center;
+    gap: 0.55rem;
+    font-family: 'Cinzel', Georgia, serif;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+}
+
+.brand-mark {
+    display: grid;
+    place-items: center;
+    width: 1.55rem;
+    height: 1.55rem;
+    border-radius: 999px;
+    background: radial-gradient(circle at 35% 30%, #ffe7a0, #c42818 72%);
+    box-shadow: 0 0 16px color-mix(in oklab, var(--ember) 55%, transparent);
+    font-size: 0.72rem;
+}
+
+.vignette {
+    position: absolute;
+    inset: 0;
+    z-index: 18;
+    pointer-events: none;
+    background:
+        radial-gradient(120% 90% at 50% 42%, transparent 48%, oklch(8% 0.03 42 / 0.58) 100%);
+}
+
+.hud {
+    position: absolute;
+    inset: 0;
+    z-index: 24;
+    pointer-events: none;
+}
+
+.hud-top {
+    position: absolute;
+    top: calc(4.4rem + var(--safe-top));
+    left: calc(16px + var(--safe-left));
+    right: calc(16px + var(--safe-right));
+    display: grid;
+    grid-template-columns: minmax(0, 1.3fr) minmax(0, 1fr) minmax(0, 1fr);
+    gap: 12px;
+    max-width: 920px;
+}
+
+.panel {
+    background: var(--panel);
+    border: 1px solid var(--line-soft);
+    border-radius: var(--radius);
+    padding: 10px 14px;
+    backdrop-filter: blur(var(--blur));
+    min-width: 0;
+}
+
+.hud-label {
+    display: block;
+    font-size: 0.64rem;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--gold);
+    margin-bottom: 4px;
+}
+
+.meta {
+    font-size: 0.72rem;
+    color: var(--text-dim);
+}
+
+.compass-panel {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.compass {
+    position: relative;
+    width: 52px;
+    height: 52px;
+    flex-shrink: 0;
+}
+
+.compass-rose {
+    position: absolute;
+    inset: 0;
+    border-radius: 50%;
+    border: 1px solid var(--line);
+    background: color-mix(in oklab, var(--ink) 50%, transparent);
+    transition: transform 0.08s linear;
+}
+
+.compass-rose span {
+    position: absolute;
+    font-size: 0.58rem;
+    letter-spacing: 0.08em;
+    color: var(--text-dim);
+}
+
+.compass-rose .n { top: 3px; left: 50%; transform: translateX(-50%); color: var(--ember); font-weight: 700; }
+.compass-rose .s { bottom: 3px; left: 50%; transform: translateX(-50%); }
+.compass-rose .e { right: 5px; top: 50%; transform: translateY(-50%); }
+.compass-rose .w { left: 4px; top: 50%; transform: translateY(-50%); }
+
+.compass-needle {
+    position: absolute;
+    left: 50%;
+    top: 8px;
+    width: 0;
+    height: 0;
+    border-left: 4px solid transparent;
+    border-right: 4px solid transparent;
+    border-bottom: 10px solid var(--gold);
+    transform: translateX(-50%);
+    z-index: 1;
+}
+
+.region-block {
+    min-width: 0;
+}
+
+.region-block strong {
+    display: block;
+    font-family: 'Cinzel', Georgia, serif;
+    font-size: clamp(0.92rem, 2.2vw, 1.12rem);
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.speed-row {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 8px;
+}
+
+.gait-panel strong {
+    font-family: 'Cinzel', Georgia, serif;
+    text-transform: capitalize;
+    font-size: 1.05rem;
+}
+
+.mark-pips {
+    display: flex;
+    gap: 5px;
+    margin-top: 6px;
+}
+
+.mark-pips i {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: color-mix(in oklab, var(--text-dim) 40%, transparent);
+    border: 1px solid var(--line-soft);
+}
+
+.mark-pips i[data-on="true"] {
+    background: var(--gold);
+    box-shadow: 0 0 8px color-mix(in oklab, var(--gold) 60%, transparent);
+}
+
+.message, .prompt {
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
+    text-align: center;
+    max-width: min(92vw, 420px);
+    pointer-events: none;
+}
+
+.message {
+    bottom: calc(96px + var(--safe-bottom));
+    font-family: 'Cinzel', Georgia, serif;
+    font-size: clamp(0.95rem, 2.4vw, 1.2rem);
+    opacity: 0;
+    transition: opacity 0.35s var(--ease);
+    text-shadow: 0 2px 16px oklch(8% 0.04 42 / 0.7);
+}
+
+.message[data-show="true"] { opacity: 1; }
+
+.prompt {
+    bottom: calc(58px + var(--safe-bottom));
+    font-size: 0.72rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--text-dim);
+}
+
+.hud-actions {
+    position: absolute;
+    top: calc(64px + var(--safe-top));
+    right: calc(18px + var(--safe-right));
+    display: none;
+}
+
+body[data-state="play"] .hud-actions {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    pointer-events: auto;
+    margin-top: 86px;
+}
+
+.icon-button {
+    width: 44px;
+    height: 44px;
+    min-width: 44px;
+    min-height: 44px;
+    border-radius: 10px;
+    background: var(--panel);
+    border: 1px solid var(--line-soft);
+    pointer-events: auto;
+}
+
+.icon-button[aria-pressed="false"] { opacity: 0.55; }
+
+.fps {
+    font-size: 0.68rem;
+    color: var(--text-dim);
+    min-width: 48px;
+}
+
+.touch-controls {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    z-index: 26;
+}
+
+.stick {
+    position: absolute;
+    left: calc(28px + var(--safe-left));
+    bottom: calc(28px + var(--safe-bottom));
+    width: 118px;
+    height: 118px;
+    border-radius: 50%;
+    border: 1px solid var(--line);
+    background: var(--panel);
+    pointer-events: auto;
+    display: grid;
+    place-items: center;
+}
+
+.stick i {
+    width: 42px;
+    height: 42px;
+    border-radius: 50%;
+    background: color-mix(in oklab, var(--gold) 55%, white);
+}
+
+.stick span {
+    position: absolute;
+    bottom: 10px;
+    font-size: 0.62rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--text-dim);
+}
+
+.look-zone {
+    position: absolute;
+    right: 0;
+    top: 20%;
+    width: 48%;
+    height: 55%;
+    pointer-events: auto;
+}
+
+.touch-buttons {
+    position: absolute;
+    right: calc(22px + var(--safe-right));
+    bottom: calc(28px + var(--safe-bottom));
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    pointer-events: auto;
+}
+
+.pad {
+    min-width: 72px;
+    min-height: 52px;
+    height: 52px;
+    border-radius: 14px;
+    background: var(--panel-strong);
+    border: 1px solid var(--line);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    font-size: 0.72rem;
+}
+
+.pad-spur {
+    background: color-mix(in oklab, var(--ember) 55%, var(--ink));
+}
+
+.overlay {
+    position: absolute;
+    inset: 0;
+    z-index: 50;
+    display: grid;
+    place-items: center;
+    padding: calc(1.2rem + var(--safe-top)) calc(1.2rem + var(--safe-right))
+             calc(1.2rem + var(--safe-bottom)) calc(1.2rem + var(--safe-left));
+    background: oklch(8% 0.03 42 / 0.55);
+    backdrop-filter: blur(10px);
+}
+
+.overlay[hidden] { display: none !important; }
+
+.overlay-card, .loading-card {
+    width: min(920px, 100%);
+    background: var(--panel-strong);
+    border: 1px solid var(--line);
+    border-radius: var(--radius-lg);
+    padding: 28px 32px;
+    box-shadow: 0 30px 80px oklch(8% 0.04 42 / 0.45);
+}
+
+.loading-card {
+    width: min(380px, 100%);
+    text-align: center;
+}
+
+.sun-loader {
+    display: block;
+    width: 42px;
+    height: 42px;
+    margin: 0 auto 12px;
+    border-radius: 50%;
+    background: radial-gradient(circle at 35% 30%, #ffe7a0, #c42818 70%);
+    box-shadow: 0 0 28px #c44020;
+    animation: pulse 1.6s ease-in-out infinite;
+}
+
+@keyframes pulse {
+    50% { transform: scale(1.08); filter: brightness(1.15); }
+}
+
+.loading-card h1, .menu-head h1, .compact-card h2 {
+    font-family: 'Cinzel', Georgia, serif;
+    font-weight: 700;
+    letter-spacing: 0.02em;
+    margin: 0 0 0.4rem;
+}
+
+.loading-card h1 { font-size: 1.7rem; }
+.menu-head h1 { font-size: clamp(2.1rem, 5vw, 3.4rem); line-height: 0.95; }
+.menu-head h1 span { color: var(--gold); }
+
+.loading-bar {
+    margin-top: 16px;
+    height: 6px;
+    border-radius: 99px;
+    background: color-mix(in oklab, var(--ink) 40%, transparent);
+    overflow: hidden;
+}
+
+.loading-bar i {
+    display: block;
+    height: 100%;
+    width: 8%;
+    background: linear-gradient(90deg, #f0c060, #c42818);
+}
+
+.eyebrow {
+    display: flex;
+    align-items: center;
+    gap: 0.55rem;
+    font-size: 0.72rem;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--text-dim);
+    margin: 0 0 0.6rem;
+}
+
+.eyebrow i {
+    width: 18px;
+    height: 2px;
+    background: var(--gold);
+    display: inline-block;
+}
+
+.eyebrow--danger { color: var(--ember); }
+
+.lede {
+    color: var(--text-soft);
+    line-height: 1.55;
+    max-width: 48ch;
+}
+
+.menu-grid {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 22px;
+    margin: 28px 0 8px;
+}
+
+.menu-section h2 {
+    font-size: 0.72rem;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--gold);
+    margin: 0 0 10px;
+}
+
+.species-preview {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 6px 14px;
+    color: var(--text-soft);
+    font-size: 0.92rem;
+}
+
+.keys {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    color: var(--text-soft);
+    font-size: 0.88rem;
+}
+
+kbd {
+    display: inline-grid;
+    place-items: center;
+    min-width: 1.4rem;
+    padding: 0.12rem 0.35rem;
+    margin-right: 0.15rem;
+    border-radius: 6px;
+    border: 1px solid var(--line);
+    background: color-mix(in oklab, var(--ink) 50%, transparent);
+    font-size: 0.72rem;
+}
+
+.settings-grid { display: grid; gap: 12px; }
+
+.field span {
+    display: flex;
+    justify-content: space-between;
+    font-size: 0.78rem;
+    color: var(--text-dim);
+    margin-bottom: 6px;
+}
+
+.field select, .field input[type="range"] {
+    width: 100%;
+    max-width: 100%;
+    background: color-mix(in oklab, var(--ink) 40%, transparent);
+    border: 1px solid var(--line-soft);
+    border-radius: 10px;
+    padding: 0.45rem 0.6rem;
+}
+
+.section-note {
+    margin: 12px 0 0;
+    font-size: 0.78rem;
+    color: var(--text-dim);
+}
+
+.menu-foot, .card-actions {
+    display: flex;
+    gap: 12px;
+    justify-content: flex-end;
+    margin-top: 22px;
+    flex-wrap: wrap;
+}
+
+.primary-button, .ghost-button {
+    pointer-events: auto;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.6rem;
+    padding: 0.75rem 1.2rem;
+    min-height: 44px;
+    border-radius: 999px;
+    font-weight: 600;
+}
+
+.primary-button {
+    background: linear-gradient(180deg, #f0c060, #c44a18);
+    color: var(--ink);
+}
+
+.primary-button:hover { filter: brightness(1.08); }
+
+.ghost-button {
+    border: 1px solid var(--line);
+    color: var(--text-soft);
+}
+
+.compact-card { width: min(460px, 100%); }
+
+.lab-foot {
+    position: absolute;
+    bottom: 8px;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 21;
+}
+
+body[data-state="play"] .lab-foot { display: none; }
+
+@media (max-width: 860px) {
+    .hud-top {
+        grid-template-columns: 1fr 1fr;
+        top: calc(4.2rem + var(--safe-top));
+    }
+    .trail-panel { display: none; }
+    .menu-grid { grid-template-columns: 1fr; }
+    .overlay-card { padding: 20px; }
+    body[data-state="play"] .hud-actions {
+        margin-top: 0;
+        top: auto;
+        bottom: calc(160px + var(--safe-bottom));
+        right: calc(18px + var(--safe-right));
+    }
+    .message { bottom: calc(11rem + var(--safe-bottom)); }
+    .prompt { bottom: calc(9.5rem + var(--safe-bottom)); }
+}
+
+@media (max-width: 768px) {
+    .hud-top { grid-template-columns: 1fr; }
+    .gait-panel { display: none; }
+    .region-block strong { white-space: nowrap; }
+}
+
+@media (pointer: coarse) {
+    .icon-button {
+        width: 44px;
+        height: 44px;
+        min-width: 44px;
+        min-height: 44px;
+    }
+}
+
+@media (max-width: 560px) {
+    .overlay,
+    .overlay-card,
+    .menu-card {
+        max-height: min(92dvh, 900px);
+    }
+    .overlay-card,
+    .menu-card {
+        overflow-y: auto;
+        -webkit-overflow-scrolling: touch;
+    }
+    .menu-head h1 { font-size: clamp(1.8rem, 8vw, 2.4rem); }
+    .lede { font-size: 0.92rem; }
+}
+
+@media (max-height: 520px) and (orientation: landscape) {
+    .hud-top {
+        grid-template-columns: 1fr 1fr;
+        gap: 8px;
+        top: calc(3rem + var(--safe-top));
+    }
+    .trail-panel, .gait-panel { display: none; }
+    .stick { width: 96px; height: 96px; }
+    .hud-actions {
+        top: calc(0.75rem + var(--safe-top));
+        bottom: auto;
+        right: calc(0.75rem + var(--safe-right));
+        margin-top: 0;
+    }
+    .touch-controls { height: 100%; }
+    .prompt { display: none; }
+    .message { bottom: calc(5.5rem + var(--safe-bottom)); }
+    .overlay-card { padding: 1rem 1.2rem; }
+    .menu-grid { padding: 0.8rem 0; margin: 12px 0; }
+    .lab-foot { display: none; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+    }
+}

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -259,6 +259,12 @@
     <priority>0.7</priority>
   </url>
   <url>
+    <loc>https://diogopaulino.com.br/labs/rastro-vermelho/</loc>
+    <lastmod>2026-08-14</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
     <loc>https://diogopaulino.com.br/labs/riftball/</loc>
     <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 🎯 Objetivo

Lab 3D de mundo aberto em three.js: galope a cavalo sem parar por serras, cânions, pradarias e povoados no espírito do faroeste.

## ✨ O que mudou

- Novo lab `/labs/rastro-vermelho/` — terreno infinito em chunks, cavalo com galope livre (não cansa), ciclo do dia, veados, marcos (povoado, fogueira, arco, carroça, manada, cachoeira)
- Serras no horizonte, hora dourada na partida, colinas à frente da sela
- Galeria, README, sitemap e home atualizados (58 experimentos)
- SEO do lab: title, description, canonical, author, OG, Twitter, JSON-LD

## 🧪 Como testar

1. Na raiz do repo: `python3 -m http.server 8000`
2. Abrir [http://localhost:8000/](http://localhost:8000/) (home) e [http://localhost:8000/labs/](http://localhost:8000/labs/) (galeria)
3. Abrir [http://localhost:8000/labs/rastro-vermelho/](http://localhost:8000/labs/rastro-vermelho/) — Montar e galopar, WASD/stick, Espaço espora, G galope livre, C câmera
4. Responsivo: DevTools em **375×667**, **390×844** e landscape curto (~667×375) — sem overflow horizontal, HUD/controles utilizáveis, alvos ≥ 44px
5. Conferir pasta ↔ card da galeria ↔ README ↔ `sitemap.xml` ↔ canonical/OG

## ✅ Checklist

- [x] Links conferidos: pasta do lab ↔ card da galeria ↔ README ↔ sitemap (e corrigidos se quebravam)
- [x] README atualizado (linha na tabela + URL + contagem no badge/texto) — obrigatório em lab novo, renomeado ou removido
- [x] SEO consistente: title, description, canonical, author, robots, OG, Twitter, JSON-LD (e contagem nos metas da galeria)
- [x] Testado via HTTP na raiz, não via `file://`
- [x] Responsivo: 375px / 390px / landscape — overflow, HUD, toque, safe-area (`viewport-fit=cover`)
- [x] Nada fora do escopo foi quebrado

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-06a9f454-796e-4384-aa51-e3a84bdfa189?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-06a9f454-796e-4384-aa51-e3a84bdfa189&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

