### PR TITLE
🧪 lab: Xadrez 3D com academia que ensina a jogar

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 Mais de 20 anos em tecnologia, entre liderança, código hands-on e design UI/UX.
 
 [![Website](https://img.shields.io/badge/Website-diogopaulino.com.br-3B82F6?style=flat-square&logo=googlechrome&logoColor=white)](https://diogopaulino.com.br/)
-[![Labs](https://img.shields.io/badge/Labs-57_experimentos-8B5CF6?style=flat-square&logo=stackblitz&logoColor=white)](https://diogopaulino.com.br/labs/)
+[![Labs](https://img.shields.io/badge/Labs-58_experimentos-8B5CF6?style=flat-square&logo=stackblitz&logoColor=white)](https://diogopaulino.com.br/labs/)
 [![GitHub](https://img.shields.io/badge/GitHub-diogopaulino-181717?style=flat-square&logo=github&logoColor=white)](https://github.com/diogopaulino)
 [![LinkedIn](https://img.shields.io/badge/LinkedIn-Diogo_Paulino-0A66C2?style=flat-square)](https://br.linkedin.com/in/diogopaulino)
 [![Spotify](https://img.shields.io/badge/Spotify-Artist-1DB954?style=flat-square&logo=spotify&logoColor=white)](https://open.spotify.com/intl-pt/artist/0ue2WfDQ1P4XR2vXdSIrYQ)
@@ -32,12 +32,13 @@ Gosto de construir coisas — de time e produto até interface e código. Nessa 
 
 > *Abre, experimenta, quebra, reconstrói. Esse é o espírito.*
 
-Um laboratório aberto com **57 experimentos** que rodam direto no navegador — HTML, CSS e JavaScript puro, sem instalar nada. Catálogo completo em [diogopaulino.com.br/labs](https://diogopaulino.com.br/labs/).
+Um laboratório aberto com **58 experimentos** que rodam direto no navegador — HTML, CSS e JavaScript puro, sem instalar nada. Catálogo completo em [diogopaulino.com.br/labs](https://diogopaulino.com.br/labs/).
 
 ### 🪐 Mundos 3D
 
 | Projeto | O que é? |
 | :--- | :--- |
+| ♟️ **[Xadrez](https://diogopaulino.com.br/labs/xadrez/)** | Atelier 3D — peças Staunton de marfim e ébano, reflexos e um mestre que ensina a jogar |
 | 🟡 **[Tatu Bola](https://diogopaulino.com.br/labs/tatu-bola/)** | Platformer 3D estilo PS1 — pule, role e colete cristais na ilha low-poly |
 | ★ **[Cúpola 64](https://diogopaulino.com.br/labs/cupola-64/)** | Platformer 3D no espírito Super Mario 64 — Nico, câmera Lakitu, pulo triplo e sete estrelas |
 | 🏮 **[A Menina da Lanterna](https://diogopaulino.com.br/labs/menina-da-lanterna/)** | Conto 3D — Clara carrega a última chama, acende Vale-da-Bruma e traz o primeiro sol |

--- a/index.html
+++ b/index.html
@@ -157,7 +157,7 @@
       </nav>
       <div class="labs-easter-egg" id="labs-easter-egg">
         <a href="/labs/" class="labs-badge"
-          aria-label="Labs de Diogo Paulino: 57 experimentos de jogos, código, música e IA">
+          aria-label="Labs de Diogo Paulino: 58 experimentos de jogos, código, música e IA">
           <span class="labs-text">labs</span>
           <svg class="labs-sparkles" width="14" height="14" viewBox="0 0 24 24" fill="currentColor" stroke="none">
             <path d="M12 2L14.4 9.6L22 12L14.4 14.4L12 22L9.6 14.4L2 12L9.6 9.6L12 2Z" />

--- a/labs/index.html
+++ b/labs/index.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <title>Labs — Diogo Paulino | Jogos 3D, código, música e IA</title>
-  <meta name="description" content="57 experimentos de Diogo Paulino: jogos 3D, ferramentas, música e inteligência artificial em HTML, CSS e JavaScript puro.">
+  <meta name="description" content="58 experimentos de Diogo Paulino: jogos 3D, ferramentas, música e inteligência artificial em HTML, CSS e JavaScript puro.">
   <meta name="author" content="Diogo Paulino">
   <meta name="robots" content="index, follow">
   <meta name="theme-color" content="#fafbfc">
@@ -16,14 +16,14 @@
   <meta property="og:site_name" content="Diogo Paulino · Labs">
   <meta property="og:title" content="Labs — Diogo Paulino | Jogos 3D, código, música e IA">
   <meta property="og:description"
-    content="57 laboratórios de Diogo Paulino: mundos 3D, jogos, ferramentas, música e IA em HTML, CSS e JavaScript puro.">
+    content="58 laboratórios de Diogo Paulino: mundos 3D, jogos, ferramentas, música e IA em HTML, CSS e JavaScript puro.">
   <meta property="og:url" content="https://diogopaulino.com.br/labs/">
   <meta property="og:image" content="https://diogopaulino.com.br/assets/img/diogo.jpeg">
   <meta property="og:image:alt" content="Diogo Paulino">
   <meta property="og:locale" content="pt_BR">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Labs — Diogo Paulino | Jogos 3D, código, música e IA">
-  <meta name="twitter:description" content="57 experimentos de Diogo Paulino: jogos, código, música e inteligência artificial.">
+  <meta name="twitter:description" content="58 experimentos de Diogo Paulino: jogos, código, música e inteligência artificial.">
   <meta name="twitter:image" content="https://diogopaulino.com.br/assets/img/diogo.jpeg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -39,7 +39,7 @@
         "@id": "https://diogopaulino.com.br/labs/#page",
         "name": "Labs — Diogo Paulino",
         "url": "https://diogopaulino.com.br/labs/",
-        "description": "57 experimentos de Diogo Paulino: jogos 3D, ferramentas, música e inteligência artificial em HTML, CSS e JavaScript puro.",
+        "description": "58 experimentos de Diogo Paulino: jogos 3D, ferramentas, música e inteligência artificial em HTML, CSS e JavaScript puro.",
         "inLanguage": "pt-BR",
         "isPartOf": {
           "@id": "https://diogopaulino.com.br/#website"
@@ -47,7 +47,7 @@
         "creator": {
           "@id": "https://diogopaulino.com.br/#person"
         },
-        "numberOfItems": 57,
+        "numberOfItems": 58,
         "mainEntity": {
           "@id": "https://diogopaulino.com.br/labs/#list"
         }
@@ -56,7 +56,7 @@
         "@type": "ItemList",
         "@id": "https://diogopaulino.com.br/labs/#list",
         "name": "Labs de Diogo Paulino",
-        "numberOfItems": 57,
+        "numberOfItems": 58,
                                         "itemListElement": [
           {
             "@type": "ListItem",
@@ -399,6 +399,12 @@
             "position": 57,
             "url": "https://diogopaulino.com.br/labs/amora/",
             "name": "Amora"
+          },
+          {
+            "@type": "ListItem",
+            "position": 58,
+            "url": "https://diogopaulino.com.br/labs/xadrez/",
+            "name": "Xadrez"
           }
         ]
       },
@@ -442,6 +448,28 @@
     </div>
 
     <div class="projects-grid">
+      <a href="/labs/xadrez/" class="project-card" data-groups="game,creative">
+        <div class="project-icon">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+            stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M8 20h8" />
+            <path d="M9 20c0-2 .8-3.2 2.2-3.8L12 12l.8 4.2C14.2 16.8 15 18 15 20" />
+            <path d="M12 12V8" />
+            <path d="M9.5 8.5 12 6l2.5 2.5" />
+            <circle cx="12" cy="4.6" r="1.2" />
+            <path d="M7 20h10" opacity="0.45" />
+          </svg>
+        </div>
+        <div class="project-content">
+          <h2>Xadrez</h2>
+          <p>Atelier 3D em three.js: peças Staunton de marfim e ébano, reflexos PBR e um mestre que ensina a jogar</p>
+          <div class="project-tags">
+            <span class="tag">three.js</span>
+            <span class="tag">Xadrez</span>
+            <span class="tag">Academia</span>
+          </div>
+        </div>
+      </a>
       <a href="/labs/tatu-bola/" class="project-card" data-groups="game,creative">
         <div class="project-icon">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"

--- a/labs/xadrez/index.html
+++ b/labs/xadrez/index.html
@@ -1,0 +1,272 @@
+<!DOCTYPE html>
+<html lang="pt-br" data-theme="dark">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport"
+        content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover">
+    <meta name="theme-color" content="#120c0a">
+    <title>Xadrez — atelier 3D que ensina | Diogo Paulino</title>
+    <meta name="description"
+        content="Xadrez 3D em three.js com peças Staunton de marfim e ébano, reflexos PBR e um mestre que ensina regras, táticas e aberturas. Um lab de Diogo Paulino.">
+    <link rel="canonical" href="https://diogopaulino.com.br/labs/xadrez/">
+    <meta name="author" content="Diogo Paulino">
+    <meta name="robots" content="index, follow">
+    <link rel="icon" href="/favicon.ico" sizes="any">
+    <meta property="og:image" content="https://diogopaulino.com.br/assets/img/diogo.jpeg">
+    <meta property="og:image:alt" content="Diogo Paulino">
+    <meta property="og:locale" content="pt_BR">
+    <meta name="twitter:image" content="https://diogopaulino.com.br/assets/img/diogo.jpeg">
+    <meta property="og:type" content="website">
+    <meta property="og:site_name" content="Diogo Paulino · Labs">
+    <meta property="og:url" content="https://diogopaulino.com.br/labs/xadrez/">
+    <meta property="og:title" content="Xadrez — atelier 3D que ensina | Diogo Paulino">
+    <meta property="og:description"
+        content="Peças Staunton com reflexo, tabuleiro laqueado e um mestre que ensina a jogar — three.js no navegador.">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Xadrez — atelier 3D que ensina | Diogo Paulino">
+    <meta name="twitter:description"
+        content="Xadrez 3D em three.js: marfim, ébano, reflexos e lições. Um lab de Diogo Paulino.">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;600;700&family=Outfit:wght@300;400;500;600;700&display=swap"
+        rel="stylesheet">
+    <link rel="stylesheet" href="/labs/shared.css?v=8">
+    <link rel="stylesheet" href="style.css">
+    <script type="importmap">
+    {
+        "imports": {
+            "three": "https://cdn.jsdelivr.net/npm/three@0.185.1/build/three.module.js",
+            "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.185.1/examples/jsm/"
+        }
+    }
+    </script>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@graph": [
+        {
+          "@type": "WebApplication",
+          "name": "Xadrez",
+          "url": "https://diogopaulino.com.br/labs/xadrez/",
+          "description": "Xadrez 3D em three.js com peças Staunton de marfim e ébano, reflexos PBR e um mestre que ensina regras, táticas e aberturas.",
+          "applicationCategory": "GameApplication",
+          "operatingSystem": "Any",
+          "inLanguage": "pt-BR",
+          "isAccessibleForFree": true,
+          "author": {
+            "@type": "Person",
+            "name": "Diogo Paulino",
+            "url": "https://diogopaulino.com.br/"
+          },
+          "image": "https://diogopaulino.com.br/assets/img/diogo.jpeg"
+        },
+        {
+          "@type": "BreadcrumbList",
+          "itemListElement": [
+            {
+              "@type": "ListItem",
+              "position": 1,
+              "name": "Diogo Paulino",
+              "item": "https://diogopaulino.com.br/"
+            },
+            {
+              "@type": "ListItem",
+              "position": 2,
+              "name": "Labs",
+              "item": "https://diogopaulino.com.br/labs/"
+            },
+            {
+              "@type": "ListItem",
+              "position": 3,
+              "name": "Xadrez",
+              "item": "https://diogopaulino.com.br/labs/xadrez/"
+            }
+          ]
+        }
+      ]
+    }
+    </script>
+</head>
+
+<body data-state="boot">
+    <main class="game-shell">
+        <header data-lab-header data-title="Xadrez" data-back-href="/labs/" data-back-label="Labs">
+            <template data-slot="logo">
+                <div class="app-logo">
+                    <span class="brand-mark" aria-hidden="true">♛</span>
+                    <span>Xadrez</span>
+                </div>
+            </template>
+        </header>
+
+        <section class="stage" aria-label="Tabuleiro de xadrez em 3D">
+            <canvas id="scene" aria-label="Atelier com tabuleiro Staunton de marfim e ébano"></canvas>
+            <div class="vignette" aria-hidden="true"></div>
+        </section>
+
+        <div id="hud" class="hud" hidden>
+            <aside id="coach" class="coach" aria-label="Mestre">
+                <button id="coachToggle" class="coach-toggle" type="button" aria-expanded="true">
+                    <span class="eyebrow"><i></i> Mestre</span>
+                    <span id="coachTitle">As 64 casas</span>
+                </button>
+                <div id="coachBody" class="coach-body">
+                    <p id="coachText" class="coach-text"></p>
+                    <p id="coachTip" class="coach-tip"></p>
+                    <div id="lessonNav" class="lesson-nav" hidden>
+                        <button id="prevLesson" class="dock-btn" type="button">Anterior</button>
+                        <button id="nextLesson" class="dock-btn accent" type="button">Próxima</button>
+                    </div>
+                    <ul id="lessonList" class="lesson-list" hidden></ul>
+                    <ul id="puzzleList" class="lesson-list" hidden></ul>
+                </div>
+            </aside>
+
+            <aside class="tray" aria-label="Partida">
+                <p id="statusLine" class="status">Brancas jogam</p>
+                <div id="captured" class="captured" aria-label="Peças capturadas"></div>
+                <ol id="moves" class="moves" aria-label="Histórico de lances"></ol>
+            </aside>
+
+            <div class="dock" role="toolbar" aria-label="Controles da partida">
+                <button id="modePlay" class="dock-btn" type="button">Jogar</button>
+                <button id="modeAcademy" class="dock-btn" type="button">Academia</button>
+                <button id="modePuzzles" class="dock-btn" type="button">Puzzles</button>
+                <button id="hintBtn" class="dock-btn accent" type="button" title="Dica">Dica</button>
+                <button id="undoBtn" class="dock-btn" type="button" title="Desfazer">Desfazer</button>
+                <button id="flipBtn" class="dock-btn" type="button" title="Virar tabuleiro">Virar</button>
+                <button id="newBtn" class="dock-btn" type="button">Nova</button>
+                <button id="muteBtn" class="dock-btn" type="button" title="Som (M)" aria-pressed="false">Som</button>
+            </div>
+        </div>
+
+        <div id="loadingOverlay" class="overlay loading-overlay">
+            <div class="overlay-card compact-card">
+                <p class="eyebrow"><i></i> three.js · PBR · Staunton</p>
+                <h2>Polindo<br>o ébano.</h2>
+                <p class="lede" id="loadingText">O atelier acende as lâmpadas.</p>
+                <div class="load-bar" aria-hidden="true"><i id="loadingFill"></i></div>
+            </div>
+        </div>
+
+        <div id="intro" class="overlay" hidden>
+            <div class="overlay-card intro-card">
+                <p class="eyebrow"><i></i> Atelier 3D</p>
+                <h2>Xadrez</h2>
+                <p class="lede">Peças Staunton de marfim e ébano sobre mogno laqueado. Um mestre comenta cada lance —
+                    da primeira casa até o xeque-mate.</p>
+                <ul class="feature-list">
+                    <li>Regras FIDE: roque, en passant, promoção, xeque e mate</li>
+                    <li>Academia com 14 lições e 8 puzzles táticos</li>
+                    <li>IA em três níveis · dois jogadores · tabuleiro livre</li>
+                </ul>
+                <div class="settings-row">
+                    <label class="field">
+                        <span>Modo</span>
+                        <select id="modeSelect">
+                            <option value="cpu">Contra a máquina</option>
+                            <option value="academy">Academia</option>
+                            <option value="puzzles">Puzzles</option>
+                            <option value="local">Dois jogadores</option>
+                            <option value="free">Tabuleiro livre</option>
+                        </select>
+                    </label>
+                    <label class="field">
+                        <span>Nível</span>
+                        <select id="levelSelect">
+                            <option value="iniciante">Iniciante</option>
+                            <option value="praticante" selected>Praticante</option>
+                            <option value="clube">Clube</option>
+                        </select>
+                    </label>
+                    <label class="field">
+                        <span>Qualidade</span>
+                        <select id="qualitySelect">
+                            <option value="auto">Automática</option>
+                            <option value="low">Leve</option>
+                            <option value="medium">Equilibrada</option>
+                            <option value="high">Atelier</option>
+                        </select>
+                    </label>
+                    <label class="field">
+                        <span>Peças</span>
+                        <select id="themeSelect">
+                            <option value="classic">Marfim &amp; ébano</option>
+                            <option value="crystal">Cristal</option>
+                        </select>
+                    </label>
+                </div>
+                <footer class="card-actions">
+                    <button id="startButton" class="primary-button" type="button">
+                        <span>Entrar no atelier</span>
+                        <i aria-hidden="true">→</i>
+                    </button>
+                </footer>
+            </div>
+        </div>
+
+        <div id="promoOverlay" class="overlay" hidden>
+            <div class="overlay-card compact-card">
+                <p class="eyebrow"><i></i> Promoção</p>
+                <h2>O peão chegou.</h2>
+                <p class="lede">Escolha a peça. Quase sempre a dama.</p>
+                <div class="promo-row">
+                    <button class="promo-btn" data-promo="q" type="button">Dama</button>
+                    <button class="promo-btn" data-promo="r" type="button">Torre</button>
+                    <button class="promo-btn" data-promo="b" type="button">Bispo</button>
+                    <button class="promo-btn" data-promo="n" type="button">Cavalo</button>
+                </div>
+            </div>
+        </div>
+
+        <div id="resultOverlay" class="overlay" hidden>
+            <div class="overlay-card compact-card">
+                <p class="eyebrow" id="resultKicker"><i></i> Fim</p>
+                <h2 id="resultTitle">Xeque-mate</h2>
+                <p class="lede" id="resultText"></p>
+                <footer class="card-actions">
+                    <button id="resultAgain" class="primary-button" type="button">
+                        <span>Jogar de novo</span>
+                    </button>
+                    <button id="resultClose" class="dock-btn" type="button">Fechar</button>
+                </footer>
+            </div>
+        </div>
+
+        <div id="errorOverlay" class="overlay" hidden>
+            <div class="overlay-card compact-card">
+                <p class="eyebrow eyebrow--danger"><i></i> WebGL indisponível</p>
+                <h2>O atelier não abriu.</h2>
+                <p class="lede" id="errorText">Este laboratório precisa de WebGL. Tente um navegador
+                    atualizado ou reative a aceleração de hardware.</p>
+            </div>
+        </div>
+
+        <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
+    </main>
+
+    <script src="/labs/shared.js?v=7" defer></script>
+    <script>
+        (function () {
+            function hasGpu() {
+                try {
+                    var c = document.createElement('canvas');
+                    return !!(c.getContext('webgl2') || c.getContext('webgl'));
+                } catch (e) { return false; }
+            }
+            if (!hasGpu()) {
+                document.addEventListener('DOMContentLoaded', function () {
+                    var err = document.getElementById('errorOverlay');
+                    var load = document.getElementById('loadingOverlay');
+                    if (load) load.hidden = true;
+                    if (err) err.hidden = false;
+                });
+            }
+        })();
+    </script>
+    <script type="module" src="src/main.js"></script>
+</body>
+
+</html>

--- a/labs/xadrez/src/ai.js
+++ b/labs/xadrez/src/ai.js
@@ -1,0 +1,195 @@
+/**
+ * IA de xadrez — minimax com poda alfa-beta e tabelas de casas.
+ *
+ * Avaliação (centipeões):
+ *   material + PST de abertura/meio + bônus de mobilidade e par de bispos
+ *   − penalidade de rei aberto se a dama inimiga ainda está no tabuleiro.
+ *
+ * Dificuldade:
+ *   iniciante  → profundidade 1 + ruído (erros didáticos)
+ *   praticante → profundidade 2
+ *   clube      → profundidade 3
+ */
+
+const VAL = {
+    p: 100, n: 320, b: 330, r: 500, q: 900, k: 20000
+};
+
+const PST = {
+    p: [
+        0, 0, 0, 0, 0, 0, 0, 0,
+        50, 50, 50, 50, 50, 50, 50, 50,
+        10, 10, 20, 30, 30, 20, 10, 10,
+        5, 5, 10, 25, 25, 10, 5, 5,
+        0, 0, 0, 20, 20, 0, 0, 0,
+        5, -5, -10, 0, 0, -10, -5, 5,
+        5, 10, 10, -20, -20, 10, 10, 5,
+        0, 0, 0, 0, 0, 0, 0, 0
+    ],
+    n: [
+        -50, -40, -30, -30, -30, -30, -40, -50,
+        -40, -20, 0, 0, 0, 0, -20, -40,
+        -30, 0, 10, 15, 15, 10, 0, -30,
+        -30, 5, 15, 20, 20, 15, 5, -30,
+        -30, 0, 15, 20, 20, 15, 0, -30,
+        -30, 5, 10, 15, 15, 10, 5, -30,
+        -40, -20, 0, 5, 5, 0, -20, -40,
+        -50, -40, -30, -30, -30, -30, -40, -50
+    ],
+    b: [
+        -20, -10, -10, -10, -10, -10, -10, -20,
+        -10, 0, 0, 0, 0, 0, 0, -10,
+        -10, 0, 5, 10, 10, 5, 0, -10,
+        -10, 5, 5, 10, 10, 5, 5, -10,
+        -10, 0, 10, 10, 10, 10, 0, -10,
+        -10, 10, 10, 10, 10, 10, 10, -10,
+        -10, 5, 0, 0, 0, 0, 5, -10,
+        -20, -10, -10, -10, -10, -10, -10, -20
+    ],
+    r: [
+        0, 0, 0, 0, 0, 0, 0, 0,
+        5, 10, 10, 10, 10, 10, 10, 5,
+        -5, 0, 0, 0, 0, 0, 0, -5,
+        -5, 0, 0, 0, 0, 0, 0, -5,
+        -5, 0, 0, 0, 0, 0, 0, -5,
+        -5, 0, 0, 0, 0, 0, 0, -5,
+        -5, 0, 0, 0, 0, 0, 0, -5,
+        0, 0, 0, 5, 5, 0, 0, 0
+    ],
+    q: [
+        -20, -10, -10, -5, -5, -10, -10, -20,
+        -10, 0, 0, 0, 0, 0, 0, -10,
+        -10, 0, 5, 5, 5, 5, 0, -10,
+        -5, 0, 5, 5, 5, 5, 0, -5,
+        0, 0, 5, 5, 5, 5, 0, -5,
+        -10, 5, 5, 5, 5, 5, 0, -10,
+        -10, 0, 5, 0, 0, 0, 0, -10,
+        -20, -10, -10, -5, -5, -10, -10, -20
+    ],
+    k: [
+        -30, -40, -40, -50, -50, -40, -40, -30,
+        -30, -40, -40, -50, -50, -40, -40, -30,
+        -30, -40, -40, -50, -50, -40, -40, -30,
+        -30, -40, -40, -50, -50, -40, -40, -30,
+        -20, -30, -30, -40, -40, -30, -30, -20,
+        -10, -20, -20, -20, -20, -20, -20, -10,
+        20, 20, 0, 0, 0, 0, 20, 20,
+        20, 30, 10, 0, 0, 10, 30, 20
+    ]
+};
+
+const DEPTH = { iniciante: 1, praticante: 2, clube: 3 };
+
+function pst(type, index, color) {
+    const table = PST[type];
+    const i = color === 'w' ? index ^ 56 : index;
+    return table[i];
+}
+
+export function evaluate(game) {
+    let score = 0;
+    let wb = 0;
+    let bb = 0;
+    for (let i = 0; i < 64; i++) {
+        const p = game.board[i];
+        if (!p) continue;
+        const s = VAL[p.t] + pst(p.t, i, p.c);
+        score += p.c === 'w' ? s : -s;
+        if (p.t === 'b') {
+            if (p.c === 'w') wb += 1;
+            else bb += 1;
+        }
+    }
+    if (wb >= 2) score += 30;
+    if (bb >= 2) score -= 30;
+    return score;
+}
+
+function order(moves) {
+    return moves.slice().sort((a, b) => scoreMove(b) - scoreMove(a));
+}
+
+function scoreMove(m) {
+    let s = 0;
+    if (m.captured) s += 10 * VAL[m.captured.t];
+    if (m.promo) s += 800;
+    if (m.flag === 'k' || m.flag === 'q') s += 40;
+    if (m.flag === 'e') s += 20;
+    return s;
+}
+
+function minimax(game, depth, alpha, beta) {
+    const st = game.status();
+    if (st.over) {
+        if (st.reason === 'xeque-mate') return game.side === 'w' ? -99999 + (3 - depth) : 99999 - (3 - depth);
+        return 0;
+    }
+    if (depth <= 0) return evaluate(game);
+
+    const moves = order(st.moves);
+    if (game.side === 'w') {
+        let best = -Infinity;
+        for (const m of moves) {
+            game.play(m);
+            const val = minimax(game, depth - 1, alpha, beta);
+            game.undo();
+            if (val > best) best = val;
+            if (best > alpha) alpha = best;
+            if (beta <= alpha) break;
+        }
+        return best;
+    }
+    let best = Infinity;
+    for (const m of moves) {
+        game.play(m);
+        const val = minimax(game, depth - 1, alpha, beta);
+        game.undo();
+        if (val < best) best = val;
+        if (best < beta) beta = best;
+        if (beta <= alpha) break;
+    }
+    return best;
+}
+
+export function pickMove(game, level = 'praticante', rng = Math.random) {
+    const moves = game.legalMoves();
+    if (!moves.length) return null;
+
+    if (level === 'iniciante' && rng() < 0.28) {
+        const captures = moves.filter((m) => m.captured);
+        const pool = captures.length && rng() < 0.7 ? captures : moves;
+        return pool[Math.floor(rng() * pool.length)];
+    }
+
+    const depth = DEPTH[level] || 2;
+    const color = game.side;
+    let best = color === 'w' ? -Infinity : Infinity;
+    const scored = [];
+
+    for (const m of order(moves)) {
+        game.play(m);
+        const val = minimax(game, depth - 1, -Infinity, Infinity);
+        game.undo();
+        scored.push({ m, val });
+        if (color === 'w') {
+            if (val > best) best = val;
+        } else if (val < best) best = best === Infinity ? val : Math.min(best, val);
+    }
+
+    scored.sort((a, b) => (color === 'w' ? b.val - a.val : a.val - b.val));
+    if (level === 'iniciante' && scored.length > 1 && rng() < 0.35) {
+        return scored[Math.min(1, scored.length - 1)].m;
+    }
+    return scored[0].m;
+}
+
+export function hintMove(game) {
+    return pickMove(game, 'praticante', () => 0.11);
+}
+
+export function moveScore(game, move) {
+    game.play(move);
+    const val = evaluate(game);
+    game.undo();
+    return game.side === 'w' ? val : -val;
+}

--- a/labs/xadrez/src/audio.js
+++ b/labs/xadrez/src/audio.js
@@ -1,0 +1,135 @@
+/**
+ * Áudio sintetizado — madeira, captura, xeque e o hush do atelier.
+ */
+
+export class SalonAudio {
+    constructor() {
+        this.ctx = null;
+        this.enabled = true;
+        this.volume = 0.7;
+    }
+
+    init() {
+        if (this.ctx) {
+            if (this.ctx.state === 'suspended') this.ctx.resume();
+            return;
+        }
+        const Ctx = window.AudioContext || window.webkitAudioContext;
+        if (!Ctx) return;
+        const ctx = new Ctx();
+        this.ctx = ctx;
+        this.master = ctx.createGain();
+        this.master.gain.value = this.enabled ? this.volume : 0;
+        this.sfx = ctx.createGain();
+        this.amb = ctx.createGain();
+        this.sfx.gain.value = 0.9;
+        this.amb.gain.value = 0.28;
+        this.sfx.connect(this.master);
+        this.amb.connect(this.master);
+        this.master.connect(ctx.destination);
+        this._room();
+    }
+
+    setEnabled(on) {
+        this.enabled = on;
+        if (!this.master || !this.ctx) return;
+        this.master.gain.setTargetAtTime(on ? this.volume : 0, this.ctx.currentTime, 0.08);
+        if (on && this.ctx.state === 'suspended') this.ctx.resume();
+    }
+
+    _now() {
+        return this.ctx ? this.ctx.currentTime : 0;
+    }
+
+    _env(g, t, a, d, peak) {
+        g.gain.setValueAtTime(0.0001, t);
+        g.gain.exponentialRampToValueAtTime(peak, t + a);
+        g.gain.exponentialRampToValueAtTime(0.0001, t + a + d);
+    }
+
+    _noise(dur, peak, freq) {
+        if (!this.ctx || !this.enabled) return;
+        const t = this._now();
+        const src = this.ctx.createBufferSource();
+        const len = Math.ceil(this.ctx.sampleRate * dur);
+        const buf = this.ctx.createBuffer(1, len, this.ctx.sampleRate);
+        const data = buf.getChannelData(0);
+        for (let i = 0; i < len; i++) data[i] = Math.random() * 2 - 1;
+        src.buffer = buf;
+        const bp = this.ctx.createBiquadFilter();
+        bp.type = 'bandpass';
+        bp.frequency.value = freq;
+        const g = this.ctx.createGain();
+        src.connect(bp);
+        bp.connect(g);
+        g.connect(this.sfx);
+        this._env(g, t, 0.004, dur, peak);
+        src.start(t);
+        src.stop(t + dur + 0.02);
+    }
+
+    _tone(type, freq, dur, peak) {
+        if (!this.ctx || !this.enabled) return;
+        const t = this._now();
+        const o = this.ctx.createOscillator();
+        const g = this.ctx.createGain();
+        o.type = type;
+        o.frequency.value = freq;
+        o.connect(g);
+        g.connect(this.sfx);
+        this._env(g, t, 0.01, dur, peak);
+        o.start(t);
+        o.stop(t + dur + 0.04);
+    }
+
+    _room() {
+        if (!this.ctx) return;
+        const o = this.ctx.createOscillator();
+        o.type = 'sine';
+        o.frequency.value = 62;
+        const g = this.ctx.createGain();
+        g.gain.value = 0.03;
+        const f = this.ctx.createBiquadFilter();
+        f.type = 'lowpass';
+        f.frequency.value = 180;
+        o.connect(f);
+        f.connect(g);
+        g.connect(this.amb);
+        o.start();
+    }
+
+    move() {
+        this._noise(0.07, 0.16, 420);
+        this._tone('sine', 180, 0.08, 0.05);
+    }
+
+    capture() {
+        this._noise(0.12, 0.22, 180);
+        this._tone('triangle', 90, 0.16, 0.08);
+    }
+
+    check() {
+        this._tone('sine', 660, 0.18, 0.07);
+        this._tone('sine', 990, 0.22, 0.05);
+    }
+
+    castle() {
+        this._noise(0.16, 0.14, 280);
+        this._tone('sine', 220, 0.2, 0.04);
+    }
+
+    illegal() {
+        this._tone('square', 140, 0.1, 0.04);
+    }
+
+    win() {
+        this._tone('sine', 523, 0.25, 0.06);
+        setTimeout(() => this._tone('sine', 659, 0.28, 0.06), 140);
+        setTimeout(() => this._tone('sine', 784, 0.4, 0.07), 280);
+    }
+
+    promote() {
+        this._tone('sine', 784, 0.2, 0.05);
+        this._tone('sine', 1046, 0.28, 0.04);
+    }
+}

--- a/labs/xadrez/src/coach.js
+++ b/labs/xadrez/src/coach.js
@@ -1,0 +1,309 @@
+/**
+ * Academia — lições, puzzles e o texto do mestre.
+ *
+ * Cada lição carrega um FEN, explica a regra e (quando há tarefa) espera um
+ * lance específico. Puzzles são posições táticas com um único lance-chave.
+ */
+
+export const LESSONS = [
+    {
+        id: 'tabuleiro',
+        title: 'As 64 casas',
+        kicker: 'Fundamento',
+        fen: '8/8/8/8/4P3/8/8/8 w - - 0 1',
+        text: 'O tabuleiro tem 8 colunas (a–h, da esquerda das brancas) e 8 fileiras (1–8). A casa h1, no canto direito das brancas, é clara. O peão em e4 já ocupa o centro — o coração de quase toda abertura.',
+        tip: 'Toque o peão em e4 e depois a casa e5 para avançá-lo. O centro vale ouro.',
+        expect: { from: 'e4', to: 'e5' },
+        success: 'Isso. Quem controla o centro restringe as peças rivais e abre linhas para as próprias.'
+    },
+    {
+        id: 'peao',
+        title: 'O peão',
+        kicker: 'Peças',
+        fen: '4k3/8/8/8/8/8/4P3/4K3 w - - 0 1',
+        text: 'O peão só anda para frente: uma casa, ou duas se ainda está na casa inicial. Ele captura na diagonal — nunca para frente. É a única peça que não recua.',
+        tip: 'Avance o peão-rei duas casas: e2 → e4. Esse é o lance mais jogado da história.',
+        expect: { from: 'e2', to: 'e4' },
+        success: 'e4 abre caminhos para o bispo de rei e para a dama. A partida começou de verdade.'
+    },
+    {
+        id: 'peao-captura',
+        title: 'Captura do peão',
+        kicker: 'Peças',
+        fen: '4k3/8/8/3p4/4P3/8/8/4K3 w - - 0 1',
+        text: 'Peões capturam uma casa na diagonal à frente. Aqui o peão branco em e4 pode tomar o preto em d5. Depois da captura, ele ocupa d5.',
+        tip: 'Toque o peão branco e a casa d5. A captura se escreve exd5.',
+        expect: { from: 'e4', to: 'd5' },
+        success: 'exd5. Note: o peão mudou de coluna. Cadeias de peões nascem dessas trocas.'
+    },
+    {
+        id: 'en-passant',
+        title: 'En passant',
+        kicker: 'Especiais',
+        fen: '4k3/8/8/3pP3/8/8/8/4K3 w - d6 0 1',
+        text: 'Se um peão inimigo avança duas casas e para ao lado do seu, você pode capturá-lo “de passagem”, como se ele tivesse andado só uma. Só vale no lance imediatamente seguinte.',
+        tip: 'O peão em e5 captura en passant em d6, e o peão preto em d5 some.',
+        expect: { from: 'e5', to: 'd6' },
+        success: 'En passant. A casa de chegada é d6 — atrás de onde o peão preto “passou”.'
+    },
+    {
+        id: 'cavalo',
+        title: 'O cavalo',
+        kicker: 'Peças',
+        fen: '4k3/8/8/8/8/8/8/1N2K3 w - - 0 1',
+        text: 'O cavalo salta em L: duas casas em linha e uma perpendicular. É a única peça que atravessa as outras. No desenvolvimento clássico ele vai a c3 ou f3.',
+        tip: 'Salte o cavalo de b1 para c3, controlando d5 e e4.',
+        expect: { from: 'b1', to: 'c3' },
+        success: 'Nc3. Dois cavalos no centro (c3 e f3) são o esqueleto de quase toda abertura aberta.'
+    },
+    {
+        id: 'bispo',
+        title: 'O bispo',
+        kicker: 'Peças',
+        fen: '4k3/8/8/8/8/8/8/2B1K3 w - - 0 1',
+        text: 'O bispo corre nas diagonais e nunca muda de cor de casa. Cada lado tem um bispo claro e um escuro. Diagonais longas atravessam o tabuleiro inteiro.',
+        tip: 'Leve o bispo de c1 a a3, na diagonal que aponta para o rei preto.',
+        expect: { from: 'c1', to: 'a3' },
+        success: 'Ba3. O bispo continua nas casas escuras para sempre — por isso o par de bispos é tão forte.'
+    },
+    {
+        id: 'bispo-centro',
+        title: 'Bispo italiano',
+        kicker: 'Peças',
+        fen: 'rnbqkbnr/pppp1ppp/8/4p3/4P3/8/PPPP1PPP/RNBQKBNR w KQkq - 0 2',
+        text: 'Na Abertura Italiana o bispo vai a c4, olhando f7 — o ponto mais fraco do preto no começo, defendido só pelo rei.',
+        tip: 'Jogue Bc4. O bispo de rei sai, o roque fica mais perto.',
+        expect: { from: 'f1', to: 'c4' },
+        success: 'Bc4. Nas próximas lições você vai ver por que f7 é tão cobiçado.'
+    },
+    {
+        id: 'torre',
+        title: 'A torre',
+        kicker: 'Peças',
+        fen: '4k3/8/8/8/8/8/8/R3K3 w Q - 0 1',
+        text: 'A torre anda em colunas e fileiras. Vale 5 peões. Ela brilha em colunas abertas e na sétima fileira, comendo peões pela base. No início fica presa até o roque.',
+        tip: 'Suba a torre pela coluna a até a5.',
+        expect: { from: 'a1', to: 'a5' },
+        success: 'Ta5. Uma torre na quinta já corta o rei. Duas torres na sétima quase sempre vencem.'
+    },
+    {
+        id: 'dama',
+        title: 'A dama',
+        kicker: 'Peças',
+        fen: 'rnbqkbnr/pppp1ppp/8/4p3/2B1P3/5Q2/PPPP1PPP/RNB1K1NR w KQkq - 0 4',
+        text: 'A dama une torre e bispo — a peça mais poderosa (9 peões). Sair cedo demais é perigoso: o rival desenvolve ganhando tempos atacando-a. Ainda assim, Qf3–Qh5 é o Mate do Pastor.',
+        tip: 'Mate do Pastor: jogue Qxf7#. A dama, protegida pelo bispo em c4, captura em f7.',
+        expect: { from: 'f3', to: 'f7' },
+        success: 'Qxf7#. O rei não pode tomar (o bispo defende f7) nem fugir. Mate em quatro lances — raro entre iguais, mortal contra iniciantes.'
+    },
+    {
+        id: 'rei',
+        title: 'O rei',
+        kicker: 'Peças',
+        fen: '8/8/8/3k4/8/4K3/8/8 w - - 0 1',
+        text: 'O rei anda uma casa em qualquer direção. No meio-jogo ele se esconde; no final ele ataca. Dois reis nunca se encostam: a casa ao lado do outro está sempre em xeque.',
+        tip: 'Ocupar a oposição: jogue Rd3, ficando de frente ao rei preto com uma casa no meio.',
+        expect: { from: 'e3', to: 'd3' },
+        success: 'Os reis estão em oposição vertical. Quem tem a vez costuma ser forçado a ceder terreno.'
+    },
+    {
+        id: 'roque',
+        title: 'O roque',
+        kicker: 'Especiais',
+        fen: 'rnbqk2r/pppp1ppp/5n2/2b1p3/2B1P3/5N2/PPPP1PPP/RNBQK2R w KQkq - 4 4',
+        text: 'O roque, único lance com duas peças, mete o rei na ala e a torre no centro. Condições: rei e torre imóvel, casas vazias no caminho, rei não em xeque e não atravessa casa atacada. Roque pequeno (O-O) vai à ala do rei; o grande (O-O-O), à da dama.',
+        tip: 'Roque pequeno: toque o rei e a casa g1 (ou a torre de h1, se preferir pensar no par).',
+        expect: { from: 'e1', to: 'g1' },
+        success: 'O-O. O rei está em g1, a torre em f1. Segurança e desenvolvimento num só lance.'
+    },
+    {
+        id: 'xeque',
+        title: 'Sair do xeque',
+        kicker: 'Regras',
+        fen: '4k3/8/8/8/8/4q3/8/4K3 w - - 0 1',
+        text: 'Xeque é um ataque ao rei. Há três respostas: capturar a peça que ataca, bloquear a linha, ou fugir com o rei. Não vale “ignorar”.',
+        tip: 'A dama em e3 dá xeque pela coluna. O rei foge para f1 — fora da coluna e da diagonal da dama.',
+        expect: { from: 'e1', to: 'f1' },
+        success: 'O rei saiu da coluna e. Bloquear só funciona contra peças que deslizam; contra um cavalo, só capturar ou fugir.'
+    },
+    {
+        id: 'mate-corredor',
+        title: 'Mate do corredor',
+        kicker: 'Tática',
+        fen: '6k1/5ppp/8/8/8/8/5PPP/4R1K1 w - - 0 1',
+        text: 'Quando a última fileira do rival está sem fuga (os peões “engaiolam” o rei), uma torre ou dama na oitava dá mate. Chama-se mate do corredor.',
+        tip: 'Te8#. A torre invade a oitava e o rei preto não tem casa nem bloqueio.',
+        expect: { from: 'e1', to: 'e8' },
+        success: 'Te8#. Deixe sempre uma “janelinha” (h3/a3) para o rei escapar desse mate.'
+    },
+    {
+        id: 'abertura',
+        title: 'Primeira abertura',
+        kicker: 'Estratégia',
+        fen: 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1',
+        text: 'Três ideias no começo: ocupar o centro (e4/d4), desenvolver cavalos e bispos, e fazer o roque. Não saia com a dama cedo, não mova o mesmo peão duas vezes, não deixe o rei no centro.',
+        tip: 'Jogue e4. Depois, nas partidas livres, siga com Cf3 e Bc4 — o começo italiano.',
+        expect: { from: 'e2', to: 'e4' },
+        success: 'e4. Você já sabe mover cada peça e o porquê do centro. Agora jogue de verdade — o mestre comenta cada lance.'
+    }
+];
+
+export const PUZZLES = [
+    {
+        id: 'pastor',
+        title: 'Mate do Pastor',
+        level: 'iniciante',
+        fen: 'rnbqkbnr/pppp1ppp/8/4p3/2B1P3/5Q2/PPPP1PPP/RNB1K1NR w KQkq - 0 4',
+        text: 'O bispo em c4 e a dama em f3 miram f7. Um lance e a partida acaba.',
+        expect: { from: 'f3', to: 'f7' },
+        success: 'Qxf7#. Mate clássico de iniciante — agora você também sabe defendê-lo (não jogue e5 e f6 fracos).'
+    },
+    {
+        id: 'corredor',
+        title: 'Mate do corredor',
+        level: 'iniciante',
+        fen: '6k1/5ppp/8/8/8/8/5PPP/4R1K1 w - - 0 1',
+        text: 'A oitava fileira está indefesa. A torre precisa só entrar.',
+        expect: { from: 'e1', to: 'e8' },
+        success: 'Te8#. Lembre-se de abrir a janelinha (h3) nas suas partidas.'
+    },
+    {
+        id: 'garfo',
+        title: 'Garfo de cavalo',
+        level: 'iniciante',
+        fen: 'q3k3/8/4N3/8/8/8/8/4K3 w - - 0 1',
+        text: 'O cavalo ataca duas peças ao mesmo tempo. Rei e dama estão no desenho do L a partir de c7.',
+        expect: { from: 'e6', to: 'c7' },
+        success: 'Cc7+. O rei sai do xeque e a dama cai no lance seguinte. Garfo é a tática mais comum do cavalo.'
+    },
+    {
+        id: 'cravada',
+        title: 'Cravada',
+        level: 'praticante',
+        fen: '4k3/8/2q5/1B6/8/8/8/4K3 w - - 0 1',
+        text: 'A dama preta está na mesma diagonal do rei. O bispo ataca a dama — e ela não pode fugir sem deixar o rei em xeque. Isso é uma cravada absoluta.',
+        expect: { from: 'b5', to: 'c6' },
+        success: 'Bxc6. A dama não pode recapturar: sairia da diagonal e o rei ficaria em xeque. Cravada.'
+    },
+    {
+        id: 'espeto',
+        title: 'Espeto',
+        level: 'praticante',
+        fen: 'r6k/8/3N4/8/8/8/8/4R2K w - - 0 1',
+        text: 'O espeto ataca a peça mais valiosa na frente; quando ela foge, a de trás cai. Rei e torre na oitava — o cavalo defende e8.',
+        expect: { from: 'e1', to: 'e8' },
+        success: 'Te8+. O rei sai do xeque e a torre de a8 cai no lance seguinte. Espeto na oitava.'
+    },
+    {
+        id: 'promocao',
+        title: 'Promoção',
+        level: 'iniciante',
+        fen: '3k4/4P3/8/8/8/8/8/4K3 w - - 0 1',
+        text: 'Peão na sétima. Ao chegar na oitava ele vira dama, torre, bispo ou cavalo. Quase sempre dama.',
+        expect: { from: 'e7', to: 'e8', promo: 'q' },
+        success: 'e8=D+. Um peão que promove vale uma dama nova — por isso finais de peão decidem partidas.'
+    },
+    {
+        id: 'descoberto',
+        title: 'Xeque descoberto',
+        level: 'praticante',
+        fen: '4k3/8/8/8/8/8/4B3/4R1K1 w - - 0 1',
+        text: 'Quando uma peça sai da linha de outra, a de trás ataca de surpresa. Se a de trás dá xeque, a da frente pode capturar à vontade.',
+        expect: { from: 'e2', to: 'a6' },
+        success: 'Ba6+. O rei está em xeque da torre. O bispo saiu da coluna e ainda ataca. Descoberta.'
+    },
+    {
+        id: 'sufocado',
+        title: 'Mate sufocado',
+        level: 'clube',
+        fen: '6rk/6pp/8/4N3/8/8/8/4K3 w - - 0 1',
+        text: 'O rei preto está preso pelos próprios peões e pela torre. O cavalo é a única peça que chega nessa casa. Mate sufocado — o mais elegante do xadrez.',
+        expect: { from: 'e5', to: 'f7' },
+        success: 'Cf7#. O rei não captura o cavalo: as próprias peças tapam todas as casas. Um clássico de Morphy.'
+    }
+];
+
+export const OPENING_NOTES = {
+    e4: 'Peão do rei — abre bispo e dama, luta imediata pelo centro.',
+    d4: 'Peão da dama — jogo mais fechado, estruturas sólidas.',
+    c4: 'Inglesa — pressiona d5 sem ocupar o centro com o peão-rei.',
+    Nf3: 'Reti / desenvolvimento — controla d4 e e5, adia o plano.',
+    Nc3: 'Desenvolve e defende e4/d5. Comum na Vienense e na dama.',
+    Bc4: 'Italiana — mira f7, o ponto mais fraco do preto.',
+    Bb5: 'Ruy López — pressiona o cavalo que defende e5.',
+    e5: 'Resposta clássica a e4. Simetria e luta pelo centro.',
+    c5: 'Siciliana — contra e4, luta assimétrica pela dama.',
+    e6: 'Francesa — sólida, contra-ataca d5 depois.',
+    c6: 'Caro-Kann — como a francesa, mas o bispo de c8 fica livre.',
+    d5: 'Escandinava (após e4) ou resposta clássica a d4.',
+    Nf6: 'Índia — flexível, impede e4 fácil.',
+    O: 'Roque. Rei a salvo, torre ao centro.'
+};
+
+const STORAGE_KEY = 'xadrez-progress';
+
+export function loadProgress() {
+    try {
+        return {
+            lessons: [],
+            puzzles: [],
+            ...JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}')
+        };
+    } catch {
+        return { lessons: [], puzzles: [] };
+    }
+}
+
+export function saveProgress(progress) {
+    try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(progress));
+    } catch { /* privado */ }
+}
+
+export function commentOnMove(san, { check, mate, captured, hangingAfter, castle, promo, opening }) {
+    if (mate) return 'Xeque-mate. A partida acabou — o rei não tem fuga, bloqueio nem captura.';
+    if (check) return `${san} dá xeque. O rival precisa sair agora: capturar, bloquear ou fugir.`;
+    if (castle) return `${san}. Rei à ala, torre ao centro — segurança e desenvolvimento juntos.`;
+    if (promo) return `${san}. O peão virou peça maior. Finais nascem desses passos.`;
+    if (captured) {
+        const names = { p: 'peão', n: 'cavalo', b: 'bispo', r: 'torre', q: 'dama', k: 'rei' };
+        return `${san} captura ${names[captured.t] || 'a peça'}. Troque quando o valor favorece você.`;
+    }
+    if (hangingAfter) return `${san} — cuidado: essa peça ficou desprotegida. O rival pode tomá-la de graça.`;
+    const key = san.replace(/[+#x]/g, '').slice(0, 3);
+    if (opening && OPENING_NOTES[san.replace(/[+#]/g, '')]) {
+        return OPENING_NOTES[san.replace(/[+#]/g, '')];
+    }
+    if (OPENING_NOTES[key]) return OPENING_NOTES[key];
+    if (san.startsWith('O')) return OPENING_NOTES.O;
+    return `${san}. Peças para o centro, rei a salvo, torres em colunas abertas.`;
+}
+
+export function describeSquare(index, game) {
+    const names = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'];
+    const file = names[index & 7];
+    const rank = (index >> 3) + 1;
+    const dark = ((index & 7) + (index >> 3)) % 2 === 0;
+    const p = game.board[index];
+    let line = `Casa ${file}${rank}, ${dark ? 'escura' : 'clara'}.`;
+    if (p) {
+        const color = p.c === 'w' ? 'branco' : 'preto';
+        line += ` ${PIECE_LABEL[p.t]} ${color}. ${HOW[p.t]}`;
+    }
+    return line;
+}
+
+const PIECE_LABEL = {
+    p: 'Peão', n: 'Cavalo', b: 'Bispo', r: 'Torre', q: 'Dama', k: 'Rei'
+};
+
+const HOW = {
+    p: 'Anda para frente, captura na diagonal.',
+    n: 'Salta em L e pode pular peças.',
+    b: 'Diagonais, sempre na mesma cor de casa.',
+    r: 'Colunas e fileiras, a peça das colunas abertas.',
+    q: 'A peça mais forte: qualquer linha reta.',
+    k: 'Uma casa em qualquer direção. Proteja-o.'
+};
+
+export { PIECE_LABEL, HOW };

--- a/labs/xadrez/src/engine.js
+++ b/labs/xadrez/src/engine.js
@@ -1,0 +1,596 @@
+/**
+ * Motor de xadrez — regras FIDE no tabuleiro 0–63.
+ *
+ * Índice = rank * 8 + file (a1 = 0, h1 = 7, a8 = 56, h8 = 63).
+ * Brancas avançam +rank. Lances legais filtram xeque próprio (cravadas).
+ *
+ * Roque: direitos + caminho vazio + rei não atravessa casa atacada.
+ * En passant: casa-alvo atrás do peão que andou dois; captura remove o peão.
+ * Promoção: peão na última fila vira D/T/B/C (padrão Dama).
+ * Mate = sem lances legais e rei em xeque; afogamento = sem lances e sem xeque.
+ */
+
+export const START_FEN = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1';
+
+export const FILES = 'abcdefgh';
+
+export const PIECE_NAME = {
+    p: 'Peão',
+    n: 'Cavalo',
+    b: 'Bispo',
+    r: 'Torre',
+    q: 'Dama',
+    k: 'Rei'
+};
+
+export const PIECE_HOW = {
+    p: 'Anda uma casa à frente (duas no primeiro lance). Captura só na diagonal. Na última fila, promove.',
+    n: 'Salta em L: duas casas numa direção e uma perpendicular. Única peça que pula as outras.',
+    b: 'Desliza nas diagonais, qualquer número de casas, sem pular peças.',
+    r: 'Desliza nas colunas e fileiras, qualquer número de casas, sem pular peças.',
+    q: 'Une torre e bispo: qualquer direção em linha reta, sem pular peças.',
+    k: 'Anda uma casa em qualquer direção. O roque é o lance especial com a torre.'
+};
+
+export const PIECE_VALUE = { p: 1, n: 3, b: 3, r: 5, q: 9, k: 0 };
+
+const KNIGHT_D = [[1, 2], [2, 1], [-1, 2], [-2, 1], [1, -2], [2, -1], [-1, -2], [-2, -1]];
+const KING_D = [[1, 0], [-1, 0], [0, 1], [0, -1], [1, 1], [1, -1], [-1, 1], [-1, -1]];
+const BISHOP_D = [[1, 1], [1, -1], [-1, 1], [-1, -1]];
+const ROOK_D = [[1, 0], [-1, 0], [0, 1], [0, -1]];
+
+export function sq(file, rank) {
+    return rank * 8 + file;
+}
+
+export function fileOf(i) {
+    return i & 7;
+}
+
+export function rankOf(i) {
+    return i >> 3;
+}
+
+export function inBoard(file, rank) {
+    return file >= 0 && file < 8 && rank >= 0 && rank < 8;
+}
+
+export function alg(i) {
+    return FILES[fileOf(i)] + (rankOf(i) + 1);
+}
+
+export function parseAlg(s) {
+    if (!s || s.length < 2) return -1;
+    const f = FILES.indexOf(s[0]);
+    const r = Number(s[1]) - 1;
+    if (!inBoard(f, r)) return -1;
+    return sq(f, r);
+}
+
+function cloneCastling(c) {
+    return { K: c.K, Q: c.Q, k: c.k, q: c.q };
+}
+
+function pieceFromChar(ch) {
+    const t = ch.toLowerCase();
+    return { t, c: ch === t ? 'b' : 'w' };
+}
+
+function charFromPiece(p) {
+    return p.c === 'w' ? p.t.toUpperCase() : p.t;
+}
+
+export class Chess {
+    constructor(fen = START_FEN) {
+        this.board = new Array(64).fill(null);
+        this.side = 'w';
+        this.castling = { K: true, Q: true, k: true, q: true };
+        this.ep = -1;
+        this.half = 0;
+        this.full = 1;
+        this.stack = [];
+        this.load(fen);
+    }
+
+    clone() {
+        const g = new Chess('8/8/8/8/8/8/8/8 w - - 0 1');
+        g.board = this.board.map((p) => (p ? { t: p.t, c: p.c } : null));
+        g.side = this.side;
+        g.castling = cloneCastling(this.castling);
+        g.ep = this.ep;
+        g.half = this.half;
+        g.full = this.full;
+        g.stack = [];
+        return g;
+    }
+
+    load(fen) {
+        const parts = fen.trim().split(/\s+/);
+        const rows = parts[0].split('/');
+        this.board.fill(null);
+        for (let r = 7; r >= 0; r--) {
+            const row = rows[7 - r];
+            let f = 0;
+            for (const ch of row) {
+                if (ch >= '1' && ch <= '8') {
+                    f += Number(ch);
+                } else {
+                    this.board[sq(f, r)] = pieceFromChar(ch);
+                    f += 1;
+                }
+            }
+        }
+        this.side = parts[1] === 'b' ? 'b' : 'w';
+        const cr = parts[2] || '-';
+        this.castling = {
+            K: cr.includes('K'),
+            Q: cr.includes('Q'),
+            k: cr.includes('k'),
+            q: cr.includes('q')
+        };
+        this.ep = parts[3] && parts[3] !== '-' ? parseAlg(parts[3]) : -1;
+        this.half = Number(parts[4] || 0);
+        this.full = Number(parts[5] || 1);
+        this.stack = [];
+    }
+
+    fen() {
+        let rows = '';
+        for (let r = 7; r >= 0; r--) {
+            let empty = 0;
+            for (let f = 0; f < 8; f++) {
+                const p = this.board[sq(f, r)];
+                if (!p) {
+                    empty += 1;
+                } else {
+                    if (empty) {
+                        rows += String(empty);
+                        empty = 0;
+                    }
+                    rows += charFromPiece(p);
+                }
+            }
+            if (empty) rows += String(empty);
+            if (r) rows += '/';
+        }
+        let cr = '';
+        if (this.castling.K) cr += 'K';
+        if (this.castling.Q) cr += 'Q';
+        if (this.castling.k) cr += 'k';
+        if (this.castling.q) cr += 'q';
+        if (!cr) cr = '-';
+        const ep = this.ep < 0 ? '-' : alg(this.ep);
+        return `${rows} ${this.side} ${cr} ${ep} ${this.half} ${this.full}`;
+    }
+
+    kingIndex(color) {
+        for (let i = 0; i < 64; i++) {
+            const p = this.board[i];
+            if (p && p.t === 'k' && p.c === color) return i;
+        }
+        return -1;
+    }
+
+    isAttacked(index, byColor) {
+        const f = fileOf(index);
+        const r = rankOf(index);
+        const pawnDir = byColor === 'w' ? -1 : 1;
+        for (const df of [-1, 1]) {
+            const pf = f + df;
+            const pr = r + pawnDir;
+            if (inBoard(pf, pr)) {
+                const p = this.board[sq(pf, pr)];
+                if (p && p.t === 'p' && p.c === byColor) return true;
+            }
+        }
+        for (const [df, dr] of KNIGHT_D) {
+            const nf = f + df;
+            const nr = r + dr;
+            if (!inBoard(nf, nr)) continue;
+            const p = this.board[sq(nf, nr)];
+            if (p && p.t === 'n' && p.c === byColor) return true;
+        }
+        for (const [df, dr] of KING_D) {
+            const nf = f + df;
+            const nr = r + dr;
+            if (!inBoard(nf, nr)) continue;
+            const p = this.board[sq(nf, nr)];
+            if (p && p.t === 'k' && p.c === byColor) return true;
+        }
+        if (this._slideHits(f, r, BISHOP_D, byColor, 'bq')) return true;
+        if (this._slideHits(f, r, ROOK_D, byColor, 'rq')) return true;
+        return false;
+    }
+
+    _slideHits(f, r, dirs, byColor, types) {
+        for (const [df, dr] of dirs) {
+            let nf = f + df;
+            let nr = r + dr;
+            while (inBoard(nf, nr)) {
+                const p = this.board[sq(nf, nr)];
+                if (p) {
+                    if (p.c === byColor && types.includes(p.t)) return true;
+                    break;
+                }
+                nf += df;
+                nr += dr;
+            }
+        }
+        return false;
+    }
+
+    inCheck(color = this.side) {
+        const k = this.kingIndex(color);
+        if (k < 0) return false;
+        return this.isAttacked(k, color === 'w' ? 'b' : 'w');
+    }
+
+    /**
+     * Lances pseudo-legais a partir de uma casa (ainda podem deixar o rei em xeque).
+     */
+    rawMovesFrom(from) {
+        const p = this.board[from];
+        if (!p) return [];
+        const out = [];
+        const f = fileOf(from);
+        const r = rankOf(from);
+        if (p.t === 'p') this._pawnMoves(from, f, r, p, out);
+        else if (p.t === 'n') this._stepMoves(from, f, r, p, KNIGHT_D, out);
+        else if (p.t === 'k') {
+            this._stepMoves(from, f, r, p, KING_D, out);
+            this._castleMoves(from, p, out);
+        } else if (p.t === 'b') this._slideMoves(from, f, r, p, BISHOP_D, out);
+        else if (p.t === 'r') this._slideMoves(from, f, r, p, ROOK_D, out);
+        else if (p.t === 'q') this._slideMoves(from, f, r, p, [...BISHOP_D, ...ROOK_D], out);
+        return out;
+    }
+
+    _push(out, from, to, extra = {}) {
+        const captured = extra.captured ?? this.board[to];
+        out.push({
+            from,
+            to,
+            promo: extra.promo || null,
+            captured: captured || null,
+            flag: extra.flag || (captured ? 'c' : 'n'),
+            epCap: extra.epCap ?? -1
+        });
+    }
+
+    _pawnMoves(from, f, r, p, out) {
+        const dir = p.c === 'w' ? 1 : -1;
+        const start = p.c === 'w' ? 1 : 6;
+        const last = p.c === 'w' ? 7 : 0;
+        const fwd = r + dir;
+        if (inBoard(f, fwd) && !this.board[sq(f, fwd)]) {
+            if (fwd === last) this._promos(out, from, sq(f, fwd), null);
+            else {
+                this._push(out, from, sq(f, fwd));
+                const two = r + dir * 2;
+                if (r === start && inBoard(f, two) && !this.board[sq(f, two)]) {
+                    this._push(out, from, sq(f, two), { flag: 'd' });
+                }
+            }
+        }
+        for (const df of [-1, 1]) {
+            const nf = f + df;
+            const nr = r + dir;
+            if (!inBoard(nf, nr)) continue;
+            const to = sq(nf, nr);
+            const t = this.board[to];
+            if (t && t.c !== p.c) {
+                if (nr === last) this._promos(out, from, to, t);
+                else this._push(out, from, to, { captured: t, flag: 'c' });
+            } else if (to === this.ep && this.ep >= 0) {
+                const capSq = sq(nf, r);
+                this._push(out, from, to, {
+                    captured: this.board[capSq],
+                    flag: 'e',
+                    epCap: capSq
+                });
+            }
+        }
+    }
+
+    _promos(out, from, to, captured) {
+        for (const promo of ['q', 'r', 'b', 'n']) {
+            this._push(out, from, to, { promo, captured, flag: captured ? 'c' : 'n' });
+        }
+    }
+
+    _stepMoves(from, f, r, p, dirs, out) {
+        for (const [df, dr] of dirs) {
+            const nf = f + df;
+            const nr = r + dr;
+            if (!inBoard(nf, nr)) continue;
+            const to = sq(nf, nr);
+            const t = this.board[to];
+            if (!t) this._push(out, from, to);
+            else if (t.c !== p.c) this._push(out, from, to, { captured: t, flag: 'c' });
+        }
+    }
+
+    _slideMoves(from, f, r, p, dirs, out) {
+        for (const [df, dr] of dirs) {
+            let nf = f + df;
+            let nr = r + dr;
+            while (inBoard(nf, nr)) {
+                const to = sq(nf, nr);
+                const t = this.board[to];
+                if (!t) this._push(out, from, to);
+                else {
+                    if (t.c !== p.c) this._push(out, from, to, { captured: t, flag: 'c' });
+                    break;
+                }
+                nf += df;
+                nr += dr;
+            }
+        }
+    }
+
+    _castleMoves(from, p, out) {
+        if (this.inCheck(p.c)) return;
+        const enemy = p.c === 'w' ? 'b' : 'w';
+        if (p.c === 'w' && from === 4) {
+            if (this.castling.K && !this.board[5] && !this.board[6]
+                && !this.isAttacked(5, enemy) && !this.isAttacked(6, enemy)
+                && this.board[7]?.t === 'r' && this.board[7]?.c === 'w') {
+                this._push(out, from, 6, { flag: 'k' });
+            }
+            if (this.castling.Q && !this.board[3] && !this.board[2] && !this.board[1]
+                && !this.isAttacked(3, enemy) && !this.isAttacked(2, enemy)
+                && this.board[0]?.t === 'r' && this.board[0]?.c === 'w') {
+                this._push(out, from, 2, { flag: 'q' });
+            }
+        }
+        if (p.c === 'b' && from === 60) {
+            if (this.castling.k && !this.board[61] && !this.board[62]
+                && !this.isAttacked(61, enemy) && !this.isAttacked(62, enemy)
+                && this.board[63]?.t === 'r' && this.board[63]?.c === 'b') {
+                this._push(out, from, 62, { flag: 'k' });
+            }
+            if (this.castling.q && !this.board[59] && !this.board[58] && !this.board[57]
+                && !this.isAttacked(59, enemy) && !this.isAttacked(58, enemy)
+                && this.board[56]?.t === 'r' && this.board[56]?.c === 'b') {
+                this._push(out, from, 58, { flag: 'q' });
+            }
+        }
+    }
+
+    legalMovesFrom(from) {
+        const p = this.board[from];
+        if (!p || p.c !== this.side) return [];
+        return this.rawMovesFrom(from).filter((m) => this._legal(m));
+    }
+
+    legalMoves() {
+        const all = [];
+        for (let i = 0; i < 64; i++) {
+            const p = this.board[i];
+            if (p && p.c === this.side) {
+                const ms = this.rawMovesFrom(i).filter((m) => this._legal(m));
+                all.push(...ms);
+            }
+        }
+        return all;
+    }
+
+    _legal(move) {
+        this.play(move);
+        const ok = !this.inCheck(this.side === 'w' ? 'b' : 'w');
+        this.undo();
+        return ok;
+    }
+
+    play(move) {
+        const piece = this.board[move.from];
+        const undo = {
+            from: move.from,
+            to: move.to,
+            piece,
+            captured: move.captured ? { t: move.captured.t, c: move.captured.c } : null,
+            promo: move.promo,
+            flag: move.flag,
+            epCap: move.epCap,
+            ep: this.ep,
+            castling: cloneCastling(this.castling),
+            half: this.half,
+            full: this.full,
+            side: this.side,
+            rookFrom: -1,
+            rookTo: -1
+        };
+
+        this.board[move.to] = piece;
+        this.board[move.from] = null;
+
+        if (move.flag === 'e' && move.epCap >= 0) {
+            this.board[move.epCap] = null;
+        }
+
+        if (move.flag === 'k' || move.flag === 'q') {
+            const rank = rankOf(move.from);
+            if (move.flag === 'k') {
+                undo.rookFrom = sq(7, rank);
+                undo.rookTo = sq(5, rank);
+            } else {
+                undo.rookFrom = sq(0, rank);
+                undo.rookTo = sq(3, rank);
+            }
+            this.board[undo.rookTo] = this.board[undo.rookFrom];
+            this.board[undo.rookFrom] = null;
+        }
+
+        if (move.promo) {
+            this.board[move.to] = { t: move.promo, c: piece.c };
+        }
+
+        if (piece.t === 'k') {
+            if (piece.c === 'w') {
+                this.castling.K = false;
+                this.castling.Q = false;
+            } else {
+                this.castling.k = false;
+                this.castling.q = false;
+            }
+        }
+        if (piece.t === 'r') {
+            if (move.from === 0) this.castling.Q = false;
+            if (move.from === 7) this.castling.K = false;
+            if (move.from === 56) this.castling.q = false;
+            if (move.from === 63) this.castling.k = false;
+        }
+        if (move.captured?.t === 'r') {
+            if (move.to === 0) this.castling.Q = false;
+            if (move.to === 7) this.castling.K = false;
+            if (move.to === 56) this.castling.q = false;
+            if (move.to === 63) this.castling.k = false;
+        }
+
+        this.ep = -1;
+        if (move.flag === 'd') {
+            this.ep = sq(fileOf(move.from), (rankOf(move.from) + rankOf(move.to)) >> 1);
+        }
+
+        const isPawn = piece.t === 'p';
+        this.half = isPawn || move.captured ? 0 : this.half + 1;
+        if (this.side === 'b') this.full += 1;
+        this.side = this.side === 'w' ? 'b' : 'w';
+        this.stack.push(undo);
+        return undo;
+    }
+
+    undo() {
+        const u = this.stack.pop();
+        if (!u) return;
+        this.board[u.from] = u.piece;
+        this.board[u.to] = u.flag === 'e' ? null : u.captured;
+        if (u.flag === 'e' && u.epCap >= 0) this.board[u.epCap] = u.captured;
+        if (u.rookFrom >= 0) {
+            this.board[u.rookFrom] = this.board[u.rookTo];
+            this.board[u.rookTo] = null;
+        }
+        this.ep = u.ep;
+        this.castling = u.castling;
+        this.half = u.half;
+        this.full = u.full;
+        this.side = u.side;
+    }
+
+    san(move) {
+        if (move.flag === 'k') return this._checkSuffix(move, 'O-O');
+        if (move.flag === 'q') return this._checkSuffix(move, 'O-O-O');
+        const piece = this.board[move.from];
+        const dest = alg(move.to);
+        const capture = !!(move.captured || move.flag === 'e' || move.flag === 'c');
+        let body;
+        if (piece.t === 'p') {
+            body = capture ? `${FILES[fileOf(move.from)]}x${dest}` : dest;
+            if (move.promo) body += `=${move.promo.toUpperCase()}`;
+        } else {
+            const letter = piece.t.toUpperCase();
+            body = `${letter}${this._disamb(move, piece)}${capture ? 'x' : ''}${dest}`;
+            if (move.promo) body += `=${move.promo.toUpperCase()}`;
+        }
+        return this._checkSuffix(move, body);
+    }
+
+    _disamb(move, piece) {
+        const others = [];
+        for (let i = 0; i < 64; i++) {
+            if (i === move.from) continue;
+            const p = this.board[i];
+            if (!p || p.t !== piece.t || p.c !== piece.c) continue;
+            const hits = this.rawMovesFrom(i).some((m) => m.to === move.to && this._legal(m));
+            if (hits) others.push(i);
+        }
+        if (!others.length) return '';
+        const sameFile = others.some((i) => fileOf(i) === fileOf(move.from));
+        const sameRank = others.some((i) => rankOf(i) === rankOf(move.from));
+        if (!sameFile) return FILES[fileOf(move.from)];
+        if (!sameRank) return String(rankOf(move.from) + 1);
+        return alg(move.from);
+    }
+
+    _checkSuffix(move, body) {
+        this.play(move);
+        const enemy = this.side;
+        const check = this.inCheck(enemy);
+        const none = this.legalMoves().length === 0;
+        this.undo();
+        if (check && none) return `${body}#`;
+        if (check) return `${body}+`;
+        return body;
+    }
+
+    status() {
+        const moves = this.legalMoves();
+        const check = this.inCheck();
+        if (!moves.length) {
+            return {
+                over: true,
+                result: check ? (this.side === 'w' ? '0-1' : '1-0') : '½-½',
+                reason: check ? 'xeque-mate' : 'afogamento',
+                check,
+                moves
+            };
+        }
+        if (this.half >= 100) {
+            return { over: true, result: '½-½', reason: '50 lances', check, moves };
+        }
+        if (this._insufficient()) {
+            return { over: true, result: '½-½', reason: 'material insuficiente', check, moves };
+        }
+        return { over: false, result: '*', reason: check ? 'xeque' : '', check, moves };
+    }
+
+    _insufficient() {
+        const pcs = this.board.filter(Boolean);
+        if (pcs.length === 2) return true;
+        if (pcs.length === 3) {
+            return pcs.some((p) => p.t === 'n' || p.t === 'b');
+        }
+        if (pcs.length === 4) {
+            const bishops = pcs.filter((p) => p.t === 'b');
+            if (bishops.length === 2) {
+                const sqs = [];
+                this.board.forEach((p, i) => { if (p?.t === 'b') sqs.push(i); });
+                const color = (i) => (fileOf(i) + rankOf(i)) & 1;
+                return color(sqs[0]) === color(sqs[1]);
+            }
+        }
+        return false;
+    }
+
+    findMove(from, to, promo = 'q') {
+        const list = this.legalMovesFrom(from);
+        const hits = list.filter((m) => m.to === to);
+        if (!hits.length) return null;
+        if (hits.length === 1) return hits[0];
+        return hits.find((m) => m.promo === promo) || hits.find((m) => m.promo === 'q') || hits[0];
+    }
+
+    moveBySan(san) {
+        const want = san.replace(/[+#]/g, '');
+        for (const m of this.legalMoves()) {
+            if (this.san(m).replace(/[+#]/g, '') === want) return m;
+        }
+        return null;
+    }
+
+    material(color) {
+        let n = 0;
+        for (const p of this.board) {
+            if (p && p.c === color) n += PIECE_VALUE[p.t];
+        }
+        return n;
+    }
+
+    hanging(index) {
+        const p = this.board[index];
+        if (!p) return false;
+        const enemy = p.c === 'w' ? 'b' : 'w';
+        if (!this.isAttacked(index, enemy)) return false;
+        return !this.isAttacked(index, p.c);
+    }
+}

--- a/labs/xadrez/src/main.js
+++ b/labs/xadrez/src/main.js
@@ -236,6 +236,8 @@ class Atelier {
         this.controls.autoRotateSpeed = 0.55;
 
         this.rebuildPieces();
+        this.renderer.compile(this.scene, this.camera);
+        this.renderer.render(this.scene, this.camera);
 
         this.canvas.addEventListener('pointerdown', (e) => this.onDown(e));
         this.canvas.addEventListener('pointerup', (e) => this.onUp(e));
@@ -778,20 +780,18 @@ class Atelier {
     }
 
     renderCaptured() {
-        const start = { w: { p: 8, n: 2, b: 2, r: 2, q: 1, k: 1 }, b: { p: 8, n: 2, b: 2, r: 2, q: 1, k: 1 } };
-        const now = { w: { p: 0, n: 0, b: 0, r: 0, q: 0, k: 0 }, b: { p: 0, n: 0, b: 0, r: 0, q: 0, k: 0 } };
-        for (const p of this.game.board) {
-            if (p) now[p.c][p.t] += 1;
+        const taken = { w: { q: 0, r: 0, b: 0, n: 0, p: 0 }, b: { q: 0, r: 0, b: 0, n: 0, p: 0 } };
+        for (const u of this.game.stack) {
+            if (u.captured) taken[u.captured.c][u.captured.t] += 1;
         }
         let html = '';
         for (const c of ['w', 'b']) {
             for (const t of ['q', 'r', 'b', 'n', 'p']) {
-                const n = start[c][t] - now[c][t];
-                for (let i = 0; i < n; i++) html += GLYPH[c][t];
+                for (let i = 0; i < taken[c][t]; i++) html += GLYPH[c][t];
             }
             if (c === 'w') html += '  ';
         }
-        document.getElementById('captured').textContent = html || '—';
+        document.getElementById('captured').textContent = html.trim() || '—';
     }
 
     renderMoves() {

--- a/labs/xadrez/src/main.js
+++ b/labs/xadrez/src/main.js
@@ -283,6 +283,7 @@ class Atelier {
         document.getElementById('hud').hidden = false;
         document.body.dataset.state = 'play';
         if (this.controls) this.controls.autoRotate = false;
+        this.resize();
         const mode = document.getElementById('modeSelect')?.value || 'cpu';
         this.setMode(mode);
     }

--- a/labs/xadrez/src/main.js
+++ b/labs/xadrez/src/main.js
@@ -247,6 +247,7 @@ class Atelier {
         document.getElementById('loadingOverlay').hidden = true;
         document.getElementById('intro').hidden = false;
         document.body.dataset.state = 'intro';
+        requestAnimationFrame(() => this.resize());
 
         this.clock.start();
         this.renderer.setAnimationLoop(() => this.frame());

--- a/labs/xadrez/src/main.js
+++ b/labs/xadrez/src/main.js
@@ -119,7 +119,17 @@ class Atelier {
     }
 
     bindUi() {
-        document.getElementById('startButton')?.addEventListener('click', () => this.start());
+        document.getElementById('startButton')?.addEventListener('click', (e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            this.start();
+        });
+        document.getElementById('intro')?.addEventListener('pointerup', (e) => {
+            if (e.target.closest('#startButton')) {
+                e.preventDefault();
+                this.start();
+            }
+        });
         document.getElementById('modePlay')?.addEventListener('click', () => this.setMode('cpu'));
         document.getElementById('modeAcademy')?.addEventListener('click', () => this.setMode('academy'));
         document.getElementById('modePuzzles')?.addEventListener('click', () => this.setMode('puzzles'));
@@ -157,9 +167,14 @@ class Atelier {
             });
         });
         window.addEventListener('keydown', (e) => {
+            if (document.body.dataset.state === 'intro' && (e.code === 'Enter' || e.code === 'Space' || e.code === 'Escape')) {
+                e.preventDefault();
+                this.start();
+                return;
+            }
             if (e.code === 'KeyM') this.toggleMute();
             if (e.code === 'KeyH') this.hint();
-            if (e.code === 'KeyU' || (e.metaKey || e.ctrlKey) && e.code === 'KeyZ') this.undo();
+            if (e.code === 'KeyU' || ((e.metaKey || e.ctrlKey) && e.code === 'KeyZ')) this.undo();
             if (e.code === 'KeyF') this.toggleFlip();
         });
     }
@@ -178,7 +193,7 @@ class Atelier {
         }
         this.renderer.outputColorSpace = THREE.SRGBColorSpace;
         this.renderer.toneMapping = THREE.ACESFilmicToneMapping;
-        this.renderer.toneMappingExposure = 1.05;
+        this.renderer.toneMappingExposure = 0.92;
         this.renderer.shadowMap.enabled = true;
         this.renderer.shadowMap.type = THREE.PCFSoftShadowMap;
         this.renderer.setClearColor(0x120c0a, 1);
@@ -234,6 +249,7 @@ class Atelier {
         this.clock.start();
         this.renderer.setAnimationLoop(() => this.frame());
         window.addEventListener('resize', () => this.resize());
+        window.visualViewport?.addEventListener('resize', () => this.resize());
     }
 
     resize() {
@@ -248,6 +264,7 @@ class Atelier {
     }
 
     start() {
+        if (document.body.dataset.state !== 'intro') return;
         this.audio.init();
         this.audio.setEnabled(!this.settings.muted);
         this.syncMute();
@@ -280,7 +297,7 @@ class Atelier {
         lessonList.hidden = mode !== 'academy';
         puzzleList.hidden = mode !== 'puzzles';
         if (isMobile()) {
-            coach?.classList.toggle('is-collapsed', mode !== 'academy' && mode !== 'puzzles');
+            coach?.classList.add('is-collapsed');
         }
         if (mode === 'academy') this.loadLesson(this.lessonIndex);
         else if (mode === 'puzzles') this.loadPuzzle(this.puzzleIndex);

--- a/labs/xadrez/src/main.js
+++ b/labs/xadrez/src/main.js
@@ -1,0 +1,843 @@
+/**
+ * Xadrez — atelier 3D.
+ * Cena PBR, seleção por raycast, animações em arco e o mestre comentando.
+ */
+
+import * as THREE from 'three';
+import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+import { RoomEnvironment } from 'three/addons/environments/RoomEnvironment.js';
+
+import { Chess, START_FEN, PIECE_NAME, PIECE_HOW, alg, parseAlg } from './engine.js';
+import { pickMove, hintMove } from './ai.js';
+import {
+    LESSONS, PUZZLES, commentOnMove, loadProgress, saveProgress
+} from './coach.js';
+import { createTextures } from './textures.js';
+import { PieceFactory } from './pieces.js';
+import {
+    buildWorld, setupLights, squareToWorld, worldToSquare, placeMark
+} from './world.js';
+import { SalonAudio } from './audio.js';
+
+const STORAGE = 'xadrez-settings';
+const GLYPH = {
+    w: { p: '♙', n: '♘', b: '♗', r: '♖', q: '♕', k: '♔' },
+    b: { p: '♟', n: '♞', b: '♝', r: '♜', q: '♛', k: '♚' }
+};
+
+const QUALITY = {
+    low: { id: 'low', pr: 1, seg: 24, shadows: true, shadowMap: 1024, reflect: 0, aniso: 4 },
+    medium: { id: 'medium', pr: 1.35, seg: 40, shadows: true, shadowMap: 2048, reflect: 512, aniso: 8 },
+    high: { id: 'high', pr: 1.75, seg: 56, shadows: true, shadowMap: 2048, reflect: 1024, aniso: 8 }
+};
+
+function isMobile() {
+    return /Mobi|Android|iPhone|iPad/i.test(navigator.userAgent) || window.innerWidth < 720;
+}
+
+function detectSoftwareGL(renderer) {
+    try {
+        const gl = renderer.getContext();
+        const info = gl.getExtension('WEBGL_debug_renderer_info');
+        const r = info ? gl.getParameter(info.UNMASKED_RENDERER_WEBGL) : '';
+        return /SwiftShader|llvmpipe|Soft/i.test(String(r));
+    } catch {
+        return false;
+    }
+}
+
+function pickQuality(mode, renderer) {
+    if (QUALITY[mode]) return QUALITY[mode];
+    if (detectSoftwareGL(renderer) || isMobile()) return QUALITY.low;
+    if ((window.devicePixelRatio || 1) >= 2 && innerWidth >= 1400) return QUALITY.high;
+    return QUALITY.medium;
+}
+
+function easeInOut(t) {
+    return t < 0.5 ? 2 * t * t : 1 - ((-2 * t + 2) ** 2) / 2;
+}
+
+class Atelier {
+    constructor() {
+        this.canvas = document.getElementById('scene');
+        this.settings = this.loadSettings();
+        this.audio = new SalonAudio();
+        this.game = new Chess();
+        this.mode = 'cpu';
+        this.level = 'praticante';
+        this.player = 'w';
+        this.flip = false;
+        this.selected = -1;
+        this.legal = [];
+        this.history = [];
+        this.busy = false;
+        this.anims = [];
+        this.pieces = new Map();
+        this.pieceRoot = new THREE.Group();
+        this.progress = loadProgress();
+        this.lessonIndex = 0;
+        this.puzzleIndex = 0;
+        this.expect = null;
+        this.pendingPromo = null;
+        this.clock = new THREE.Clock();
+        this.pointer = new THREE.Vector2();
+        this.raycaster = new THREE.Raycaster();
+        this.drag = { x: 0, y: 0, active: false };
+        this.bindUi();
+        this.boot();
+    }
+
+    loadSettings() {
+        try {
+            return {
+                quality: 'auto', theme: 'classic', level: 'praticante',
+                muted: false, ...JSON.parse(localStorage.getItem(STORAGE) || '{}')
+            };
+        } catch {
+            return { quality: 'auto', theme: 'classic', level: 'praticante', muted: false };
+        }
+    }
+
+    saveSettings() {
+        try { localStorage.setItem(STORAGE, JSON.stringify(this.settings)); } catch { /* privado */ }
+    }
+
+    setLoad(p, text) {
+        const fill = document.getElementById('loadingFill');
+        const line = document.getElementById('loadingText');
+        if (fill) fill.style.width = `${Math.round(p * 100)}%`;
+        if (text && line) line.textContent = text;
+    }
+
+    fail(err) {
+        console.error(err);
+        document.getElementById('loadingOverlay').hidden = true;
+        const overlay = document.getElementById('errorOverlay');
+        overlay.hidden = false;
+        const t = document.getElementById('errorText');
+        if (t && err) t.textContent = String(err.message || err);
+    }
+
+    bindUi() {
+        document.getElementById('startButton')?.addEventListener('click', () => this.start());
+        document.getElementById('modePlay')?.addEventListener('click', () => this.setMode('cpu'));
+        document.getElementById('modeAcademy')?.addEventListener('click', () => this.setMode('academy'));
+        document.getElementById('modePuzzles')?.addEventListener('click', () => this.setMode('puzzles'));
+        document.getElementById('hintBtn')?.addEventListener('click', () => this.hint());
+        document.getElementById('undoBtn')?.addEventListener('click', () => this.undo());
+        document.getElementById('flipBtn')?.addEventListener('click', () => this.toggleFlip());
+        document.getElementById('newBtn')?.addEventListener('click', () => this.fresh());
+        document.getElementById('muteBtn')?.addEventListener('click', () => this.toggleMute());
+        document.getElementById('prevLesson')?.addEventListener('click', () => this.shiftLesson(-1));
+        document.getElementById('nextLesson')?.addEventListener('click', () => this.shiftLesson(1));
+        document.getElementById('coachToggle')?.addEventListener('click', () => {
+            document.getElementById('coach')?.classList.toggle('is-collapsed');
+        });
+        document.getElementById('resultAgain')?.addEventListener('click', () => {
+            document.getElementById('resultOverlay').hidden = true;
+            this.fresh();
+        });
+        document.getElementById('resultClose')?.addEventListener('click', () => {
+            document.getElementById('resultOverlay').hidden = true;
+        });
+        document.querySelectorAll('.promo-btn').forEach((btn) => {
+            btn.addEventListener('click', () => this.finishPromo(btn.dataset.promo));
+        });
+        ['qualitySelect', 'themeSelect', 'levelSelect', 'modeSelect'].forEach((id) => {
+            const el = document.getElementById(id);
+            if (!el) return;
+            if (id === 'qualitySelect') el.value = this.settings.quality;
+            if (id === 'themeSelect') el.value = this.settings.theme;
+            if (id === 'levelSelect') el.value = this.settings.level;
+            el.addEventListener('change', () => {
+                if (id === 'qualitySelect') this.settings.quality = el.value;
+                if (id === 'themeSelect') this.settings.theme = el.value;
+                if (id === 'levelSelect') this.settings.level = el.value;
+                this.saveSettings();
+            });
+        });
+        window.addEventListener('keydown', (e) => {
+            if (e.code === 'KeyM') this.toggleMute();
+            if (e.code === 'KeyH') this.hint();
+            if (e.code === 'KeyU' || (e.metaKey || e.ctrlKey) && e.code === 'KeyZ') this.undo();
+            if (e.code === 'KeyF') this.toggleFlip();
+        });
+    }
+
+    async boot() {
+        try {
+            this.renderer = new THREE.WebGLRenderer({
+                canvas: this.canvas,
+                antialias: true,
+                alpha: false,
+                powerPreference: 'high-performance'
+            });
+        } catch (err) {
+            this.fail(err);
+            return;
+        }
+        this.renderer.outputColorSpace = THREE.SRGBColorSpace;
+        this.renderer.toneMapping = THREE.ACESFilmicToneMapping;
+        this.renderer.toneMappingExposure = 1.05;
+        this.renderer.shadowMap.enabled = true;
+        this.renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+        this.renderer.setClearColor(0x120c0a, 1);
+
+        this.quality = pickQuality(this.settings.quality, this.renderer);
+        this.renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, this.quality.pr));
+        this.resize();
+
+        this.scene = new THREE.Scene();
+        this.scene.fog = new THREE.Fog(0x120c0a, 16, 32);
+        this.camera = new THREE.PerspectiveCamera(38, innerWidth / innerHeight, 0.1, 80);
+        this.camera.position.set(0, 8.4, 10.6);
+
+        this.setLoad(0.2, 'Talhando o marfim…');
+        const tex = createTextures(this.quality.aniso);
+        this.setLoad(0.45, 'Montando o tabuleiro…');
+        this.world = buildWorld(tex, this.quality);
+        this.scene.add(this.world.root);
+        this.scene.add(this.pieceRoot);
+        this.factory = new PieceFactory(tex, this.quality);
+        if (this.settings.theme === 'crystal') this.factory.setTheme('crystal');
+
+        this.setLoad(0.7, 'Acendendo o lustre…');
+        setupLights(this.scene, this.quality);
+        const pmrem = new THREE.PMREMGenerator(this.renderer);
+        this.scene.environment = pmrem.fromScene(new RoomEnvironment(), 0.04).texture;
+        this.scene.environmentIntensity = 0.85;
+        pmrem.dispose();
+
+        this.controls = new OrbitControls(this.camera, this.canvas);
+        this.controls.enableDamping = true;
+        this.controls.dampingFactor = 0.07;
+        this.controls.target.set(0, 0.35, 0);
+        this.controls.minDistance = 6;
+        this.controls.maxDistance = 18;
+        this.controls.minPolarAngle = 0.35;
+        this.controls.maxPolarAngle = 1.25;
+        this.controls.enablePan = false;
+        this.controls.autoRotate = true;
+        this.controls.autoRotateSpeed = 0.55;
+
+        this.rebuildPieces();
+
+        this.canvas.addEventListener('pointerdown', (e) => this.onDown(e));
+        this.canvas.addEventListener('pointerup', (e) => this.onUp(e));
+
+        this.fillLists();
+        this.setLoad(1, 'O atelier está pronto.');
+        document.getElementById('loadingOverlay').hidden = true;
+        document.getElementById('intro').hidden = false;
+        document.body.dataset.state = 'intro';
+
+        this.clock.start();
+        this.renderer.setAnimationLoop(() => this.frame());
+        window.addEventListener('resize', () => this.resize());
+    }
+
+    resize() {
+        if (!this.renderer) return;
+        const w = innerWidth;
+        const h = innerHeight;
+        this.renderer.setSize(w, h, false);
+        if (this.camera) {
+            this.camera.aspect = w / Math.max(1, h);
+            this.camera.updateProjectionMatrix();
+        }
+    }
+
+    start() {
+        this.audio.init();
+        this.audio.setEnabled(!this.settings.muted);
+        this.syncMute();
+        this.level = document.getElementById('levelSelect')?.value || 'praticante';
+        this.settings.level = this.level;
+        const theme = document.getElementById('themeSelect')?.value || 'classic';
+        if (theme !== this.factory.mats.theme) {
+            this.factory.setTheme(theme);
+            this.settings.theme = theme;
+        }
+        this.saveSettings();
+        document.getElementById('intro').hidden = true;
+        document.getElementById('hud').hidden = false;
+        document.body.dataset.state = 'play';
+        if (this.controls) this.controls.autoRotate = false;
+        const mode = document.getElementById('modeSelect')?.value || 'cpu';
+        this.setMode(mode);
+    }
+
+    setMode(mode) {
+        this.mode = mode;
+        document.getElementById('modePlay')?.setAttribute('aria-pressed', String(mode === 'cpu' || mode === 'local' || mode === 'free'));
+        document.getElementById('modeAcademy')?.setAttribute('aria-pressed', String(mode === 'academy'));
+        document.getElementById('modePuzzles')?.setAttribute('aria-pressed', String(mode === 'puzzles'));
+        const lessonNav = document.getElementById('lessonNav');
+        const lessonList = document.getElementById('lessonList');
+        const puzzleList = document.getElementById('puzzleList');
+        const coach = document.getElementById('coach');
+        lessonNav.hidden = mode !== 'academy' && mode !== 'puzzles';
+        lessonList.hidden = mode !== 'academy';
+        puzzleList.hidden = mode !== 'puzzles';
+        if (isMobile()) {
+            coach?.classList.toggle('is-collapsed', mode !== 'academy' && mode !== 'puzzles');
+        }
+        if (mode === 'academy') this.loadLesson(this.lessonIndex);
+        else if (mode === 'puzzles') this.loadPuzzle(this.puzzleIndex);
+        else this.loadGame(START_FEN);
+        this.speakMode();
+    }
+
+    speakMode() {
+        if (this.mode === 'cpu') {
+            this.coach('Contra a máquina', 'Você joga de brancas. Toque uma peça e depois a casa de destino. O mestre comenta cada lance.', 'Dica destaca um bom lance. Desfazer volta o último par.');
+        } else if (this.mode === 'local') {
+            this.coach('Dois jogadores', 'Passem o aparelho. As brancas começam. Casas legais acendem ao selecionar.', 'Vire o tabuleiro depois do lance, se quiser.');
+        } else if (this.mode === 'free') {
+            this.coach('Tabuleiro livre', 'Os dois lados se movem. Experimente peças, roque e en passant sem o relógio da partida.', 'Nada é cobrado — só o que o mestre explica.');
+        }
+    }
+
+    fillLists() {
+        const lessonList = document.getElementById('lessonList');
+        const puzzleList = document.getElementById('puzzleList');
+        lessonList.innerHTML = '';
+        puzzleList.innerHTML = '';
+        LESSONS.forEach((ls, i) => {
+            const b = document.createElement('button');
+            b.type = 'button';
+            b.textContent = `${i + 1}. ${ls.title}`;
+            if (this.progress.lessons.includes(ls.id)) b.classList.add('is-done');
+            b.addEventListener('click', () => this.loadLesson(i));
+            lessonList.appendChild(b);
+        });
+        PUZZLES.forEach((pz, i) => {
+            const b = document.createElement('button');
+            b.type = 'button';
+            b.textContent = pz.title;
+            if (this.progress.puzzles.includes(pz.id)) b.classList.add('is-done');
+            b.addEventListener('click', () => this.loadPuzzle(i));
+            puzzleList.appendChild(b);
+        });
+    }
+
+    loadGame(fen) {
+        this.game.load(fen);
+        this.history = [];
+        this.selected = -1;
+        this.expect = null;
+        this.busy = false;
+        this.pendingPromo = null;
+        this.clearMarks();
+        this.rebuildPieces();
+        this.renderHud();
+    }
+
+    loadLesson(i) {
+        this.lessonIndex = (i + LESSONS.length) % LESSONS.length;
+        const ls = LESSONS[this.lessonIndex];
+        this.mode = 'academy';
+        this.loadGame(ls.fen);
+        this.expect = ls.expect;
+        this.coach(ls.title, ls.text, ls.tip);
+        this.markList('lessonList', this.lessonIndex);
+        document.getElementById('lessonNav').hidden = false;
+        document.getElementById('lessonList').hidden = false;
+        document.getElementById('puzzleList').hidden = true;
+    }
+
+    loadPuzzle(i) {
+        this.puzzleIndex = (i + PUZZLES.length) % PUZZLES.length;
+        const pz = PUZZLES[this.puzzleIndex];
+        this.mode = 'puzzles';
+        this.loadGame(pz.fen);
+        this.expect = pz.expect;
+        this.coach(pz.title, pz.text, 'Encontre o lance. Dica acende a peça certa.');
+        this.markList('puzzleList', this.puzzleIndex);
+        document.getElementById('lessonNav').hidden = false;
+        document.getElementById('lessonList').hidden = true;
+        document.getElementById('puzzleList').hidden = false;
+    }
+
+    markList(id, index) {
+        const list = document.getElementById(id);
+        [...list.children].forEach((el, i) => el.setAttribute('aria-current', String(i === index)));
+    }
+
+    shiftLesson(dir) {
+        if (this.mode === 'puzzles') this.loadPuzzle(this.puzzleIndex + dir);
+        else this.loadLesson(this.lessonIndex + dir);
+    }
+
+    coach(title, text, tip = '') {
+        document.getElementById('coachTitle').textContent = title;
+        document.getElementById('coachText').textContent = text;
+        document.getElementById('coachTip').textContent = tip;
+    }
+
+    rebuildPieces() {
+        while (this.pieceRoot.children.length) {
+            this.pieceRoot.remove(this.pieceRoot.children[0]);
+        }
+        this.pieces.clear();
+        for (let i = 0; i < 64; i++) {
+            const p = this.game.board[i];
+            if (!p) continue;
+            const mesh = this.factory.spawn(p.t, p.c);
+            const pos = squareToWorld(i, this.flip);
+            mesh.position.set(pos.x, 0.07, pos.z);
+            mesh.userData.index = i;
+            this.pieceRoot.add(mesh);
+            this.pieces.set(i, mesh);
+        }
+        this.refreshMarks();
+    }
+
+    pieceAt(index) {
+        return this.pieces.get(index) || null;
+    }
+
+    onDown(e) {
+        this.drag = { x: e.clientX, y: e.clientY, active: true };
+    }
+
+    onUp(e) {
+        if (!this.drag.active) return;
+        this.drag.active = false;
+        const dx = e.clientX - this.drag.x;
+        const dy = e.clientY - this.drag.y;
+        if (Math.hypot(dx, dy) > 8) return;
+        if (this.busy || this.pendingPromo) return;
+        const hit = this.hit(e);
+        if (hit < 0) {
+            this.selected = -1;
+            this.refreshMarks();
+            return;
+        }
+        this.onSquare(hit);
+    }
+
+    hit(e) {
+        const rect = this.canvas.getBoundingClientRect();
+        this.pointer.x = ((e.clientX - rect.left) / rect.width) * 2 - 1;
+        this.pointer.y = -((e.clientY - rect.top) / rect.height) * 2 + 1;
+        this.raycaster.setFromCamera(this.pointer, this.camera);
+        const objs = [...this.world.squares, ...this.pieceRoot.children];
+        const hits = this.raycaster.intersectObjects(objs, true);
+        for (const h of hits) {
+            let o = h.object;
+            while (o && o.userData.index === undefined) o = o.parent;
+            if (o && o.userData.index !== undefined) return o.userData.index;
+        }
+        const plane = new THREE.Plane(new THREE.Vector3(0, 1, 0), 0);
+        const p = new THREE.Vector3();
+        this.raycaster.ray.intersectPlane(plane, p);
+        if (p) return worldToSquare(p.x, p.z, this.flip);
+        return -1;
+    }
+
+    onSquare(index) {
+        const piece = this.game.board[index];
+        if (this.selected >= 0) {
+            const move = this.game.findMove(this.selected, index, this.expect?.promo || 'q');
+            if (move) {
+                this.tryMove(move);
+                return;
+            }
+        }
+        const side = this.game.side;
+        const canSelect = this.mode !== 'cpu' || side === this.player;
+        if (piece && piece.c === side && canSelect) {
+            this.selected = index;
+            this.legal = this.game.legalMovesFrom(index);
+            this.refreshMarks();
+            this.explainPiece(piece, index);
+            return;
+        }
+        this.selected = -1;
+        this.legal = [];
+        this.refreshMarks();
+    }
+
+    explainPiece(piece, index) {
+        const moves = this.game.legalMovesFrom(index);
+        const name = PIECE_NAME[piece.t];
+        const how = PIECE_HOW[piece.t];
+        const n = moves.length;
+        const hang = this.game.hanging(index) ? ' Esta peça está desprotegida.' : '';
+        this.coach(name, `${how}${hang}`, n ? `${n} lance${n > 1 ? 's' : ''} legal${n > 1 ? 'is' : ''} a partir de ${alg(index)}.` : `Nenhum lance legal em ${alg(index)} — talvez esteja cravada.`);
+    }
+
+    tryMove(move) {
+        if (this.expect) {
+            const okFrom = alg(move.from) === this.expect.from;
+            const okTo = alg(move.to) === this.expect.to;
+            const okPromo = !this.expect.promo || move.promo === this.expect.promo;
+            if (!(okFrom && okTo && okPromo)) {
+                this.audio.illegal();
+                this.coach('Quase', 'Esse não é o lance da lição. Olhe o destaque do mestre — a peça certa e a casa certa.', this.currentTip());
+                this.flashHint();
+                return;
+            }
+        }
+        if (this.needsPromoChoice(move)) {
+            this.pendingPromo = move;
+            document.getElementById('promoOverlay').hidden = false;
+            return;
+        }
+        this.commit(move);
+    }
+
+    needsPromoChoice(move) {
+        return !!move.promo && this.isHumanTurn() && !this.expect?.promo;
+    }
+
+    isHumanTurn() {
+        if (this.mode === 'cpu') return this.game.side === this.player;
+        return true;
+    }
+
+    finishPromo(promo) {
+        document.getElementById('promoOverlay').hidden = true;
+        if (!this.pendingPromo) return;
+        const move = this.game.findMove(this.pendingPromo.from, this.pendingPromo.to, promo);
+        this.pendingPromo = null;
+        if (move) this.commit(move);
+    }
+
+    currentTip() {
+        if (this.mode === 'academy') return LESSONS[this.lessonIndex].tip;
+        if (this.mode === 'puzzles') return PUZZLES[this.puzzleIndex].text;
+        return '';
+    }
+
+    commit(move) {
+        const san = this.game.san(move);
+        const captured = move.captured;
+        const from = move.from;
+        const to = move.to;
+        const mesh = this.pieceAt(from);
+        const capMesh = move.flag === 'e' && move.epCap >= 0
+            ? this.pieceAt(move.epCap)
+            : this.pieceAt(to);
+        const rookDest = move.flag === 'k' ? (from === 4 ? 5 : 61) : move.flag === 'q' ? (from === 4 ? 3 : 59) : -1;
+        const rookSrc = move.flag === 'k' ? (from === 4 ? 7 : 63) : move.flag === 'q' ? (from === 4 ? 0 : 56) : -1;
+        const rookMesh = rookSrc >= 0 ? this.pieceAt(rookSrc) : null;
+
+        this.game.play(move);
+        const mover = this.game.side === 'w' ? 'b' : 'w';
+        this.history.push({ san, color: mover });
+
+        this.selected = -1;
+        this.legal = [];
+        this.busy = true;
+
+        if (move.flag === 'k' || move.flag === 'q') this.audio.castle();
+        else if (captured) this.audio.capture();
+        else if (move.promo) this.audio.promote();
+        else this.audio.move();
+
+        const hops = [];
+        if (mesh) hops.push(this.hop(mesh, from, to));
+        if (rookMesh && rookDest >= 0) hops.push(this.hop(rookMesh, rookSrc, rookDest));
+        if (capMesh) hops.push(this.fadeOut(capMesh));
+
+        Promise.all(hops).then(() => {
+            this.rebuildPieces();
+            this.busy = false;
+            this.afterMove(san, move, captured);
+        });
+    }
+
+    hop(mesh, from, to) {
+        const a = squareToWorld(from, this.flip);
+        const b = squareToWorld(to, this.flip);
+        return this.tween(0.38, (t) => {
+            const k = easeInOut(t);
+            mesh.position.x = a.x + (b.x - a.x) * k;
+            mesh.position.z = a.z + (b.z - a.z) * k;
+            mesh.position.y = 0.07 + Math.sin(k * Math.PI) * 0.55;
+        });
+    }
+
+    fadeOut(mesh) {
+        const start = mesh.position.clone();
+        return this.tween(0.32, (t) => {
+            mesh.position.y = start.y - t * 0.4;
+            mesh.scale.setScalar(1 - t * 0.85);
+        }).then(() => {
+            mesh.visible = false;
+        });
+    }
+
+    tween(dur, fn) {
+        return new Promise((resolve) => {
+            this.anims.push({ t: 0, dur, fn, resolve });
+        });
+    }
+
+    afterMove(san, move, captured) {
+        const st = this.game.status();
+        if (st.check) this.audio.check();
+        if (st.over && st.reason === 'xeque-mate') this.audio.win();
+
+        const hangingAfter = move && this.game.board[move.to] && this.game.hanging(move.to);
+        const text = commentOnMove(san, {
+            check: st.check,
+            mate: st.reason === 'xeque-mate',
+            captured,
+            hangingAfter,
+            castle: move.flag === 'k' || move.flag === 'q',
+            promo: !!move.promo,
+            opening: this.history.length <= 6
+        });
+
+        if (this.expect) {
+            this.completeTask(text);
+        } else {
+            this.coach(st.check ? 'Xeque' : 'Lance', text, st.over ? this.endLine(st) : '');
+        }
+
+        this.renderHud();
+        this.refreshMarks();
+
+        if (st.over && this.mode !== 'academy' && this.mode !== 'puzzles') {
+            this.showResult(st);
+            return;
+        }
+        if (this.mode === 'cpu' && !st.over && this.game.side !== this.player) {
+            this.queueAi();
+        }
+    }
+
+    completeTask(text) {
+        const pack = this.mode === 'puzzles' ? PUZZLES[this.puzzleIndex] : LESSONS[this.lessonIndex];
+        const success = pack.success || text;
+        this.coach('Isso.', success, this.mode === 'academy' ? 'Toque em Próxima para continuar.' : 'Toque em Próxima para o próximo puzzle.');
+        this.expect = null;
+        if (this.mode === 'academy') {
+            if (!this.progress.lessons.includes(pack.id)) this.progress.lessons.push(pack.id);
+        } else if (!this.progress.puzzles.includes(pack.id)) this.progress.puzzles.push(pack.id);
+        saveProgress(this.progress);
+        this.fillLists();
+        if (this.mode === 'academy') this.markList('lessonList', this.lessonIndex);
+        else this.markList('puzzleList', this.puzzleIndex);
+    }
+
+    queueAi() {
+        this.busy = true;
+        this.coach('A máquina pensa', 'Calculando um lance no atelier…', '');
+        const delay = this.level === 'clube' ? 380 : 220;
+        setTimeout(() => {
+            const mv = pickMove(this.game, this.level);
+            this.busy = false;
+            if (mv) this.commit(mv);
+            else this.renderHud();
+        }, delay);
+    }
+
+    hint() {
+        if (this.busy) return;
+        if (this.expect) {
+            this.flashHint();
+            return;
+        }
+        const mv = hintMove(this.game);
+        if (!mv) return;
+        this.selected = mv.from;
+        this.legal = this.game.legalMovesFrom(mv.from);
+        this.refreshMarks();
+        placeMark(this.world.marks.hint, mv.to, this.flip);
+        const p = this.game.board[mv.from];
+        this.coach('Dica', `Considere ${this.game.san(mv)}. ${p ? PIECE_HOW[p.t] : ''}`, 'Toque a peça destacada e a casa verde.');
+    }
+
+    flashHint() {
+        if (!this.expect) return;
+        const from = parseAlg(this.expect.from);
+        const to = parseAlg(this.expect.to);
+        this.selected = from;
+        this.legal = this.game.legalMovesFrom(from);
+        this.refreshMarks();
+        placeMark(this.world.marks.hint, to, this.flip);
+    }
+
+    undo() {
+        if (this.busy || this.game.stack.length === 0) return;
+        this.game.undo();
+        this.history.pop();
+        if (this.mode === 'cpu' && this.game.side !== this.player && this.game.stack.length) {
+            this.game.undo();
+            this.history.pop();
+        }
+        this.selected = -1;
+        this.rebuildPieces();
+        this.renderHud();
+        this.coach('Desfeito', 'O último lance voltou. O tabuleiro não guarda rancor.', '');
+    }
+
+    toggleFlip() {
+        this.flip = !this.flip;
+        this.rebuildPieces();
+        const az = this.flip ? Math.PI : 0;
+        this.camera.position.set(Math.sin(az) * 10.6, 8.4, Math.cos(az) * 10.6);
+        this.controls.target.set(0, 0.35, 0);
+    }
+
+    fresh() {
+        document.getElementById('resultOverlay').hidden = true;
+        if (this.mode === 'academy') this.loadLesson(this.lessonIndex);
+        else if (this.mode === 'puzzles') this.loadPuzzle(this.puzzleIndex);
+        else this.loadGame(START_FEN);
+        this.speakMode();
+    }
+
+    toggleMute() {
+        this.settings.muted = !this.settings.muted;
+        this.saveSettings();
+        this.audio.init();
+        this.audio.setEnabled(!this.settings.muted);
+        this.syncMute();
+    }
+
+    syncMute() {
+        const btn = document.getElementById('muteBtn');
+        if (!btn) return;
+        btn.setAttribute('aria-pressed', String(!this.settings.muted));
+        btn.textContent = this.settings.muted ? 'Mudo' : 'Som';
+    }
+
+    clearMarks() {
+        const m = this.world.marks;
+        m.dots.forEach((d) => { d.visible = false; });
+        m.caps.forEach((c) => { c.visible = false; });
+        m.select.visible = false;
+        m.lastFrom.visible = false;
+        m.lastTo.visible = false;
+        m.check.visible = false;
+        m.hint.visible = false;
+    }
+
+    refreshMarks() {
+        this.clearMarks();
+        const m = this.world.marks;
+        if (this.selected >= 0) placeMark(m.select, this.selected, this.flip);
+        let di = 0;
+        let ci = 0;
+        for (const mv of this.legal) {
+            if (mv.captured || mv.flag === 'e') {
+                if (ci < m.caps.length) placeMark(m.caps[ci++], mv.to, this.flip);
+            } else if (di < m.dots.length) {
+                placeMark(m.dots[di++], mv.to, this.flip);
+            }
+        }
+        const last = this.game.stack[this.game.stack.length - 1];
+        if (last) {
+            placeMark(m.lastFrom, last.from, this.flip);
+            placeMark(m.lastTo, last.to, this.flip);
+        }
+        if (this.game.inCheck()) {
+            const k = this.game.kingIndex(this.game.side);
+            if (k >= 0) placeMark(m.check, k, this.flip);
+        }
+    }
+
+    renderHud() {
+        const st = this.game.status();
+        const line = document.getElementById('statusLine');
+        if (st.over) {
+            line.textContent = st.reason === 'xeque-mate'
+                ? `Xeque-mate · ${st.result}`
+                : `Empate · ${st.reason}`;
+            line.classList.toggle('is-check', st.reason === 'xeque-mate');
+        } else {
+            line.textContent = st.check
+                ? `Xeque · ${this.game.side === 'w' ? 'brancas' : 'pretas'}`
+                : `${this.game.side === 'w' ? 'Brancas' : 'Pretas'} jogam`;
+            line.classList.toggle('is-check', st.check);
+        }
+        this.renderCaptured();
+        this.renderMoves();
+    }
+
+    renderCaptured() {
+        const start = { w: { p: 8, n: 2, b: 2, r: 2, q: 1, k: 1 }, b: { p: 8, n: 2, b: 2, r: 2, q: 1, k: 1 } };
+        const now = { w: { p: 0, n: 0, b: 0, r: 0, q: 0, k: 0 }, b: { p: 0, n: 0, b: 0, r: 0, q: 0, k: 0 } };
+        for (const p of this.game.board) {
+            if (p) now[p.c][p.t] += 1;
+        }
+        let html = '';
+        for (const c of ['w', 'b']) {
+            for (const t of ['q', 'r', 'b', 'n', 'p']) {
+                const n = start[c][t] - now[c][t];
+                for (let i = 0; i < n; i++) html += GLYPH[c][t];
+            }
+            if (c === 'w') html += '  ';
+        }
+        document.getElementById('captured').textContent = html || '—';
+    }
+
+    renderMoves() {
+        const ol = document.getElementById('moves');
+        ol.innerHTML = '';
+        for (let i = 0; i < this.history.length; i += 2) {
+            const li = document.createElement('li');
+            const n = document.createElement('span');
+            n.className = 'n';
+            n.textContent = `${(i / 2) + 1}.`;
+            const a = document.createElement('span');
+            a.textContent = this.history[i].san;
+            const b = document.createElement('span');
+            b.textContent = this.history[i + 1]?.san || '';
+            li.append(n, a, b);
+            ol.appendChild(li);
+        }
+        ol.scrollTop = ol.scrollHeight;
+    }
+
+    endLine(st) {
+        if (st.reason === 'xeque-mate') {
+            return this.game.side === 'b' ? 'As brancas venceram.' : 'As pretas venceram.';
+        }
+        return `Empate por ${st.reason}.`;
+    }
+
+    showResult(st) {
+        document.getElementById('resultOverlay').hidden = false;
+        document.getElementById('resultKicker').innerHTML = '<i></i> Fim';
+        document.getElementById('resultTitle').textContent = st.reason === 'xeque-mate' ? 'Xeque-mate' : 'Empate';
+        document.getElementById('resultText').textContent = this.endLine(st);
+    }
+
+    frame() {
+        const dt = Math.min(0.05, this.clock.getDelta());
+        for (let i = this.anims.length - 1; i >= 0; i--) {
+            const a = this.anims[i];
+            a.t += dt;
+            const k = Math.min(1, a.t / a.dur);
+            a.fn(k);
+            if (k >= 1) {
+                a.resolve();
+                this.anims.splice(i, 1);
+            }
+        }
+        if (this.world?.marks?.select?.visible) {
+            this.world.marks.select.rotation.z += dt * 0.6;
+        }
+        if (this.world?.marks?.check?.visible) {
+            this.world.marks.check.material.opacity = 0.55 + Math.sin(this.clock.elapsedTime * 4) * 0.3;
+        }
+        this.controls?.update();
+        this.renderer.render(this.scene, this.camera);
+    }
+}
+
+try {
+    new Atelier();
+} catch (err) {
+    console.error(err);
+    const overlay = document.getElementById('errorOverlay');
+    const load = document.getElementById('loadingOverlay');
+    if (load) load.hidden = true;
+    if (overlay) overlay.hidden = false;
+}

--- a/labs/xadrez/src/pieces.js
+++ b/labs/xadrez/src/pieces.js
@@ -30,71 +30,87 @@ function merge(list) {
     return g;
 }
 
+function collar(radius, y, tube, seg) {
+    const t = new THREE.TorusGeometry(radius, tube, 8, Math.max(16, seg >> 1));
+    t.rotateX(Math.PI / 2);
+    t.translate(0, y, 0);
+    return t;
+}
+
 export function buildPieceGeometries(seg = 48) {
-    const pawn = lathe([
-        [0, 0], [0.34, 0], [0.36, 0.04], [0.30, 0.09],
-        [0.28, 0.16], [0.20, 0.22], [0.18, 0.42],
-        [0.16, 0.52], [0.22, 0.56], [0.18, 0.60],
-        [0.14, 0.66], [0.20, 0.72], [0.22, 0.82],
-        [0.18, 0.90], [0.10, 0.94], [0, 0.95]
-    ], seg);
+    const pawn = merge([
+        lathe([
+            [0, 0], [0.33, 0], [0.35, 0.035], [0.30, 0.08],
+            [0.27, 0.14], [0.16, 0.20], [0.135, 0.46],
+            [0.13, 0.54], [0.20, 0.58], [0.13, 0.62],
+            [0.12, 0.68], [0.185, 0.74], [0.20, 0.84],
+            [0.16, 0.91], [0.08, 0.94], [0, 0.95]
+        ], seg),
+        collar(0.175, 0.58, 0.028, seg)
+    ]);
 
     const merlons = [];
-    const rookR = 0.22;
-    const rookY = 1.02;
+    const rookR = 0.20;
+    const rookY = 1.04;
     for (let i = 0; i < 4; i++) {
         const a = (i / 4) * Math.PI * 2 + Math.PI / 4;
-        merlons.push(box(0.16, 0.16, 0.14, Math.cos(a) * rookR, rookY, Math.sin(a) * rookR));
+        merlons.push(box(0.15, 0.15, 0.13, Math.cos(a) * rookR, rookY, Math.sin(a) * rookR));
     }
     const rook = merge([
         lathe([
-            [0, 0], [0.38, 0], [0.40, 0.05], [0.33, 0.11],
-            [0.30, 0.20], [0.24, 0.28], [0.22, 0.70],
-            [0.26, 0.76], [0.28, 0.82], [0.30, 0.90],
-            [0.30, 0.96], [0.18, 0.96], [0.18, 0.88],
+            [0, 0], [0.36, 0], [0.38, 0.04], [0.32, 0.10],
+            [0.28, 0.18], [0.20, 0.26], [0.175, 0.68],
+            [0.24, 0.74], [0.26, 0.80], [0.28, 0.90],
+            [0.28, 0.96], [0.16, 0.96], [0.16, 0.88],
             [0, 0.88]
         ], seg),
+        collar(0.22, 0.74, 0.03, seg),
         ...merlons
     ]);
 
-    const bishop = lathe([
-        [0, 0], [0.36, 0], [0.38, 0.045], [0.31, 0.10],
-        [0.28, 0.18], [0.20, 0.26], [0.17, 0.55],
-        [0.22, 0.62], [0.18, 0.68], [0.14, 0.78],
-        [0.16, 0.92], [0.20, 1.08], [0.16, 1.22],
-        [0.10, 1.32], [0.055, 1.34], [0.09, 1.36], [0, 1.38]
-    ], seg);
+    const bishop = merge([
+        lathe([
+            [0, 0], [0.34, 0], [0.36, 0.04], [0.30, 0.09],
+            [0.26, 0.16], [0.16, 0.24], [0.135, 0.52],
+            [0.20, 0.60], [0.14, 0.66], [0.12, 0.78],
+            [0.14, 0.94], [0.175, 1.10], [0.14, 1.24],
+            [0.08, 1.33], [0.05, 1.35], [0.085, 1.37], [0, 1.38]
+        ], seg),
+        collar(0.175, 0.60, 0.028, seg)
+    ]);
 
     const jewels = [];
     for (let i = 0; i < 8; i++) {
         const a = (i / 8) * Math.PI * 2;
-        const c = new THREE.ConeGeometry(0.045, 0.14, 8);
-        c.translate(Math.cos(a) * 0.16, 1.50, Math.sin(a) * 0.16);
+        const c = new THREE.ConeGeometry(0.042, 0.13, 8);
+        c.translate(Math.cos(a) * 0.155, 1.50, Math.sin(a) * 0.155);
         jewels.push(c);
     }
     const queen = merge([
         lathe([
-            [0, 0], [0.38, 0], [0.40, 0.05], [0.33, 0.11],
-            [0.30, 0.20], [0.22, 0.28], [0.18, 0.62],
-            [0.24, 0.70], [0.20, 0.76], [0.15, 0.90],
-            [0.14, 1.12], [0.18, 1.28], [0.20, 1.40],
-            [0.16, 1.44], [0.08, 1.46], [0, 1.48]
+            [0, 0], [0.36, 0], [0.38, 0.045], [0.32, 0.10],
+            [0.28, 0.18], [0.175, 0.26], [0.145, 0.60],
+            [0.22, 0.68], [0.15, 0.74], [0.125, 0.92],
+            [0.12, 1.14], [0.16, 1.30], [0.185, 1.40],
+            [0.15, 1.44], [0.07, 1.46], [0, 1.48]
         ], seg),
+        collar(0.195, 0.68, 0.03, seg),
         ...jewels
     ]);
 
     const cross = merge([
-        box(0.055, 0.28, 0.055, 0, 1.66, 0),
-        box(0.18, 0.05, 0.05, 0, 1.70, 0)
+        box(0.05, 0.26, 0.05, 0, 1.66, 0),
+        box(0.17, 0.045, 0.045, 0, 1.70, 0)
     ]);
     const king = merge([
         lathe([
-            [0, 0], [0.40, 0], [0.42, 0.05], [0.34, 0.12],
-            [0.31, 0.22], [0.22, 0.30], [0.19, 0.68],
-            [0.26, 0.76], [0.21, 0.82], [0.16, 0.96],
-            [0.15, 1.22], [0.20, 1.40], [0.22, 1.50],
-            [0.16, 1.54], [0.08, 1.52], [0, 1.52]
+            [0, 0], [0.38, 0], [0.40, 0.045], [0.33, 0.11],
+            [0.29, 0.20], [0.18, 0.28], [0.15, 0.64],
+            [0.24, 0.74], [0.16, 0.80], [0.13, 0.96],
+            [0.125, 1.22], [0.175, 1.40], [0.20, 1.50],
+            [0.15, 1.54], [0.07, 1.52], [0, 1.52]
         ], seg),
+        collar(0.21, 0.74, 0.032, seg),
         cross
     ]);
 
@@ -127,6 +143,12 @@ export function buildKnightTemplate(seg, material, accent) {
     base.castShadow = true;
     base.receiveShadow = true;
     g.add(base);
+
+    const ring = new THREE.Mesh(new THREE.TorusGeometry(0.20, 0.03, 8, 24), material);
+    ring.rotation.x = Math.PI / 2;
+    ring.position.y = 0.50;
+    ring.castShadow = true;
+    g.add(ring);
 
     const neck = new THREE.Mesh(lathe([
         [0, 0], [0.16, 0], [0.15, 0.18], [0.13, 0.36], [0.11, 0.48], [0, 0.50]
@@ -182,31 +204,31 @@ export function buildKnightTemplate(seg, material, accent) {
 
 export function makeMaterials(tex, theme = 'classic') {
     const ivory = new THREE.MeshPhysicalMaterial({
-        color: 0xf3ead8,
+        color: 0xe4d2b4,
         map: tex.ivory.map,
         normalMap: tex.ivory.normalMap,
         roughnessMap: tex.ivory.roughnessMap,
-        roughness: 0.22,
-        metalness: 0.04,
-        clearcoat: 0.85,
-        clearcoatRoughness: 0.18,
-        sheen: 0.4,
-        sheenColor: new THREE.Color(0xf7e7c6),
-        sheenRoughness: 0.45,
-        envMapIntensity: 1.15
+        roughness: 0.34,
+        metalness: 0.02,
+        clearcoat: 0.45,
+        clearcoatRoughness: 0.32,
+        sheen: 0.12,
+        sheenColor: new THREE.Color(0xe8d7b8),
+        sheenRoughness: 0.6,
+        envMapIntensity: 0.55
     });
     const ebony = new THREE.MeshPhysicalMaterial({
-        color: 0x1c1410,
+        color: 0x16100c,
         map: tex.ebony.map,
         normalMap: tex.ebony.normalMap,
         roughnessMap: tex.ebony.roughnessMap,
-        roughness: 0.18,
-        metalness: 0.12,
-        clearcoat: 1,
-        clearcoatRoughness: 0.12,
-        sheen: 0.2,
-        sheenColor: new THREE.Color(0x4a2010),
-        envMapIntensity: 1.25
+        roughness: 0.22,
+        metalness: 0.08,
+        clearcoat: 0.7,
+        clearcoatRoughness: 0.18,
+        sheen: 0.12,
+        sheenColor: new THREE.Color(0x3a1c10),
+        envMapIntensity: 0.85
     });
     const accentDark = new THREE.MeshPhysicalMaterial({
         color: 0x0a0604, roughness: 0.4, metalness: 0.2

--- a/labs/xadrez/src/pieces.js
+++ b/labs/xadrez/src/pieces.js
@@ -1,0 +1,303 @@
+/**
+ * Peças Staunton procedurais — torno (LatheGeometry) + ornamentos.
+ *
+ * Alturas relativas ao rei (1.78 u, casa = 1 u): peão 0.95, torre 1.15,
+ * cavalo 1.22, bispo 1.38, dama 1.58. Materiais PBR: marfim / ébano / cristal.
+ */
+
+import * as THREE from 'three';
+import { mergeGeometries } from 'three/addons/utils/BufferGeometryUtils.js';
+
+function lathe(xy, seg) {
+    const pts = xy.map(([x, y]) => new THREE.Vector2(x, y));
+    const g = new THREE.LatheGeometry(pts, seg);
+    g.computeVertexNormals();
+    return g;
+}
+
+function box(w, h, d, x, y, z) {
+    const g = new THREE.BoxGeometry(w, h, d);
+    g.translate(x, y, z);
+    return g;
+}
+
+function merge(list) {
+    const geos = list.filter(Boolean);
+    const g = mergeGeometries(geos, false);
+    if (!g) return geos[0];
+    geos.forEach((x) => x.dispose?.());
+    g.computeVertexNormals();
+    return g;
+}
+
+export function buildPieceGeometries(seg = 48) {
+    const pawn = lathe([
+        [0, 0], [0.34, 0], [0.36, 0.04], [0.30, 0.09],
+        [0.28, 0.16], [0.20, 0.22], [0.18, 0.42],
+        [0.16, 0.52], [0.22, 0.56], [0.18, 0.60],
+        [0.14, 0.66], [0.20, 0.72], [0.22, 0.82],
+        [0.18, 0.90], [0.10, 0.94], [0, 0.95]
+    ], seg);
+
+    const merlons = [];
+    const rookR = 0.22;
+    const rookY = 1.02;
+    for (let i = 0; i < 4; i++) {
+        const a = (i / 4) * Math.PI * 2 + Math.PI / 4;
+        merlons.push(box(0.16, 0.16, 0.14, Math.cos(a) * rookR, rookY, Math.sin(a) * rookR));
+    }
+    const rook = merge([
+        lathe([
+            [0, 0], [0.38, 0], [0.40, 0.05], [0.33, 0.11],
+            [0.30, 0.20], [0.24, 0.28], [0.22, 0.70],
+            [0.26, 0.76], [0.28, 0.82], [0.30, 0.90],
+            [0.30, 0.96], [0.18, 0.96], [0.18, 0.88],
+            [0, 0.88]
+        ], seg),
+        ...merlons
+    ]);
+
+    const bishop = lathe([
+        [0, 0], [0.36, 0], [0.38, 0.045], [0.31, 0.10],
+        [0.28, 0.18], [0.20, 0.26], [0.17, 0.55],
+        [0.22, 0.62], [0.18, 0.68], [0.14, 0.78],
+        [0.16, 0.92], [0.20, 1.08], [0.16, 1.22],
+        [0.10, 1.32], [0.055, 1.34], [0.09, 1.36], [0, 1.38]
+    ], seg);
+
+    const jewels = [];
+    for (let i = 0; i < 8; i++) {
+        const a = (i / 8) * Math.PI * 2;
+        const c = new THREE.ConeGeometry(0.045, 0.14, 8);
+        c.translate(Math.cos(a) * 0.16, 1.50, Math.sin(a) * 0.16);
+        jewels.push(c);
+    }
+    const queen = merge([
+        lathe([
+            [0, 0], [0.38, 0], [0.40, 0.05], [0.33, 0.11],
+            [0.30, 0.20], [0.22, 0.28], [0.18, 0.62],
+            [0.24, 0.70], [0.20, 0.76], [0.15, 0.90],
+            [0.14, 1.12], [0.18, 1.28], [0.20, 1.40],
+            [0.16, 1.44], [0.08, 1.46], [0, 1.48]
+        ], seg),
+        ...jewels
+    ]);
+
+    const cross = merge([
+        box(0.055, 0.28, 0.055, 0, 1.66, 0),
+        box(0.18, 0.05, 0.05, 0, 1.70, 0)
+    ]);
+    const king = merge([
+        lathe([
+            [0, 0], [0.40, 0], [0.42, 0.05], [0.34, 0.12],
+            [0.31, 0.22], [0.22, 0.30], [0.19, 0.68],
+            [0.26, 0.76], [0.21, 0.82], [0.16, 0.96],
+            [0.15, 1.22], [0.20, 1.40], [0.22, 1.50],
+            [0.16, 1.54], [0.08, 1.52], [0, 1.52]
+        ], seg),
+        cross
+    ]);
+
+    return { p: pawn, r: rook, b: bishop, q: queen, k: king, n: null };
+}
+
+function knightHeadShape() {
+    const s = new THREE.Shape();
+    s.moveTo(0.00, 0.02);
+    s.bezierCurveTo(0.10, 0.00, 0.18, 0.08, 0.20, 0.22);
+    s.bezierCurveTo(0.22, 0.38, 0.18, 0.52, 0.16, 0.62);
+    s.bezierCurveTo(0.14, 0.74, 0.10, 0.84, 0.12, 0.94);
+    s.lineTo(0.22, 0.86);
+    s.bezierCurveTo(0.28, 0.80, 0.36, 0.70, 0.46, 0.58);
+    s.bezierCurveTo(0.54, 0.50, 0.58, 0.42, 0.56, 0.34);
+    s.bezierCurveTo(0.54, 0.28, 0.48, 0.26, 0.42, 0.30);
+    s.lineTo(0.34, 0.34);
+    s.bezierCurveTo(0.30, 0.24, 0.24, 0.14, 0.14, 0.08);
+    s.bezierCurveTo(0.08, 0.05, 0.03, 0.04, 0.00, 0.02);
+    return s;
+}
+
+export function buildKnightTemplate(seg, material, accent) {
+    const g = new THREE.Group();
+    const base = new THREE.Mesh(lathe([
+        [0, 0], [0.36, 0], [0.38, 0.045], [0.31, 0.10],
+        [0.28, 0.18], [0.22, 0.26], [0.20, 0.42],
+        [0.22, 0.50], [0.18, 0.54]
+    ], seg), material);
+    base.castShadow = true;
+    base.receiveShadow = true;
+    g.add(base);
+
+    const neck = new THREE.Mesh(lathe([
+        [0, 0], [0.16, 0], [0.15, 0.18], [0.13, 0.36], [0.11, 0.48], [0, 0.50]
+    ], Math.max(12, seg >> 1)), material);
+    neck.position.set(0.02, 0.48, 0);
+    neck.rotation.z = -0.18;
+    neck.castShadow = true;
+    g.add(neck);
+
+    const extrude = new THREE.ExtrudeGeometry(knightHeadShape(), {
+        depth: 0.22,
+        bevelEnabled: true,
+        bevelThickness: 0.035,
+        bevelSize: 0.03,
+        bevelSegments: Math.max(2, seg >> 3),
+        steps: 1
+    });
+    extrude.translate(0, 0, -0.11);
+    const head = new THREE.Mesh(extrude, material);
+    head.position.set(-0.06, 0.58, 0);
+    head.rotation.y = Math.PI / 2;
+    head.scale.set(0.95, 0.95, 1);
+    head.castShadow = true;
+    g.add(head);
+
+    const earG = new THREE.ConeGeometry(0.045, 0.16, 8);
+    const earL = new THREE.Mesh(earG, material);
+    earL.position.set(0.02, 1.16, 0.07);
+    earL.rotation.z = -0.35;
+    earL.rotation.x = 0.25;
+    earL.castShadow = true;
+    const earR = earL.clone();
+    earR.position.z = -0.07;
+    earR.rotation.x = -0.25;
+    g.add(earL, earR);
+
+    const eyeG = new THREE.SphereGeometry(0.025, 10, 8);
+    const eyeL = new THREE.Mesh(eyeG, accent);
+    eyeL.position.set(0.22, 1.02, 0.09);
+    const eyeR = eyeL.clone();
+    eyeR.position.z = -0.09;
+    g.add(eyeL, eyeR);
+
+    const nostril = new THREE.Mesh(new THREE.SphereGeometry(0.018, 8, 6), accent);
+    nostril.position.set(0.42, 0.90, 0.04);
+    const nostril2 = nostril.clone();
+    nostril2.position.z = -0.04;
+    g.add(nostril, nostril2);
+
+    g.userData.kind = 'n';
+    return g;
+}
+
+export function makeMaterials(tex, theme = 'classic') {
+    const ivory = new THREE.MeshPhysicalMaterial({
+        color: 0xf3ead8,
+        map: tex.ivory.map,
+        normalMap: tex.ivory.normalMap,
+        roughnessMap: tex.ivory.roughnessMap,
+        roughness: 0.22,
+        metalness: 0.04,
+        clearcoat: 0.85,
+        clearcoatRoughness: 0.18,
+        sheen: 0.4,
+        sheenColor: new THREE.Color(0xf7e7c6),
+        sheenRoughness: 0.45,
+        envMapIntensity: 1.15
+    });
+    const ebony = new THREE.MeshPhysicalMaterial({
+        color: 0x1c1410,
+        map: tex.ebony.map,
+        normalMap: tex.ebony.normalMap,
+        roughnessMap: tex.ebony.roughnessMap,
+        roughness: 0.18,
+        metalness: 0.12,
+        clearcoat: 1,
+        clearcoatRoughness: 0.12,
+        sheen: 0.2,
+        sheenColor: new THREE.Color(0x4a2010),
+        envMapIntensity: 1.25
+    });
+    const accentDark = new THREE.MeshPhysicalMaterial({
+        color: 0x0a0604, roughness: 0.4, metalness: 0.2
+    });
+    const accentLight = new THREE.MeshPhysicalMaterial({
+        color: 0x3a2418, roughness: 0.35, metalness: 0.15
+    });
+
+    if (theme === 'crystal') {
+        const glassW = new THREE.MeshPhysicalMaterial({
+            color: 0xf2fbff,
+            roughness: 0.04,
+            metalness: 0.05,
+            transmission: 0.72,
+            thickness: 0.55,
+            ior: 1.52,
+            clearcoat: 1,
+            clearcoatRoughness: 0.04,
+            attenuationColor: new THREE.Color(0xd8f0ff),
+            attenuationDistance: 0.8,
+            envMapIntensity: 1.6
+        });
+        const glassB = new THREE.MeshPhysicalMaterial({
+            color: 0x1a0c08,
+            roughness: 0.06,
+            metalness: 0.35,
+            transmission: 0.35,
+            thickness: 0.5,
+            ior: 1.5,
+            clearcoat: 1,
+            clearcoatRoughness: 0.08,
+            attenuationColor: new THREE.Color(0x4a1808),
+            attenuationDistance: 0.6,
+            envMapIntensity: 1.8
+        });
+        const gold = new THREE.MeshPhysicalMaterial({
+            color: 0xd4a657, roughness: 0.18, metalness: 1, envMapIntensity: 1.5
+        });
+        return {
+            w: glassW, b: glassB, accentW: gold, accentB: gold, theme: 'crystal'
+        };
+    }
+
+    return {
+        w: ivory, b: ebony, accentW: accentLight, accentB: accentDark, theme: 'classic'
+    };
+}
+
+export class PieceFactory {
+    constructor(tex, quality) {
+        this.seg = quality.seg;
+        this.geos = buildPieceGeometries(quality.seg);
+        this.tex = tex;
+        this.mats = makeMaterials(tex, 'classic');
+        this.knightW = buildKnightTemplate(quality.seg, this.mats.w, this.mats.accentW);
+        this.knightB = buildKnightTemplate(quality.seg, this.mats.b, this.mats.accentB);
+        this.knightW.visible = false;
+        this.knightB.visible = false;
+    }
+
+    setTheme(theme) {
+        this.mats = makeMaterials(this.tex, theme);
+        this.knightW.traverse((o) => {
+            if (o.isMesh) o.material = o.geometry.type === 'SphereGeometry' ? this.mats.accentW : this.mats.w;
+        });
+        this.knightB.traverse((o) => {
+            if (o.isMesh) o.material = o.geometry.type === 'SphereGeometry' ? this.mats.accentB : this.mats.b;
+        });
+    }
+
+    spawn(type, color) {
+        if (type === 'n') {
+            const src = color === 'w' ? this.knightW : this.knightB;
+            const g = src.clone(true);
+            g.visible = true;
+            g.traverse((o) => {
+                if (o.isMesh) {
+                    o.castShadow = true;
+                    o.receiveShadow = true;
+                }
+            });
+            g.userData.kind = 'n';
+            g.userData.color = color;
+            if (color === 'b') g.rotation.y = Math.PI;
+            return g;
+        }
+        const mesh = new THREE.Mesh(this.geos[type], color === 'w' ? this.mats.w : this.mats.b);
+        mesh.castShadow = true;
+        mesh.receiveShadow = true;
+        mesh.userData.kind = type;
+        mesh.userData.color = color;
+        return mesh;
+    }
+}

--- a/labs/xadrez/src/textures.js
+++ b/labs/xadrez/src/textures.js
@@ -1,0 +1,194 @@
+/**
+ * Texturas PBR procedurais — madeira, marfim, ébano, feltro e mármore.
+ * Sem arquivos externos: cada mapa é um canvas reutilizado pelos materiais.
+ */
+
+import * as THREE from 'three';
+
+function canvas(w, h = w) {
+    const el = document.createElement('canvas');
+    el.width = w;
+    el.height = h;
+    return el;
+}
+
+function ctx2d(el) {
+    return el.getContext('2d', { willReadFrequently: true });
+}
+
+function rng(seed = 1) {
+    let s = seed >>> 0;
+    return () => (s = (s * 1664525 + 1013904223) >>> 0) / 4294967296;
+}
+
+function toTex(el, { repeat = [1, 1], srgb = true, aniso = 8, wrap = true } = {}) {
+    const tex = new THREE.CanvasTexture(el);
+    tex.wrapS = tex.wrapT = wrap ? THREE.RepeatWrapping : THREE.ClampToEdgeWrapping;
+    tex.repeat.set(repeat[0], repeat[1]);
+    tex.anisotropy = aniso;
+    if (srgb) tex.colorSpace = THREE.SRGBColorSpace;
+    tex.needsUpdate = true;
+    return tex;
+}
+
+function heightToNormal(srcCtx, w, h, strength = 2.2) {
+    const src = srcCtx.getImageData(0, 0, w, h).data;
+    const out = canvas(w, h);
+    const ctx = ctx2d(out);
+    const img = ctx.createImageData(w, h);
+    const d = img.data;
+    const lum = (x, y) => {
+        const i = (((y + h) % h) * w + ((x + w) % w)) * 4;
+        return (src[i] * 0.299 + src[i + 1] * 0.587 + src[i + 2] * 0.114) / 255;
+    };
+    for (let y = 0; y < h; y++) {
+        for (let x = 0; x < w; x++) {
+            const dx = (lum(x + 1, y) - lum(x - 1, y)) * strength;
+            const dy = (lum(x, y + 1) - lum(x, y - 1)) * strength;
+            const len = Math.hypot(dx, dy, 1) || 1;
+            const i = (y * w + x) * 4;
+            d[i] = ((-dx / len) * 0.5 + 0.5) * 255;
+            d[i + 1] = ((-dy / len) * 0.5 + 0.5) * 255;
+            d[i + 2] = (1 / len) * 0.5 * 255 + 128;
+            d[i + 3] = 255;
+        }
+    }
+    ctx.putImageData(img, 0, 0);
+    return out;
+}
+
+function roughnessFrom(srcCtx, w, h, base = 0.35, contrast = 0.25) {
+    const src = srcCtx.getImageData(0, 0, w, h).data;
+    const out = canvas(w, h);
+    const ctx = ctx2d(out);
+    const img = ctx.createImageData(w, h);
+    const d = img.data;
+    for (let i = 0; i < src.length; i += 4) {
+        const v = (src[i] + src[i + 1] + src[i + 2]) / (3 * 255);
+        const r = Math.max(0, Math.min(1, base + (v - 0.5) * contrast));
+        d[i] = d[i + 1] = d[i + 2] = r * 255;
+        d[i + 3] = 255;
+    }
+    ctx.putImageData(img, 0, 0);
+    return out;
+}
+
+function pack(draw, { w = 512, strength = 1.8, roughBase = 0.32, roughContrast = 0.22, aniso = 8, repeat = [1, 1] } = {}) {
+    const el = canvas(w);
+    const ctx = ctx2d(el);
+    draw(ctx, w);
+    const n = heightToNormal(ctx, w, w, strength);
+    const r = roughnessFrom(ctx, w, w, roughBase, roughContrast);
+    return {
+        map: toTex(el, { aniso, repeat }),
+        normalMap: toTex(n, { aniso, repeat, srgb: false }),
+        roughnessMap: toTex(r, { aniso, repeat, srgb: false })
+    };
+}
+
+function grain(ctx, w, rand, colorA, colorB, bands = 28) {
+    const g = ctx.createLinearGradient(0, 0, w, 0);
+    for (let i = 0; i <= bands; i++) {
+        const t = i / bands;
+        const wobble = (rand() - 0.5) * 0.08;
+        g.addColorStop(Math.min(1, Math.max(0, t + wobble)), rand() > 0.5 ? colorA : colorB);
+    }
+    ctx.fillStyle = g;
+    ctx.fillRect(0, 0, w, w);
+    for (let i = 0; i < w * 4; i++) {
+        const x = rand() * w;
+        ctx.strokeStyle = `rgba(0,0,0,${0.03 + rand() * 0.05})`;
+        ctx.lineWidth = 0.6 + rand();
+        ctx.beginPath();
+        ctx.moveTo(x, 0);
+        ctx.bezierCurveTo(x + (rand() - 0.5) * 18, w * 0.33, x + (rand() - 0.5) * 18, w * 0.66, x + (rand() - 0.5) * 10, w);
+        ctx.stroke();
+    }
+}
+
+export function createTextures(aniso = 8) {
+    const maple = pack((ctx, w) => {
+        grain(ctx, w, rng(11), '#e2c9a0', '#c9a574', 22);
+    }, { aniso, repeat: [1, 1], roughBase: 0.28, strength: 1.4 });
+
+    const walnut = pack((ctx, w) => {
+        grain(ctx, w, rng(29), '#5a3418', '#3a1e0c', 18);
+    }, { aniso, repeat: [1, 1], roughBase: 0.34, strength: 1.6 });
+
+    const mahogany = pack((ctx, w) => {
+        grain(ctx, w, rng(71), '#6b2e18', '#3d140c', 16);
+    }, { aniso, repeat: [3, 3], roughBase: 0.22, strength: 1.2 });
+
+    const ebony = pack((ctx, w) => {
+        const rand = rng(101);
+        ctx.fillStyle = '#1a120f';
+        ctx.fillRect(0, 0, w, w);
+        grain(ctx, w, rand, '#241610', '#0e0a08', 12);
+        ctx.globalAlpha = 0.18;
+        ctx.fillStyle = '#4a2818';
+        for (let i = 0; i < 40; i++) {
+            ctx.fillRect(rand() * w, 0, 1 + rand() * 2, w);
+        }
+        ctx.globalAlpha = 1;
+    }, { aniso, repeat: [2, 2], roughBase: 0.18, roughContrast: 0.15, strength: 1.1 });
+
+    const ivory = pack((ctx, w) => {
+        const rand = rng(53);
+        const g = ctx.createRadialGradient(w * 0.4, w * 0.3, 10, w * 0.5, w * 0.5, w * 0.8);
+        g.addColorStop(0, '#f7f0e2');
+        g.addColorStop(0.5, '#efe2c8');
+        g.addColorStop(1, '#e2d0b0');
+        ctx.fillStyle = g;
+        ctx.fillRect(0, 0, w, w);
+        ctx.strokeStyle = 'rgba(160,130,90,0.18)';
+        for (let i = 0; i < 18; i++) {
+            ctx.lineWidth = 0.8 + rand();
+            ctx.beginPath();
+            const y = rand() * w;
+            ctx.moveTo(0, y);
+            ctx.bezierCurveTo(w * 0.3, y + (rand() - 0.5) * 40, w * 0.7, y + (rand() - 0.5) * 40, w, y + (rand() - 0.5) * 20);
+            ctx.stroke();
+        }
+    }, { aniso, repeat: [1, 1], roughBase: 0.16, strength: 0.9 });
+
+    const felt = pack((ctx, w) => {
+        const rand = rng(7);
+        ctx.fillStyle = '#1e4a32';
+        ctx.fillRect(0, 0, w, w);
+        for (let i = 0; i < 8000; i++) {
+            ctx.fillStyle = `rgba(${20 + rand() * 40},${80 + rand() * 50},${40 + rand() * 30},${0.15})`;
+            ctx.fillRect(rand() * w, rand() * w, 1.2, 1.2);
+        }
+    }, { aniso, repeat: [4, 4], roughBase: 0.92, strength: 2.4 });
+
+    const marble = pack((ctx, w) => {
+        const rand = rng(90);
+        ctx.fillStyle = '#d8d2c8';
+        ctx.fillRect(0, 0, w, w);
+        for (let i = 0; i < 12; i++) {
+            ctx.strokeStyle = `rgba(90,80,70,${0.08 + rand() * 0.12})`;
+            ctx.lineWidth = 1 + rand() * 3;
+            ctx.beginPath();
+            ctx.moveTo(rand() * w, 0);
+            ctx.bezierCurveTo(rand() * w, w * 0.3, rand() * w, w * 0.6, rand() * w, w);
+            ctx.stroke();
+        }
+    }, { aniso, repeat: [2, 2], roughBase: 0.12, strength: 0.8 });
+
+    const rim = (() => {
+        const el = canvas(1024, 128);
+        const ctx = ctx2d(el);
+        grain(ctx, 1024, rng(17), '#6b3a1c', '#3d1c0c', 20);
+        ctx.fillStyle = '#e8d2a8';
+        ctx.font = '600 52px "Cinzel", Georgia, serif';
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'middle';
+        const letters = 'ABCDEFGH';
+        for (let i = 0; i < 8; i++) {
+            ctx.fillText(letters[i], 64 + i * 128, 64);
+        }
+        return toTex(el, { wrap: false, aniso });
+    })();
+
+    return { maple, walnut, mahogany, ebony, ivory, felt, marble, rim };
+}

--- a/labs/xadrez/src/textures.js
+++ b/labs/xadrez/src/textures.js
@@ -134,10 +134,10 @@ export function createTextures(aniso = 8) {
 
     const ivory = pack((ctx, w) => {
         const rand = rng(53);
-        const g = ctx.createRadialGradient(w * 0.4, w * 0.3, 10, w * 0.5, w * 0.5, w * 0.8);
-        g.addColorStop(0, '#f7f0e2');
-        g.addColorStop(0.5, '#efe2c8');
-        g.addColorStop(1, '#e2d0b0');
+        const g = ctx.createLinearGradient(0, 0, w, w);
+        g.addColorStop(0, '#eadcc4');
+        g.addColorStop(0.45, '#e2d0b4');
+        g.addColorStop(1, '#d4c09a');
         ctx.fillStyle = g;
         ctx.fillRect(0, 0, w, w);
         ctx.strokeStyle = 'rgba(160,130,90,0.18)';

--- a/labs/xadrez/src/world.js
+++ b/labs/xadrez/src/world.js
@@ -57,8 +57,12 @@ export function buildWorld(tex, quality) {
     board.name = 'board';
     root.add(board);
 
-    const lightMat = phys(tex.maple, { color: 0xf0d7b0, clearcoat: 0.95, roughness: 0.22 });
-    const darkMat = phys(tex.walnut, { color: 0x5a3014, clearcoat: 0.9, roughness: 0.26 });
+    const lightMat = phys(tex.maple, {
+        color: 0xf4deba, clearcoat: 0.28, roughness: 0.42, envMapIntensity: 0.45
+    });
+    const darkMat = phys(tex.walnut, {
+        color: 0x4a2410, clearcoat: 0.32, roughness: 0.48, envMapIntensity: 0.4
+    });
     const squares = [];
     const squareGeo = new THREE.BoxGeometry(SQUARE * 0.985, 0.07, SQUARE * 0.985);
 
@@ -313,7 +317,7 @@ export function setupLights(scene, quality) {
     const hemi = new THREE.HemisphereLight(0x9eb4d4, 0x3a2214, 0.45);
     scene.add(hemi);
 
-    const key = new THREE.DirectionalLight(0xffe6c4, 2.15);
+    const key = new THREE.DirectionalLight(0xffe6c4, 1.65);
     key.position.set(4.5, 10, 6.5);
     key.castShadow = quality.shadows;
     if (quality.shadows) {
@@ -338,7 +342,7 @@ export function setupLights(scene, quality) {
     windowLight.lookAt(0, 0.5, 0);
     scene.add(windowLight);
 
-    const chandelier = new THREE.SpotLight(0xffd9a8, 4.5, 22, 0.55, 0.45, 1.1);
+    const chandelier = new THREE.SpotLight(0xffd9a8, 3.2, 22, 0.55, 0.45, 1.1);
     chandelier.position.set(0, 7.4, 0.4);
     chandelier.target.position.set(0, 0, 0);
     chandelier.castShadow = quality.shadows;

--- a/labs/xadrez/src/world.js
+++ b/labs/xadrez/src/world.js
@@ -1,0 +1,352 @@
+/**
+ * Atelier — tabuleiro laqueado, mesa de mogno, piso de mármore com reflexo.
+ *
+ * Casa = 1 u. Origem no centro. Brancas em z positivo (câmera inicial).
+ * Destaques: disco de lance legal, anel de captura, brilho de seleção e xeque.
+ */
+
+import * as THREE from 'three';
+import { Reflector } from 'three/addons/objects/Reflector.js';
+import { RectAreaLightUniformsLib } from 'three/addons/lights/RectAreaLightUniformsLib.js';
+import { fileOf, rankOf } from './engine.js';
+
+export const SQUARE = 1;
+const ORIGIN = 3.5;
+
+export function squareToWorld(index, flip = false) {
+    let f = fileOf(index);
+    let r = rankOf(index);
+    if (flip) {
+        f = 7 - f;
+        r = 7 - r;
+    }
+    return {
+        x: f - ORIGIN,
+        z: ORIGIN - r
+    };
+}
+
+export function worldToSquare(x, z, flip = false) {
+    let f = Math.round(x + ORIGIN);
+    let r = Math.round(ORIGIN - z);
+    if (flip) {
+        f = 7 - f;
+        r = 7 - r;
+    }
+    if (f < 0 || f > 7 || r < 0 || r > 7) return -1;
+    return r * 8 + f;
+}
+
+function phys(tex, extra = {}) {
+    return new THREE.MeshPhysicalMaterial({
+        map: tex.map,
+        normalMap: tex.normalMap,
+        roughnessMap: tex.roughnessMap,
+        roughness: 0.28,
+        metalness: 0.04,
+        clearcoat: 0.7,
+        clearcoatRoughness: 0.2,
+        envMapIntensity: 1.1,
+        ...extra
+    });
+}
+
+export function buildWorld(tex, quality) {
+    const root = new THREE.Group();
+    const board = new THREE.Group();
+    board.name = 'board';
+    root.add(board);
+
+    const lightMat = phys(tex.maple, { color: 0xf0d7b0, clearcoat: 0.95, roughness: 0.22 });
+    const darkMat = phys(tex.walnut, { color: 0x5a3014, clearcoat: 0.9, roughness: 0.26 });
+    const squares = [];
+    const squareGeo = new THREE.BoxGeometry(SQUARE * 0.985, 0.07, SQUARE * 0.985);
+
+    for (let r = 0; r < 8; r++) {
+        for (let f = 0; f < 8; f++) {
+            const dark = (f + r) % 2 === 0;
+            const mesh = new THREE.Mesh(squareGeo, dark ? darkMat : lightMat);
+            mesh.position.set(f - ORIGIN, 0.035, ORIGIN - r);
+            mesh.receiveShadow = true;
+            mesh.castShadow = true;
+            mesh.userData.index = r * 8 + f;
+            mesh.userData.kind = 'square';
+            board.add(mesh);
+            squares.push(mesh);
+        }
+    }
+
+    const frameMat = phys(tex.mahogany, { color: 0x4a2212, clearcoat: 0.8, roughness: 0.3 });
+    const frame = new THREE.Mesh(new THREE.BoxGeometry(9.15, 0.22, 9.15), frameMat);
+    frame.position.y = -0.04;
+    frame.receiveShadow = true;
+    frame.castShadow = true;
+    board.add(frame);
+
+    const felt = new THREE.Mesh(
+        new THREE.BoxGeometry(8.02, 0.02, 8.02),
+        new THREE.MeshStandardMaterial({
+            map: tex.felt.map,
+            roughness: 0.95,
+            metalness: 0,
+            color: 0x1a5a38
+        })
+    );
+    felt.position.y = 0.0;
+    felt.receiveShadow = true;
+    board.add(felt);
+
+    const labels = makeCoordLabels(tex);
+    board.add(labels);
+
+    const table = new THREE.Mesh(new THREE.BoxGeometry(16, 0.28, 12), phys(tex.mahogany, {
+        color: 0x3d1a0e, roughness: 0.18, clearcoat: 1, clearcoatRoughness: 0.08
+    }));
+    table.position.y = -0.28;
+    table.receiveShadow = true;
+    table.castShadow = true;
+    root.add(table);
+
+    const legGeo = new THREE.CylinderGeometry(0.22, 0.28, 2.4, 12);
+    const legMat = phys(tex.mahogany, { color: 0x2a120a });
+    for (const [x, z] of [[-6.8, -4.6], [6.8, -4.6], [-6.8, 4.6], [6.8, 4.6]]) {
+        const leg = new THREE.Mesh(legGeo, legMat);
+        leg.position.set(x, -1.62, z);
+        leg.castShadow = true;
+        root.add(leg);
+    }
+
+    const floor = new THREE.Mesh(
+        new THREE.CircleGeometry(18, 64),
+        phys(tex.marble, { color: 0xc8c0b4, roughness: 0.12, clearcoat: 1, metalness: 0.08 })
+    );
+    floor.rotation.x = -Math.PI / 2;
+    floor.position.y = -2.85;
+    floor.receiveShadow = true;
+    root.add(floor);
+
+    let mirror = null;
+    if (quality.reflect > 0) {
+        mirror = new Reflector(new THREE.CircleGeometry(10, 48), {
+            clipBias: 0.003,
+            textureWidth: quality.reflect,
+            textureHeight: quality.reflect,
+            color: 0x6a5a48
+        });
+        mirror.rotation.x = -Math.PI / 2;
+        mirror.position.y = -2.84;
+        root.add(mirror);
+    }
+
+    const rug = new THREE.Mesh(
+        new THREE.CircleGeometry(7.5, 48),
+        new THREE.MeshStandardMaterial({
+            map: tex.felt.map,
+            color: 0x6a1c1c,
+            roughness: 0.9
+        })
+    );
+    rug.rotation.x = -Math.PI / 2;
+    rug.position.y = -2.83;
+    rug.receiveShadow = true;
+    root.add(rug);
+
+    const wallMat = new THREE.MeshStandardMaterial({ color: 0x1a1210, roughness: 0.9 });
+    const back = new THREE.Mesh(new THREE.PlaneGeometry(28, 12), wallMat);
+    back.position.set(0, 2.2, -14);
+    root.add(back);
+    const sideL = new THREE.Mesh(new THREE.PlaneGeometry(28, 12), wallMat);
+    sideL.rotation.y = Math.PI / 2;
+    sideL.position.set(-14, 2.2, 0);
+    root.add(sideL);
+    const sideR = sideL.clone();
+    sideR.position.x = 14;
+    sideR.rotation.y = -Math.PI / 2;
+    root.add(sideR);
+
+    const lamp = makeLamp();
+    lamp.position.set(6.2, 0.1, -3.4);
+    root.add(lamp);
+
+    const marks = buildMarks();
+    root.add(marks.group);
+
+    return { root, board, squares, marks, mirror, lamp };
+}
+
+function makeCoordLabels() {
+    const g = new THREE.Group();
+    const files = 'abcdefgh';
+    const make = (text) => {
+        const el = document.createElement('canvas');
+        el.width = 128;
+        el.height = 128;
+        const ctx = el.getContext('2d');
+        ctx.fillStyle = '#e6d2a8';
+        ctx.font = '700 78px Cinzel, Georgia, serif';
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'middle';
+        ctx.fillText(text, 64, 68);
+        const tex = new THREE.CanvasTexture(el);
+        tex.colorSpace = THREE.SRGBColorSpace;
+        const mat = new THREE.MeshBasicMaterial({ map: tex, transparent: true });
+        const m = new THREE.Mesh(new THREE.PlaneGeometry(0.28, 0.28), mat);
+        m.rotation.x = -Math.PI / 2;
+        return m;
+    };
+    for (let i = 0; i < 8; i++) {
+        const f = make(files[i]);
+        f.position.set(i - ORIGIN, 0.12, ORIGIN + 0.62);
+        g.add(f);
+        const f2 = make(files[i]);
+        f2.position.set(i - ORIGIN, 0.12, -ORIGIN - 0.62);
+        f2.rotation.z = Math.PI;
+        g.add(f2);
+        const r = make(String(i + 1));
+        r.position.set(-ORIGIN - 0.62, 0.12, ORIGIN - i);
+        g.add(r);
+        const r2 = make(String(i + 1));
+        r2.position.set(ORIGIN + 0.62, 0.12, ORIGIN - i);
+        g.add(r2);
+    }
+    return g;
+}
+
+function makeLamp() {
+    const g = new THREE.Group();
+    const brass = new THREE.MeshPhysicalMaterial({
+        color: 0xb8863a, metalness: 1, roughness: 0.22, envMapIntensity: 1.4
+    });
+    const shade = new THREE.MeshPhysicalMaterial({
+        color: 0xf0d8a8, roughness: 0.6, transmission: 0.35, thickness: 0.2, emissive: 0x6a4010, emissiveIntensity: 0.25
+    });
+    const base = new THREE.Mesh(new THREE.CylinderGeometry(0.28, 0.36, 0.12, 20), brass);
+    g.add(base);
+    const stem = new THREE.Mesh(new THREE.CylinderGeometry(0.04, 0.05, 1.6, 12), brass);
+    stem.position.y = 0.86;
+    g.add(stem);
+    const hat = new THREE.Mesh(new THREE.ConeGeometry(0.42, 0.38, 20, 1, true), shade);
+    hat.position.y = 1.72;
+    g.add(hat);
+    const bulb = new THREE.PointLight(0xffcc88, 3.2, 9, 1.6);
+    bulb.position.y = 1.55;
+    bulb.castShadow = false;
+    g.add(bulb);
+    return g;
+}
+
+export function buildMarks() {
+    const group = new THREE.Group();
+    group.name = 'marks';
+
+    const dots = [];
+    const dotGeo = new THREE.CylinderGeometry(0.12, 0.12, 0.04, 20);
+    const dotMat = new THREE.MeshBasicMaterial({
+        color: 0xd4b06a, transparent: true, opacity: 0.72, depthWrite: false
+    });
+    const capGeo = new THREE.RingGeometry(0.28, 0.40, 28);
+    const capMat = new THREE.MeshBasicMaterial({
+        color: 0xc45c48, transparent: true, opacity: 0.85, side: THREE.DoubleSide, depthWrite: false
+    });
+    const caps = [];
+    for (let i = 0; i < 32; i++) {
+        const d = new THREE.Mesh(dotGeo, dotMat.clone());
+        d.visible = false;
+        d.position.y = 0.09;
+        group.add(d);
+        dots.push(d);
+        const c = new THREE.Mesh(capGeo, capMat.clone());
+        c.rotation.x = -Math.PI / 2;
+        c.visible = false;
+        c.position.y = 0.09;
+        group.add(c);
+        caps.push(c);
+    }
+
+    const selectGeo = new THREE.RingGeometry(0.42, 0.50, 32);
+    const select = new THREE.Mesh(selectGeo, new THREE.MeshBasicMaterial({
+        color: 0xf0d48a, transparent: true, opacity: 0.95, side: THREE.DoubleSide, depthWrite: false
+    }));
+    select.rotation.x = -Math.PI / 2;
+    select.position.y = 0.1;
+    select.visible = false;
+    group.add(select);
+
+    const lastFrom = select.clone();
+    lastFrom.material = new THREE.MeshBasicMaterial({
+        color: 0x7aa0d4, transparent: true, opacity: 0.55, side: THREE.DoubleSide, depthWrite: false
+    });
+    const lastTo = lastFrom.clone();
+    lastTo.material = lastFrom.material.clone();
+    group.add(lastFrom, lastTo);
+
+    const check = new THREE.Mesh(
+        new THREE.RingGeometry(0.36, 0.52, 32),
+        new THREE.MeshBasicMaterial({
+            color: 0xe05040, transparent: true, opacity: 0.9, side: THREE.DoubleSide, depthWrite: false
+        })
+    );
+    check.rotation.x = -Math.PI / 2;
+    check.position.y = 0.11;
+    check.visible = false;
+    group.add(check);
+
+    const hint = select.clone();
+    hint.material = new THREE.MeshBasicMaterial({
+        color: 0x6ad4a0, transparent: true, opacity: 0.9, side: THREE.DoubleSide, depthWrite: false
+    });
+    group.add(hint);
+
+    return { group, dots, caps, select, lastFrom, lastTo, check, hint };
+}
+
+export function placeMark(mesh, index, flip) {
+    const p = squareToWorld(index, flip);
+    mesh.position.x = p.x;
+    mesh.position.z = p.z;
+    mesh.visible = true;
+}
+
+export function setupLights(scene, quality) {
+    RectAreaLightUniformsLib.init();
+
+    const hemi = new THREE.HemisphereLight(0x9eb4d4, 0x3a2214, 0.45);
+    scene.add(hemi);
+
+    const key = new THREE.DirectionalLight(0xffe6c4, 2.15);
+    key.position.set(4.5, 10, 6.5);
+    key.castShadow = quality.shadows;
+    if (quality.shadows) {
+        key.shadow.mapSize.set(quality.shadowMap, quality.shadowMap);
+        key.shadow.camera.near = 1;
+        key.shadow.camera.far = 28;
+        key.shadow.camera.left = -10;
+        key.shadow.camera.right = 10;
+        key.shadow.camera.top = 10;
+        key.shadow.camera.bottom = -10;
+        key.shadow.bias = -0.0002;
+        key.shadow.normalBias = 0.03;
+    }
+    scene.add(key);
+
+    const fill = new THREE.DirectionalLight(0x88a4cc, 0.55);
+    fill.position.set(-6, 5, -4);
+    scene.add(fill);
+
+    const windowLight = new THREE.RectAreaLight(0xc8dcff, 8, 6, 4);
+    windowLight.position.set(0, 4.2, -13.2);
+    windowLight.lookAt(0, 0.5, 0);
+    scene.add(windowLight);
+
+    const chandelier = new THREE.SpotLight(0xffd9a8, 4.5, 22, 0.55, 0.45, 1.1);
+    chandelier.position.set(0, 7.4, 0.4);
+    chandelier.target.position.set(0, 0, 0);
+    chandelier.castShadow = quality.shadows;
+    if (quality.shadows) {
+        chandelier.shadow.mapSize.set(Math.min(quality.shadowMap, 2048), Math.min(quality.shadowMap, 2048));
+        chandelier.shadow.bias = -0.00015;
+    }
+    scene.add(chandelier, chandelier.target);
+
+    return { key, chandelier, hemi };
+}

--- a/labs/xadrez/style.css
+++ b/labs/xadrez/style.css
@@ -596,6 +596,23 @@ button {
 }
 
 @media (max-width: 768px) {
+    .feature-list {
+        display: none;
+    }
+
+    .overlay-card {
+        padding: 1.25rem 1.1rem 1.1rem;
+    }
+
+    .overlay-card h2 {
+        font-size: clamp(1.7rem, 8vw, 2.3rem);
+        margin-bottom: 0.55rem;
+    }
+
+    .lede {
+        font-size: 0.9rem;
+        margin-bottom: 0.8rem;
+    }
     .coach {
         top: auto;
         bottom: calc(5.6rem + var(--safe-bottom));

--- a/labs/xadrez/style.css
+++ b/labs/xadrez/style.css
@@ -63,6 +63,14 @@ body {
     touch-action: none;
 }
 
+.overlay,
+.overlay-card,
+.hud,
+button,
+select {
+    touch-action: manipulation;
+}
+
 button,
 input,
 select {
@@ -275,6 +283,11 @@ button {
     margin-bottom: 0.7rem;
 }
 
+.lesson-nav[hidden],
+.lesson-list[hidden] {
+    display: none !important;
+}
+
 .lesson-list {
     list-style: none;
     margin: 0;
@@ -422,7 +435,7 @@ button {
     padding: max(1rem, var(--safe-top)) max(1rem, var(--safe-right)) max(1rem, var(--safe-bottom)) max(1rem, var(--safe-left));
     background:
         radial-gradient(ellipse at 50% 18%, color-mix(in oklab, var(--gold) 14%, transparent), transparent 52%),
-        oklch(6% 0.02 50 / 0.62);
+        oklch(6% 0.02 50 / 0.42);
     backdrop-filter: blur(10px);
 }
 
@@ -533,6 +546,9 @@ button {
     font-weight: 650;
     letter-spacing: 0.02em;
     box-shadow: 0 10px 30px color-mix(in oklab, var(--gold) 40%, transparent);
+    pointer-events: auto;
+    position: relative;
+    z-index: 2;
 }
 
 .primary-button i {

--- a/labs/xadrez/style.css
+++ b/labs/xadrez/style.css
@@ -1,0 +1,682 @@
+/* ================================================================
+   Xadrez — atelier 3D
+   Paleta: mogno, ouro velho, marfim, ébano, feltro verde.
+   ================================================================ */
+
+:root {
+    --ink: oklch(11% 0.02 55);
+    --ink-deep: oklch(7% 0.018 50);
+    --gold: oklch(80% 0.12 82);
+    --gold-deep: oklch(64% 0.12 68);
+    --ivory: oklch(92% 0.03 90);
+    --felt: oklch(42% 0.08 155);
+    --blood: oklch(55% 0.16 28);
+
+    --text: oklch(95% 0.015 85);
+    --text-soft: oklch(82% 0.03 80);
+    --text-dim: oklch(64% 0.03 75);
+
+    --panel: color-mix(in oklab, oklch(14% 0.03 55) 68%, transparent);
+    --panel-strong: color-mix(in oklab, oklch(10% 0.03 50) 88%, transparent);
+    --line: color-mix(in oklab, var(--gold) 30%, transparent);
+    --line-soft: color-mix(in oklab, var(--ivory) 12%, transparent);
+
+    --radius: 14px;
+    --radius-lg: 22px;
+    --blur: 20px;
+
+    --safe-top: env(safe-area-inset-top, 0px);
+    --safe-bottom: env(safe-area-inset-bottom, 0px);
+    --safe-left: env(safe-area-inset-left, 0px);
+    --safe-right: env(safe-area-inset-right, 0px);
+
+    --ease: cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+*,
+*::before,
+*::after {
+    box-sizing: border-box;
+    -webkit-tap-highlight-color: transparent;
+}
+
+html,
+body {
+    margin: 0;
+    width: 100%;
+    height: 100%;
+    overflow: clip;
+    overflow-x: clip;
+    overscroll-behavior: none;
+    background: var(--ink-deep);
+}
+
+body {
+    min-height: 100dvh;
+    padding: 0 !important;
+    display: block !important;
+    align-items: stretch !important;
+    color: var(--text);
+    font-family: 'Outfit', system-ui, -apple-system, 'Segoe UI', sans-serif;
+    user-select: none;
+    -webkit-user-select: none;
+    touch-action: none;
+}
+
+button,
+input,
+select {
+    font: inherit;
+    color: inherit;
+}
+
+button {
+    background: none;
+    border: 0;
+    cursor: pointer;
+}
+
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip-path: inset(50%);
+}
+
+:focus-visible {
+    outline: 2px solid var(--gold);
+    outline-offset: 3px;
+}
+
+.game-shell {
+    position: fixed;
+    inset: 0;
+    overflow: hidden;
+    background: var(--ink-deep);
+}
+
+.stage {
+    position: absolute;
+    inset: 0;
+}
+
+#scene {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    display: block;
+    cursor: grab;
+    touch-action: none;
+}
+
+#scene.is-dragging {
+    cursor: grabbing;
+}
+
+.vignette {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background:
+        radial-gradient(ellipse at 50% 42%, transparent 42%, oklch(6% 0.02 50 / 0.58) 100%),
+        linear-gradient(to top, oklch(6% 0.02 50 / 0.35), transparent 22%);
+    z-index: 2;
+}
+
+.game-shell > header {
+    position: absolute;
+    top: calc(0.7rem + var(--safe-top));
+    left: calc(0.8rem + var(--safe-left));
+    right: calc(0.8rem + var(--safe-right));
+    z-index: 40;
+    margin: 0;
+    padding: 0;
+    max-width: none;
+    width: auto;
+    pointer-events: none;
+    gap: 0.45rem;
+}
+
+.game-shell > header > * {
+    pointer-events: auto;
+}
+
+.game-shell > header .back-link {
+    background: var(--panel-strong);
+    backdrop-filter: blur(var(--blur));
+    -webkit-backdrop-filter: blur(var(--blur));
+    border-color: var(--line);
+    color: var(--text-soft);
+    min-height: 44px;
+}
+
+.game-shell > header .app-logo {
+    font-family: 'Cinzel', Georgia, serif;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    font-size: clamp(0.82rem, 2.4vw, 1.05rem);
+}
+
+.brand-mark {
+    color: var(--gold);
+}
+
+.lab-foot {
+    position: absolute;
+    right: calc(0.8rem + var(--safe-right));
+    bottom: calc(0.4rem + var(--safe-bottom));
+    z-index: 8;
+    pointer-events: auto;
+    opacity: 0.55;
+    font-size: 0.7rem;
+}
+
+.hud {
+    position: absolute;
+    inset: 0;
+    z-index: 12;
+    pointer-events: none;
+}
+
+.hud > * {
+    pointer-events: auto;
+}
+
+.coach {
+    position: absolute;
+    top: calc(4.4rem + var(--safe-top));
+    left: calc(0.8rem + var(--safe-left));
+    width: min(340px, calc(100vw - 1.6rem));
+    max-height: min(52dvh, 420px);
+    display: flex;
+    flex-direction: column;
+    background: var(--panel);
+    border: 1px solid var(--line-soft);
+    border-radius: var(--radius-lg);
+    backdrop-filter: blur(var(--blur));
+    -webkit-backdrop-filter: blur(var(--blur));
+    box-shadow: 0 18px 50px oklch(0% 0 0 / 0.32);
+    overflow: hidden;
+}
+
+.coach-toggle {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.15rem;
+    padding: 0.85rem 1rem 0.55rem;
+    min-height: 44px;
+    text-align: left;
+    width: 100%;
+}
+
+.coach-toggle #coachTitle {
+    font-family: 'Cinzel', Georgia, serif;
+    font-size: 1.05rem;
+    letter-spacing: 0.04em;
+    color: var(--ivory);
+}
+
+.coach-body {
+    padding: 0 1rem 1rem;
+    overflow-y: auto;
+    max-height: min(40dvh, 340px);
+}
+
+.coach.is-collapsed .coach-body {
+    display: none;
+}
+
+.coach-text,
+.coach-tip {
+    margin: 0 0 0.7rem;
+    line-height: 1.5;
+    font-size: 0.88rem;
+    color: var(--text-soft);
+}
+
+.coach-tip {
+    color: var(--gold);
+    font-size: 0.82rem;
+}
+
+.eyebrow {
+    display: flex;
+    align-items: center;
+    gap: 0.45rem;
+    font-size: 0.68rem;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: var(--gold);
+    margin: 0;
+}
+
+.eyebrow i {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: var(--gold);
+    box-shadow: 0 0 10px var(--gold);
+}
+
+.eyebrow--danger {
+    color: oklch(72% 0.18 25);
+}
+
+.eyebrow--danger i {
+    background: oklch(72% 0.18 25);
+}
+
+.lesson-nav {
+    display: flex;
+    gap: 0.4rem;
+    margin-bottom: 0.7rem;
+}
+
+.lesson-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 0.28rem;
+}
+
+.lesson-list button {
+    width: 100%;
+    text-align: left;
+    padding: 0.55rem 0.7rem;
+    min-height: 44px;
+    border-radius: 10px;
+    border: 1px solid transparent;
+    color: var(--text-soft);
+    font-size: 0.82rem;
+    background: color-mix(in oklab, var(--ink) 35%, transparent);
+}
+
+.lesson-list button[aria-current="true"],
+.lesson-list button:hover {
+    border-color: var(--line);
+    color: var(--ivory);
+}
+
+.lesson-list button.is-done::after {
+    content: ' ✓';
+    color: var(--felt);
+}
+
+.tray {
+    position: absolute;
+    top: calc(4.4rem + var(--safe-top));
+    right: calc(0.8rem + var(--safe-right));
+    width: min(220px, calc(100vw - 1.6rem));
+    max-height: min(48dvh, 380px);
+    display: flex;
+    flex-direction: column;
+    gap: 0.55rem;
+    padding: 0.85rem 0.9rem;
+    background: var(--panel);
+    border: 1px solid var(--line-soft);
+    border-radius: var(--radius);
+    backdrop-filter: blur(var(--blur));
+    -webkit-backdrop-filter: blur(var(--blur));
+    overflow: hidden;
+}
+
+.status {
+    margin: 0;
+    font-family: 'Cinzel', Georgia, serif;
+    font-size: 0.92rem;
+    letter-spacing: 0.04em;
+    color: var(--ivory);
+}
+
+.status.is-check {
+    color: oklch(78% 0.14 30);
+}
+
+.captured {
+    min-height: 1.2rem;
+    font-size: 1.05rem;
+    letter-spacing: 0.08em;
+    color: var(--text-soft);
+    word-break: break-word;
+}
+
+.moves {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    overflow-y: auto;
+    font-variant-numeric: tabular-nums;
+    font-size: 0.8rem;
+    color: var(--text-dim);
+    display: grid;
+    gap: 0.2rem;
+}
+
+.moves li {
+    display: grid;
+    grid-template-columns: 1.6rem 1fr 1fr;
+    gap: 0.25rem;
+}
+
+.moves .n {
+    color: var(--gold);
+    opacity: 0.8;
+}
+
+.dock {
+    position: absolute;
+    left: 50%;
+    bottom: calc(1rem + var(--safe-bottom));
+    transform: translateX(-50%);
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: center;
+    gap: 0.4rem;
+    padding: 0.45rem;
+    width: max-content;
+    max-width: calc(100vw - 1.2rem - var(--safe-left) - var(--safe-right));
+    background: var(--panel);
+    backdrop-filter: blur(var(--blur));
+    -webkit-backdrop-filter: blur(var(--blur));
+    border: 1px solid var(--line-soft);
+    border-radius: var(--radius);
+    box-shadow: 0 18px 50px oklch(0% 0 0 / 0.28);
+}
+
+.dock-btn {
+    padding: 0.55rem 0.8rem;
+    border-radius: 999px;
+    border: 1px solid var(--line-soft);
+    color: var(--text-soft);
+    font-size: 0.78rem;
+    font-weight: 500;
+    min-height: 44px;
+    min-width: 44px;
+    transition: background 0.2s var(--ease), color 0.2s, border-color 0.2s;
+}
+
+.dock-btn:hover,
+.dock-btn[aria-pressed="true"] {
+    color: var(--text);
+    border-color: var(--gold);
+    background: color-mix(in oklab, var(--gold) 14%, transparent);
+}
+
+.dock-btn.accent {
+    background: linear-gradient(135deg, color-mix(in oklab, var(--gold-deep) 55%, transparent), color-mix(in oklab, var(--gold) 40%, transparent));
+    border-color: color-mix(in oklab, var(--gold) 45%, transparent);
+    color: oklch(16% 0.04 80);
+}
+
+.overlay {
+    position: absolute;
+    inset: 0;
+    z-index: 50;
+    display: grid;
+    place-items: center;
+    padding: max(1rem, var(--safe-top)) max(1rem, var(--safe-right)) max(1rem, var(--safe-bottom)) max(1rem, var(--safe-left));
+    background:
+        radial-gradient(ellipse at 50% 18%, color-mix(in oklab, var(--gold) 14%, transparent), transparent 52%),
+        oklch(6% 0.02 50 / 0.62);
+    backdrop-filter: blur(10px);
+}
+
+.overlay[hidden] {
+    display: none !important;
+}
+
+.overlay-card {
+    width: min(540px, 100%);
+    max-height: min(92dvh, 720px);
+    overflow-y: auto;
+    padding: 2rem 1.8rem 1.6rem;
+    border-radius: var(--radius-lg);
+    background: var(--panel-strong);
+    border: 1px solid var(--line);
+    box-shadow:
+        0 30px 80px oklch(0% 0 0 / 0.5),
+        inset 0 1px 0 color-mix(in oklab, var(--gold) 18%, transparent);
+    backdrop-filter: blur(28px);
+    -webkit-backdrop-filter: blur(28px);
+}
+
+.compact-card {
+    width: min(420px, 100%);
+}
+
+.overlay-card h2 {
+    font-family: 'Cinzel', Georgia, serif;
+    font-size: clamp(2rem, 6vw, 3.1rem);
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    line-height: 0.95;
+    margin: 0.4rem 0 0.9rem;
+    color: var(--ivory);
+}
+
+.lede {
+    margin: 0 0 1.1rem;
+    color: var(--text-soft);
+    line-height: 1.55;
+    font-size: 0.98rem;
+}
+
+.feature-list {
+    margin: 0 0 1.3rem;
+    padding: 0;
+    list-style: none;
+    display: grid;
+    gap: 0.45rem;
+    color: var(--text-soft);
+    font-size: 0.9rem;
+}
+
+.feature-list li {
+    padding-left: 1.1rem;
+    position: relative;
+}
+
+.feature-list li::before {
+    content: '♛';
+    position: absolute;
+    left: 0;
+    color: var(--gold);
+    font-size: 0.7rem;
+    top: 0.15rem;
+}
+
+.settings-row {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.8rem;
+    margin-bottom: 1.2rem;
+}
+
+.field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    font-size: 0.8rem;
+    color: var(--text-dim);
+}
+
+.field select {
+    appearance: none;
+    background: color-mix(in oklab, var(--ink) 55%, transparent);
+    border: 1px solid var(--line);
+    border-radius: 12px;
+    padding: 0.7rem 0.9rem;
+    min-height: 44px;
+    color: var(--text);
+}
+
+.card-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.6rem;
+}
+
+.primary-button {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.7rem;
+    padding: 0.85rem 1.25rem;
+    min-height: 48px;
+    border-radius: 999px;
+    background: linear-gradient(135deg, var(--gold-deep), var(--gold));
+    color: oklch(14% 0.04 80);
+    font-weight: 650;
+    letter-spacing: 0.02em;
+    box-shadow: 0 10px 30px color-mix(in oklab, var(--gold) 40%, transparent);
+}
+
+.primary-button i {
+    font-style: normal;
+}
+
+.primary-button:hover {
+    transform: translateY(-1px);
+}
+
+.load-bar {
+    height: 4px;
+    border-radius: 99px;
+    background: color-mix(in oklab, var(--ivory) 12%, transparent);
+    overflow: hidden;
+}
+
+.load-bar i {
+    display: block;
+    height: 100%;
+    width: 8%;
+    background: linear-gradient(90deg, var(--gold-deep), var(--gold));
+    border-radius: inherit;
+    transition: width 0.35s var(--ease);
+}
+
+.promo-row {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.5rem;
+}
+
+.promo-btn {
+    min-height: 48px;
+    border-radius: 12px;
+    border: 1px solid var(--line);
+    background: color-mix(in oklab, var(--ink) 40%, transparent);
+    font-family: 'Cinzel', Georgia, serif;
+    letter-spacing: 0.06em;
+}
+
+.promo-btn:hover {
+    border-color: var(--gold);
+    color: var(--gold);
+}
+
+@media (max-width: 768px) {
+    .coach {
+        top: auto;
+        bottom: calc(5.6rem + var(--safe-bottom));
+        left: calc(0.6rem + var(--safe-left));
+        right: calc(0.6rem + var(--safe-right));
+        width: auto;
+        max-height: min(38dvh, 280px);
+    }
+
+    .tray {
+        top: calc(4.2rem + var(--safe-top));
+        right: calc(0.6rem + var(--safe-right));
+        left: auto;
+        width: min(160px, 42vw);
+        max-height: 28dvh;
+        padding: 0.65rem 0.7rem;
+    }
+
+    .moves {
+        display: none;
+    }
+
+    .game-shell > header .app-logo span:last-child {
+        max-width: 42vw;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    .dock {
+        bottom: calc(0.7rem + var(--safe-bottom));
+        gap: 0.28rem;
+        padding: 0.35rem;
+    }
+
+    .dock-btn {
+        padding: 0.45rem 0.62rem;
+        font-size: 0.72rem;
+    }
+
+    .settings-row {
+        grid-template-columns: 1fr;
+    }
+
+    .lab-foot {
+        display: none;
+    }
+}
+
+@media (max-height: 520px) and (orientation: landscape) {
+    .coach {
+        top: calc(3.6rem + var(--safe-top));
+        bottom: calc(4.6rem + var(--safe-bottom));
+        left: calc(0.5rem + var(--safe-left));
+        width: min(260px, 38vw);
+        max-height: none;
+    }
+
+    .tray {
+        top: calc(3.6rem + var(--safe-top));
+        max-height: 42dvh;
+        width: min(150px, 28vw);
+    }
+
+    .dock {
+        bottom: calc(0.45rem + var(--safe-bottom));
+    }
+
+    .overlay-card {
+        padding: 1.1rem 1.2rem;
+    }
+
+    .overlay-card h2 {
+        font-size: clamp(1.5rem, 5vh, 2.2rem);
+        margin-bottom: 0.5rem;
+    }
+
+    .feature-list {
+        display: none;
+    }
+}
+
+@media (pointer: coarse) {
+    .dock-btn,
+    .lesson-list button,
+    .promo-btn,
+    .primary-button {
+        min-height: 44px;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .primary-button:hover {
+        transform: none;
+    }
+
+    .load-bar i {
+        transition: none;
+    }
+}

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -349,6 +349,12 @@
     <priority>0.7</priority>
   </url>
   <url>
+    <loc>https://diogopaulino.com.br/labs/xadrez/</loc>
+    <lastmod>2026-08-14</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
     <loc>https://diogopaulino.com.br/labs/cupola-64/</loc>
     <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 🎯 Objetivo

Novo lab de xadrez 3D em three.js — peças Staunton realistas com reflexo, e um mestre que ensina regras, táticas e aberturas.

## ✨ O que mudou

- Lab `/labs/xadrez/`: atelier PBR (marfim, ébano, cristal), tabuleiro laqueado e mesa de mogno
- Motor FIDE: roque, en passant, promoção, xeque, mate e afogamento
- Academia com 14 lições + 8 puzzles; IA em três níveis; dois jogadores e tabuleiro livre
- Catálogo 57 → 59: galeria, README, sitemap, home e SEO (canonical, OG, JSON-LD), incluindo Rastro Vermelho já no master

## 🧪 Como testar

1. Na raiz do repo: `python3 -m http.server 8000`
2. Abrir [http://localhost:8000/](http://localhost:8000/) (home) e [http://localhost:8000/labs/](http://localhost:8000/labs/) (galeria)
3. Abrir [http://localhost:8000/labs/xadrez/](http://localhost:8000/labs/xadrez/)
4. Academia: completar a primeira lição (peão e4 → e5) e um puzzle (Mate do Pastor)
5. Jogar contra a máquina (nível Iniciante), desfazer, dica, virar o tabuleiro
6. Responsivo: DevTools em **375×667**, **390×844** e landscape curto (~667×375) — sem overflow horizontal, HUD/controles utilizáveis, alvos ≥ 44px
7. Conferir pasta ↔ card da galeria ↔ README ↔ `sitemap.xml` ↔ canonical/OG (Xadrez e Rastro Vermelho)

## ✅ Checklist

- [x] Links conferidos: pasta do lab ↔ card da galeria ↔ README ↔ sitemap
- [x] README atualizado (linha na tabela + URL + contagem no badge/texto)
- [x] SEO consistente: title, description, canonical, author, robots, OG, Twitter, JSON-LD (e contagem nos metas da galeria)
- [x] Testado via HTTP na raiz, não via `file://`
- [x] Responsivo: 375px / 390px / landscape — overflow, HUD, toque, safe-area (`viewport-fit=cover`)
- [x] Nada fora do escopo foi quebrado
- [x] Merge com `master` resolvido (catálogo 59: Xadrez + Rastro Vermelho)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7f9f66c0-95f6-4260-8a02-01de706d506f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7f9f66c0-95f6-4260-8a02-01de706d506f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

