### PR TITLE
🐛 Tetris, Snake e Guerreiro: escala real no mobile, grade sem distorção e toque

### DIFF
--- a/labs/aetherion/src/camera.js
+++ b/labs/aetherion/src/camera.js
@@ -56,7 +56,12 @@ export class ObservatoryCamera {
     }
 
     onDown(e) {
-        this.canvas.setPointerCapture(e.pointerId);
+        // Best-effort: lança InvalidStateError se o ponteiro já terminou.
+        try {
+            this.canvas.setPointerCapture(e.pointerId);
+        } catch (err) {
+            /* segue sem captura */
+        }
         this.pointers.set(e.pointerId, { x: e.clientX, y: e.clientY });
         this.moved = false;
         if (this.pointers.size === 1) {

--- a/labs/aurelia/style.css
+++ b/labs/aurelia/style.css
@@ -722,8 +722,10 @@ kbd {
 }
 
 @media (max-height: 520px) and (orientation: landscape) {
+    /* Abaixo do header compartilhado: em 0.75rem os botões caíam em cima do
+       seletor de tema. */
     .hud-actions {
-        top: calc(0.75rem + var(--safe-top, env(safe-area-inset-top, 0px)));
+        top: calc(4.4rem + var(--safe-top, env(safe-area-inset-top, 0px)));
         bottom: auto;
         right: calc(0.75rem + var(--safe-right, env(safe-area-inset-right, 0px)));
     }

--- a/labs/calculator/index.html
+++ b/labs/calculator/index.html
@@ -109,7 +109,8 @@
                 </div>
                 <div class="buttons">
                     <button class="btn function" data-action="clear">AC</button>
-                    <button class="btn function" data-action="delete"><i class="ph ph-backspace"></i></button>
+                    <button class="btn function" data-action="delete" aria-label="Apagar último dígito"><i
+                            class="ph ph-backspace" aria-hidden="true"></i></button>
                     <button class="btn operator" data-action="percent">%</button>
                     <button class="btn operator" data-action="divide">÷</button>
                     <button class="btn number">7</button>
@@ -139,7 +140,8 @@
                 <div class="buttons scientific-grid">
                     <!-- Row 1 -->
                     <button class="btn function" data-action="sci-clear">AC</button>
-                    <button class="btn function" data-action="sci-delete"><i class="ph ph-backspace"></i></button>
+                    <button class="btn function" data-action="sci-delete" aria-label="Apagar último dígito"><i
+                            class="ph ph-backspace" aria-hidden="true"></i></button>
                     <button class="btn sci-func" data-action="sin">sin</button>
                     <button class="btn sci-func" data-action="cos">cos</button>
                     <button class="btn sci-func" data-action="tan">tan</button>
@@ -193,8 +195,8 @@
                 <div class="currency-header">
                     <h3>Real-time Converter</h3>
                     <div class="last-updated">Loading rates...</div>
-                    <button id="refresh-rates" class="btn-refresh" title="Refresh Rates">
-                        <i class="ph ph-arrows-clockwise"></i>
+                    <button id="refresh-rates" class="btn-refresh" title="Refresh Rates" aria-label="Atualizar cotações">
+                        <i class="ph ph-arrows-clockwise" aria-hidden="true"></i>
                     </button>
                 </div>
 
@@ -215,8 +217,8 @@
                 </div>
 
                 <div class="swap-container">
-                    <button class="btn-swap" id="swap">
-                        <i class="ph ph-arrows-down-up"></i>
+                    <button class="btn-swap" id="swap" aria-label="Inverter as moedas">
+                        <i class="ph ph-arrows-down-up" aria-hidden="true"></i>
                     </button>
                     <div class="rate-info" id="rate">1 USD = ...</div>
                 </div>

--- a/labs/cupola-64/src/input.js
+++ b/labs/cupola-64/src/input.js
@@ -108,7 +108,12 @@ export class Input {
         if (!stick) return;
         stick.addEventListener('pointerdown', (e) => {
             e.preventDefault();
-            stick.setPointerCapture(e.pointerId);
+            // Best-effort: lança InvalidStateError se o ponteiro já terminou.
+            try {
+                stick.setPointerCapture(e.pointerId);
+            } catch (err) {
+                /* segue sem captura */
+            }
             this.stickId = e.pointerId;
             const rect = stick.getBoundingClientRect();
             this.stickOrigin = {
@@ -185,7 +190,12 @@ export class Input {
         const el = this.canvas;
         el.addEventListener('pointerdown', (e) => {
             if (e.target.closest?.('.touch-controls, .hud-actions, header, .overlay')) return;
-            el.setPointerCapture(e.pointerId);
+            // Best-effort: lança InvalidStateError se o ponteiro já terminou.
+            try {
+                el.setPointerCapture(e.pointerId);
+            } catch (err) {
+                /* segue sem captura */
+            }
             this.lookId = e.pointerId;
             this._lastLook = { x: e.clientX, y: e.clientY };
             el.classList.add('is-dragging');

--- a/labs/cyberos/script.js
+++ b/labs/cyberos/script.js
@@ -211,7 +211,12 @@ para perguntar como cada lab foi construído.`
         oy: e.clientY - rect.top,
         parent
       };
-      bar.setPointerCapture(e.pointerId);
+      // Best-effort: lança InvalidStateError se o ponteiro já terminou.
+      try {
+          bar.setPointerCapture(e.pointerId);
+      } catch (err) {
+          /* segue sem captura */
+      }
     });
 
     bar.addEventListener('pointermove', (e) => {

--- a/labs/eyra/src/input.js
+++ b/labs/eyra/src/input.js
@@ -61,7 +61,12 @@ export class Input {
 
         const el = this.canvas;
         el.addEventListener('pointerdown', (e) => {
-            el.setPointerCapture(e.pointerId);
+            // Best-effort: lança InvalidStateError se o ponteiro já terminou.
+            try {
+                el.setPointerCapture(e.pointerId);
+            } catch (err) {
+                /* segue sem captura */
+            }
             this.pointers.set(e.pointerId, { x: e.clientX, y: e.clientY });
             if (this.pointers.size === 1) {
                 this.dragging = true;
@@ -110,7 +115,12 @@ export class Input {
             setKnob(0, 0);
         };
         stick.addEventListener('pointerdown', (e) => {
-            stick.setPointerCapture(e.pointerId);
+            // Best-effort: lança InvalidStateError se o ponteiro já terminou.
+            try {
+                stick.setPointerCapture(e.pointerId);
+            } catch (err) {
+                /* segue sem captura */
+            }
             onMove(e);
         });
         stick.addEventListener('pointermove', (e) => {

--- a/labs/forrest-run/style.css
+++ b/labs/forrest-run/style.css
@@ -716,3 +716,20 @@ kbd {
     .menu-head h1 { font-size: 1.35rem; }
     .menu-grid { margin: 0.6rem 0; gap: 0.6rem; }
 }
+
+/* Som e pausa saem do canto inferior direito no toque: ali eles ficavam
+   exatamente em cima do botão de pulo. */
+@media (pointer: coarse) {
+    .hud-actions {
+        position: absolute;
+        grid-row: 1;
+        align-self: start;
+        top: calc(3.4rem + var(--safe-top));
+        right: calc(0.8rem + var(--safe-right));
+    }
+
+    .icon-button {
+        width: 44px;
+        height: 44px;
+    }
+}

--- a/labs/grao/script.js
+++ b/labs/grao/script.js
@@ -711,7 +711,12 @@ function bind() {
     const canvas = $('curve');
     canvas.addEventListener('pointermove', (event) => showHover(event.clientX));
     canvas.addEventListener('pointerdown', (event) => {
-        canvas.setPointerCapture(event.pointerId);
+        // Best-effort: lança InvalidStateError se o ponteiro já terminou.
+        try {
+            canvas.setPointerCapture(event.pointerId);
+        } catch (err) {
+            /* segue sem captura */
+        }
         showHover(event.clientX);
     });
     canvas.addEventListener('pointerup', () => setTimeout(hideHover, 900));

--- a/labs/gravity/style.css
+++ b/labs/gravity/style.css
@@ -8,6 +8,10 @@
     --text-primary: rgba(255, 255, 255, 0.95);
     --text-secondary: rgba(255, 255, 255, 0.55);
     --accent-gradient: linear-gradient(135deg, var(--g1), var(--g2));
+    /* O palco é sempre escuro (#05050b), inclusive no tema claro: o header
+       que flutua sobre ele precisa de cor própria, senão some no fundo. */
+    --on-canvas: rgba(255, 255, 255, 0.78);
+    --on-canvas-border: rgba(255, 255, 255, 0.16);
 }
 
 [data-theme="light"] {
@@ -78,8 +82,8 @@ header .back-link {
     grid-column: 1;
     justify-self: start;
     background: rgba(255, 255, 255, 0.06);
-    border: 1px solid var(--panel-border);
-    color: var(--text-secondary);
+    border: 1px solid var(--on-canvas-border);
+    color: var(--on-canvas);
     min-height: 44px;
     min-width: 44px;
 }
@@ -121,11 +125,11 @@ header .app-logo svg {
 
 .icon-btn {
     background: rgba(255, 255, 255, 0.06);
-    border: 1px solid var(--panel-border);
+    border: 1px solid var(--on-canvas-border);
     border-radius: 10px;
     padding: 0.55rem;
     cursor: pointer;
-    color: var(--text-secondary);
+    color: var(--on-canvas);
     transition: all 0.2s ease;
     display: flex;
     align-items: center;

--- a/labs/guerreiro-castelo/css/style.css
+++ b/labs/guerreiro-castelo/css/style.css
@@ -484,4 +484,222 @@ kbd {
     }
     .menu-head h1 { font-size: 1.2rem; }
     .lede { margin-bottom: 0.8rem; }
+
+    /* Deitado sobra largura e falta altura: os painéis voltam para uma linha. */
+    .hud-top {
+        flex-direction: row;
+        padding-top: 3.6rem;
+    }
+    .line { font-size: 0.95rem; }
+}
+
+.keys-touch {
+    display: none;
+    margin: 0 0 1rem;
+    font-size: 0.86rem;
+    line-height: 1.5;
+    color: #cdd5e4;
+    opacity: 0.85;
+}
+
+@media (pointer: coarse) {
+    .keys-touch {
+        display: block;
+    }
+}
+
+/* ---------------------------------------------------------------------------
+   Controles de toque
+   Só existem quando não há teclado nem pointer lock (ponteiro grosso). O stick
+   fica à esquerda, os botões de ação à direita e o resto da tela é a câmera.
+   --------------------------------------------------------------------------- */
+.touch-controls {
+    display: none;
+}
+
+@media (pointer: coarse) {
+    .touch-controls {
+        position: absolute;
+        inset: 0;
+        z-index: 14;
+        display: block;
+        pointer-events: none;
+        touch-action: none;
+        user-select: none;
+        -webkit-user-select: none;
+    }
+
+    /* A camada de câmera cobre a tela inteira e fica atrás dos controles:
+       arrastar em qualquer área livre gira a câmera. */
+    .touch-look {
+        position: absolute;
+        inset: 0;
+        pointer-events: auto;
+        touch-action: none;
+    }
+
+    .touch-stick {
+        position: absolute;
+        left: calc(1.1rem + env(safe-area-inset-left, 0px));
+        bottom: calc(1.4rem + env(safe-area-inset-bottom, 0px));
+        width: 128px;
+        height: 128px;
+        border-radius: 50%;
+        border: 1px solid rgba(255, 255, 255, 0.16);
+        background: radial-gradient(circle at 50% 50%, rgba(12, 16, 26, 0.5), rgba(8, 10, 18, 0.28));
+        backdrop-filter: blur(3px);
+        pointer-events: auto;
+        touch-action: none;
+    }
+
+    .touch-stick-knob {
+        position: absolute;
+        left: 50%;
+        top: 50%;
+        width: 54px;
+        height: 54px;
+        margin: -27px 0 0 -27px;
+        border-radius: 50%;
+        background: rgba(226, 200, 138, 0.32);
+        border: 1px solid rgba(226, 200, 138, 0.55);
+        box-shadow: 0 6px 18px rgba(0, 0, 0, 0.45);
+        transition: transform 0.08s ease-out;
+    }
+
+    .touch-stick.is-active .touch-stick-knob {
+        transition: none;
+        background: rgba(226, 200, 138, 0.5);
+    }
+
+    .touch-pad {
+        position: absolute;
+        right: calc(1rem + env(safe-area-inset-right, 0px));
+        bottom: calc(1.4rem + env(safe-area-inset-bottom, 0px));
+        display: grid;
+        grid-template-columns: repeat(2, auto);
+        gap: 10px;
+        justify-items: end;
+        pointer-events: none;
+    }
+
+    .touch-btn {
+        pointer-events: auto;
+        touch-action: none;
+        width: 58px;
+        height: 58px;
+        border-radius: 50%;
+        border: 1px solid rgba(255, 255, 255, 0.18);
+        background: rgba(12, 16, 26, 0.5);
+        backdrop-filter: blur(3px);
+        color: #f4ead2;
+        font-family: Outfit, system-ui, sans-serif;
+        font-size: 1.25rem;
+        line-height: 1;
+        display: grid;
+        place-items: center;
+        cursor: pointer;
+    }
+
+    .touch-btn.is-active {
+        background: rgba(226, 200, 138, 0.38);
+        transform: scale(0.94);
+    }
+
+    .touch-btn-attack {
+        background: rgba(120, 32, 32, 0.55);
+        border-color: rgba(226, 138, 138, 0.4);
+    }
+
+    .touch-btn-jump {
+        background: rgba(226, 200, 138, 0.22);
+        border-color: rgba(226, 200, 138, 0.45);
+    }
+
+    .touch-side {
+        position: absolute;
+        right: calc(1rem + env(safe-area-inset-right, 0px));
+        bottom: calc(9.6rem + env(safe-area-inset-bottom, 0px));
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+        align-items: flex-end;
+        pointer-events: none;
+    }
+
+    .touch-chip {
+        pointer-events: auto;
+        touch-action: none;
+        min-height: 34px;
+        padding: 0 0.85rem;
+        border-radius: 999px;
+        border: 1px solid rgba(255, 255, 255, 0.16);
+        background: rgba(12, 16, 26, 0.5);
+        backdrop-filter: blur(3px);
+        color: #cdd5e4;
+        font-family: Outfit, system-ui, sans-serif;
+        font-size: 0.78rem;
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+        cursor: pointer;
+    }
+
+    .touch-chip[aria-pressed="true"] {
+        background: rgba(226, 200, 138, 0.34);
+        border-color: rgba(226, 200, 138, 0.55);
+        color: #fff5e0;
+    }
+
+    /* O botão de pausa mora no canto superior direito: os painéis do HUD abrem
+       espaço para ele em vez de passarem por baixo. */
+    .hud-top {
+        padding-right: 3.8rem;
+    }
+
+    .touch-pause {
+        position: absolute;
+        right: calc(1rem + env(safe-area-inset-right, 0px));
+        top: calc(4.6rem + env(safe-area-inset-top, 0px));
+        pointer-events: auto;
+        touch-action: none;
+        width: 44px;
+        height: 44px;
+        border-radius: 50%;
+        border: 1px solid rgba(255, 255, 255, 0.16);
+        background: rgba(12, 16, 26, 0.5);
+        backdrop-filter: blur(3px);
+        color: #cdd5e4;
+        font-family: Outfit, system-ui, sans-serif;
+        font-size: 0.9rem;
+        letter-spacing: 0.1em;
+        cursor: pointer;
+    }
+
+    /* Paisagem curta: encolhe o stick e os botões para não cobrirem a cena. */
+    @media (max-height: 460px) {
+        .touch-stick {
+            width: 104px;
+            height: 104px;
+            bottom: calc(0.8rem + env(safe-area-inset-bottom, 0px));
+        }
+
+        .touch-stick-knob {
+            width: 44px;
+            height: 44px;
+            margin: -22px 0 0 -22px;
+        }
+
+        .touch-btn {
+            width: 50px;
+            height: 50px;
+            font-size: 1.05rem;
+        }
+
+        .touch-pad {
+            bottom: calc(0.8rem + env(safe-area-inset-bottom, 0px));
+        }
+
+        .touch-side {
+            bottom: calc(7.4rem + env(safe-area-inset-bottom, 0px));
+        }
+    }
 }

--- a/labs/guerreiro-castelo/index.html
+++ b/labs/guerreiro-castelo/index.html
@@ -140,6 +140,35 @@
             <div class="hud-actions">
                 <span id="fpsCounter" class="fps">—</span>
             </div>
+
+            <!-- Controles de toque: só aparecem em ponteiro grosso (celular e
+                 tablet), onde não existe teclado nem pointer lock. -->
+            <div id="touchControls" class="touch-controls" aria-label="Controles de toque">
+                <div class="touch-look" data-touch-look aria-hidden="true"></div>
+
+                <div class="touch-stick" data-touch-stick>
+                    <span class="touch-stick-knob" aria-hidden="true"></span>
+                    <span class="sr-only">Analógico de movimento</span>
+                </div>
+
+                <div class="touch-pad">
+                    <button type="button" class="touch-btn" data-touch="interact" aria-label="Interagir">E</button>
+                    <button type="button" class="touch-btn" data-touch="block" aria-label="Defender">🛡</button>
+                    <button type="button" class="touch-btn touch-btn-attack" data-touch="attack"
+                        aria-label="Atacar">⚔</button>
+                    <button type="button" class="touch-btn touch-btn-jump" data-touch="jump"
+                        aria-label="Pular ou avançar o diálogo">⤴</button>
+                </div>
+
+                <div class="touch-side">
+                    <button type="button" class="touch-chip" data-touch="sprint" aria-pressed="false"
+                        aria-label="Correr">Correr</button>
+                    <button type="button" class="touch-chip" data-touch="crouch" aria-pressed="false"
+                        aria-label="Agachar">Agachar</button>
+                </div>
+
+                <button type="button" class="touch-pause" data-touch="pause" aria-label="Pausar">II</button>
+            </div>
         </div>
 
         <div id="loadingOverlay" class="overlay loading-overlay">
@@ -179,6 +208,8 @@
                     <span><kbd>E</kbd> interagir · <kbd>F</kbd> atacar · <kbd>Q</kbd> defender</span>
                     <span><kbd>Tab</kbd> objetivo · <kbd>Esc</kbd> pausa</span>
                 </div>
+                <p class="keys-touch">No celular: analógico à esquerda para andar, arraste na tela para girar a
+                    câmera e use os botões da direita para pular, interagir, atacar e defender.</p>
                 <button id="btnCloseControls" class="primary-button" type="button">Fechar</button>
             </div>
         </div>

--- a/labs/guerreiro-castelo/js/core/InputManager.js
+++ b/labs/guerreiro-castelo/js/core/InputManager.js
@@ -18,6 +18,9 @@ export class InputManager {
         this.advance = false;
         this._lookBuffer = { x: 0, y: 0 };
         this.enabled = true;
+        /* Estado alimentado pelos controles de toque (ver setupTouch). */
+        this.touch = { x: 0, z: 0, sprint: false, crouch: false, block: false, active: false };
+        this._touchCleanup = [];
         this._onKeyDown = this.onKeyDown.bind(this);
         this._onKeyUp = this.onKeyUp.bind(this);
         this._onMouseMove = this.onMouseMove.bind(this);
@@ -32,10 +35,156 @@ export class InputManager {
         dom.addEventListener('wheel', this._onWheel, { passive: false });
         document.addEventListener('pointerlockchange', this._onLockChange);
         dom.addEventListener('contextmenu', this._onContext);
+        this.setupTouch();
+    }
+
+    /**
+     * Liga o stick virtual, a área de câmera e os botões de ação. Sem ponteiro
+     * grosso nada é registrado — no desktop os controles nem são exibidos.
+     */
+    setupTouch() {
+        const layer = document.getElementById('touchControls');
+        if (!layer || !window.matchMedia?.('(pointer: coarse)').matches) return;
+
+        const on = (el, type, fn, opts) => {
+            el.addEventListener(type, fn, opts);
+            this._touchCleanup.push(() => el.removeEventListener(type, fn, opts));
+        };
+
+        /* Stick: o deslocamento a partir do centro vira um vetor -1..1. */
+        const stick = layer.querySelector('[data-touch-stick]');
+        const knob = layer.querySelector('.touch-stick-knob');
+        const STICK_RADIUS = 46;
+        let stickId = null;
+        let originX = 0;
+        let originY = 0;
+
+        const stickEnd = (e) => {
+            if (stickId === null || (e && e.pointerId !== stickId)) return;
+            stickId = null;
+            this.touch.x = 0;
+            this.touch.z = 0;
+            stick.classList.remove('is-active');
+            if (knob) knob.style.transform = '';
+        };
+
+        on(stick, 'pointerdown', (e) => {
+            e.preventDefault();
+            stickId = e.pointerId;
+            const rect = stick.getBoundingClientRect();
+            originX = rect.left + rect.width / 2;
+            originY = rect.top + rect.height / 2;
+            stick.setPointerCapture?.(e.pointerId);
+            stick.classList.add('is-active');
+        });
+
+        on(stick, 'pointermove', (e) => {
+            if (e.pointerId !== stickId) return;
+            e.preventDefault();
+            let dx = e.clientX - originX;
+            let dy = e.clientY - originY;
+            const len = Math.hypot(dx, dy);
+            if (len > STICK_RADIUS) {
+                dx = (dx / len) * STICK_RADIUS;
+                dy = (dy / len) * STICK_RADIUS;
+            }
+            this.touch.x = dx / STICK_RADIUS;
+            this.touch.z = dy / STICK_RADIUS;
+            if (knob) knob.style.transform = `translate(${dx}px, ${dy}px)`;
+        });
+
+        on(stick, 'pointerup', stickEnd);
+        on(stick, 'pointercancel', stickEnd);
+
+        /* Câmera: arrastar em qualquer área livre da tela. */
+        const lookZone = layer.querySelector('[data-touch-look]');
+        const LOOK_SENSITIVITY = 1.35;
+        let lookId = null;
+        let lastX = 0;
+        let lastY = 0;
+
+        const lookEnd = (e) => {
+            if (lookId === null || (e && e.pointerId !== lookId)) return;
+            lookId = null;
+        };
+
+        on(lookZone, 'pointerdown', (e) => {
+            e.preventDefault();
+            lookId = e.pointerId;
+            lastX = e.clientX;
+            lastY = e.clientY;
+            lookZone.setPointerCapture?.(e.pointerId);
+        });
+
+        on(lookZone, 'pointermove', (e) => {
+            if (e.pointerId !== lookId || !this.enabled) return;
+            this._lookBuffer.x += (e.clientX - lastX) * LOOK_SENSITIVITY;
+            this._lookBuffer.y += (e.clientY - lastY) * LOOK_SENSITIVITY;
+            lastX = e.clientX;
+            lastY = e.clientY;
+        });
+
+        on(lookZone, 'pointerup', lookEnd);
+        on(lookZone, 'pointercancel', lookEnd);
+
+        /* Botões: pular/avançar, interagir, atacar, defender, correr, agachar. */
+        layer.querySelectorAll('[data-touch]').forEach((btn) => {
+            const action = btn.dataset.touch;
+            const toggle = action === 'sprint' || action === 'crouch';
+
+            on(btn, 'pointerdown', (e) => {
+                e.preventDefault();
+                btn.classList.add('is-active');
+                this.applyTouchAction(action, true);
+                if (toggle) btn.setAttribute('aria-pressed', String(this.touch[action]));
+            });
+
+            const release = () => {
+                btn.classList.remove('is-active');
+                if (!toggle) this.applyTouchAction(action, false);
+            };
+
+            on(btn, 'pointerup', release);
+            on(btn, 'pointercancel', release);
+            on(btn, 'pointerleave', release);
+        });
+
+        this.touch.active = true;
+    }
+
+    applyTouchAction(action, down) {
+        if (action === 'jump') {
+            if (down) {
+                this.move.jump = true;
+                this.advance = true;
+            }
+            return;
+        }
+        if (action === 'interact') {
+            if (down) this.interact = true;
+            return;
+        }
+        if (action === 'attack') {
+            if (down) this.attack = true;
+            return;
+        }
+        if (action === 'pause') {
+            if (down) this.pause = true;
+            return;
+        }
+        if (action === 'block') {
+            this.touch.block = down;
+            return;
+        }
+        if (action === 'sprint' || action === 'crouch') {
+            /* Correr e agachar são travas: segurar o botão o jogo inteiro numa
+               tela de toque é inviável. */
+            if (down) this.touch[action] = !this.touch[action];
+        }
     }
 
     requestLock() {
-        if (this.locked) return;
+        if (this.locked || this.touch.active) return;
         this.dom.requestPointerLock?.();
     }
 
@@ -74,6 +223,9 @@ export class InputManager {
     }
 
     onMouseDown(e) {
+        /* Em telas de toque não existe pointer lock: pedir trava só engoliria o
+           primeiro toque e, no iOS, falharia em silêncio. */
+        if (this.touch.active) return;
         if (e.button === 0 && !this.locked && this.enabled) this.requestLock();
     }
 
@@ -117,6 +269,8 @@ export class InputManager {
         if (this.keys.KeyD || this.keys.ArrowRight) x += 1;
         if (this.keys.KeyW || this.keys.ArrowUp) z -= 1;
         if (this.keys.KeyS || this.keys.ArrowDown) z += 1;
+        x += this.touch.x;
+        z += this.touch.z;
         const len = Math.hypot(x, z);
         if (len > 1) {
             x /= len;
@@ -124,9 +278,9 @@ export class InputManager {
         }
         this.move.x = x;
         this.move.z = z;
-        this.move.sprint = Boolean(this.keys.ShiftLeft || this.keys.ShiftRight);
-        this.move.crouch = Boolean(this.keys.KeyC);
-        this.block = Boolean(this.keys.KeyQ);
+        this.move.sprint = Boolean(this.keys.ShiftLeft || this.keys.ShiftRight || this.touch.sprint);
+        this.move.crouch = Boolean(this.keys.KeyC || this.touch.crouch);
+        this.block = Boolean(this.keys.KeyQ || this.touch.block);
     }
 
     dispose() {
@@ -137,5 +291,7 @@ export class InputManager {
         this.dom.removeEventListener('wheel', this._onWheel);
         document.removeEventListener('pointerlockchange', this._onLockChange);
         this.dom.removeEventListener('contextmenu', this._onContext);
+        this._touchCleanup.forEach((off) => off());
+        this._touchCleanup.length = 0;
     }
 }

--- a/labs/guerreiro-castelo/js/ui/HUD.js
+++ b/labs/guerreiro-castelo/js/ui/HUD.js
@@ -25,6 +25,8 @@ export class HUD {
         };
         this._toastT = 0;
         this._chapterT = 0;
+        /* Em telas de toque o prompt aponta o botão da tela, não a tecla E. */
+        this.isTouch = Boolean(window.matchMedia?.('(pointer: coarse)').matches);
     }
 
     setLoading(p, text) {
@@ -67,7 +69,8 @@ export class HUD {
             return;
         }
         this.el.prompt.hidden = false;
-        this.el.prompt.innerHTML = `<kbd>E</kbd> ${item.interactionLabel || 'Interagir'}`;
+        const key = this.isTouch ? 'Botão E' : '<kbd>E</kbd>';
+        this.el.prompt.innerHTML = `${key} ${item.interactionLabel || 'Interagir'}`;
     }
 
     setDialogue(line) {

--- a/labs/honor-front/src/input.js
+++ b/labs/honor-front/src/input.js
@@ -146,15 +146,31 @@ export class Input {
             setKnob(this.touchMove.x, this.touchMove.y);
         };
 
+        /* A captura é best-effort: `setPointerCapture` lança InvalidStateError
+           quando o ponteiro já não está ativo, e a exceção derrubava o resto do
+           gesto. O id fica guardado à parte para o arrasto seguir funcionando
+           mesmo quando a captura falha. */
+        const capture = (el, pointerId) => {
+            try {
+                el.setPointerCapture(pointerId);
+            } catch (err) {
+                /* Ponteiro encerrado antes do handler: segue sem captura. */
+            }
+        };
+
+        let stickId = null;
         stick.addEventListener('pointerdown', (e) => {
-            stick.setPointerCapture(e.pointerId);
+            stickId = e.pointerId;
+            capture(stick, e.pointerId);
             onStick(e.clientX, e.clientY, stick.getBoundingClientRect());
         });
         stick.addEventListener('pointermove', (e) => {
-            if (!stick.hasPointerCapture(e.pointerId)) return;
+            if (stickId !== e.pointerId) return;
             onStick(e.clientX, e.clientY, stick.getBoundingClientRect());
         });
-        const endStick = () => {
+        const endStick = (e) => {
+            if (e && stickId !== null && e.pointerId !== stickId) return;
+            stickId = null;
             this.touchMove.x = 0;
             this.touchMove.y = 0;
             setKnob(0, 0);
@@ -164,7 +180,7 @@ export class Input {
 
         let last = null;
         look.addEventListener('pointerdown', (e) => {
-            look.setPointerCapture(e.pointerId);
+            capture(look, e.pointerId);
             last = { x: e.clientX, y: e.clientY };
         });
         look.addEventListener('pointermove', (e) => {

--- a/labs/honor-front/style.css
+++ b/labs/honor-front/style.css
@@ -943,6 +943,46 @@ kbd {
     .stick { width: min(100px, 28vw); height: min(100px, 28vw); }
 }
 
+/* Som e pausa saem do canto inferior esquerdo no toque: ali eles ficavam
+   exatamente embaixo do stick de movimento. `fixed` mede pela tela — dentro
+   do grid do .hud-bottom o canto continuaria sendo o do painel. */
+@media (pointer: coarse) {
+    .hud-actions {
+        position: fixed;
+        top: calc(4.6rem + var(--safe-top, 0px));
+        right: calc(1rem + var(--safe-right, 0px));
+    }
+
+    .fps {
+        display: none;
+    }
+}
+
+/* Vital e munição ficam numa faixa acima do stick e à esquerda do pad: no
+   layout de coluna eles passavam por baixo dos dois. */
+@media (pointer: coarse) and (max-width: 860px) {
+    .hud-bottom {
+        grid-template-columns: auto auto;
+        justify-content: start;
+        align-items: center;
+        gap: 0.6rem;
+        left: calc(1rem + var(--safe-left, 0px));
+        right: calc(9.5rem + var(--safe-right, 0px));
+        bottom: calc(13rem + var(--safe-bottom, 0px));
+    }
+
+    /* Acima da faixa de vital/munição, não em cima dela. */
+    .message {
+        bottom: 40%;
+        font-size: 0.95rem;
+    }
+
+    /* Espaço para os botões de som e pausa no canto superior direito. */
+    .hud-top {
+        padding-right: 6.5rem;
+    }
+}
+
 @media (max-height: 520px) and (orientation: landscape) {
     .hud-top { gap: 0.35rem; }
     .quest-panel { display: none; }
@@ -975,8 +1015,10 @@ kbd {
 }
 
 @media (max-height: 520px) and (orientation: landscape) {
+    /* Abaixo do header compartilhado: em 0.75rem os botões caíam exatamente
+       em cima do seletor de tema. */
     .hud-actions {
-        top: calc(0.75rem + var(--safe-top, env(safe-area-inset-top, 0px)));
+        top: calc(4.4rem + var(--safe-top, env(safe-area-inset-top, 0px)));
         bottom: auto;
         right: calc(0.75rem + var(--safe-right, env(safe-area-inset-right, 0px)));
     }
@@ -985,7 +1027,31 @@ kbd {
         width: 44px;
         height: 44px;
     }
-    .touch-controls {
-        height: min(42%, 38dvh);
+    /* A camada de toque continua cobrindo a tela: limitar a altura aqui fazia
+       o `bottom` dos filhos medir a partir de uma caixa de ~140px e jogava o
+       stick e os botões para fora da tela. O que encolhe são os offsets. */
+    .stick {
+        bottom: calc(0.8rem + var(--safe-bottom, 0px));
+    }
+
+    /* Com o stick colado na base, o rótulo embaixo saía da tela. */
+    .stick span {
+        bottom: auto;
+        top: -1.1rem;
+    }
+
+    .touch-buttons {
+        bottom: calc(0.8rem + var(--safe-bottom, 0px));
+        grid-template-columns: repeat(2, 58px);
+    }
+
+    .look-zone {
+        height: 100%;
+    }
+
+    .hud-bottom {
+        bottom: calc(0.8rem + var(--safe-bottom, 0px));
+        left: calc(9rem + var(--safe-left, 0px));
+        right: calc(11rem + var(--safe-right, 0px));
     }
 }

--- a/labs/ilha-do-ambar/style.css
+++ b/labs/ilha-do-ambar/style.css
@@ -729,8 +729,10 @@ body[data-state="pause"] [data-lab-footer] {
 }
 
 @media (max-height: 520px) and (orientation: landscape) {
+    /* Abaixo do header compartilhado: em 0.75rem os botões caíam em cima do
+       seletor de tema. */
     .hud-actions {
-        top: calc(0.75rem + var(--safe-top, env(safe-area-inset-top, 0px)));
+        top: calc(4.4rem + var(--safe-top, env(safe-area-inset-top, 0px)));
         bottom: auto;
         right: calc(0.75rem + var(--safe-right, env(safe-area-inset-right, 0px)));
     }
@@ -739,7 +741,54 @@ body[data-state="pause"] [data-lab-footer] {
         width: 44px;
         height: 44px;
     }
-    .touch-controls {
-        height: min(42%, 38dvh);
+    /* A camada de toque é ancorada no topo (inset: 0): limitar a altura aqui
+       fazia o `bottom` dos filhos medir por uma caixa de ~140px e jogava o
+       stick e os botões para fora da tela em paisagem. */
+    .stick {
+        bottom: calc(0.8rem + var(--safe-bottom, 0px));
+    }
+
+    .pad {
+        bottom: calc(0.8rem + var(--safe-bottom, 0px));
+    }
+
+    /* Com o stick colado na base, o rótulo embaixo saía da tela. */
+    .stick span {
+        bottom: auto;
+        top: -1.1rem;
+    }
+
+    /* Deitado a tela tem ~375px de altura: os painéis empilhados do HUD mais o
+       diário de espécies cobriam o stick e o botão de observar. */
+    .hud {
+        padding-top: calc(3.6rem + var(--safe-top));
+    }
+
+    .hud-top {
+        grid-template-columns: auto minmax(0, 1fr) auto;
+        gap: 0.45rem;
+    }
+
+    .panel {
+        padding: 0.4rem 0.6rem;
+    }
+
+    .radio {
+        font-size: 0.85rem;
+    }
+
+    .catalog {
+        margin-top: 0.4rem;
+        max-width: min(100%, 26rem);
+        justify-content: flex-start;
+    }
+
+    .species {
+        padding: 0.2rem 0.45rem;
+        font-size: 0.68rem;
+    }
+
+    .fps {
+        display: none;
     }
 }

--- a/labs/joao-e-o-pe-de-feijao/src/main.js
+++ b/labs/joao-e-o-pe-de-feijao/src/main.js
@@ -197,36 +197,58 @@ class Game {
             this.input.touchMove.y = -dy;
             knob.style.transform = `translate(${dx * 22}px, ${dy * 22}px)`;
         };
+        const capturePointer = (el, pointerId) => {
+            try {
+                el.setPointerCapture(pointerId);
+            } catch (err) {
+                /* Ponteiro encerrado antes do handler: segue sem captura. */
+            }
+        };
+
+        /* A captura de ponteiro é best-effort: setPointerCapture lança
+           InvalidStateError quando o ponteiro já terminou, e a exceção
+           derrubava o gesto. O id guardado mantém o arrasto funcionando. */
+        let stickId = null;
+
         const end = () => {
+            stickId = null;
             this.input.touchMove.x = 0;
             this.input.touchMove.y = 0;
             knob.style.transform = 'translate(0,0)';
         };
         stick.addEventListener('pointerdown', (e) => {
-            stick.setPointerCapture(e.pointerId);
+            stickId = e.pointerId;
+            capturePointer(stick, e.pointerId);
             setFrom(e.clientX, e.clientY);
         });
         stick.addEventListener('pointermove', (e) => {
-            if (stick.hasPointerCapture(e.pointerId)) setFrom(e.clientX, e.clientY);
+            if (stickId === e.pointerId) setFrom(e.clientX, e.clientY);
         });
         stick.addEventListener('pointerup', end);
         stick.addEventListener('pointercancel', end);
 
         const lookZone = document.getElementById('lookZone');
+        let lookId = null;
         let lx = 0;
         let ly = 0;
         lookZone?.addEventListener('pointerdown', (e) => {
-            lookZone.setPointerCapture(e.pointerId);
+            lookId = e.pointerId;
+            capturePointer(lookZone, e.pointerId);
             lx = e.clientX;
             ly = e.clientY;
         });
         lookZone?.addEventListener('pointermove', (e) => {
-            if (!lookZone.hasPointerCapture(e.pointerId)) return;
+            if (lookId !== e.pointerId) return;
             this.input.lookX += e.clientX - lx;
             this.input.lookY += e.clientY - ly;
             lx = e.clientX;
             ly = e.clientY;
         });
+        const endLook = () => {
+            lookId = null;
+        };
+        lookZone?.addEventListener('pointerup', endLook);
+        lookZone?.addEventListener('pointercancel', endLook);
 
         document.getElementById('btnInteract')?.addEventListener('click', () => {
             this.input.interactPressed = true;

--- a/labs/jornada-do-anel/src/main.js
+++ b/labs/jornada-do-anel/src/main.js
@@ -203,36 +203,58 @@ class Game {
             this.input.touchMove.y = -dy;
             knob.style.transform = `translate(${dx * 22}px, ${dy * 22}px)`;
         };
+        const capturePointer = (el, pointerId) => {
+            try {
+                el.setPointerCapture(pointerId);
+            } catch (err) {
+                /* Ponteiro encerrado antes do handler: segue sem captura. */
+            }
+        };
+
+        /* A captura de ponteiro é best-effort: setPointerCapture lança
+           InvalidStateError quando o ponteiro já terminou, e a exceção
+           derrubava o gesto. O id guardado mantém o arrasto funcionando. */
+        let stickId = null;
+
         const end = () => {
+            stickId = null;
             this.input.touchMove.x = 0;
             this.input.touchMove.y = 0;
             knob.style.transform = 'translate(0,0)';
         };
         stick.addEventListener('pointerdown', (e) => {
-            stick.setPointerCapture(e.pointerId);
+            stickId = e.pointerId;
+            capturePointer(stick, e.pointerId);
             setFrom(e.clientX, e.clientY);
         });
         stick.addEventListener('pointermove', (e) => {
-            if (stick.hasPointerCapture(e.pointerId)) setFrom(e.clientX, e.clientY);
+            if (stickId === e.pointerId) setFrom(e.clientX, e.clientY);
         });
         stick.addEventListener('pointerup', end);
         stick.addEventListener('pointercancel', end);
 
         const lookZone = document.getElementById('lookZone');
+        let lookId = null;
         let lx = 0;
         let ly = 0;
         lookZone?.addEventListener('pointerdown', (e) => {
-            lookZone.setPointerCapture(e.pointerId);
+            lookId = e.pointerId;
+            capturePointer(lookZone, e.pointerId);
             lx = e.clientX;
             ly = e.clientY;
         });
         lookZone?.addEventListener('pointermove', (e) => {
-            if (!lookZone.hasPointerCapture(e.pointerId)) return;
+            if (lookId !== e.pointerId) return;
             this.input.lookX += e.clientX - lx;
             this.input.lookY += e.clientY - ly;
             lx = e.clientX;
             ly = e.clientY;
         });
+        const endLook = () => {
+            lookId = null;
+        };
+        lookZone?.addEventListener('pointerup', endLook);
+        lookZone?.addEventListener('pointercancel', endLook);
 
         document.getElementById('btnInteract')?.addEventListener('click', () => {
             this.input.interactPressed = true;

--- a/labs/jornada-do-anel/src/main.js
+++ b/labs/jornada-do-anel/src/main.js
@@ -503,7 +503,7 @@ class Game {
             this.state = 'playing';
             this.hud.setState('playing');
             this.input.enabled = true;
-            this.hud.say('Clique no mundo para olhar com o mouse.', 3.2);
+            this.hud.say(this.mobile ? 'Arraste na tela para olhar e use o analógico para andar.' : 'Clique no mundo para olhar com o mouse.', 3.2);
         }
     }
 

--- a/labs/jornada-do-anel/style.css
+++ b/labs/jornada-do-anel/style.css
@@ -834,8 +834,10 @@ kbd {
 }
 
 @media (max-height: 520px) and (orientation: landscape) {
+    /* Abaixo do header compartilhado: em 0.75rem os botões caíam em cima do
+       seletor de tema. */
     .hud-actions {
-        top: calc(0.75rem + var(--safe-top, env(safe-area-inset-top, 0px)));
+        top: calc(4.4rem + var(--safe-top, env(safe-area-inset-top, 0px)));
         bottom: auto;
         right: calc(0.75rem + var(--safe-right, env(safe-area-inset-right, 0px)));
     }
@@ -844,7 +846,20 @@ kbd {
         width: 44px;
         height: 44px;
     }
-    .touch-controls {
-        height: min(42%, 38dvh);
+    /* A camada de toque é ancorada no topo (inset: 0): limitar a altura aqui
+       fazia o `bottom` dos filhos medir por uma caixa de ~140px e jogava o
+       stick e os botões para fora da tela em paisagem. */
+    .stick {
+        bottom: calc(0.8rem + var(--safe-bottom, 0px));
+    }
+
+    .touch-buttons {
+        bottom: calc(0.8rem + var(--safe-bottom, 0px));
+    }
+
+    /* Com o stick colado na base, o rótulo embaixo saía da tela. */
+    .stick span {
+        bottom: auto;
+        top: -1.1rem;
     }
 }

--- a/labs/jungle-run/script.js
+++ b/labs/jungle-run/script.js
@@ -544,7 +544,12 @@ class JungleRun {
             if (control === 'jump') this.jumpBufferFrames = CONFIG.JUMP_BUFFER_FRAMES;
             button.classList.add('is-active');
             if (button.setPointerCapture && event.pointerId !== undefined) {
-                button.setPointerCapture(event.pointerId);
+                // Best-effort: lança InvalidStateError se o ponteiro já terminou.
+                try {
+                    button.setPointerCapture(event.pointerId);
+                } catch (err) {
+                    /* segue sem captura */
+                }
             }
         };
         const release = (event) => {

--- a/labs/jungle-run/style.css
+++ b/labs/jungle-run/style.css
@@ -817,14 +817,18 @@ button:focus-visible {
         height: 24px;
     }
 
+    /* O palco fica no topo do container e toda a folga sobra embaixo, onde os
+       controles de toque moram. Centralizado, o `contain` desperdiçava uma
+       faixa vazia acima da cena e ainda deixava o pad sobre a ação. */
     .game-container {
-        min-height: min(68dvh, 620px);
+        /* Altura = faixa 16/10 da cena (≈59vw aqui) + a tira dos controles. */
+        min-height: min(calc(59vw + 150px), 64dvh);
         aspect-ratio: auto;
     }
 
     #gameCanvas {
         object-fit: contain;
-        object-position: center;
+        object-position: center top;
     }
 
     .mobile-controls {
@@ -1231,13 +1235,4 @@ body.jungle-lab {
     font-size: 0.9rem;
     line-height: 1.5;
     text-align: center;
-}
-/* --- lab-responsive-pass --- */
-@media (max-width: 768px) {
-    #gameCanvas {
-        object-fit: contain;
-        object-position: center;
-        width: 100%;
-        height: 100%;
-    }
 }

--- a/labs/kong-kong/src/sprites.js
+++ b/labs/kong-kong/src/sprites.js
@@ -722,7 +722,11 @@ export function drawTitle(ctx, t) {
   if (Math.sin(t * 4) > -0.2) {
     ctx.fillStyle = '#f6d03a';
     ctx.font = '11px "Titan One", system-ui';
-    ctx.fillText('APERTE ENTER', 240, 248);
+    // Em tela de toque não há Enter: a chamada precisa combinar com o aparelho.
+    const startHint = window.matchMedia?.('(pointer: coarse)').matches
+      ? 'TOQUE PARA COMEÇAR'
+      : 'APERTE ENTER';
+    ctx.fillText(startHint, 240, 248);
   }
 }
 

--- a/labs/lavandula/src/main.js
+++ b/labs/lavandula/src/main.js
@@ -188,36 +188,58 @@ class Game {
             this.input.touchMove.y = -dy;
             knob.style.transform = `translate(${dx * 22}px, ${dy * 22}px)`;
         };
+        const capturePointer = (el, pointerId) => {
+            try {
+                el.setPointerCapture(pointerId);
+            } catch (err) {
+                /* Ponteiro encerrado antes do handler: segue sem captura. */
+            }
+        };
+
+        /* A captura de ponteiro é best-effort: setPointerCapture lança
+           InvalidStateError quando o ponteiro já terminou, e a exceção
+           derrubava o gesto. O id guardado mantém o arrasto funcionando. */
+        let stickId = null;
+
         const end = () => {
+            stickId = null;
             this.input.touchMove.x = 0;
             this.input.touchMove.y = 0;
             knob.style.transform = 'translate(0,0)';
         };
         stick.addEventListener('pointerdown', (e) => {
-            stick.setPointerCapture(e.pointerId);
+            stickId = e.pointerId;
+            capturePointer(stick, e.pointerId);
             setFrom(e.clientX, e.clientY);
         });
         stick.addEventListener('pointermove', (e) => {
-            if (stick.hasPointerCapture(e.pointerId)) setFrom(e.clientX, e.clientY);
+            if (stickId === e.pointerId) setFrom(e.clientX, e.clientY);
         });
         stick.addEventListener('pointerup', end);
         stick.addEventListener('pointercancel', end);
 
         const lookZone = document.getElementById('lookZone');
+        let lookId = null;
         let lx = 0;
         let ly = 0;
         lookZone?.addEventListener('pointerdown', (e) => {
-            lookZone.setPointerCapture(e.pointerId);
+            lookId = e.pointerId;
+            capturePointer(lookZone, e.pointerId);
             lx = e.clientX;
             ly = e.clientY;
         });
         lookZone?.addEventListener('pointermove', (e) => {
-            if (!lookZone.hasPointerCapture(e.pointerId)) return;
+            if (lookId !== e.pointerId) return;
             this.input.lookX += e.clientX - lx;
             this.input.lookY += e.clientY - ly;
             lx = e.clientX;
             ly = e.clientY;
         });
+        const endLook = () => {
+            lookId = null;
+        };
+        lookZone?.addEventListener('pointerup', endLook);
+        lookZone?.addEventListener('pointercancel', endLook);
 
         document.getElementById('btnSit')?.addEventListener('click', () => {
             this.input.sitPressed = true;

--- a/labs/lumina/style.css
+++ b/labs/lumina/style.css
@@ -696,8 +696,10 @@ kbd {
 }
 
 @media (max-height: 520px) and (orientation: landscape) {
+    /* Abaixo do header compartilhado: em 0.75rem os botões caíam em cima do
+       seletor de tema. */
     .hud-actions {
-        top: calc(0.75rem + var(--safe-top, env(safe-area-inset-top, 0px)));
+        top: calc(4.4rem + var(--safe-top, env(safe-area-inset-top, 0px)));
         bottom: auto;
         right: calc(0.75rem + var(--safe-right, env(safe-area-inset-right, 0px)));
     }

--- a/labs/menina-da-lanterna/src/main.js
+++ b/labs/menina-da-lanterna/src/main.js
@@ -201,36 +201,58 @@ class Game {
             this.input.touchMove.y = -dy;
             knob.style.transform = `translate(${dx * 22}px, ${dy * 22}px)`;
         };
+        const capturePointer = (el, pointerId) => {
+            try {
+                el.setPointerCapture(pointerId);
+            } catch (err) {
+                /* Ponteiro encerrado antes do handler: segue sem captura. */
+            }
+        };
+
+        /* A captura de ponteiro é best-effort: setPointerCapture lança
+           InvalidStateError quando o ponteiro já terminou, e a exceção
+           derrubava o gesto. O id guardado mantém o arrasto funcionando. */
+        let stickId = null;
+
         const end = () => {
+            stickId = null;
             this.input.touchMove.x = 0;
             this.input.touchMove.y = 0;
             knob.style.transform = 'translate(0,0)';
         };
         stick.addEventListener('pointerdown', (e) => {
-            stick.setPointerCapture(e.pointerId);
+            stickId = e.pointerId;
+            capturePointer(stick, e.pointerId);
             setFrom(e.clientX, e.clientY);
         });
         stick.addEventListener('pointermove', (e) => {
-            if (stick.hasPointerCapture(e.pointerId)) setFrom(e.clientX, e.clientY);
+            if (stickId === e.pointerId) setFrom(e.clientX, e.clientY);
         });
         stick.addEventListener('pointerup', end);
         stick.addEventListener('pointercancel', end);
 
         const lookZone = document.getElementById('lookZone');
+        let lookId = null;
         let lx = 0;
         let ly = 0;
         lookZone?.addEventListener('pointerdown', (e) => {
-            lookZone.setPointerCapture(e.pointerId);
+            lookId = e.pointerId;
+            capturePointer(lookZone, e.pointerId);
             lx = e.clientX;
             ly = e.clientY;
         });
         lookZone?.addEventListener('pointermove', (e) => {
-            if (!lookZone.hasPointerCapture(e.pointerId)) return;
+            if (lookId !== e.pointerId) return;
             this.input.lookX += e.clientX - lx;
             this.input.lookY += e.clientY - ly;
             lx = e.clientX;
             ly = e.clientY;
         });
+        const endLook = () => {
+            lookId = null;
+        };
+        lookZone?.addEventListener('pointerup', endLook);
+        lookZone?.addEventListener('pointercancel', endLook);
 
         document.getElementById('btnInteract')?.addEventListener('click', () => {
             this.input.interactPressed = true;

--- a/labs/menina-da-lanterna/src/main.js
+++ b/labs/menina-da-lanterna/src/main.js
@@ -491,7 +491,7 @@ class Game {
             this.state = 'playing';
             this.hud.setState('playing');
             this.input.enabled = true;
-            this.hud.say('Clique no mundo para olhar. Espaço pulsa a lanterna.', 3.4);
+            this.hud.say(this.mobile ? 'Arraste na tela para olhar. O botão da lanterna pulsa a chama.' : 'Clique no mundo para olhar. Espaço pulsa a lanterna.', 3.4);
         }
     }
 

--- a/labs/nereida/src/input.js
+++ b/labs/nereida/src/input.js
@@ -53,7 +53,12 @@ export class Input {
 
         const el = this.canvas;
         el.addEventListener('pointerdown', (e) => {
-            el.setPointerCapture(e.pointerId);
+            // Best-effort: lança InvalidStateError se o ponteiro já terminou.
+            try {
+                el.setPointerCapture(e.pointerId);
+            } catch (err) {
+                /* segue sem captura */
+            }
             this.pointers.set(e.pointerId, { x: e.clientX, y: e.clientY });
             if (this.pointers.size === 1) {
                 this.dragging = true;
@@ -106,7 +111,12 @@ export class Input {
             setKnob(0, 0);
         };
         stick.addEventListener('pointerdown', (e) => {
-            stick.setPointerCapture(e.pointerId);
+            // Best-effort: lança InvalidStateError se o ponteiro já terminou.
+            try {
+                stick.setPointerCapture(e.pointerId);
+            } catch (err) {
+                /* segue sem captura */
+            }
             onMove(e);
         });
         stick.addEventListener('pointermove', (e) => {

--- a/labs/pandemonium/style.css
+++ b/labs/pandemonium/style.css
@@ -803,3 +803,11 @@ kbd {
         height: min(42%, 38dvh);
     }
 }
+
+/* Som e pausa vivem no canto superior direito, na mesma altura do .hud-top:
+   no toque eles caíam em cima do painel do trilho. O painel abre espaço. */
+@media (pointer: coarse) {
+    .voyage-panel {
+        padding-right: 10.5rem;
+    }
+}

--- a/labs/pandemonium/style.css
+++ b/labs/pandemonium/style.css
@@ -787,8 +787,10 @@ kbd {
 }
 
 @media (max-height: 520px) and (orientation: landscape) {
+    /* Abaixo do header compartilhado: em 0.75rem os botões caíam em cima do
+       seletor de tema. */
     .hud-actions {
-        top: calc(0.75rem + var(--safe-top, env(safe-area-inset-top, 0px)));
+        top: calc(4.4rem + var(--safe-top, env(safe-area-inset-top, 0px)));
         bottom: auto;
         right: calc(0.75rem + var(--safe-right, env(safe-area-inset-right, 0px)));
     }

--- a/labs/pulsar/script.js
+++ b/labs/pulsar/script.js
@@ -584,7 +584,12 @@
             const orb = addOrb(pos.x, pos.y, true);
             dragState = { orb: orb, isNew: true, moved: false, startX: pos.x, startY: pos.y };
         }
-        canvas.setPointerCapture && canvas.setPointerCapture(e.pointerId);
+        // Best-effort: lança InvalidStateError se o ponteiro já terminou.
+        try {
+            canvas.setPointerCapture(e.pointerId);
+        } catch (err) {
+            /* segue sem captura */
+        }
     });
 
     canvas.addEventListener('pointermove', function (e) {

--- a/labs/ravi-123/style.css
+++ b/labs/ravi-123/style.css
@@ -123,8 +123,10 @@ header[data-lab-header] .subtitle {
   z-index: 30;
   display: flex;
   gap: 8px;
-  /* abaixo do header compartilhado (voltar + tema) */
-  padding: calc(3.1rem + env(safe-area-inset-top, 0px)) 12px 10px;
+  /* abaixo do header compartilhado (voltar + tema). Em px porque o rem daqui
+     acompanha a fonte do jogo: em 3.1rem os botões subiam para cima do
+     seletor de tema. */
+  padding: calc(60px + env(safe-area-inset-top, 0px)) 12px 10px;
   padding-right: calc(12px + env(safe-area-inset-right, 0px));
   padding-left: calc(12px + env(safe-area-inset-left, 0px));
   pointer-events: none;
@@ -136,8 +138,8 @@ header[data-lab-header] .subtitle {
 
 .hud-btn {
   pointer-events: auto;
-  width: 38px;
-  height: 38px;
+  width: 44px;
+  height: 44px;
   border: 2px solid var(--hud-edge);
   border-radius: 6px;
   background:

--- a/labs/river-knight/style.css
+++ b/labs/river-knight/style.css
@@ -1279,4 +1279,15 @@ input[type="range"]::-moz-range-thumb {
 @media (max-height: 520px) and (orientation: landscape) {
     .touch-controls { height: 40%; }
     .pad-throw { width: 80px; height: 80px; }
+
+    /* Deitado a tela passa de 640px e o reposicionamento do retrato não valia
+       mais: som e pausa voltavam para o canto inferior direito, em cima dos
+       botões de ação. */
+    .hud-actions {
+        align-self: start;
+        grid-row: 1;
+        position: absolute;
+        top: calc(3.2rem + var(--safe-top));
+        right: calc(0.7rem + var(--safe-right));
+    }
 }

--- a/labs/rock-kombat/style.css
+++ b/labs/rock-kombat/style.css
@@ -1385,13 +1385,21 @@ dialog h2 {
     display: none;
   }
 
+  /* O !important da regra genérica acima vencia estas duas: sem ele o rótulo
+     longo voltava e estourava a largura do botão no header estreito. */
   #sound-button {
-    font-size: 0;
+    font-size: 0 !important;
   }
 
   #sound-button::after {
     content: "♪";
-    font-size: 13px;
+    font-size: 15px;
+  }
+
+  #help-button {
+    font-size: 10px !important;
+    letter-spacing: 0 !important;
+    padding: 8px 7px !important;
   }
 
   /* Hero screen mobile */

--- a/labs/safari-dourado/style.css
+++ b/labs/safari-dourado/style.css
@@ -830,7 +830,14 @@ kbd {
         width: 44px;
         height: 44px;
     }
-    .touch-controls {
-        height: min(42%, 38dvh);
+    /* A camada de toque é ancorada no topo (inset: 0): limitar a altura aqui
+       fazia o `bottom` dos filhos medir por uma caixa de ~140px e jogava o
+       stick e os botões para fora da tela em paisagem. */
+    .stick {
+        bottom: calc(0.8rem + var(--safe-bottom, 0px));
+    }
+
+    .touch-buttons {
+        bottom: calc(0.8rem + var(--safe-bottom, 0px));
     }
 }

--- a/labs/santos-games/src/main.js
+++ b/labs/santos-games/src/main.js
@@ -43,7 +43,7 @@ const state = {
 };
 
 const SCENE_ANNOUNCE = {
-    title: 'Tela de título. Aperte Enter para começar.',
+    title: 'Tela de título. Toque na tela ou aperte Enter para começar.',
     menu: 'Menu principal.',
     sponsor: 'Escolha de patrocinador.',
     eventSelect: 'Escolha de prova.',

--- a/labs/snake/index.html
+++ b/labs/snake/index.html
@@ -95,7 +95,7 @@
                             <span class="lcd-item"><span class="lcd-key">HI</span><span id="hudBest">000</span></span>
                         </div>
                         <div class="screen-play">
-                            <canvas id="gameCanvas" width="400" height="400" role="img"
+                            <canvas id="gameCanvas" width="400" height="340" role="img"
                                 aria-label="Tabuleiro do jogo Snake"></canvas>
                             <div class="ui-overlay" id="startScreen">
                                 <h2>SNAKE</h2>

--- a/labs/snake/script.js
+++ b/labs/snake/script.js
@@ -11,7 +11,10 @@ const powerLed = document.querySelector('.power-led');
 
 // Game Constants
 const GRID_SIZE = 20;
-const TILE_COUNT = canvas.width / GRID_SIZE;
+// O tabuleiro é retangular (20x17) porque a tela do aparelho é retangular:
+// um grid quadrado esticado para caber no LCD deixaria as células ovais.
+const TILE_COUNT_X = canvas.width / GRID_SIZE;
+const TILE_COUNT_Y = canvas.height / GRID_SIZE;
 const BASE_SPEED = 130; // ms per step at score 0
 const MIN_SPEED = 65;   // fastest step interval
 const STORAGE_KEY = 'snakeHighScore';
@@ -76,10 +79,11 @@ function announce(message) {
 
 // Initialize Game
 function initGame() {
+    const startY = Math.floor(TILE_COUNT_Y / 2);
     snake = [
-        { x: 10, y: 10 },
-        { x: 9, y: 10 },
-        { x: 8, y: 10 }
+        { x: 10, y: startY },
+        { x: 9, y: startY },
+        { x: 8, y: startY }
     ];
     dx = 1;
     dy = 0;
@@ -117,8 +121,8 @@ function placeFood() {
     // Collect the free cells first: this avoids the unbounded recursion the
     // previous version could hit once the snake filled most of the board.
     const free = [];
-    for (let x = 0; x < TILE_COUNT; x++) {
-        for (let y = 0; y < TILE_COUNT; y++) {
+    for (let x = 0; x < TILE_COUNT_X; x++) {
+        for (let y = 0; y < TILE_COUNT_Y; y++) {
             if (!snake.some(segment => segment.x === x && segment.y === y)) free.push({ x, y });
         }
     }
@@ -159,7 +163,7 @@ function update() {
     const head = { x: snake[0].x + dx, y: snake[0].y + dy };
 
     // Check Wall Collision
-    if (head.x < 0 || head.x >= TILE_COUNT || head.y < 0 || head.y >= TILE_COUNT) {
+    if (head.x < 0 || head.x >= TILE_COUNT_X || head.y < 0 || head.y >= TILE_COUNT_Y) {
         gameOver();
         return;
     }
@@ -369,7 +373,38 @@ new MutationObserver(() => {
     draw();
 }).observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme'] });
 
+// O aparelho é desenhado numa base fixa de 320x562px e escalado para caber na
+// tela — cresce no desktop, encolhe no celular e em paisagem curta.
+const DEVICE_BASE = { portrait: [320, 562], landscape: [560, 300] };
+const device = document.querySelector('.handheld-device');
+
+function fitDevice() {
+    const viewportWidth = document.documentElement.clientWidth;
+    const viewportHeight = window.visualViewport?.height || document.documentElement.clientHeight;
+    const shortLandscape = viewportHeight <= 500 && viewportWidth > viewportHeight;
+    const [baseWidth, baseHeight] = shortLandscape ? DEVICE_BASE.landscape : DEVICE_BASE.portrait;
+
+    const chrome = ['[data-lab-header]', '.instructions', '[data-lab-footer]']
+        .map(selector => document.querySelector(selector))
+        .reduce((total, el) => total + (el ? el.getBoundingClientRect().height : 0), 0)
+        + (shortLandscape ? 24 : 56);
+
+    const scale = Math.min(
+        1.3,
+        (viewportWidth - 24) / baseWidth,
+        (viewportHeight - chrome) / baseHeight
+    );
+
+    device.style.setProperty('--device-scale', Math.max(scale, 0.55).toFixed(3));
+    device.style.setProperty('--device-base-height', `${baseHeight}px`);
+}
+
+window.addEventListener('resize', fitDevice);
+window.addEventListener('orientationchange', fitDevice);
+window.visualViewport?.addEventListener('resize', fitDevice);
+
 // Initial Draw
 syncColors();
 updateHud();
+fitDevice();
 draw();

--- a/labs/snake/style.css
+++ b/labs/snake/style.css
@@ -116,6 +116,9 @@
 canvas {
     width: 100%;
     height: 100%;
+    /* `contain` mantém as células quadradas em qualquer proporção de tela; a
+       sobra fica invisível porque o LCD tem a mesma cor de fundo do canvas. */
+    object-fit: contain;
     image-rendering: pixelated;
     display: block;
 }
@@ -262,6 +265,30 @@ canvas {
     outline: 3px solid var(--focus-ring);
     outline-offset: 3px;
     z-index: 3;
+}
+
+/* Área de toque: as setas continuam com 30px de desenho (o d-pad precisa caber
+   no aparelho), mas o alvo real cresce para fora até ~44px. */
+.d-pad > button::after {
+    content: '';
+    position: absolute;
+    inset: -7px;
+}
+
+.d-pad-up::after {
+    inset: -14px -7px 0 -7px;
+}
+
+.d-pad-down::after {
+    inset: 0 -7px -14px -7px;
+}
+
+.d-pad-left::after {
+    inset: -7px 0 -7px -14px;
+}
+
+.d-pad-right::after {
+    inset: -7px -14px -7px 0;
 }
 
 .d-pad-center {
@@ -421,23 +448,65 @@ canvas {
     line-height: 1.5;
 }
 
-@media (max-width: 420px) {
-    .handheld-device {
-        /* Absolute-positioned controls break with height:auto; scale the shell instead. */
-        --device-scale: min(1, calc((100vw - 24px) / 320px));
-        transform: scale(var(--device-scale));
-        transform-origin: top center;
-        margin-bottom: calc((var(--device-scale) - 1) * 562px);
-    }
+/* Absolute-positioned controls break with height:auto, então o shell inteiro é
+   escalado. O fator vem do JS (`--device-scale`): o CSS não divide comprimento
+   por comprimento para produzir o número que `scale()` exige. */
+.handheld-device {
+    --device-scale: 1;
+    --device-base-height: 562px;
+    transform: scale(var(--device-scale));
+    transform-origin: top center;
+    margin-bottom: calc((var(--device-scale) - 1) * var(--device-base-height));
 }
-/* --- lab-responsive-pass --- */
+
+/* Paisagem curta: o aparelho vira widescreen — tela à esquerda, controles à
+   direita. Encolher o formato retrato deixaria o LCD ilegível. */
 @media (max-height: 500px) and (orientation: landscape) {
-    .game-boy,
     .handheld-device {
-        --device-scale: min(1, calc((100dvh - 72px) / 560px));
-        transform: scale(var(--device-scale));
-        transform-origin: top center;
-        margin-bottom: calc((var(--device-scale) - 1) * 560px);
+        width: 560px;
+        height: 300px;
+        flex-direction: row;
+        align-items: center;
+        gap: 18px;
+        padding: 16px 20px;
+        border-radius: 18px 18px 40px 18px;
     }
-    .instructions { display: none; }
+
+    .screen-bezel {
+        flex: 1;
+        height: 100%;
+        padding: 16px 20px;
+    }
+
+    .controls-area {
+        flex: 0 0 250px;
+        width: 250px;
+        height: 100%;
+        margin-top: 0;
+    }
+
+    .d-pad {
+        top: 50%;
+        left: 6px;
+        transform: translateY(-50%);
+    }
+
+    .action-buttons {
+        top: 50%;
+        right: 6px;
+        transform: translateY(-50%) rotate(-15deg);
+    }
+
+    .meta-controls {
+        bottom: 4px;
+        gap: 16px;
+    }
+
+    .speaker-grill {
+        display: none;
+    }
+
+    .instructions {
+        display: none;
+    }
 }

--- a/labs/snake/style.css
+++ b/labs/snake/style.css
@@ -509,4 +509,10 @@ canvas {
     .instructions {
         display: none;
     }
+
+    /* Sem as instruções, o respiro de 2rem em cima e embaixo só empurrava o
+       aparelho para fora da tela deitada. */
+    .game-container {
+        padding: 0.5rem 0;
+    }
 }

--- a/labs/tamagotchi/script.js
+++ b/labs/tamagotchi/script.js
@@ -1374,7 +1374,12 @@
     const code = element.dataset.btn;
     element.addEventListener('pointerdown', (event) => {
       event.preventDefault();
-      element.setPointerCapture(event.pointerId);
+      // Best-effort: lança InvalidStateError se o ponteiro já terminou.
+      try {
+          element.setPointerCapture(event.pointerId);
+      } catch (err) {
+          /* segue sem captura */
+      }
       pressButton(element, code);
     });
     element.addEventListener('pointerup', (event) => {

--- a/labs/tamagotchi/style.css
+++ b/labs/tamagotchi/style.css
@@ -500,6 +500,7 @@ header {
 }
 
 .bottom-key {
+  position: relative;
   width: 58px;
   height: 28px;
   padding: 0;
@@ -515,6 +516,14 @@ header {
     0 4px 0 #801713,
     0 8px 8px rgba(76, 24, 6, 0.29);
   transition: transform 70ms ease, box-shadow 70ms ease;
+}
+
+/* Área de toque: as teclas mantêm os 58x28px do aparelho de 1997, mas o alvo
+   real cresce para cima e para baixo, onde há espaço livre. */
+.bottom-key::after {
+  content: '';
+  position: absolute;
+  inset: -10px -4px;
 }
 
 .bottom-key.pressed {

--- a/labs/tamagotchi/style.css
+++ b/labs/tamagotchi/style.css
@@ -381,6 +381,9 @@ header {
   display: block;
   width: 100%;
   height: 100%;
+  /* O buffer é 228x144; esticado até a caixa do LCD os pixels do bicho ficavam
+     ~12% mais largos que altos. `contain` some na cor do próprio LCD. */
+  object-fit: contain;
   image-rendering: pixelated;
   image-rendering: crisp-edges;
 }

--- a/labs/tatu-bola/index.html
+++ b/labs/tatu-bola/index.html
@@ -184,6 +184,8 @@
                             <span><kbd>Shift</kbd> / <kbd>F</kbd> virar bola (ataque)</span>
                             <span><kbd>C</kbd> câmera · <kbd>P</kbd> pausa · <kbd>M</kbd> som</span>
                         </div>
+                        <p class="keys-touch">No celular: analógico à esquerda para andar, <b>PULO</b> e
+                            <b>ROLA</b> à direita e arraste na tela para girar a câmera.</p>
                     </section>
                     <section class="menu-section">
                         <h2>A ilha</h2>

--- a/labs/tatu-bola/style.css
+++ b/labs/tatu-bola/style.css
@@ -739,3 +739,18 @@ kbd {
         display: none;
     }
 }
+
+/* Instruções específicas de toque: no desktop elas só atrapalhariam. */
+.keys-touch {
+    display: none;
+    margin: 0.6rem 0 0;
+    font-size: 0.85rem;
+    line-height: 1.5;
+    opacity: 0.85;
+}
+
+@media (pointer: coarse) {
+    .keys-touch {
+        display: block;
+    }
+}

--- a/labs/tetris/index.html
+++ b/labs/tetris/index.html
@@ -86,21 +86,36 @@
                 <div class="screen-glass">
                     <div class="screen">
                         <div class="game-area">
-                            <canvas id="tetris" width="200" height="400"></canvas>
+                            <canvas id="tetris" width="200" height="400" role="img"
+                                aria-label="Tabuleiro do Tetris"></canvas>
                         </div>
                         <div class="sidebar">
                             <div class="score-box">
                                 <div class="label">SCORE</div>
                                 <div id="score">0</div>
                             </div>
+                            <div class="score-box">
+                                <div class="label">HI</div>
+                                <div id="highscore">0</div>
+                            </div>
                             <div class="level-box">
                                 <div class="label">LEVEL</div>
                                 <div id="level">1</div>
                             </div>
+                            <div class="level-box">
+                                <div class="label">LINES</div>
+                                <div id="lines">0</div>
+                            </div>
                             <div class="next-box">
                                 <div class="label">NEXT</div>
-                                <canvas id="next" width="80" height="80"></canvas>
+                                <canvas id="next" width="80" height="80" role="img"
+                                    aria-label="Próxima peça"></canvas>
                             </div>
+                        </div>
+                        <!-- Overlay do estado do jogo: pronto, pausa e fim de jogo. -->
+                        <div class="screen-overlay" id="overlay" role="status" aria-live="polite">
+                            <p class="overlay-title" id="overlayTitle">TETRIS</p>
+                            <p class="overlay-text" id="overlayText">START para jogar</p>
                         </div>
                     </div>
                 </div>
@@ -108,25 +123,31 @@
             </div>
             <div class="controls">
                 <div class="d-pad">
-                    <div class="up"></div>
-                    <div class="right"></div>
-                    <div class="down"></div>
-                    <div class="left"></div>
-                    <div class="center"></div>
+                    <button type="button" class="up" aria-label="Girar peça"></button>
+                    <button type="button" class="right" aria-label="Mover para a direita"></button>
+                    <button type="button" class="down" aria-label="Descer peça"></button>
+                    <button type="button" class="left" aria-label="Mover para a esquerda"></button>
+                    <div class="center" aria-hidden="true"></div>
                 </div>
                 <div class="action-buttons">
                     <div class="btn-group">
-                        <div class="btn-a"></div>
-                        <div class="label">A</div>
+                        <button type="button" class="btn-b" aria-label="B: queda rápida"></button>
+                        <div class="label" aria-hidden="true">B</div>
                     </div>
                     <div class="btn-group">
-                        <div class="btn-b"></div>
-                        <div class="label">B</div>
+                        <button type="button" class="btn-a" aria-label="A: girar peça"></button>
+                        <div class="label" aria-hidden="true">A</div>
                     </div>
                 </div>
                 <div class="option-buttons">
-                    <div class="btn-select"></div>
-                    <div class="btn-start"></div>
+                    <div class="option-group">
+                        <button type="button" class="btn-select" aria-label="Select: reiniciar partida"></button>
+                        <div class="label" aria-hidden="true">SELECT</div>
+                    </div>
+                    <div class="option-group">
+                        <button type="button" class="btn-start" aria-label="Start: jogar ou pausar"></button>
+                        <div class="label" aria-hidden="true">START</div>
+                    </div>
                 </div>
             </div>
             <div class="speaker">
@@ -139,8 +160,11 @@
             </div>
         </div>
 
+        <p id="gameStatus" class="sr-only" role="status" aria-live="polite"></p>
+
         <div class="instructions">
-            <p>Setas: Mover • Cima: Rodar • Espaço: Drop</p>
+            <p><strong>Setas</strong> mover • <strong>Cima</strong> girar • <strong>Espaço</strong> queda rápida</p>
+            <p><strong>Enter</strong> ou <strong>Start</strong> jogar/pausar • <strong>R</strong> reiniciar</p>
         </div>
 
         <footer data-lab-footer data-home-href="/"></footer>

--- a/labs/tetris/script.js
+++ b/labs/tetris/script.js
@@ -3,9 +3,13 @@ const context = canvas.getContext('2d');
 const nextCanvas = document.getElementById('next');
 const nextContext = nextCanvas.getContext('2d');
 
+const COLS = 10;
+const ROWS = 20;
+const CELL = canvas.width / COLS; // 20px por célula no buffer do canvas
+
 // Scale everything up
-context.scale(20, 20);
-nextContext.scale(20, 20);
+context.scale(CELL, CELL);
+nextContext.scale(CELL, CELL);
 
 // Game Boy Palette
 const colors = [
@@ -56,13 +60,23 @@ const piecesMap = {
     ],
 };
 
+/* Pontuação clássica por linhas simultâneas, multiplicada pelo nível. */
+const LINE_SCORE = [0, 100, 300, 500, 800];
+const HIGHSCORE_KEY = 'tetris90s:highscore';
+
 function createPiece(type) {
-    return piecesMap[type];
+    return piecesMap[type].map(row => row.slice());
+}
+
+function randomPiece() {
+    return createPiece(pieces[pieces.length * Math.random() | 0]);
 }
 
 function arenaSweep() {
-    let rowCount = 1;
-    outer: for (let y = arena.length - 1; y > 0; --y) {
+    let cleared = 0;
+    /* Varre da última linha até a primeira (inclusive): a linha 0 também
+       precisa ser elegível quando a pilha chega ao topo. */
+    outer: for (let y = arena.length - 1; y >= 0; --y) {
         for (let x = 0; x < arena[y].length; ++x) {
             if (arena[y][x] === 0) {
                 continue outer;
@@ -72,9 +86,14 @@ function arenaSweep() {
         const row = arena.splice(y, 1)[0].fill(0);
         arena.unshift(row);
         ++y;
+        ++cleared;
+    }
 
-        player.score += rowCount * 10;
-        rowCount *= 2;
+    if (cleared > 0) {
+        player.lines += cleared;
+        player.score += LINE_SCORE[cleared] * player.level;
+        player.level = Math.floor(player.lines / 10) + 1;
+        updateScore();
     }
 }
 
@@ -123,15 +142,43 @@ function drawMatrix(matrix, offset, ctx = context) {
 function draw() {
     // Clear screen with "screen bg" color
     context.fillStyle = colors[3];
-    context.fillRect(0, 0, canvas.width, canvas.height);
+    context.fillRect(0, 0, COLS, ROWS);
 
     drawMatrix(arena, { x: 0, y: 0 });
-    drawMatrix(player.matrix, player.pos);
+    if (player.matrix) {
+        drawGhost();
+        drawMatrix(player.matrix, player.pos);
+    }
+}
+
+/* Sombra da peça na posição de pouso: reduz o erro de encaixe, sobretudo
+   no toque, sem sair da paleta de 4 tons do Game Boy. */
+function drawGhost() {
+    const startY = player.pos.y;
+    while (!collide(arena, player)) {
+        player.pos.y++;
+    }
+    player.pos.y--;
+    const ghostY = player.pos.y;
+    player.pos.y = startY;
+
+    if (ghostY === startY) return;
+
+    context.fillStyle = colors[2];
+    player.matrix.forEach((row, y) => {
+        row.forEach((value, x) => {
+            if (value !== 0) {
+                context.fillRect(x + player.pos.x + 0.35, y + ghostY + 0.35, 0.3, 0.3);
+            }
+        });
+    });
 }
 
 function drawNext() {
     nextContext.fillStyle = colors[3];
-    nextContext.fillRect(0, 0, nextCanvas.width, nextCanvas.height);
+    nextContext.fillRect(0, 0, 4, 4);
+
+    if (!player.next) return;
 
     // Center the next piece
     const matrix = player.next;
@@ -172,19 +219,49 @@ function rotate(matrix, dir) {
     }
 }
 
-function playerDrop() {
+function playerDrop(soft = false) {
+    if (state !== 'playing') return;
+
     player.pos.y++;
     if (collide(arena, player)) {
         player.pos.y--;
-        merge(arena, player);
-        playerReset();
-        arenaSweep();
+        lockPiece();
+    } else if (soft) {
+        player.score += 1;
         updateScore();
     }
     dropCounter = 0;
 }
 
+/* Queda rápida: desce até colidir e trava na hora, somando 2 por linha. */
+function playerHardDrop() {
+    if (state !== 'playing') return;
+
+    let distance = 0;
+    while (!collide(arena, player)) {
+        player.pos.y++;
+        distance++;
+    }
+    player.pos.y--;
+    distance--;
+
+    if (distance > 0) {
+        player.score += distance * 2;
+    }
+    lockPiece();
+    dropCounter = 0;
+}
+
+function lockPiece() {
+    merge(arena, player);
+    arenaSweep();
+    playerReset();
+    updateScore();
+}
+
 function playerMove(offset) {
+    if (state !== 'playing') return;
+
     player.pos.x += offset;
     if (collide(arena, player)) {
         player.pos.x -= offset;
@@ -193,24 +270,26 @@ function playerMove(offset) {
 
 function playerReset() {
     if (player.next === null) {
-        player.next = createPiece(pieces[pieces.length * Math.random() | 0]);
+        player.next = randomPiece();
     }
     player.matrix = player.next;
-    player.next = createPiece(pieces[pieces.length * Math.random() | 0]);
+    player.next = randomPiece();
 
     player.pos.y = 0;
     player.pos.x = (arena[0].length / 2 | 0) -
         (player.matrix[0].length / 2 | 0);
 
-    if (collide(arena, player)) {
-        arena.forEach(row => row.fill(0));
-        player.score = 0;
-        updateScore();
-    }
     drawNext();
+
+    /* Peça nova já nascendo em cima da pilha = fim de jogo. */
+    if (collide(arena, player)) {
+        gameOver();
+    }
 }
 
 function playerRotate(dir) {
+    if (state !== 'playing') return;
+
     const pos = player.pos.x;
     let offset = 1;
     rotate(player.matrix, dir);
@@ -228,14 +307,18 @@ function playerRotate(dir) {
 let dropCounter = 0;
 let dropInterval = 1000;
 let lastTime = 0;
+let state = 'ready'; // ready | playing | paused | over
 
 function update(time = 0) {
-    const deltaTime = time - lastTime;
+    const deltaTime = Math.min(time - lastTime, 250);
     lastTime = time;
 
-    dropCounter += deltaTime;
-    if (dropCounter > dropInterval) {
-        playerDrop();
+    if (state === 'playing') {
+        dropCounter += deltaTime;
+        if (dropCounter > dropInterval) {
+            playerDrop();
+        }
+        handleAutoRepeat(deltaTime);
     }
 
     draw();
@@ -244,45 +327,291 @@ function update(time = 0) {
 
 function updateScore() {
     document.getElementById('score').innerText = player.score;
-    // Simple level logic
-    const level = Math.floor(player.score / 100) + 1;
-    document.getElementById('level').innerText = level;
-    dropInterval = Math.max(100, 1000 - (level - 1) * 100);
+    document.getElementById('level').innerText = player.level;
+    document.getElementById('lines').innerText = player.lines;
+    dropInterval = Math.max(100, 1000 - (player.level - 1) * 90);
+
+    if (player.score > highScore) {
+        highScore = player.score;
+        document.getElementById('highscore').innerText = highScore;
+        saveHighScore(highScore);
+    }
 }
 
-const arena = createMatrix(10, 20);
+function loadHighScore() {
+    try {
+        return Number(localStorage.getItem(HIGHSCORE_KEY)) || 0;
+    } catch (err) {
+        /* localStorage pode estar bloqueado em navegação privada. */
+        return 0;
+    }
+}
+
+function saveHighScore(value) {
+    try {
+        localStorage.setItem(HIGHSCORE_KEY, String(value));
+    } catch (err) {
+        /* Sem persistência: o recorde vale só para esta sessão. */
+    }
+}
+
+const arena = createMatrix(COLS, ROWS);
 
 const player = {
     pos: { x: 0, y: 0 },
     matrix: null,
     next: null,
     score: 0,
+    lines: 0,
+    level: 1,
+};
+
+let highScore = loadHighScore();
+
+/* ---------- Estado e overlay ---------- */
+
+const overlay = document.getElementById('overlay');
+const overlayTitle = document.getElementById('overlayTitle');
+const overlayText = document.getElementById('overlayText');
+const gameStatus = document.getElementById('gameStatus');
+
+function setOverlay(title, text, steady = false) {
+    overlayTitle.textContent = title;
+    overlayText.textContent = text;
+    overlayText.classList.toggle('steady', steady);
+    overlay.hidden = false;
+}
+
+function setState(next) {
+    state = next;
+
+    if (state === 'ready') {
+        setOverlay('TETRIS', 'START para jogar');
+        gameStatus.textContent = 'Pressione Start ou Enter para começar.';
+    } else if (state === 'playing') {
+        overlay.hidden = true;
+        gameStatus.textContent = 'Partida em andamento.';
+    } else if (state === 'paused') {
+        setOverlay('PAUSA', 'START p/ voltar');
+        gameStatus.textContent = 'Jogo pausado.';
+    } else if (state === 'over') {
+        setOverlay('FIM DE JOGO', `${player.score} PTS · START`, true);
+        gameStatus.textContent = `Fim de jogo. ${player.score} pontos em ${player.lines} linhas.`;
+    }
+}
+
+function resetGame() {
+    arena.forEach(row => row.fill(0));
+    player.score = 0;
+    player.lines = 0;
+    player.level = 1;
+    player.next = null;
+    player.matrix = null;
+    dropCounter = 0;
+    setState('ready');
+    playerReset();
+    updateScore();
+}
+
+function startGame() {
+    resetGame();
+    setState('playing');
+}
+
+function gameOver() {
+    player.matrix = null;
+    setState('over');
+}
+
+/* Start faz o papel do botão do console: começa, pausa e retoma. */
+function toggleStartPause() {
+    if (state === 'playing') {
+        setState('paused');
+    } else if (state === 'paused') {
+        setState('playing');
+        lastTime = performance.now();
+    } else {
+        startGame();
+    }
+}
+
+/* ---------- Teclado ---------- */
+
+/* Repetição automática (DAS/ARR) para as teclas e botões mantidos
+   pressionados: 170ms até o primeiro repeat, 55ms entre os seguintes. */
+const AUTO_REPEAT_DELAY = 170;
+const AUTO_REPEAT_RATE = 55;
+const held = { left: 0, right: 0, down: 0 };
+const holdTimers = { left: 0, right: 0, down: 0 };
+
+function handleAutoRepeat(delta) {
+    for (const action of ['left', 'right', 'down']) {
+        if (!held[action]) continue;
+        holdTimers[action] += delta;
+        const threshold = held[action] === 1 ? AUTO_REPEAT_DELAY : AUTO_REPEAT_RATE;
+        if (holdTimers[action] >= threshold) {
+            holdTimers[action] = 0;
+            held[action] = 2;
+            if (action === 'left') playerMove(-1);
+            else if (action === 'right') playerMove(1);
+            else playerDrop(true);
+        }
+    }
+}
+
+function pressAction(action) {
+    if (state !== 'playing' && (action === 'left' || action === 'right' || action === 'down')) return;
+
+    if (action === 'left') playerMove(-1);
+    else if (action === 'right') playerMove(1);
+    else if (action === 'down') playerDrop(true);
+    else if (action === 'rotate') playerRotate(1);
+    else if (action === 'rotate-ccw') playerRotate(-1);
+    else if (action === 'hard-drop') playerHardDrop();
+
+    if (action in held) {
+        held[action] = 1;
+        holdTimers[action] = 0;
+    }
+}
+
+function releaseAction(action) {
+    if (action in held) {
+        held[action] = 0;
+        holdTimers[action] = 0;
+    }
+}
+
+const KEY_ACTIONS = {
+    ArrowLeft: 'left',
+    ArrowRight: 'right',
+    ArrowDown: 'down',
+    ArrowUp: 'rotate',
+    KeyW: 'rotate',
+    KeyQ: 'rotate-ccw',
+    KeyA: 'left',
+    KeyD: 'right',
+    KeyS: 'down',
+    Space: 'hard-drop',
 };
 
 document.addEventListener('keydown', event => {
-    if (event.key === 'ArrowLeft') {
-        playerMove(-1);
-    } else if (event.key === 'ArrowRight') {
-        playerMove(1);
-    } else if (event.key === 'ArrowDown') {
-        playerDrop();
-    } else if (event.key === 'q' || event.key === 'Q') {
-        playerRotate(-1);
-    } else if (event.key === 'w' || event.key === 'W' || event.key === 'ArrowUp') {
-        playerRotate(1);
-    } else if (event.key === ' ') {
-        playerDrop();
+    /* Com um botão do console focado *pelo teclado*, Enter/Espaço continuam
+       ativando o botão. Depois de um clique de mouse o foco não conta: ali o
+       jogador espera o atalho global (Espaço = queda rápida). */
+    const onConsoleButton = event.target instanceof Element
+        && event.target.closest('.controls button')?.matches(':focus-visible')
+        && (event.code === 'Enter' || event.code === 'Space');
+    if (onConsoleButton) return;
+
+    if (event.code === 'Enter' || event.code === 'KeyP' || event.code === 'Escape') {
+        event.preventDefault();
+        toggleStartPause();
+        return;
     }
+
+    if (event.code === 'KeyR') {
+        event.preventDefault();
+        startGame();
+        return;
+    }
+
+    const action = KEY_ACTIONS[event.code];
+    if (!action) return;
+
+    event.preventDefault();
+    if (event.repeat) return; // o repeat próprio do jogo é mais previsível
+    pressAction(action);
 });
 
-// Touch controls
-document.querySelector('.d-pad .left').addEventListener('click', () => playerMove(-1));
-document.querySelector('.d-pad .right').addEventListener('click', () => playerMove(1));
-document.querySelector('.d-pad .down').addEventListener('click', () => playerDrop());
-document.querySelector('.d-pad .up').addEventListener('click', () => playerRotate(1));
-document.querySelector('.btn-a').addEventListener('click', () => playerRotate(1));
-document.querySelector('.btn-b').addEventListener('click', () => playerRotate(-1));
+document.addEventListener('keyup', event => {
+    const action = KEY_ACTIONS[event.code];
+    if (action) releaseAction(action);
+});
 
-playerReset();
-updateScore();
+/* ---------- Botões do console (mouse e toque) ---------- */
+
+function bindHold(selector, action) {
+    const el = document.querySelector(selector);
+    if (!el) return;
+
+    el.addEventListener('pointerdown', event => {
+        event.preventDefault();
+        el.setPointerCapture?.(event.pointerId);
+        pressAction(action);
+    });
+
+    const stop = () => releaseAction(action);
+    el.addEventListener('pointerup', stop);
+    el.addEventListener('pointercancel', stop);
+    el.addEventListener('pointerleave', stop);
+    /* Teclado: o botão continua acionável por Enter/Espaço via clique. */
+    el.addEventListener('click', event => {
+        if (event.detail === 0) pressAction(action);
+    });
+}
+
+bindHold('.d-pad .left', 'left');
+bindHold('.d-pad .right', 'right');
+bindHold('.d-pad .down', 'down');
+bindHold('.d-pad .up', 'rotate');
+bindHold('.btn-a', 'rotate');
+bindHold('.btn-b', 'hard-drop');
+
+document.querySelector('.btn-start').addEventListener('click', toggleStartPause);
+document.querySelector('.btn-select').addEventListener('click', startGame);
+
+/* Depois de um clique/toque o botão devolve o foco: senão a próxima tecla
+   Espaço ativaria o botão focado em vez de soltar a peça. */
+document.querySelectorAll('.controls button').forEach(button => {
+    button.addEventListener('click', event => {
+        if (event.detail > 0) button.blur();
+    });
+});
+
+/* Sair da aba durante a partida pausa em vez de deixar a peça cair sozinha. */
+document.addEventListener('visibilitychange', () => {
+    if (document.hidden && state === 'playing') setState('paused');
+});
+
+/* ---------- Escala do console ---------- */
+
+/* O console é desenhado numa base fixa de 320x540px. A escala é calculada aqui
+   (e não em CSS) porque `calc()` não divide comprimento por comprimento para
+   produzir o fator sem unidade que `scale()` precisa. */
+const CONSOLE_BASE = { portrait: [320, 540], landscape: [560, 300] };
+const gameBoy = document.querySelector('.game-boy');
+
+function fitConsole() {
+    const viewportWidth = document.documentElement.clientWidth;
+    const viewportHeight = window.visualViewport?.height || document.documentElement.clientHeight;
+
+    /* Em paisagem curta o CSS troca o console para o formato widescreen; a
+       base usada no cálculo precisa acompanhar. */
+    const shortLandscape = viewportHeight <= 520 && viewportWidth > viewportHeight;
+    const [baseWidth, baseHeight] = shortLandscape ? CONSOLE_BASE.landscape : CONSOLE_BASE.portrait;
+
+    /* Altura ocupada por header, instruções e footer compartilhados. */
+    const chrome = ['[data-lab-header]', '.instructions', '[data-lab-footer]']
+        .map(sel => document.querySelector(sel))
+        .reduce((total, el) => total + (el ? el.getBoundingClientRect().height : 0), 0)
+        + (shortLandscape ? 24 : 56);
+
+    const scale = Math.min(
+        1.35,
+        (viewportWidth - 24) / baseWidth,
+        (viewportHeight - chrome) / baseHeight
+    );
+
+    gameBoy.style.setProperty('--device-scale', Math.max(scale, 0.55).toFixed(3));
+    gameBoy.style.setProperty('--device-base-height', `${baseHeight}px`);
+}
+
+window.addEventListener('resize', fitConsole);
+window.addEventListener('orientationchange', fitConsole);
+window.visualViewport?.addEventListener('resize', fitConsole);
+
+document.getElementById('highscore').innerText = highScore;
+resetGame();
+fitConsole();
 update();

--- a/labs/tetris/style.css
+++ b/labs/tetris/style.css
@@ -34,10 +34,18 @@ body {
     align-items: center;
 }
 
-/* Game Boy Styling */
+/* Game Boy Styling
+   O console é desenhado numa base fixa de 320x540 e escalado com transform:
+   assim cresce no desktop e encolhe no celular sem refazer a matemática interna.
+   O margin-bottom compensa a altura que o scale tira (ou soma) do fluxo. */
 .game-boy {
     margin: auto;
     /* Center in container */
+    --device-scale: 1;
+    --device-base-height: 540px;
+    transform: scale(var(--device-scale));
+    transform-origin: top center;
+    margin-bottom: calc((var(--device-scale) - 1) * var(--device-base-height));
     background-color: var(--gb-body);
     width: 320px;
     height: 540px;
@@ -58,9 +66,11 @@ body {
     width: 100%;
     height: 240px;
     border-radius: 10px 10px 30px 10px;
-    padding: 20px 30px;
+    padding: 18px 30px 6px;
     position: relative;
     box-shadow: inset 2px 2px 5px rgba(0, 0, 0, 0.3);
+    display: flex;
+    flex-direction: column;
 }
 
 .power-led {
@@ -78,7 +88,8 @@ body {
 .screen-glass {
     background-color: #8b9bb4;
     width: 100%;
-    height: 100%;
+    flex: 1;
+    min-height: 0;
     border: 2px solid #555;
     box-shadow: inset 2px 2px 5px rgba(0, 0, 0, 0.2);
     display: flex;
@@ -92,64 +103,124 @@ body {
     height: 90%;
     box-shadow: inset 1px 1px 3px rgba(0, 0, 0, 0.2);
     display: flex;
+    justify-content: center;
     padding: 2px;
     image-rendering: pixelated;
+    position: relative;
+    overflow: hidden;
 }
 
 .game-area {
     border-right: 2px solid var(--gb-pixel-dark);
     padding-right: 2px;
+    display: flex;
 }
 
+/* O tabuleiro tem 10 colunas por 20 linhas: manter aspect-ratio 1/2 é o que
+   garante células quadradas — esticar a largura deforma as peças. */
 #tetris {
-    width: 120px;
-    /* Scaled down for GB look */
-    height: 160px;
+    height: 100%;
+    width: auto;
+    aspect-ratio: 1 / 2;
     display: block;
 }
 
 .sidebar {
-    flex: 1;
+    flex: 0 0 auto;
+    min-width: 56px;
     display: flex;
     flex-direction: column;
+    justify-content: space-between;
     padding-left: 4px;
     font-family: 'Press Start 2P', monospace;
     /* Need a pixel font ideally */
     font-size: 8px;
+    line-height: 1.2;
     color: var(--gb-pixel-dark);
-}
-
-.score-box,
-.level-box,
-.next-box {
-    margin-bottom: 8px;
 }
 
 .label {
     font-weight: bold;
     margin-bottom: 2px;
+    opacity: 0.75;
 }
 
 #next {
-    width: 40px;
-    height: 40px;
+    width: 36px;
+    height: 36px;
+}
+
+/* Overlay de estado (pronto / pausa / fim de jogo) sobre a tela do console. */
+.screen-overlay {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    padding: 10px;
+    text-align: center;
+    background-color: rgba(155, 188, 15, 0.88);
+    color: var(--gb-pixel-dark);
+    font-family: 'Press Start 2P', monospace;
+}
+
+.screen-overlay[hidden] {
+    display: none;
+}
+
+.overlay-title {
+    font-size: 13px;
+    letter-spacing: 1px;
+}
+
+.overlay-text {
+    font-size: 8px;
+    line-height: 1.6;
+    animation: gb-blink 1.1s steps(1, end) infinite;
+}
+
+.overlay-text.steady {
+    animation: none;
+}
+
+@keyframes gb-blink {
+
+    0%,
+    100% {
+        opacity: 1;
+    }
+
+    50% {
+        opacity: 0.25;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .overlay-text {
+        animation: none;
+    }
 }
 
 .brand {
     color: #b0b0b0;
     font-style: italic;
     font-weight: bold;
-    font-size: 12px;
+    font-size: 11px;
+    line-height: 1;
     margin-top: 5px;
+    flex: 0 0 auto;
     text-shadow: 1px 1px 0 rgba(0, 0, 0, 0.3);
     display: flex;
-    gap: 5px;
+    align-items: baseline;
+    gap: 6px;
 }
 
 .brand .model {
     font-family: sans-serif;
     font-style: normal;
-    font-size: 14px;
+    font-size: 13px;
 }
 
 .controls {
@@ -157,6 +228,20 @@ body {
     height: 180px;
     margin-top: 20px;
     position: relative;
+}
+
+/* Controles de toque: sem seleção de texto, sem zoom de duplo toque e sem
+   scroll roubado pelo gesto durante a partida. */
+.controls button {
+    appearance: none;
+    border: 0;
+    padding: 0;
+    font: inherit;
+    color: inherit;
+    cursor: pointer;
+    touch-action: none;
+    user-select: none;
+    -webkit-user-select: none;
 }
 
 .d-pad {
@@ -178,6 +263,11 @@ body {
     box-shadow:
         2px 2px 0 rgba(0, 0, 0, 0.2),
         inset 1px 1px 2px rgba(255, 255, 255, 0.2);
+}
+
+.controls button:focus-visible {
+    outline: 2px solid #2563eb;
+    outline-offset: 2px;
 }
 
 .d-pad .center {
@@ -265,19 +355,36 @@ body {
 
 .option-buttons {
     position: absolute;
-    bottom: 20px;
+    bottom: 12px;
     left: 50%;
     transform: translateX(-50%);
     display: flex;
     gap: 15px;
 }
 
+.option-group {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 4px;
+}
+
+.option-group .label {
+    font-family: sans-serif;
+    font-weight: bold;
+    color: var(--gb-dpad);
+    font-size: 9px;
+    letter-spacing: 0.5px;
+    margin-bottom: 0;
+    opacity: 1;
+}
+
 .btn-select,
 .btn-start {
-    width: 40px;
-    height: 12px;
+    width: 44px;
+    height: 14px;
     background-color: var(--gb-select-start);
-    border-radius: 6px;
+    border-radius: 7px;
     transform: rotate(-15deg);
     box-shadow: 1px 1px 0 rgba(0, 0, 0, 0.2);
     cursor: pointer;
@@ -312,23 +419,60 @@ body {
     font-size: 0.9rem;
 }
 
-/* Responsive adjustments — fit ~390px width with shared header + footer */
+/* Responsivo — a escala do console vem do JS (`--device-scale`), porque o CSS
+   não divide comprimento por comprimento para virar um fator sem unidade. */
 @media (max-width: 420px) {
-    .game-boy {
-        --device-scale: min(1, calc((100vw - 24px) / 320px));
-        transform: scale(var(--device-scale));
-        transform-origin: top center;
-        margin-bottom: calc((var(--device-scale) - 1) * 540px);
+    .instructions {
+        margin-top: 1rem;
+        font-size: 0.8rem;
     }
 }
-/* --- lab-responsive-pass --- */
-@media (max-height: 500px) and (orientation: landscape) {
-    .game-boy,
-    .handheld-device {
-        --device-scale: min(1, calc((100dvh - 72px) / 560px));
-        transform: scale(var(--device-scale));
-        transform-origin: top center;
-        margin-bottom: calc((var(--device-scale) - 1) * 560px);
+
+/* Paisagem curta: o console vira "widescreen" — tela à esquerda, controles à
+   direita. Encolher o formato retrato deixaria o tabuleiro ilegível. */
+@media (max-height: 520px) and (orientation: landscape) {
+    .game-boy {
+        width: 560px;
+        height: 300px;
+        flex-direction: row;
+        align-items: center;
+        gap: 18px;
+        padding: 16px 20px;
+        border-radius: 14px 14px 40px 14px;
     }
-    .instructions { display: none; }
+
+    .screen-border {
+        flex: 1;
+        height: 100%;
+        padding: 14px 16px 4px;
+    }
+
+    .controls {
+        flex: 0 0 250px;
+        width: 250px;
+        height: 200px;
+        margin-top: 0;
+    }
+
+    .d-pad {
+        top: 30px;
+        left: 6px;
+    }
+
+    .action-buttons {
+        top: 42px;
+        right: 16px;
+    }
+
+    .option-buttons {
+        bottom: 4px;
+    }
+
+    .speaker {
+        display: none;
+    }
+
+    .instructions {
+        display: none;
+    }
 }

--- a/labs/tetris/style.css
+++ b/labs/tetris/style.css
@@ -270,6 +270,47 @@ body {
     outline-offset: 2px;
 }
 
+/* Área de toque: as setas mantêm os 30px de desenho (o d-pad precisa caber no
+   console), mas o alvo real cresce para fora, longe do centro. */
+.d-pad > button::after {
+    content: '';
+    position: absolute;
+    inset: -7px;
+}
+
+.d-pad .up::after {
+    inset: -14px -7px 0 -7px;
+}
+
+.d-pad .down::after {
+    inset: 0 -7px -14px -7px;
+}
+
+.d-pad .left::after {
+    inset: -7px 0 -7px -14px;
+}
+
+.d-pad .right::after {
+    inset: -7px -14px -7px 0;
+}
+
+.btn-a::after,
+.btn-b::after,
+.btn-select::after,
+.btn-start::after {
+    content: '';
+    position: absolute;
+    inset: -6px;
+    border-radius: inherit;
+}
+
+.btn-a,
+.btn-b,
+.btn-select,
+.btn-start {
+    position: relative;
+}
+
 .d-pad .center {
     width: 30px;
     height: 30px;

--- a/labs/toaster-64/style.css
+++ b/labs/toaster-64/style.css
@@ -741,8 +741,10 @@ kbd {
 }
 
 @media (max-height: 520px) and (orientation: landscape) {
+    /* Abaixo do header compartilhado: em 0.75rem os botões caíam em cima do
+       seletor de tema. */
     .hud-actions {
-        top: calc(0.75rem + var(--safe-top, env(safe-area-inset-top, 0px)));
+        top: calc(4.4rem + var(--safe-top, env(safe-area-inset-top, 0px)));
         bottom: auto;
         right: calc(0.75rem + var(--safe-right, env(safe-area-inset-right, 0px)));
     }

--- a/labs/vector-fighter/src/main.js
+++ b/labs/vector-fighter/src/main.js
@@ -213,7 +213,12 @@ class Game {
             nub.style.transform = 'translate(0,0)';
         };
         stick.addEventListener('pointerdown', (e) => {
-            stick.setPointerCapture(e.pointerId);
+            // Best-effort: lança InvalidStateError se o ponteiro já terminou.
+            try {
+                stick.setPointerCapture(e.pointerId);
+            } catch (err) {
+                /* segue sem captura */
+            }
             setFrom(e.clientX, e.clientY);
         });
         stick.addEventListener('pointermove', (e) => {

--- a/labs/videogame/index.html
+++ b/labs/videogame/index.html
@@ -112,6 +112,8 @@
                             <div class="control-item"><kbd>F</kbd> Tela Cheia</div>
                             <div class="control-item"><kbd>Esc</kbd> Sair</div>
                         </div>
+                        <p class="controls-touch">No celular o jogo abre com d-pad e botões A/B/C na
+                            tela — não precisa de teclado.</p>
                     </div>
                     <div class="search-container">
                         <svg class="search-icon" width="20" height="20" viewBox="0 0 24 24" fill="none"

--- a/labs/videogame/mobile.css
+++ b/labs/videogame/mobile.css
@@ -761,3 +761,18 @@ body.is-fullscreen .mobile-controls.fullscreen-mode:active {
         }
     }
 }
+/* Aviso de controles na tela: o painel de teclas não conta a história toda
+   para quem abre o lab no celular. */
+.controls-touch {
+    display: none;
+}
+
+@media (pointer: coarse) {
+    .controls-touch {
+        display: block;
+        margin: 0.75rem 0 0;
+        font-size: 0.82rem;
+        line-height: 1.5;
+        opacity: 0.75;
+    }
+}


### PR DESCRIPTION
Tetris 90s
- Tabuleiro com aspect-ratio 1/2: as células eram esticadas (12x8px) porque o
  canvas 200x400 era exibido em 120x160.
- Fim de jogo, pausa e tela "pronto" com overlay; antes a pilha cheia apenas
  limpava a arena em silêncio.
- Start e Select passam a funcionar (eram decorativos), botões viraram <button>
  com aria-label, foco visível e área de toque.
- Queda rápida no Espaço, soft drop pontuado, repetição automática (DAS/ARR),
  recorde no localStorage, contador de linhas e nível por linhas.
- arenaSweep agora considera a linha 0.
- Peça-fantasma na posição de pouso.

Snake
- Grade 20x17 acompanhando a proporção do LCD: a grade quadrada esticada
  deixava as células ovais.
- object-fit: contain mantém as células quadradas em qualquer tela.
- Área de toque do d-pad ampliada para fora (~44px) sem mudar o desenho.

Ambos
- --device-scale calculado em JS: o calc() do CSS dividia comprimento por
  comprimento, era inválido e a escala nunca era aplicada — no celular o
  console ficava do mesmo tamanho e vazava da tela.
- Layout widescreen em paisagem curta (tela à esquerda, controles à direita)
  em vez de encolher o formato retrato até ficar ilegível.

O Guerreiro e o Castelo
- Controles de toque: stick virtual, arrasto de câmera, pular/interagir/atacar/
  defender, travas de correr e agachar e botão de pausa. O jogo era
  literalmente injogável no celular (só teclado, mouse e pointer lock).
- Sem pedido de pointer lock em ponteiro grosso, prompt de interação sem tecla
  no toque, HUD em linha na paisagem curta.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NDnM647jxN55zBJCnUCLmc