### PR TITLE
🎨 Adjust chess board frame geometry and position

### DIFF
--- a/labs/xadrez/src/world.js
+++ b/labs/xadrez/src/world.js
@@ -81,8 +81,8 @@ export function buildWorld(tex, quality) {
     }
 
     const frameMat = phys(tex.mahogany, { color: 0x4a2212, clearcoat: 0.8, roughness: 0.3 });
-    const frame = new THREE.Mesh(new THREE.BoxGeometry(9.15, 0.22, 9.15), frameMat);
-    frame.position.y = -0.04;
+    const frame = new THREE.Mesh(new THREE.BoxGeometry(9.15, 0.14, 9.15), frameMat);
+    frame.position.y = -0.08;
     frame.receiveShadow = true;
     frame.castShadow = true;
     board.add(frame);


### PR DESCRIPTION
## 🎯 Objetivo

Refinar a geometria e posicionamento do frame do tabuleiro de xadrez para melhor proporção visual.

## ✨ O que mudou

- Reduzir altura do frame de 0.22 para 0.14 unidades
- Ajustar posição Y do frame de -0.04 para -0.08 para compensar a redução de altura

## 🧪 Como testar

1. Na raiz do repo: `python3 -m http.server 8000`
2. Abrir [http://localhost:8000/labs/xadrez/](http://localhost:8000/labs/xadrez/)
3. Verificar que o frame do tabuleiro tem proporção visual correta e está posicionado adequadamente em relação ao tabuleiro
4. Confirmar que não há clipping ou desalinhamento visual

## ✅ Checklist

- [ ] Testado via HTTP na raiz, não via `file://`
- [ ] Nada fora do escopo foi quebrado

https://claude.ai/code/session_01SomrkTb4iXZvvf9Qnoj2i2