### PR TITLE
🎨 Fix PS1 snap grid aspect ratio and HUD layout on mobile

### DIFF
--- a/labs/tatu-bola/src/main.js
+++ b/labs/tatu-bola/src/main.js
@@ -13,7 +13,7 @@ import { World } from './world.js';
 import { Player } from './player.js';
 import { Entities } from './entities.js';
 import { Effects } from './effects.js';
-import { setSnap } from './models.js';
+import { setSnap, setSnapAspect } from './models.js';
 
 const CAMERAS = [
     { name: 'atrás', dist: 7.4, height: 3.6, look: 0.55 },
@@ -176,6 +176,7 @@ class Game {
         this.renderer.setSize(w, h, false);
         this.camera.aspect = w / Math.max(1, h);
         this.camera.updateProjectionMatrix();
+        setSnapAspect(this.camera.aspect);
     }
 
     gotoMenu() {

--- a/labs/tatu-bola/src/models.js
+++ b/labs/tatu-bola/src/models.js
@@ -13,6 +13,20 @@ function geo(key, factory) {
 
 export const retroMaterials = [];
 
+/** Aspecto (largura/altura) do canvas — mantém a célula do snap quadrada em pixels. */
+let snapAspect = 1;
+
+/** Grade do snap em NDC: uSnap.x células na horizontal, uSnap.y na vertical. */
+function snapCell(mat, out) {
+    const s = mat.userData.snap;
+    return out.set(s, s / snapAspect);
+}
+
+function refreshSnap(mat) {
+    const uniform = mat.userData.shader?.uniforms.uSnap;
+    if (uniform) snapCell(mat, uniform.value);
+}
+
 export function retroMat(color, { snap = 80, ...props } = {}) {
     const mat = new THREE.MeshLambertMaterial({
         color,
@@ -22,9 +36,9 @@ export function retroMat(color, { snap = 80, ...props } = {}) {
     mat.userData.retro = true;
     mat.userData.snap = snap;
     mat.onBeforeCompile = (shader) => {
-        shader.uniforms.uSnap = { value: mat.userData.snap };
+        shader.uniforms.uSnap = { value: snapCell(mat, new THREE.Vector2()) };
         mat.userData.shader = shader;
-        shader.vertexShader = `uniform float uSnap;\n${shader.vertexShader}`.replace(
+        shader.vertexShader = `uniform vec2 uSnap;\n${shader.vertexShader}`.replace(
             '#include <project_vertex>',
             /* glsl */ `
             vec4 mvPosition = vec4( transformed, 1.0 );
@@ -36,11 +50,17 @@ export function retroMat(color, { snap = 80, ...props } = {}) {
             #endif
             mvPosition = modelViewMatrix * mvPosition;
             gl_Position = projectionMatrix * mvPosition;
-            gl_Position.xy = floor(gl_Position.xy / max(gl_Position.w, 0.0001) * uSnap) / uSnap * gl_Position.w;
+            // Snap de vértice PS1 — só vale à frente do olho. Atrás da câmera
+            // w é negativo: dividir por ele inverte o sinal do NDC e atira o
+            // triângulo para o outro lado da tela (polígonos gigantes piscando).
+            if ( gl_Position.w > 0.0001 ) {
+                vec2 ndc = gl_Position.xy / gl_Position.w;
+                gl_Position.xy = floor( ndc * uSnap + 0.5 ) / uSnap * gl_Position.w;
+            }
             `
         );
     };
-    mat.customProgramCacheKey = () => `tatubola-ps1-${snap}`;
+    mat.customProgramCacheKey = () => 'tatubola-ps1';
     retroMaterials.push(mat);
     return mat;
 }
@@ -48,8 +68,14 @@ export function retroMat(color, { snap = 80, ...props } = {}) {
 export function setSnap(value) {
     for (const mat of retroMaterials) {
         mat.userData.snap = value;
-        if (mat.userData.shader) mat.userData.shader.uniforms.uSnap.value = value;
+        refreshSnap(mat);
     }
+}
+
+/** Chamar no resize: `aspect` = largura/altura do canvas. */
+export function setSnapAspect(aspect) {
+    snapAspect = aspect > 0 ? aspect : 1;
+    for (const mat of retroMaterials) refreshSnap(mat);
 }
 
 function mesh(geometry, color, extras) {

--- a/labs/tatu-bola/src/player.js
+++ b/labs/tatu-bola/src/player.js
@@ -122,12 +122,14 @@ export class Player {
         this._wasRolling = this.rollT > 0;
         this._setBall(this.rolling);
 
+        // Eixos relativos à câmera: frente = (sin camYaw, cos camYaw);
+        // direita da tela = frente × cima = (-cos camYaw, sin camYaw).
         const sx = Math.sin(camYaw);
         const sz = Math.cos(camYaw);
         this._wish.set(
-            input.axisX * sz + input.axisY * sx,
+            input.axisY * sx - input.axisX * sz,
             0,
-            -input.axisX * sx + input.axisY * sz
+            input.axisY * sz + input.axisX * sx
         );
         const wishLen = this._wish.length();
         if (wishLen > 1) this._wish.multiplyScalar(1 / wishLen);

--- a/labs/tatu-bola/style.css
+++ b/labs/tatu-bola/style.css
@@ -701,6 +701,11 @@ kbd {
         width: 44px;
         height: 44px;
     }
+    /* O rodapé fica por cima do HUD (z-index 7 > 6) e engolia os toques em
+       PULO e ROLA. No toque o caminho de volta é o link do header. */
+    .lab-foot {
+        display: none;
+    }
 }
 
 @media (max-height: 520px) and (orientation: landscape) {
@@ -714,10 +719,14 @@ kbd {
     .panel {
         padding: 0.4rem 0.55rem;
     }
+    /* No topo à direita mora o botão de tema do header — som e pausa descem
+       para a folga entre o analógico e os pads. */
     .hud-actions {
-        top: calc(0.75rem + var(--safe-top));
-        bottom: auto;
-        right: calc(0.75rem + var(--safe-right));
+        top: auto;
+        bottom: calc(0.9rem + var(--safe-bottom));
+        right: auto;
+        left: 50%;
+        transform: translateX(-50%);
     }
     .steer-zone {
         width: 100px;


### PR DESCRIPTION
## 🎯 Objetivo

Corrigir o efeito de snap de vértices PS1 para respeitar a proporção do canvas (mantendo células quadradas) e reorganizar o HUD em telas pequenas landscape.

## ✨ O que mudou

- **Snap grid aspect-aware**: Introduzido `snapAspect` para manter células do snap quadradas em pixels, independente da proporção do canvas. `uSnap` agora é `vec2` em vez de `float`.
- **Segurança de clipping**: Adicionada verificação `gl_Position.w > 0.0001` no shader para evitar polígonos gigantes piscando quando triângulos estão atrás da câmera.
- **Arredondamento melhorado**: Mudado de `floor()` para `floor(ndc * uSnap + 0.5)` para melhor quantização.
- **Cache key simplificado**: `customProgramCacheKey` agora retorna constante em vez de incluir `snap`, já que o valor é uniforme dinâmico.
- **Controles mobile landscape**: `.hud-actions` movido para baixo-centro em telas pequenas landscape, evitando sobreposição com botão de tema do header.
- **Rodapé oculto em mobile**: `.lab-foot` desaparece em telas pequenas para não engolir toques nos botões PULO/ROLA.
- **Correção de input**: Eixos de movimento ajustados para corresponder corretamente aos eixos da câmera (frente e direita da tela).

## 🧪 Como testar

1. Na raiz do repo: `python3 -m http.server 8000`
2. Abrir [http://localhost:8000/labs/tatu-bola/](http://localhost:8000/labs/tatu-bola/)
3. Verificar que o efeito PS1 mantém células quadradas ao redimensionar a janela
4. Responsivo: DevTools em **375×667**, **390×844** e landscape curto (~667×375)
   - HUD/controles devem estar acessíveis e não sobrepostos
   - Botões PULO/ROLA devem ser tocáveis
   - Sem overflow horizontal
5. Testar movimento do jogador com analógico/teclado — deve corresponder à câmera

## ✅ Checklist

- [ ] Testado via HTTP na raiz, não via `file://`
- [ ] Responsivo: 375px / 390px / landscape — HUD utilizável, sem overflow
- [ ] Nada fora do escopo foi quebrado

https://claude.ai/code/session_01Hy2iCWmQwUb5HQkG5W6E6g