### PR TITLE
✨ lab: refatora O Guerreiro e o Castelo com engine Babylon.js

### DIFF
--- a/labs/guerreiro-castelo/index.html
+++ b/labs/guerreiro-castelo/index.html
@@ -8,7 +8,7 @@
     <meta name="theme-color" content="#0a0c12">
     <title>O Guerreiro e o Castelo — aventura 3D | Diogo Paulino</title>
     <meta name="description"
-        content="Aventura 3D em three.js de Diogo Paulino: Dico, Teco e a travessia do mar até o castelo para resgatar Camila. Terceira pessoa, stealth, puzzles e fuga cinematográfica.">
+        content="Aventura 3D cinematográfica em Babylon.js de Diogo Paulino: Dico, Teco e a travessia do mar até o castelo para resgatar Camila. Terceira pessoa, stealth, puzzles e fuga.">
     <meta name="author" content="Diogo Paulino">
     <meta name="robots" content="index, follow">
     <link rel="canonical" href="https://diogopaulino.com.br/labs/guerreiro-castelo/">
@@ -18,32 +18,24 @@
     <meta property="og:url" content="https://diogopaulino.com.br/labs/guerreiro-castelo/">
     <meta property="og:title" content="O Guerreiro e o Castelo do Outro Lado do Mar | Diogo Paulino">
     <meta property="og:description"
-        content="Uma história antes de dormir vira travessia, tempestade, stealth e fuga. Jogo 3D em terceira pessoa no navegador.">
+        content="Uma história antes de dormir vira travessia, tempestade, stealth e fuga. Jogo 3D em terceira pessoa no navegador feito em Babylon.js.">
     <meta property="og:image" content="https://diogopaulino.com.br/assets/img/diogo.jpeg">
-    <meta property="og:image:alt" content="Diogo Paulino">
+    <meta property="og:image:alt" content="Diogo Paulino - O Guerreiro e o Castelo">
     <meta property="og:locale" content="pt_BR">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="O Guerreiro e o Castelo do Outro Lado do Mar | Diogo Paulino">
     <meta name="twitter:description"
-        content="Aventura 3D cinematográfica: navio, castelo, Teco e o resgate de Camila. three.js no navegador.">
+        content="Aventura 3D cinematográfica: navio, castelo, Teco e o resgate de Camila em Babylon.js.">
     <meta name="twitter:image" content="https://diogopaulino.com.br/assets/img/diogo.jpeg">
 
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
+    <link rel="preconnect" href="https://cdn.babylonjs.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;600;700;800&family=Outfit:wght@300;400;500;600;700&display=swap"
         rel="stylesheet">
     <link rel="stylesheet" href="/labs/shared.css?v=9">
     <link rel="stylesheet" href="css/style.css">
 
-    <script type="importmap">
-    {
-        "imports": {
-            "three": "https://cdn.jsdelivr.net/npm/three@0.185.1/build/three.module.js",
-            "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.185.1/examples/jsm/"
-        }
-    }
-    </script>
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
@@ -52,9 +44,10 @@
           "@type": "WebApplication",
           "name": "O Guerreiro e o Castelo do Outro Lado do Mar",
           "url": "https://diogopaulino.com.br/labs/guerreiro-castelo/",
-          "description": "Aventura 3D em three.js: Dico, Teco e a travessia do mar até o castelo para resgatar Camila.",
+          "description": "Aventura 3D em Babylon.js: Dico, Teco e a travessia do mar até o castelo para resgatar Camila.",
           "applicationCategory": "GameApplication",
           "operatingSystem": "Any",
+          "browserRequirements": "WebGL 2",
           "inLanguage": "pt-BR",
           "isAccessibleForFree": true,
           "author": {
@@ -141,8 +134,7 @@
                 <span id="fpsCounter" class="fps">—</span>
             </div>
 
-            <!-- Controles de toque: só aparecem em ponteiro grosso (celular e
-                 tablet), onde não existe teclado nem pointer lock. -->
+            <!-- Controles de toque para celular e tablet -->
             <div id="touchControls" class="touch-controls" aria-label="Controles de toque">
                 <div class="touch-look" data-touch-look aria-hidden="true"></div>
 
@@ -222,7 +214,7 @@
                     <select id="qualitySelect">
                         <option value="low">Baixo</option>
                         <option value="medium">Médio</option>
-                        <option value="high">Alto</option>
+                        <option value="high" selected>Alto</option>
                         <option value="ultra">Ultra</option>
                     </select>
                 </label>
@@ -250,7 +242,7 @@
             <div class="overlay-card end-card">
                 <p class="eyebrow">fim</p>
                 <h1>O Guerreiro e o Castelo<br><span>do Outro Lado do Mar</span></h1>
-                <p class="lede">Fim</p>
+                <p class="lede">Fim da história. Dico, Teco e Camila voltaram em segurança para casa.</p>
                 <div class="menu-actions">
                     <button id="btnPlayAgain" class="primary-button" type="button">Jogar novamente</button>
                     <button id="btnEndMenu" class="ghost-button" type="button">Menu</button>
@@ -261,6 +253,9 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
+    <script src="https://cdn.babylonjs.com/babylon.js"></script>
+    <script src="https://cdn.babylonjs.com/loaders/babylonjs.loaders.min.js"></script>
+    <script src="https://cdn.babylonjs.com/materialsLibrary/babylonjs.materials.min.js"></script>
     <script src="/labs/shared.js?v=8" defer></script>
     <script type="module" src="js/main.js"></script>
 </body>

--- a/labs/guerreiro-castelo/js/ai/GuardAI.js
+++ b/labs/guerreiro-castelo/js/ai/GuardAI.js
@@ -1,15 +1,14 @@
 /**
- * Percepção de guarda: cone de visão, raycast, audição e estados.
+ * Percepção de guarda: cone de visão, raycast em obstáculos, audição e estados.
  */
 
-import * as THREE from 'three';
 import { damp } from '../utils/math.js';
 
 export class GuardAI {
     constructor(guard, opts = {}) {
         this.guard = guard;
         this.state = opts.sleep ? 'SLEEP' : 'IDLE';
-        this.home = new THREE.Vector3();
+        this.home = new BABYLON.Vector3();
         this.facing = 0;
         this.viewDist = opts.viewDist ?? 9;
         this.viewAngle = opts.viewAngle ?? 0.7;
@@ -20,8 +19,6 @@ export class GuardAI {
         this.suspicion = 0;
         this.attackCd = 0;
         this.sleep = Boolean(opts.sleep);
-        this.ray = new THREE.Raycaster();
-        this._dir = new THREE.Vector3();
         this.snoreT = 0;
     }
 
@@ -32,16 +29,23 @@ export class GuardAI {
         const dz = p.z - g.position.z;
         const dist = Math.hypot(dx, dz);
         if (dist > this.viewDist) return false;
+
         const ang = Math.atan2(dx, dz);
         let d = Math.abs(((ang - this.facing + Math.PI) % (Math.PI * 2)) - Math.PI);
         if (d > this.viewAngle) return false;
-        this.ray.set(
-            new THREE.Vector3(g.position.x, g.position.y + 1.4, g.position.z),
-            this._dir.set(dx, 0, dz).normalize()
-        );
-        this.ray.far = dist;
-        const hits = this.ray.intersectObjects(game.cameraRig?._obstacles || [], true);
-        if (hits.length && hits[0].distance < dist - 0.4) return false;
+
+        // Raycast Babylon
+        const origin = new BABYLON.Vector3(g.position.x, g.position.y + 1.4, g.position.z);
+        const dir = new BABYLON.Vector3(dx, 0, dz).normalize();
+        const ray = new BABYLON.Ray(origin, dir, dist);
+
+        const obstacles = game.cameraRig?._obstacles || [];
+        for (const obs of obstacles) {
+            if (!obs || !obs.isEnabled?.()) continue;
+            const pick = ray.intersectsMesh(obs, false);
+            if (pick.hit && pick.distance < dist - 0.4) return false;
+        }
+
         return true;
     }
 
@@ -49,10 +53,11 @@ export class GuardAI {
         const g = this.guard;
         const p = game.player.position;
         const dist = Math.hypot(p.x - g.position.x, p.z - g.position.z);
-        const noise = game.player.noise;
+        const noise = game.player.noise || 0;
         let hear = noise * this.hearRadius;
         if (game.player.crouching) hear *= 0.55;
         if (dist < hear) return true;
+
         for (const n of game.collision.noiseSources) {
             if (Math.hypot(n.x - g.position.x, n.z - g.position.z) < n.amount * 5) return true;
         }
@@ -69,7 +74,7 @@ export class GuardAI {
             this.snoreT += dt;
             if (this.snoreT > 2.4) {
                 this.snoreT = 0;
-                game.audio.play('snore');
+                game.audio?.play('snore');
                 game.hud?.flashStealth?.('Ronc… ronc…');
             }
             if (this.hear(game) && game.player.noise > 0.9) {
@@ -110,8 +115,8 @@ export class GuardAI {
             if (this.attackCd <= 0 && dist < 2.1) {
                 this.attackCd = 1.1;
                 if (!game.player.blockT) game.player.hurt(1);
-                game.audio.play('hit');
-                game.cameraRig.addShake(0.1, 0.2);
+                game.audio?.play('hit');
+                game.cameraRig?.addShake(0.1, 0.2);
             }
             return;
         }

--- a/labs/guerreiro-castelo/js/ai/MonkeyAI.js
+++ b/labs/guerreiro-castelo/js/ai/MonkeyAI.js
@@ -1,9 +1,7 @@
 /**
- * Companion Teco — estados reutilizáveis para seguir, pousar no ombro,
- * ir a um alvo, escalar, interagir e voltar.
+ * Companheiro Teco (Macaco) — IA de acompanhamento, ombro, escalada e interação.
  */
 
-import * as THREE from 'three';
 import { damp } from '../utils/math.js';
 
 export const MonkeyState = {
@@ -17,8 +15,6 @@ export const MonkeyState = {
     SCARED: 'SCARED',
     CELEBRATE: 'CELEBRATE'
 };
-
-const _tmp = new THREE.Vector3();
 
 export class MonkeyAI {
     constructor(teco) {
@@ -42,12 +38,8 @@ export class MonkeyAI {
         this.teco.onShoulder = false;
     }
 
-    /**
-     * Tarefa especial: waypoints em espaço local do parent do Teco.
-     * onArrive é chamado no INTERACT.
-     */
     command(path, { climb = false, scared = false, celebrate = false, onComplete = null } = {}) {
-        this.path = path.map((p) => p.clone());
+        this.path = path.map((p) => p.clone ? p.clone() : new BABYLON.Vector3(p.x, p.y, p.z));
         this.pathI = 0;
         this.onComplete = onComplete;
         this.state = climb ? MonkeyState.CLIMB : MonkeyState.MOVE_TO;
@@ -63,12 +55,12 @@ export class MonkeyAI {
         this.timer += dt;
 
         if (this.state === MonkeyState.PERCHED) {
-            const shoulder = _tmp.set(0.22, 1.52, 0.05);
-            shoulder.applyAxisAngle(new THREE.Vector3(0, 1, 0), player.facing);
+            const shoulderX = Math.cos(player.facing) * 0.22 - Math.sin(player.facing) * 0.05;
+            const shoulderZ = -Math.sin(player.facing) * 0.22 - Math.cos(player.facing) * 0.05;
             teco.position.set(
-                player.position.x + shoulder.x,
-                player.position.y + shoulder.y,
-                player.position.z + shoulder.z
+                player.position.x + shoulderX,
+                player.position.y + 1.52,
+                player.position.z + shoulderZ
             );
             this.facing = player.facing;
             teco.play('Shoulder');

--- a/labs/guerreiro-castelo/js/ai/PrincessAI.js
+++ b/labs/guerreiro-castelo/js/ai/PrincessAI.js
@@ -1,8 +1,7 @@
 /**
- * Camila segue Dico com offset, sem bloquear portas.
+ * Camila segue Dico com offset sem bloquear passagens estreitas.
  */
 
-import * as THREE from 'three';
 import { damp } from '../utils/math.js';
 
 export class PrincessAI {
@@ -10,9 +9,8 @@ export class PrincessAI {
         this.camila = camila;
         this.state = 'WAIT';
         this.facing = 0;
-        this.offset = new THREE.Vector3(-0.7, 0, -0.9);
         this.stuck = 0;
-        this.last = new THREE.Vector3();
+        this.last = new BABYLON.Vector3();
     }
 
     reset() {
@@ -69,7 +67,9 @@ export class PrincessAI {
                 c.position.z = tz;
                 this.stuck = 0;
             }
-        } else this.stuck = 0;
-        this.last.copy(c.position);
+        } else {
+            this.stuck = 0;
+        }
+        this.last.copyFrom(c.position);
     }
 }

--- a/labs/guerreiro-castelo/js/ai/TigerAI.js
+++ b/labs/guerreiro-castelo/js/ai/TigerAI.js
@@ -1,16 +1,14 @@
 /**
- * Tigre da sala — tensão e puzzle, não boss fight.
- * Reage a Teco na rota superior; permanece na sala.
+ * IA do Tigre na sala do castelo em Babylon.js.
  */
 
-import * as THREE from 'three';
 import { damp } from '../utils/math.js';
 
 export class TigerAI {
     constructor(tiger) {
         this.tiger = tiger;
         this.state = 'REST';
-        this.home = new THREE.Vector3();
+        this.home = new BABYLON.Vector3();
         this.timer = 0;
         this.bounds = { minX: -6, maxX: 6, minZ: -6, maxZ: 6 };
     }
@@ -18,7 +16,7 @@ export class TigerAI {
     reset() {
         this.state = 'REST';
         this.timer = 0;
-        this.home.copy(this.tiger.position);
+        this.home.copyFrom(this.tiger.position);
     }
 
     setBounds(minX, maxX, minZ, maxZ) {
@@ -36,7 +34,7 @@ export class TigerAI {
             if (this.timer > 0.4) {
                 this.state = 'WATCH';
                 t.animator.play('Growl');
-                game.audio.play('growl');
+                game.audio?.play('growl');
             }
             return;
         }

--- a/labs/guerreiro-castelo/js/characters/Camila.js
+++ b/labs/guerreiro-castelo/js/characters/Camila.js
@@ -1,52 +1,53 @@
-import * as THREE from 'three';
-import { buildCamila, CharacterAnimator, applyLocomotion } from './builders.js';
+/**
+ * Princesa Camila para Babylon.js.
+ */
+
+import { buildCamila, CharacterAnimator } from './builders.js';
 import { PrincessAI } from '../ai/PrincessAI.js';
 import { angleDamp } from '../utils/math.js';
 
 export class Camila {
     constructor(scene) {
-        const built = buildCamila();
-        this.root = built.group;
+        this.scene = scene;
+        const built = buildCamila(scene);
+        this.root = built.root;
         this.parts = built.parts;
-        this.animator = new CharacterAnimator(built.group, built.clips);
-        scene.add(this.root);
-        this.root.traverse((c) => { if (c.isMesh) c.userData.ignoreCamera = true; });
-        this.position = new THREE.Vector3();
+        this.animator = new CharacterAnimator(built.root, built.clips);
+        this.position = new BABYLON.Vector3(0, 0, 0);
         this.facing = 0;
-        this.ai = new PrincessAI(this);
-        this.freed = false;
-        this.shackled = true;
-        this.active = false;
-        this.root.visible = false;
         this.speed = 0;
+        this.active = false;
+        this.freed = false;
+        this.ai = new PrincessAI(this);
     }
 
     spawn(x, y, z) {
         this.position.set(x, y, z);
-        this.root.position.copy(this.position);
-        this.root.visible = true;
-        this.active = true;
+        this.root.position.copyFrom(this.position);
         this.ai.reset();
     }
 
-    setShackles(on) {
-        this.shackled = on;
-        if (this.parts.shackles) this.parts.shackles.visible = on;
+    attachTo(parent) {
+        this.root.parent = parent;
     }
 
-    attachTo(parent) {
-        if (this.root.parent) this.root.parent.remove(this.root);
-        parent.add(this.root);
+    setShackles(on) {
+        if (this.parts.shackles) {
+            this.parts.shackles.setEnabled(on);
+        }
     }
 
     update(dt, game) {
         if (!this.active) return;
         this.ai.update(dt, game);
-        this.facing = angleDamp(this.facing, this.ai.facing, 8, dt);
-        this.root.position.copy(this.position);
+        this.facing = angleDamp(this.facing, this.ai.facing, 10, dt);
+        this.root.position.copyFrom(this.position);
         this.root.rotation.y = this.facing;
-        applyLocomotion(this.animator, this.speed, false, true, false, false, false);
-        if (this.ai.state === 'HIDE' || this.ai.state === 'SCARED') this.animator.play('Idle');
+
+        if (this.speed > 4.5) this.animator.play('Run', 0.12);
+        else if (this.speed > 0.2) this.animator.play('Walk', 0.14);
+        else this.animator.play('Idle', 0.2);
+
         this.animator.update(dt);
     }
 }

--- a/labs/guerreiro-castelo/js/characters/Dico.js
+++ b/labs/guerreiro-castelo/js/characters/Dico.js
@@ -2,9 +2,9 @@ import { CharacterAnimator, applyLocomotion } from './builders.js';
 
 export class Dico {
     constructor(built) {
-        this.root = built.group;
+        this.root = built.root;
         this.parts = built.parts;
-        this.animator = new CharacterAnimator(built.group, built.clips);
+        this.animator = new CharacterAnimator(built.root, built.clips);
     }
 
     update(dt, state) {

--- a/labs/guerreiro-castelo/js/characters/Friend.js
+++ b/labs/guerreiro-castelo/js/characters/Friend.js
@@ -1,18 +1,15 @@
 import { buildFriend, CharacterAnimator, applyLocomotion } from './builders.js';
-import { FollowerAI } from '../ai/FollowerAI.js';
 
 export class Friend {
-    constructor(parent, variant = 0, offset = { x: 0.8, z: -0.8 }) {
-        const built = buildFriend(variant);
-        this.root = built.group;
-        this.animator = new CharacterAnimator(built.group, built.clips);
-        parent.add(this.root);
-        this.ai = new FollowerAI(this.root, offset);
+    constructor(parent, variant = 0) {
+        const scene = parent.getScene ? parent.getScene() : parent;
+        const built = buildFriend(scene, variant);
+        this.root = built.root;
+        this.animator = new CharacterAnimator(built.root, built.clips);
+        this.root.parent = parent;
     }
 
-    update(dt, player) {
-        this.ai.update(dt, player);
-        applyLocomotion(this.animator, this.ai.speed, false, true, false, false, false);
+    update(dt) {
         this.animator.update(dt);
     }
 }

--- a/labs/guerreiro-castelo/js/characters/Guard.js
+++ b/labs/guerreiro-castelo/js/characters/Guard.js
@@ -1,62 +1,69 @@
-import * as THREE from 'three';
-import { buildGuard, CharacterAnimator, applyLocomotion } from './builders.js';
+/**
+ * Guarda do castelo / Arqueiro para Babylon.js.
+ */
+
+import { buildGuard, CharacterAnimator } from './builders.js';
 import { GuardAI } from '../ai/GuardAI.js';
 import { angleDamp } from '../utils/math.js';
 
 export class Guard {
-    constructor(scene, opts = {}) {
-        const built = buildGuard(opts);
-        this.root = built.group;
+    constructor(parentOrScene, opts = {}) {
+        const scene = parentOrScene.getScene ? parentOrScene.getScene() : parentOrScene;
+        const built = buildGuard(scene, opts);
+        this.root = built.root;
         this.parts = built.parts;
-        this.animator = new CharacterAnimator(built.group, built.clips);
-        scene.add(this.root);
-        this.position = new THREE.Vector3();
+        this.animator = new CharacterAnimator(built.root, built.clips);
+
+        if (parentOrScene.getScene) {
+            this.root.parent = parentOrScene;
+        }
+
+        this.position = new BABYLON.Vector3(0, 0, 0);
         this.facing = 0;
-        this.ai = new GuardAI(this, opts);
-        this.health = 3;
-        this.maxHealth = 3;
-        this.alive = true;
-        this.fat = Boolean(opts.fat);
-        this.archer = Boolean(opts.archer);
-        this.hasKeys = Boolean(opts.fat);
         this.speed = 0;
-        this.hitT = 0;
+        this.health = opts.health || 2;
+        this.alive = true;
+        this.hasKeys = Boolean(opts.fat);
+        this.ai = new GuardAI(this, opts);
     }
 
     spawn(x, y, z, yaw = 0) {
         this.position.set(x, y, z);
         this.facing = yaw;
-        this.ai.home.set(x, y, z);
+        this.root.position.copyFrom(this.position);
+        this.root.rotation.y = this.facing;
+        this.ai.home.copyFrom(this.position);
         this.ai.facing = yaw;
-        this.root.position.copy(this.position);
-        this.root.rotation.y = yaw;
-        this.alive = true;
-        this.health = this.maxHealth;
     }
 
     takeHit(amount = 1) {
-        if (!this.alive) return;
         this.health -= amount;
-        this.hitT = 0.2;
         if (this.health <= 0) {
+            this.health = 0;
             this.alive = false;
-            this.ai.state = 'IDLE';
+            this.root.setEnabled(false);
+        } else {
+            this.ai.state = 'ATTACK';
         }
     }
 
     update(dt, game) {
-        if (!this.alive) {
-            this.root.rotation.x = Math.min(1.4, this.root.rotation.x + dt * 3);
-            return;
-        }
-        this.hitT = Math.max(0, this.hitT - dt);
+        if (!this.alive) return;
         this.ai.update(dt, game);
         this.facing = angleDamp(this.facing, this.ai.facing, 8, dt);
-        this.root.position.copy(this.position);
+        this.root.position.copyFrom(this.position);
         this.root.rotation.y = this.facing;
-        if (this.ai.state === 'SLEEP') this.animator.play('Idle');
-        else applyLocomotion(this.animator, this.speed, false, true, this.ai.state === 'ATTACK', false, false);
+
+        if (this.ai.state === 'ATTACK') {
+            this.animator.play('Attack', 0.1);
+        } else if (this.speed > 2.5) {
+            this.animator.play('Run', 0.12);
+        } else if (this.speed > 0.2) {
+            this.animator.play('Walk', 0.14);
+        } else {
+            this.animator.play('Idle', 0.2);
+        }
+
         this.animator.update(dt);
-        if (this.parts.keys) this.parts.keys.visible = this.hasKeys;
     }
 }

--- a/labs/guerreiro-castelo/js/characters/Ravi.js
+++ b/labs/guerreiro-castelo/js/characters/Ravi.js
@@ -2,11 +2,12 @@ import { buildRavi, CharacterAnimator } from './builders.js';
 
 export class Ravi {
     constructor(parent) {
-        const built = buildRavi();
-        this.root = built.group;
+        const scene = parent.getScene ? parent.getScene() : parent;
+        const built = buildRavi(scene);
+        this.root = built.root;
         this.parts = built.parts;
-        this.animator = new CharacterAnimator(built.group, built.clips);
-        parent.add(this.root);
+        this.animator = new CharacterAnimator(built.root, built.clips);
+        this.root.parent = parent;
     }
 
     update(dt) {

--- a/labs/guerreiro-castelo/js/characters/Teco.js
+++ b/labs/guerreiro-castelo/js/characters/Teco.js
@@ -1,17 +1,19 @@
-import * as THREE from 'three';
+/**
+ * Companheiro Teco (Macaco) para Babylon.js.
+ */
+
 import { buildTeco, CharacterAnimator } from './builders.js';
 import { MonkeyAI } from '../ai/MonkeyAI.js';
 import { angleDamp } from '../utils/math.js';
 
 export class Teco {
     constructor(scene) {
-        const built = buildTeco();
-        this.root = built.group;
+        this.scene = scene;
+        const built = buildTeco(scene);
+        this.root = built.root;
         this.parts = built.parts;
-        this.animator = new CharacterAnimator(built.group, built.clips);
-        scene.add(this.root);
-        this.root.traverse((c) => { if (c.isMesh) c.userData.ignoreCamera = true; });
-        this.position = new THREE.Vector3();
+        this.animator = new CharacterAnimator(built.root, built.clips);
+        this.position = new BABYLON.Vector3(0, 0, 0);
         this.facing = 0;
         this.ai = new MonkeyAI(this);
         this.onShoulder = false;
@@ -20,13 +22,12 @@ export class Teco {
 
     spawn(x, y, z) {
         this.position.set(x, y, z);
-        this.root.position.copy(this.position);
+        this.root.position.copyFrom(this.position);
         this.ai.reset();
     }
 
     attachTo(parent) {
-        if (this.root.parent) this.root.parent.remove(this.root);
-        parent.add(this.root);
+        this.root.parent = parent;
     }
 
     play(name) {
@@ -36,9 +37,9 @@ export class Teco {
     update(dt, game) {
         this.ai.update(dt, game);
         this.facing = angleDamp(this.facing, this.ai.facing, 10, dt);
-        this.root.position.copy(this.position);
+        this.root.position.copyFrom(this.position);
         this.root.rotation.y = this.facing;
-        this.root.visible = this.visible;
+        this.root.setEnabled(this.visible);
         this.animator.update(dt);
     }
 }

--- a/labs/guerreiro-castelo/js/characters/Tiger.js
+++ b/labs/guerreiro-castelo/js/characters/Tiger.js
@@ -1,35 +1,40 @@
-import * as THREE from 'three';
+/**
+ * Tigre do castelo para Babylon.js.
+ */
+
 import { buildTiger, CharacterAnimator } from './builders.js';
 import { TigerAI } from '../ai/TigerAI.js';
+import { angleDamp } from '../utils/math.js';
 
 export class Tiger {
-    constructor(scene) {
-        const built = buildTiger();
-        this.root = built.group;
+    constructor(parentOrScene) {
+        const scene = parentOrScene.getScene ? parentOrScene.getScene() : parentOrScene;
+        const built = buildTiger(scene);
+        this.root = built.root;
         this.parts = built.parts;
-        this.animator = new CharacterAnimator(built.group, built.clips);
-        scene.add(this.root);
-        this.position = new THREE.Vector3();
+        this.animator = new CharacterAnimator(built.root, built.clips);
+
+        if (parentOrScene.getScene) {
+            this.root.parent = parentOrScene;
+        }
+
+        this.position = new BABYLON.Vector3(0, 0, 0);
         this.facing = 0;
         this.ai = new TigerAI(this);
-        this.active = false;
-        this.root.visible = false;
     }
 
     spawn(x, y, z, yaw = 0) {
         this.position.set(x, y, z);
         this.facing = yaw;
-        this.root.position.copy(this.position);
-        this.root.rotation.y = yaw;
-        this.root.visible = true;
-        this.active = true;
+        this.root.position.copyFrom(this.position);
+        this.root.rotation.y = this.facing;
         this.ai.reset();
     }
 
     update(dt, game) {
-        if (!this.active) return;
         this.ai.update(dt, game);
-        this.root.position.copy(this.position);
+        this.facing = angleDamp(this.facing, this.ai.facing, 8, dt);
+        this.root.position.copyFrom(this.position);
         this.root.rotation.y = this.facing;
         this.animator.update(dt);
     }

--- a/labs/guerreiro-castelo/js/characters/builders.js
+++ b/labs/guerreiro-castelo/js/characters/builders.js
@@ -1,625 +1,853 @@
 /**
- * Humanoides procedurais com ossos nomeados + AnimationMixer.
- * Fallbacks apresentáveis para quando o GLB não existe.
+ * Humanoides e animais procedurais estilizados em Babylon.js com hierarquia de nós e animador procedural.
  */
 
-import * as THREE from 'three';
 import { leatherTexture, clothTexture } from '../world/Textures.js';
-
-const matCache = new Map();
-
-export function std(color, roughness = 0.78, metalness = 0.04, extra = {}) {
-    const key = `s:${color}:${roughness}:${metalness}:${JSON.stringify(extra)}`;
-    if (!matCache.has(key)) {
-        matCache.set(key, new THREE.MeshStandardMaterial({ color, roughness, metalness, ...extra }));
-    }
-    return matCache.get(key);
-}
-
-export function mapped(map, color = 0xffffff, roughness = 0.86, metalness = 0.03) {
-    return new THREE.MeshStandardMaterial({ map, color, roughness, metalness });
-}
-
-export function enableShadows(root) {
-    root.traverse((c) => {
-        if (c.isMesh) {
-            c.castShadow = true;
-            c.receiveShadow = true;
-        }
-    });
-}
-
-function nameBone(obj, name) {
-    obj.name = name;
-    return obj;
-}
-
-function makeClips(parts) {
-    const clips = {};
-    const mk = (name, duration, channels) => {
-        const tracks = channels.map((ch) => {
-            const n = 8;
-            const times = [];
-            const values = [];
-            for (let i = 0; i <= n; i++) {
-                const t = (i / n) * duration;
-                times.push(t);
-                values.push(Math.sin((i / n) * Math.PI * 2 + ch.phase) * ch.amp + (ch.base || 0));
-            }
-            return new THREE.NumberKeyframeTrack(`${ch.target.name}.rotation[${ch.axis}]`, times, values);
-        });
-        clips[name] = new THREE.AnimationClip(name, duration, tracks);
-    };
-
-    mk('Idle', 2.4, [
-        { target: parts.chest, axis: 'x', amp: 0.03, phase: 0 },
-        { target: parts.head, axis: 'y', amp: 0.04, phase: 1 }
-    ]);
-    mk('Walk', 0.85, [
-        { target: parts.legL, axis: 'x', amp: 0.55, phase: 0 },
-        { target: parts.legR, axis: 'x', amp: 0.55, phase: Math.PI },
-        { target: parts.armL, axis: 'x', amp: 0.45, phase: Math.PI },
-        { target: parts.armR, axis: 'x', amp: 0.45, phase: 0 }
-    ]);
-    mk('Run', 0.55, [
-        { target: parts.legL, axis: 'x', amp: 0.85, phase: 0 },
-        { target: parts.legR, axis: 'x', amp: 0.85, phase: Math.PI },
-        { target: parts.armL, axis: 'x', amp: 0.7, phase: Math.PI },
-        { target: parts.armR, axis: 'x', amp: 0.7, phase: 0 },
-        { target: parts.chest, axis: 'z', amp: 0.06, phase: 0 }
-    ]);
-    mk('Sprint', 0.42, [
-        { target: parts.legL, axis: 'x', amp: 1.05, phase: 0 },
-        { target: parts.legR, axis: 'x', amp: 1.05, phase: Math.PI },
-        { target: parts.armL, axis: 'x', amp: 0.9, phase: Math.PI },
-        { target: parts.armR, axis: 'x', amp: 0.9, phase: 0 }
-    ]);
-    mk('Crouch', 1.2, [
-        { target: parts.legL, axis: 'x', amp: 0.12, phase: 0, base: 0.55 },
-        { target: parts.legR, axis: 'x', amp: 0.12, phase: Math.PI, base: 0.55 }
-    ]);
-    mk('Attack', 0.45, [
-        { target: parts.armR, axis: 'x', amp: 1.1, phase: 0, base: -0.4 },
-        { target: parts.chest, axis: 'y', amp: 0.25, phase: 0 }
-    ]);
-    mk('Block', 0.8, [
-        { target: parts.armL, axis: 'x', amp: 0.05, phase: 0, base: -0.9 }
-    ]);
-    mk('Interact', 0.9, [
-        { target: parts.armR, axis: 'x', amp: 0.4, phase: 0, base: -0.6 }
-    ]);
-    mk('Jump', 0.6, [
-        { target: parts.legL, axis: 'x', amp: 0.2, phase: 0, base: 0.4 },
-        { target: parts.legR, axis: 'x', amp: 0.2, phase: 0, base: 0.4 }
-    ]);
-    return clips;
-}
+import { angleLerp, damp } from '../utils/math.js';
 
 export class CharacterAnimator {
     constructor(root, clips) {
-        this.mixer = new THREE.AnimationMixer(root);
-        this.actions = {};
-        for (const [name, clip] of Object.entries(clips)) {
-            const action = this.mixer.clipAction(clip);
-            action.enabled = true;
-            this.actions[name] = action;
-        }
-        this.current = null;
+        this.root = root;
+        this.clips = clips || {};
         this.currentName = 'Idle';
-        this.play('Idle', 0);
+        this.targetName = 'Idle';
+        this.time = 0;
+        this.transitionTime = 0;
+        this.transitionDuration = 0.15;
+        this.prevClip = null;
+        this.currentClip = this.clips.Idle || null;
     }
 
-    play(name, fade = 0.18) {
-        const next = this.actions[name] || this.actions.Idle;
-        if (!next || this.current === next) return;
-        next.reset();
-        next.setEffectiveWeight(1);
-        next.play();
-        if (this.current) this.current.crossFadeTo(next, fade, false);
-        else next.fadeIn(fade);
-        this.current = next;
-        this.currentName = name;
+    play(name, fade = 0.15) {
+        if (this.targetName === name) return;
+        if (!this.clips[name]) return;
+        this.prevClip = this.currentClip;
+        this.targetName = name;
+        this.currentClip = this.clips[name];
+        this.transitionTime = 0;
+        this.transitionDuration = Math.max(0.01, fade);
     }
 
     update(dt) {
-        this.mixer.update(dt);
+        this.time += dt;
+        this.transitionTime += dt;
+        const blend = Math.min(1, this.transitionTime / this.transitionDuration);
+
+        if (this.currentClip) {
+            const curPose = this.currentClip.sample(this.time);
+            if (blend < 1 && this.prevClip) {
+                const prevPose = this.prevClip.sample(this.time);
+                for (const nodeName of Object.keys(curPose)) {
+                    const node = this.root.userData?.parts?.[nodeName];
+                    if (node && node.rotation) {
+                        const p = prevPose[nodeName] || { x: 0, y: 0, z: 0 };
+                        const c = curPose[nodeName];
+                        node.rotation.x = angleLerp(p.x || 0, c.x || 0, blend);
+                        node.rotation.y = angleLerp(p.y || 0, c.y || 0, blend);
+                        node.rotation.z = angleLerp(p.z || 0, c.z || 0, blend);
+                    }
+                }
+            } else {
+                for (const nodeName of Object.keys(curPose)) {
+                    const node = this.root.userData?.parts?.[nodeName];
+                    if (node && node.rotation) {
+                        const c = curPose[nodeName];
+                        if (c.x !== undefined) node.rotation.x = c.x;
+                        if (c.y !== undefined) node.rotation.y = c.y;
+                        if (c.z !== undefined) node.rotation.z = c.z;
+                    }
+                }
+            }
+        }
     }
 }
 
-function addEyes(head, skin, sx, color = 0x2a2418) {
-    for (const s of [-1, 1]) {
-        const white = new THREE.Mesh(new THREE.SphereGeometry(0.028, 8, 6), std(0xf4efe6, 0.35));
-        white.position.set(s * sx, 0.04, 0.12);
-        head.add(white);
-        const iris = new THREE.Mesh(new THREE.SphereGeometry(0.016, 8, 6), std(color, 0.35));
-        iris.position.set(s * sx, 0.04, 0.142);
-        head.add(iris);
-        const pupil = new THREE.Mesh(new THREE.SphereGeometry(0.008, 6, 5), std(0x111111, 0.2));
-        pupil.position.set(s * sx, 0.04, 0.154);
-        head.add(pupil);
+class ProceduralClip {
+    constructor(duration, channels) {
+        this.duration = duration;
+        this.channels = channels; // array of { target, axis, amp, phase, base }
+    }
+
+    sample(time) {
+        const pose = {};
+        const t = (time % this.duration) / this.duration;
+        for (const ch of this.channels) {
+            if (!pose[ch.target]) pose[ch.target] = {};
+            const val = Math.sin(t * Math.PI * 2 + (ch.phase || 0)) * ch.amp + (ch.base || 0);
+            pose[ch.target][ch.axis] = val;
+        }
+        return pose;
     }
 }
 
-function curlyHair(head, mat, radius, count, yOff = 0.1) {
-    for (let i = 0; i < count; i++) {
-        const curl = new THREE.Mesh(new THREE.SphereGeometry(0.045, 8, 6), mat);
-        const a = (i / count) * Math.PI * 2;
-        const h = 0.04 + (i % 3) * 0.03;
-        curl.position.set(Math.cos(a) * radius, yOff + h, Math.sin(a) * radius * 0.9);
-        head.add(curl);
-    }
+function makeHumanoidClips() {
+    return {
+        Idle: new ProceduralClip(2.4, [
+            { target: 'chest', axis: 'x', amp: 0.03, phase: 0 },
+            { target: 'head', axis: 'y', amp: 0.04, phase: 1 }
+        ]),
+        Walk: new ProceduralClip(0.85, [
+            { target: 'legL', axis: 'x', amp: 0.55, phase: 0 },
+            { target: 'legR', axis: 'x', amp: 0.55, phase: Math.PI },
+            { target: 'armL', axis: 'x', amp: 0.45, phase: Math.PI },
+            { target: 'armR', axis: 'x', amp: 0.45, phase: 0 }
+        ]),
+        Run: new ProceduralClip(0.55, [
+            { target: 'legL', axis: 'x', amp: 0.85, phase: 0 },
+            { target: 'legR', axis: 'x', amp: 0.85, phase: Math.PI },
+            { target: 'armL', axis: 'x', amp: 0.7, phase: Math.PI },
+            { target: 'armR', axis: 'x', amp: 0.7, phase: 0 },
+            { target: 'chest', axis: 'z', amp: 0.06, phase: 0 }
+        ]),
+        Sprint: new ProceduralClip(0.42, [
+            { target: 'legL', axis: 'x', amp: 1.05, phase: 0 },
+            { target: 'legR', axis: 'x', amp: 1.05, phase: Math.PI },
+            { target: 'armL', axis: 'x', amp: 0.9, phase: Math.PI },
+            { target: 'armR', axis: 'x', amp: 0.9, phase: 0 }
+        ]),
+        Crouch: new ProceduralClip(1.2, [
+            { target: 'legL', axis: 'x', amp: 0.12, phase: 0, base: 0.55 },
+            { target: 'legR', axis: 'x', amp: 0.12, phase: Math.PI, base: 0.55 }
+        ]),
+        Attack: new ProceduralClip(0.45, [
+            { target: 'armR', axis: 'x', amp: 1.1, phase: 0, base: -0.4 },
+            { target: 'chest', axis: 'y', amp: 0.25, phase: 0 }
+        ]),
+        Block: new ProceduralClip(0.8, [
+            { target: 'armL', axis: 'x', amp: 0.05, phase: 0, base: -0.9 }
+        ]),
+        Interact: new ProceduralClip(0.9, [
+            { target: 'armR', axis: 'x', amp: 0.4, phase: 0, base: -0.6 }
+        ]),
+        Jump: new ProceduralClip(0.6, [
+            { target: 'legL', axis: 'x', amp: 0.2, phase: 0, base: 0.4 },
+            { target: 'legR', axis: 'x', amp: 0.2, phase: 0, base: 0.4 }
+        ])
+    };
 }
 
-/**
- * Ossos compartilhados: hips, spine, chest, head, armL/R, legL/R.
- */
 export function buildHumanoid({
+    scene,
     height = 1.8,
     thin = 1,
-    skin = 0xe0b089,
-    hair = 0x1a120e,
-    shirt = 0x4a3a2a,
-    pants = 0x2c2418,
-    boots = 0x3a2414,
-    eye = 0x3a2a18
+    skinColor = new BABYLON.Color3(0.88, 0.7, 0.55),
+    hairColor = new BABYLON.Color3(0.12, 0.08, 0.05),
+    shirtColor = new BABYLON.Color3(0.3, 0.22, 0.16),
+    pantsColor = new BABYLON.Color3(0.18, 0.15, 0.1),
+    bootColor = new BABYLON.Color3(0.24, 0.16, 0.1)
 } = {}) {
     const scale = height / 1.8;
-    const group = new THREE.Group();
-    const skinM = std(skin, 0.7);
-    const shirtM = mapped(clothTexture(), shirt, 0.9);
-    const pantsM = mapped(clothTexture(), pants, 0.88);
-    const bootM = mapped(leatherTexture(), boots, 0.7, 0.05);
-    const hairM = std(hair, 0.92);
+    const root = new BABYLON.TransformNode('humanoidRoot', scene);
 
-    const hips = nameBone(new THREE.Group(), 'hips');
-    group.add(hips);
+    const skinMat = new BABYLON.StandardMaterial('skinMat', scene);
+    skinMat.diffuseColor = skinColor;
+    skinMat.specularColor = new BABYLON.Color3(0.1, 0.1, 0.1);
 
-    const legL = nameBone(new THREE.Group(), 'legL');
-    const legR = nameBone(new THREE.Group(), 'legR');
+    const hairMat = new BABYLON.StandardMaterial('hairMat', scene);
+    hairMat.diffuseColor = hairColor;
+
+    const shirtMat = new BABYLON.StandardMaterial('shirtMat', scene);
+    shirtMat.diffuseColor = shirtColor;
+
+    const pantsMat = new BABYLON.StandardMaterial('pantsMat', scene);
+    pantsMat.diffuseColor = pantsColor;
+
+    const bootMat = new BABYLON.StandardMaterial('bootMat', scene);
+    bootMat.diffuseColor = bootColor;
+
+    // Hips
+    const hips = new BABYLON.TransformNode('hips', scene);
+    hips.parent = root;
+
+    // Legs
+    const legL = new BABYLON.TransformNode('legL', scene);
+    const legR = new BABYLON.TransformNode('legR', scene);
     legL.position.set(-0.12 * thin * scale, 0.92 * scale, 0);
     legR.position.set(0.12 * thin * scale, 0.92 * scale, 0);
-    hips.add(legL, legR);
+    legL.parent = hips;
+    legR.parent = hips;
 
     for (const leg of [legL, legR]) {
-        const thigh = new THREE.Mesh(new THREE.CylinderGeometry(0.07 * thin * scale, 0.06 * thin * scale, 0.46 * scale, 8), pantsM);
+        const thigh = BABYLON.MeshBuilder.CreateCylinder('thigh', {
+            diameterTop: 0.14 * thin * scale,
+            diameterBottom: 0.12 * thin * scale,
+            height: 0.46 * scale,
+            tessellation: 8
+        }, scene);
         thigh.position.y = -0.23 * scale;
-        leg.add(thigh);
-        const shin = new THREE.Mesh(new THREE.CylinderGeometry(0.055 * thin * scale, 0.05 * thin * scale, 0.42 * scale, 8), pantsM);
+        thigh.material = pantsMat;
+        thigh.parent = leg;
+
+        const shin = BABYLON.MeshBuilder.CreateCylinder('shin', {
+            diameterTop: 0.11 * thin * scale,
+            diameterBottom: 0.1 * thin * scale,
+            height: 0.42 * scale,
+            tessellation: 8
+        }, scene);
         shin.position.y = -0.66 * scale;
-        leg.add(shin);
-        const foot = new THREE.Mesh(new THREE.BoxGeometry(0.1 * scale, 0.08 * scale, 0.22 * scale), bootM);
+        shin.material = pantsMat;
+        shin.parent = leg;
+
+        const foot = BABYLON.MeshBuilder.CreateBox('foot', {
+            width: 0.1 * scale,
+            height: 0.08 * scale,
+            depth: 0.22 * scale
+        }, scene);
         foot.position.set(0, -0.9 * scale, 0.04 * scale);
-        leg.add(foot);
+        foot.material = bootMat;
+        foot.parent = leg;
     }
 
-    const spine = nameBone(new THREE.Group(), 'spine');
+    // Spine & Chest
+    const spine = new BABYLON.TransformNode('spine', scene);
     spine.position.y = 0.95 * scale;
-    hips.add(spine);
+    spine.parent = hips;
 
-    const chest = nameBone(new THREE.Group(), 'chest');
-    spine.add(chest);
-    const torso = new THREE.Mesh(
-        new THREE.CapsuleGeometry(0.2 * thin * scale, 0.42 * scale, 6, 10),
-        shirtM
-    );
+    const chest = new BABYLON.TransformNode('chest', scene);
+    chest.parent = spine;
+
+    const torso = BABYLON.MeshBuilder.CreateCapsule('torso', {
+        radius: 0.16 * thin * scale,
+        height: 0.58 * scale,
+        tessellation: 8
+    }, scene);
     torso.position.y = 0.28 * scale;
-    chest.add(torso);
+    torso.material = shirtMat;
+    torso.parent = chest;
 
-    const armL = nameBone(new THREE.Group(), 'armL');
-    const armR = nameBone(new THREE.Group(), 'armR');
+    // Arms
+    const armL = new BABYLON.TransformNode('armL', scene);
+    const armR = new BABYLON.TransformNode('armR', scene);
     armL.position.set(-0.26 * thin * scale, 0.42 * scale, 0);
     armR.position.set(0.26 * thin * scale, 0.42 * scale, 0);
-    chest.add(armL, armR);
+    armL.parent = chest;
+    armR.parent = chest;
+
     for (const arm of [armL, armR]) {
-        const upper = new THREE.Mesh(new THREE.CylinderGeometry(0.05 * scale, 0.045 * scale, 0.32 * scale, 8), shirtM);
+        const upper = BABYLON.MeshBuilder.CreateCylinder('armUpper', {
+            diameterTop: 0.1 * scale,
+            diameterBottom: 0.09 * scale,
+            height: 0.32 * scale,
+            tessellation: 8
+        }, scene);
         upper.position.y = -0.16 * scale;
-        arm.add(upper);
-        const fore = new THREE.Mesh(new THREE.CylinderGeometry(0.042 * scale, 0.038 * scale, 0.3 * scale, 8), skinM);
+        upper.material = shirtMat;
+        upper.parent = arm;
+
+        const fore = BABYLON.MeshBuilder.CreateCylinder('armFore', {
+            diameterTop: 0.084 * scale,
+            diameterBottom: 0.076 * scale,
+            height: 0.3 * scale,
+            tessellation: 8
+        }, scene);
         fore.position.y = -0.46 * scale;
-        arm.add(fore);
-        const hand = new THREE.Mesh(new THREE.SphereGeometry(0.045 * scale, 8, 6), skinM);
+        fore.material = skinMat;
+        fore.parent = arm;
+
+        const hand = BABYLON.MeshBuilder.CreateSphere('hand', {
+            diameter: 0.09 * scale,
+            segments: 6
+        }, scene);
         hand.position.y = -0.64 * scale;
-        arm.add(hand);
-        arm.userData.hand = hand;
+        hand.material = skinMat;
+        hand.parent = arm;
+        arm.userData = { hand };
     }
 
-    const head = nameBone(new THREE.Group(), 'head');
+    // Head
+    const head = new BABYLON.TransformNode('head', scene);
     head.position.y = 0.62 * scale;
-    chest.add(head);
-    const skull = new THREE.Mesh(new THREE.SphereGeometry(0.125 * scale, 14, 12), skinM);
-    skull.scale.set(0.92, 1.05, 0.95);
-    head.add(skull);
-    addEyes(head, skinM, 0.045 * scale, eye);
+    head.parent = chest;
 
-    const parts = { hips, spine, chest, head, armL, armR, legL, legR, group, scale, skinM, hairM };
-    const clips = makeClips(parts);
-    enableShadows(group);
-    group.userData.parts = parts;
-    group.userData.clips = clips;
-    return { group, parts, clips };
+    const skull = BABYLON.MeshBuilder.CreateSphere('skull', {
+        diameter: 0.25 * scale,
+        segments: 10
+    }, scene);
+    skull.scaling.set(0.92, 1.05, 0.95);
+    skull.material = skinMat;
+    skull.parent = head;
+
+    // Olhos
+    for (const s of [-1, 1]) {
+        const eye = BABYLON.MeshBuilder.CreateSphere('eye', { diameter: 0.04 * scale, segments: 6 }, scene);
+        eye.position.set(s * 0.045 * scale, 0.04 * scale, 0.11 * scale);
+        const eyeMat = new BABYLON.StandardMaterial('eyeMat', scene);
+        eyeMat.diffuseColor = new BABYLON.Color3(0.1, 0.1, 0.1);
+        eye.material = eyeMat;
+        eye.parent = head;
+    }
+
+    const parts = { hips, spine, chest, head, armL, armR, legL, legR, root, skinMat, hairMat };
+    const clips = makeHumanoidClips();
+    root.userData = { parts, clips };
+
+    return { root, parts, clips };
 }
 
-export function buildDico() {
-    const { group, parts, clips } = buildHumanoid({
+export function buildDico(scene) {
+    const built = buildHumanoid({
+        scene,
         height: 1.9,
         thin: 0.88,
-        skin: 0xd9a878,
-        hair: 0x1a140f,
-        shirt: 0x4a3a2c,
-        pants: 0x2a2218,
-        boots: 0x3a2416,
-        eye: 0x3d4a28
+        skinColor: new BABYLON.Color3(0.85, 0.66, 0.48),
+        hairColor: new BABYLON.Color3(0.1, 0.08, 0.06),
+        shirtColor: new BABYLON.Color3(0.3, 0.23, 0.17),
+        pantsColor: new BABYLON.Color3(0.16, 0.13, 0.1),
+        bootColor: new BABYLON.Color3(0.22, 0.14, 0.09)
     });
 
-    curlyHair(parts.head, parts.hairM, 0.12, 16, 0.08);
-    const bang = new THREE.Mesh(new THREE.SphereGeometry(0.07, 8, 6), parts.hairM);
-    bang.position.set(0, 0.12, 0.08);
-    parts.head.add(bang);
+    const parts = built.parts;
 
-    const mustache = new THREE.Mesh(new THREE.BoxGeometry(0.09, 0.015, 0.03), parts.hairM);
+    // Cabelo crespo e barba
+    const hairCluster = new BABYLON.TransformNode('dicoHair', scene);
+    hairCluster.parent = parts.head;
+    for (let i = 0; i < 16; i++) {
+        const curl = BABYLON.MeshBuilder.CreateSphere(`curl_${i}`, { diameter: 0.09, segments: 6 }, scene);
+        const a = (i / 16) * Math.PI * 2;
+        curl.position.set(Math.cos(a) * 0.12, 0.1 + (i % 3) * 0.03, Math.sin(a) * 0.11);
+        curl.material = parts.hairMat;
+        curl.parent = hairCluster;
+    }
+
+    const mustache = BABYLON.MeshBuilder.CreateBox('mustache', { width: 0.09, height: 0.015, depth: 0.03 }, scene);
     mustache.position.set(0, -0.02, 0.12);
-    parts.head.add(mustache);
-    const goatee = new THREE.Mesh(new THREE.SphereGeometry(0.03, 8, 6), parts.hairM);
-    goatee.scale.set(0.7, 1.1, 0.6);
+    mustache.material = parts.hairMat;
+    mustache.parent = parts.head;
+
+    const goatee = BABYLON.MeshBuilder.CreateSphere('goatee', { diameter: 0.06, segments: 6 }, scene);
     goatee.position.set(0, -0.08, 0.1);
-    parts.head.add(goatee);
+    goatee.material = parts.hairMat;
+    goatee.parent = parts.head;
 
-    const leather = mapped(leatherTexture(), 0x5a3a22, 0.7, 0.08);
-    const vest = new THREE.Mesh(new THREE.CylinderGeometry(0.2, 0.22, 0.36, 10), leather);
+    // Colete de couro
+    const vest = BABYLON.MeshBuilder.CreateCylinder('vest', {
+        diameterTop: 0.4,
+        diameterBottom: 0.44,
+        height: 0.36,
+        tessellation: 10
+    }, scene);
     vest.position.y = 0.26;
-    parts.chest.add(vest);
+    const vestMat = new BABYLON.StandardMaterial('vestMat', scene);
+    vestMat.diffuseColor = new BABYLON.Color3(0.35, 0.22, 0.13);
+    vest.material = vestMat;
+    vest.parent = parts.chest;
 
-    const belt = new THREE.Mesh(new THREE.TorusGeometry(0.2, 0.025, 6, 16), std(0x3a2414, 0.6, 0.15));
-    belt.rotation.x = Math.PI / 2;
-    belt.position.y = 0.08;
-    parts.chest.add(belt);
-
-    const sword = new THREE.Group();
-    sword.name = 'sword';
-    const blade = new THREE.Mesh(new THREE.BoxGeometry(0.04, 0.72, 0.012), std(0xc5cdd6, 0.25, 0.85));
-    blade.position.y = 0.36;
-    sword.add(blade);
-    const guard = new THREE.Mesh(new THREE.BoxGeometry(0.16, 0.03, 0.03), std(0xb08a3a, 0.35, 0.8));
-    sword.add(guard);
-    const hilt = new THREE.Mesh(new THREE.CylinderGeometry(0.02, 0.022, 0.14, 8), std(0x3a2414, 0.7));
-    hilt.position.y = -0.08;
-    sword.add(hilt);
+    // Espada na mão direita
+    const sword = new BABYLON.TransformNode('swordRoot', scene);
+    sword.parent = parts.armR.userData.hand;
     sword.position.set(0.02, -0.2, 0.02);
     sword.rotation.z = 0.15;
-    parts.armR.userData.hand.add(sword);
 
-    const shield = new THREE.Mesh(new THREE.CylinderGeometry(0.18, 0.18, 0.04, 10), mapped(leatherTexture(), 0x6b1c1c, 0.55, 0.2));
+    const blade = BABYLON.MeshBuilder.CreateBox('swordBlade', { width: 0.04, height: 0.72, depth: 0.012 }, scene);
+    blade.position.y = 0.36;
+    const bladeMat = new BABYLON.StandardMaterial('bladeMat', scene);
+    bladeMat.diffuseColor = new BABYLON.Color3(0.78, 0.82, 0.86);
+    bladeMat.specularColor = new BABYLON.Color3(0.9, 0.9, 0.9);
+    blade.material = bladeMat;
+    blade.parent = sword;
+
+    const guard = BABYLON.MeshBuilder.CreateBox('swordGuard', { width: 0.16, height: 0.03, depth: 0.03 }, scene);
+    const goldMat = new BABYLON.StandardMaterial('goldMat', scene);
+    goldMat.diffuseColor = new BABYLON.Color3(0.7, 0.55, 0.2);
+    guard.material = goldMat;
+    guard.parent = sword;
+
+    const hilt = BABYLON.MeshBuilder.CreateCylinder('swordHilt', { diameter: 0.04, height: 0.14 }, scene);
+    hilt.position.y = -0.08;
+    const hiltMat = new BABYLON.StandardMaterial('hiltMat', scene);
+    hiltMat.diffuseColor = new BABYLON.Color3(0.2, 0.12, 0.08);
+    hilt.material = hiltMat;
+    hilt.parent = sword;
+
+    // Escudo no braço esquerdo
+    const shield = BABYLON.MeshBuilder.CreateCylinder('shield', {
+        diameter: 0.38,
+        height: 0.04,
+        tessellation: 10
+    }, scene);
     shield.rotation.z = Math.PI / 2;
     shield.position.set(-0.08, -0.15, 0.06);
-    parts.armL.add(shield);
+    const shieldMat = new BABYLON.StandardMaterial('shieldMat', scene);
+    shieldMat.diffuseColor = new BABYLON.Color3(0.45, 0.12, 0.12);
+    shield.material = shieldMat;
+    shield.parent = parts.armL;
 
-    const torch = new THREE.Group();
-    torch.visible = false;
-    const stick = new THREE.Mesh(new THREE.CylinderGeometry(0.02, 0.025, 0.32, 6), std(0x4a3218, 0.9));
-    torch.add(stick);
-    const flame = new THREE.Mesh(
-        new THREE.SphereGeometry(0.06, 8, 6),
-        new THREE.MeshStandardMaterial({ color: 0xffaa33, emissive: 0xff7711, emissiveIntensity: 2.2 })
-    );
-    flame.position.y = 0.2;
-    torch.add(flame);
+    // Tocha portátil na mão esquerda
+    const torch = new BABYLON.TransformNode('torchDico', scene);
+    torch.parent = parts.armL.userData.hand;
     torch.position.set(0.05, -0.2, 0.05);
-    parts.armL.userData.hand.add(torch);
+
+    const stick = BABYLON.MeshBuilder.CreateCylinder('torchStickDico', { diameter: 0.04, height: 0.32 }, scene);
+    stick.material = hiltMat;
+    stick.parent = torch;
+
+    const flame = BABYLON.MeshBuilder.CreateSphere('flameDico', { diameter: 0.12, segments: 6 }, scene);
+    flame.position.y = 0.2;
+    const flameMat = new BABYLON.StandardMaterial('flameMatDico', scene);
+    flameMat.diffuseColor = new BABYLON.Color3(1.0, 0.6, 0.2);
+    flameMat.emissiveColor = new BABYLON.Color3(1.0, 0.5, 0.1);
+    flame.material = flameMat;
+    flame.parent = torch;
+    torch.setEnabled(false);
+
     parts.torch = torch;
     parts.torchFlame = flame;
     parts.sword = sword;
     parts.shield = shield;
 
-    enableShadows(group);
-    return { group, parts, clips };
-}
-
-export function buildRavi() {
-    const { group, parts, clips } = buildHumanoid({
-        height: 1.05,
-        thin: 0.95,
-        skin: 0xe8c49a,
-        hair: 0xd8c48a,
-        shirt: 0x3a5a8a,
-        pants: 0x4a3a28,
-        boots: 0x5a3a22,
-        eye: 0x4a6a8a
-    });
-    curlyHair(parts.head, std(0xe8d4a0, 0.9), 0.08, 14, 0.06);
-    const blanket = new THREE.Mesh(new THREE.BoxGeometry(0.55, 0.08, 0.7), std(0x6a2a2a, 0.92));
-    blanket.position.set(0, 0.4, 0.05);
-    blanket.visible = true;
-    group.add(blanket);
-    parts.blanket = blanket;
-    return { group, parts, clips };
-}
-
-export function buildCamila() {
-    const { group, parts, clips } = buildHumanoid({
-        height: 1.68,
-        thin: 0.9,
-        skin: 0xf0c8a8,
-        hair: 0xe8d48a,
-        shirt: 0xc9b8d4,
-        pants: 0x8a6a9a,
-        boots: 0x5a3a44,
-        eye: 0x4a6a8a
-    });
-    const hairM = std(0xe8d48a, 0.55);
-    const hair = new THREE.Mesh(new THREE.CapsuleGeometry(0.12, 0.35, 6, 10), hairM);
-    hair.position.set(0, 0.02, -0.04);
-    parts.head.add(hair);
-    const bangs = new THREE.Mesh(new THREE.BoxGeometry(0.2, 0.04, 0.08), hairM);
-    bangs.position.set(0, 0.1, 0.1);
-    parts.head.add(bangs);
-    const dress = new THREE.Mesh(new THREE.ConeGeometry(0.32, 0.7, 10), std(0xc9b8d4, 0.88));
-    dress.position.y = 0.55;
-    parts.hips.add(dress);
-    const shackles = new THREE.Group();
-    const left = new THREE.Mesh(new THREE.TorusGeometry(0.05, 0.012, 6, 12), std(0x888888, 0.4, 0.8));
-    left.position.set(-0.12, 0.9, 0.12);
-    const right = left.clone();
-    right.position.x = 0.12;
-    const chain = new THREE.Mesh(new THREE.CylinderGeometry(0.012, 0.012, 0.24, 6), std(0x777777, 0.4, 0.8));
-    chain.rotation.z = Math.PI / 2;
-    chain.position.set(0, 0.9, 0.12);
-    shackles.add(left, right, chain);
-    parts.hips.add(shackles);
-    parts.shackles = shackles;
-    return { group, parts, clips };
-}
-
-export function buildGuard({ fat = false, archer = false } = {}) {
-    const { group, parts, clips } = buildHumanoid({
-        height: fat ? 1.7 : 1.82,
-        thin: fat ? 1.35 : 1.08,
-        skin: 0xd2a07a,
-        hair: 0x3a2a18,
-        shirt: 0x4a4a3a,
-        pants: 0x2a2a22,
-        boots: 0x3a2a18,
-        eye: 0x2a2a18
-    });
-    const helm = new THREE.Mesh(new THREE.SphereGeometry(0.15, 10, 8, 0, Math.PI * 2, 0, Math.PI * 0.58), std(0x8a8a82, 0.35, 0.7));
-    helm.position.y = 0.04;
-    parts.head.add(helm);
-    const tunic = new THREE.Mesh(
-        new THREE.CylinderGeometry(fat ? 0.32 : 0.22, fat ? 0.28 : 0.2, 0.5, 10),
-        std(0x5a1c1c, 0.85)
-    );
-    tunic.position.y = 0.22;
-    parts.chest.add(tunic);
-    if (fat) {
-        const belly = new THREE.Mesh(new THREE.SphereGeometry(0.28, 12, 10), std(0x5a1c1c, 0.88));
-        belly.position.y = 0.12;
-        parts.chest.add(belly);
-    }
-    const spear = new THREE.Group();
-    const shaft = new THREE.Mesh(new THREE.CylinderGeometry(0.018, 0.018, 1.6, 6), std(0x5a3a18, 0.8));
-    spear.add(shaft);
-    const tip = new THREE.Mesh(new THREE.ConeGeometry(0.04, 0.16, 6), std(0xb0b8c0, 0.3, 0.8));
-    tip.position.y = 0.86;
-    spear.add(tip);
-    spear.position.set(0.05, -0.2, 0.1);
-    parts.armR.userData.hand.add(spear);
-    if (archer) {
-        spear.visible = false;
-        const bow = new THREE.Mesh(new THREE.TorusGeometry(0.28, 0.018, 6, 16, Math.PI), std(0x5a3a18, 0.7));
-        bow.rotation.y = Math.PI / 2;
-        parts.armL.add(bow);
-    }
-    const keys = new THREE.Group();
-    for (let i = 0; i < 3; i++) {
-        const k = new THREE.Mesh(new THREE.BoxGeometry(0.04, 0.12, 0.02), std(0xc9a227, 0.4, 0.7));
-        k.position.set(0.08, 0.7 + i * 0.02, 0.14);
-        k.rotation.z = 0.3 * i;
-        keys.add(k);
-    }
-    keys.visible = fat;
-    parts.hips.add(keys);
-    parts.keys = keys;
-    parts.spear = spear;
-    return { group, parts, clips };
-}
-
-export function buildFriend(variant = 0) {
-    const palettes = [
-        { shirt: 0x3a4a3a, pants: 0x2a2218, hair: 0x3a2414 },
-        { shirt: 0x3a3a5a, pants: 0x2a2a22, hair: 0x1a1a12 },
-        { shirt: 0x5a3a2a, pants: 0x3a2a18, hair: 0x6a4a22 }
-    ];
-    const p = palettes[variant % 3];
-    const built = buildHumanoid({
-        height: 1.78 + variant * 0.04,
-        thin: 1,
-        shirt: p.shirt,
-        pants: p.pants,
-        hair: p.hair
-    });
-    curlyHair(built.parts.head, std(p.hair, 0.9), 0.11, 10, 0.08);
-    const pack = new THREE.Mesh(new THREE.BoxGeometry(0.28, 0.32, 0.16), mapped(leatherTexture(), 0x4a3218, 0.8));
-    pack.position.set(0, 0.28, -0.22);
-    built.parts.chest.add(pack);
     return built;
 }
 
-export function buildTeco() {
-    const group = new THREE.Group();
-    const fur = std(0x6a4a2a, 0.9);
-    const dark = std(0x3a2a18, 0.88);
-    const face = std(0xe0b090, 0.65);
+export function buildRavi(scene) {
+    const built = buildHumanoid({
+        scene,
+        height: 1.05,
+        thin: 0.95,
+        skinColor: new BABYLON.Color3(0.9, 0.76, 0.6),
+        hairColor: new BABYLON.Color3(0.85, 0.75, 0.5),
+        shirtColor: new BABYLON.Color3(0.22, 0.35, 0.55),
+        pantsColor: new BABYLON.Color3(0.3, 0.22, 0.16),
+        bootColor: new BABYLON.Color3(0.35, 0.22, 0.14)
+    });
 
-    const hips = nameBone(new THREE.Group(), 'hips');
-    group.add(hips);
-    const body = new THREE.Mesh(new THREE.SphereGeometry(0.12, 12, 10), fur);
-    body.scale.set(0.9, 1.15, 0.8);
-    body.position.y = 0.22;
-    hips.add(body);
+    const blanket = BABYLON.MeshBuilder.CreateBox('raviBlanket', { width: 0.55, height: 0.08, depth: 0.7 }, scene);
+    blanket.position.set(0, 0.4, 0.05);
+    const bMat = new BABYLON.StandardMaterial('blanketMat', scene);
+    bMat.diffuseColor = new BABYLON.Color3(0.42, 0.16, 0.16);
+    blanket.material = bMat;
+    blanket.parent = built.root;
 
-    const chest = nameBone(new THREE.Group(), 'chest');
-    chest.position.y = 0.28;
-    hips.add(chest);
-
-    const head = nameBone(new THREE.Group(), 'head');
-    head.position.y = 0.16;
-    chest.add(head);
-    const skull = new THREE.Mesh(new THREE.SphereGeometry(0.09, 12, 10), fur);
-    head.add(skull);
-    const muzzle = new THREE.Mesh(new THREE.SphereGeometry(0.05, 10, 8), face);
-    muzzle.scale.set(1, 0.8, 1.2);
-    muzzle.position.set(0, -0.02, 0.07);
-    head.add(muzzle);
-    addEyes(head, face, 0.03, 0x221808);
-    for (const s of [-1, 1]) {
-        const ear = new THREE.Mesh(new THREE.SphereGeometry(0.035, 8, 6), fur);
-        ear.position.set(s * 0.08, 0.06, 0);
-        head.add(ear);
-    }
-
-    const armL = nameBone(new THREE.Group(), 'armL');
-    const armR = nameBone(new THREE.Group(), 'armR');
-    armL.position.set(-0.12, 0.06, 0);
-    armR.position.set(0.12, 0.06, 0);
-    chest.add(armL, armR);
-    for (const arm of [armL, armR]) {
-        const m = new THREE.Mesh(new THREE.CylinderGeometry(0.025, 0.02, 0.22, 6), fur);
-        m.position.y = -0.1;
-        arm.add(m);
-        const hand = new THREE.Mesh(new THREE.SphereGeometry(0.03, 6, 5), dark);
-        hand.position.y = -0.22;
-        arm.add(hand);
-        arm.userData.hand = hand;
-    }
-
-    const legL = nameBone(new THREE.Group(), 'legL');
-    const legR = nameBone(new THREE.Group(), 'legR');
-    legL.position.set(-0.06, 0.12, 0);
-    legR.position.set(0.06, 0.12, 0);
-    hips.add(legL, legR);
-    for (const leg of [legL, legR]) {
-        const m = new THREE.Mesh(new THREE.CylinderGeometry(0.028, 0.022, 0.18, 6), fur);
-        m.position.y = -0.08;
-        leg.add(m);
-        const foot = new THREE.Mesh(new THREE.SphereGeometry(0.03, 6, 5), dark);
-        foot.scale.set(1, 0.6, 1.4);
-        foot.position.set(0, -0.18, 0.02);
-        leg.add(foot);
-    }
-
-    const tail = nameBone(new THREE.Group(), 'tail');
-    tail.position.set(0, 0.16, -0.1);
-    hips.add(tail);
-    const tailM = new THREE.Mesh(new THREE.CylinderGeometry(0.018, 0.01, 0.32, 6), fur);
-    tailM.rotation.x = 0.9;
-    tailM.position.set(0, 0.05, -0.12);
-    tail.add(tailM);
-
-    const parts = { hips, chest, head, armL, armR, legL, legR, tail, group };
-    const clips = makeClips(parts);
-    const extra = [
-        new THREE.NumberKeyframeTrack('tail.rotation[1]', [0, 0.4, 0.8], [0.4, -0.4, 0.4])
-    ];
-    clips.Climb = new THREE.AnimationClip('Climb', 0.6, [
-        new THREE.NumberKeyframeTrack('armL.rotation[0]', [0, 0.3, 0.6], [0.8, -0.8, 0.8]),
-        new THREE.NumberKeyframeTrack('armR.rotation[0]', [0, 0.3, 0.6], [-0.8, 0.8, -0.8]),
-        new THREE.NumberKeyframeTrack('legL.rotation[0]', [0, 0.3, 0.6], [-0.5, 0.5, -0.5])
-    ]);
-    clips.Grab = new THREE.AnimationClip('Grab', 0.5, extra);
-    clips.Shoulder = clips.Idle;
-    clips.Scared = new THREE.AnimationClip('Scared', 0.4, [
-        new THREE.NumberKeyframeTrack('head.rotation[0]', [0, 0.2, 0.4], [0.2, -0.1, 0.2])
-    ]);
-    clips.Celebrate = new THREE.AnimationClip('Celebrate', 0.6, [
-        new THREE.NumberKeyframeTrack('armL.rotation[0]', [0, 0.3, 0.6], [-1.2, -0.2, -1.2]),
-        new THREE.NumberKeyframeTrack('armR.rotation[0]', [0, 0.3, 0.6], [-0.2, -1.2, -0.2])
-    ]);
-    enableShadows(group);
-    group.userData.parts = parts;
-    group.userData.clips = clips;
-    return { group, parts, clips };
+    built.parts.blanket = blanket;
+    return built;
 }
 
-export function buildTiger() {
-    const group = new THREE.Group();
-    const orange = std(0xc45a18, 0.75);
-    const white = std(0xeee6d6, 0.8);
-    const black = std(0x1a120c, 0.85);
+export function buildCamila(scene) {
+    const built = buildHumanoid({
+        scene,
+        height: 1.68,
+        thin: 0.9,
+        skinColor: new BABYLON.Color3(0.94, 0.78, 0.65),
+        hairColor: new BABYLON.Color3(0.9, 0.82, 0.52),
+        shirtColor: new BABYLON.Color3(0.8, 0.72, 0.84),
+        pantsColor: new BABYLON.Color3(0.55, 0.42, 0.6),
+        bootColor: new BABYLON.Color3(0.35, 0.22, 0.28)
+    });
 
-    const body = new THREE.Mesh(new THREE.CapsuleGeometry(0.38, 1.15, 8, 12), orange);
-    body.rotation.z = Math.PI / 2;
-    body.position.set(0, 0.55, 0);
-    group.add(body);
+    const parts = built.parts;
 
-    const belly = new THREE.Mesh(new THREE.CapsuleGeometry(0.22, 0.9, 6, 10), white);
-    belly.rotation.z = Math.PI / 2;
-    belly.position.set(0, 0.38, 0.05);
-    group.add(belly);
+    // Cabelo longo da princesa
+    const hair = BABYLON.MeshBuilder.CreateCapsule('camilaHair', { radius: 0.12, height: 0.45 }, scene);
+    hair.position.set(0, 0.02, -0.04);
+    hair.material = parts.hairMat;
+    hair.parent = parts.head;
 
-    const head = nameBone(new THREE.Group(), 'head');
-    head.position.set(0.85, 0.62, 0);
-    group.add(head);
-    const skull = new THREE.Mesh(new THREE.SphereGeometry(0.28, 12, 10), orange);
-    skull.scale.set(1.15, 0.9, 0.85);
-    head.add(skull);
-    const muzzle = new THREE.Mesh(new THREE.SphereGeometry(0.14, 10, 8), white);
-    muzzle.position.set(0.18, -0.04, 0);
-    head.add(muzzle);
-    const nose = new THREE.Mesh(new THREE.SphereGeometry(0.05, 8, 6), black);
-    nose.position.set(0.3, 0.02, 0);
-    head.add(nose);
+    // Vestido
+    const dress = BABYLON.MeshBuilder.CreateCylinder('camilaDress', {
+        diameterTop: 0.35,
+        diameterBottom: 0.65,
+        height: 0.7,
+        tessellation: 10
+    }, scene);
+    dress.position.y = 0.55;
+    const dressMat = new BABYLON.StandardMaterial('dressMat', scene);
+    dressMat.diffuseColor = new BABYLON.Color3(0.8, 0.72, 0.84);
+    dress.material = dressMat;
+    dress.parent = parts.hips;
+
+    // Grilhões nos pulsos
+    const shackles = new BABYLON.TransformNode('camilaShackles', scene);
+    shackles.parent = parts.hips;
+
+    const shackleMat = new BABYLON.StandardMaterial('shackleMat', scene);
+    shackleMat.diffuseColor = new BABYLON.Color3(0.5, 0.5, 0.5);
+
+    const leftRing = BABYLON.MeshBuilder.CreateTorus('leftRing', { diameter: 0.1, thickness: 0.024 }, scene);
+    leftRing.position.set(-0.12, 0.9, 0.12);
+    leftRing.material = shackleMat;
+    leftRing.parent = shackles;
+
+    const rightRing = BABYLON.MeshBuilder.CreateTorus('rightRing', { diameter: 0.1, thickness: 0.024 }, scene);
+    rightRing.position.set(0.12, 0.9, 0.12);
+    rightRing.material = shackleMat;
+    rightRing.parent = shackles;
+
+    const chain = BABYLON.MeshBuilder.CreateCylinder('shackleChain', { diameter: 0.024, height: 0.24 }, scene);
+    chain.rotation.z = Math.PI / 2;
+    chain.position.set(0, 0.9, 0.12);
+    chain.material = shackleMat;
+    chain.parent = shackles;
+
+    parts.shackles = shackles;
+    return built;
+}
+
+export function buildGuard(scene, { fat = false, archer = false } = {}) {
+    const built = buildHumanoid({
+        scene,
+        height: fat ? 1.7 : 1.82,
+        thin: fat ? 1.35 : 1.08,
+        skinColor: new BABYLON.Color3(0.82, 0.62, 0.48),
+        hairColor: new BABYLON.Color3(0.2, 0.15, 0.1),
+        shirtColor: new BABYLON.Color3(0.35, 0.12, 0.12),
+        pantsColor: new BABYLON.Color3(0.16, 0.16, 0.14),
+        bootColor: new BABYLON.Color3(0.2, 0.15, 0.1)
+    });
+
+    const parts = built.parts;
+
+    // Elmo de ferro
+    const helm = BABYLON.MeshBuilder.CreateSphere('guardHelm', { diameter: 0.3, segments: 8 }, scene);
+    helm.position.y = 0.04;
+    const ironMat = new BABYLON.StandardMaterial('ironMat', scene);
+    ironMat.diffuseColor = new BABYLON.Color3(0.55, 0.55, 0.52);
+    ironMat.specularColor = new BABYLON.Color3(0.7, 0.7, 0.7);
+    helm.material = ironMat;
+    helm.parent = parts.head;
+
+    if (fat) {
+        const belly = BABYLON.MeshBuilder.CreateSphere('guardBelly', { diameter: 0.56, segments: 8 }, scene);
+        belly.position.y = 0.12;
+        const tunicMat = new BABYLON.StandardMaterial('tunicMat', scene);
+        tunicMat.diffuseColor = new BABYLON.Color3(0.35, 0.12, 0.12);
+        belly.material = tunicMat;
+        belly.parent = parts.chest;
+    }
+
+    // Lança ou Arco
+    const spear = new BABYLON.TransformNode('guardSpear', scene);
+    spear.parent = parts.armR.userData.hand;
+    spear.position.set(0.05, -0.2, 0.1);
+
+    const shaft = BABYLON.MeshBuilder.CreateCylinder('spearShaft', { diameter: 0.036, height: 1.6 }, scene);
+    const woodM = new BABYLON.StandardMaterial('spearWood', scene);
+    woodM.diffuseColor = new BABYLON.Color3(0.35, 0.22, 0.1);
+    shaft.material = woodM;
+    shaft.parent = spear;
+
+    const tip = BABYLON.MeshBuilder.CreateCylinder('spearTip', { diameterTop: 0, diameterBottom: 0.08, height: 0.16 }, scene);
+    tip.position.y = 0.86;
+    tip.material = ironMat;
+    tip.parent = spear;
+
+    if (archer) {
+        spear.setEnabled(false);
+        const bow = BABYLON.MeshBuilder.CreateTorus('guardBow', {
+            diameter: 0.56,
+            thickness: 0.036,
+            tessellation: 12
+        }, scene);
+        bow.rotation.y = Math.PI / 2;
+        bow.material = woodM;
+        bow.parent = parts.armL;
+    }
+
+    // Molho de chaves na cintura
+    const keys = new BABYLON.TransformNode('guardKeys', scene);
+    keys.parent = parts.hips;
+    const goldKeyMat = new BABYLON.StandardMaterial('goldKeyMat', scene);
+    goldKeyMat.diffuseColor = new BABYLON.Color3(0.8, 0.65, 0.15);
+
+    for (let i = 0; i < 3; i++) {
+        const k = BABYLON.MeshBuilder.CreateBox(`guardKey_${i}`, { width: 0.04, height: 0.12, depth: 0.02 }, scene);
+        k.position.set(0.08, 0.7 + i * 0.02, 0.14);
+        k.rotation.z = 0.3 * i;
+        k.material = goldKeyMat;
+        k.parent = keys;
+    }
+    keys.setEnabled(fat);
+
+    parts.keys = keys;
+    parts.spear = spear;
+    return built;
+}
+
+export function buildFriend(scene, variant = 0) {
+    const palettes = [
+        { shirt: new BABYLON.Color3(0.22, 0.3, 0.22), pants: new BABYLON.Color3(0.16, 0.13, 0.1), hair: new BABYLON.Color3(0.22, 0.14, 0.08) },
+        { shirt: new BABYLON.Color3(0.22, 0.22, 0.35), pants: new BABYLON.Color3(0.16, 0.16, 0.13), hair: new BABYLON.Color3(0.1, 0.1, 0.08) },
+        { shirt: new BABYLON.Color3(0.35, 0.22, 0.16), pants: new BABYLON.Color3(0.22, 0.16, 0.1), hair: new BABYLON.Color3(0.4, 0.28, 0.14) }
+    ];
+    const p = palettes[variant % 3];
+    const built = buildHumanoid({
+        scene,
+        height: 1.78 + variant * 0.04,
+        thin: 1,
+        shirtColor: p.shirt,
+        pantsColor: p.pants,
+        hairColor: p.hair
+    });
+
+    const pack = BABYLON.MeshBuilder.CreateBox('friendPack', { width: 0.28, height: 0.32, depth: 0.16 }, scene);
+    pack.position.set(0, 0.28, -0.22);
+    const packMat = new BABYLON.StandardMaterial('packMat', scene);
+    packMat.diffuseColor = new BABYLON.Color3(0.28, 0.2, 0.1);
+    pack.material = packMat;
+    pack.parent = built.parts.chest;
+
+    return built;
+}
+
+export function buildTeco(scene) {
+    const root = new BABYLON.TransformNode('tecoRoot', scene);
+
+    const furMat = new BABYLON.StandardMaterial('tecoFurMat', scene);
+    furMat.diffuseColor = new BABYLON.Color3(0.42, 0.28, 0.16);
+
+    const darkMat = new BABYLON.StandardMaterial('tecoDarkMat', scene);
+    darkMat.diffuseColor = new BABYLON.Color3(0.22, 0.16, 0.1);
+
+    const faceMat = new BABYLON.StandardMaterial('tecoFaceMat', scene);
+    faceMat.diffuseColor = new BABYLON.Color3(0.88, 0.7, 0.56);
+
+    // Hips
+    const hips = new BABYLON.TransformNode('hips', scene);
+    hips.parent = root;
+
+    const body = BABYLON.MeshBuilder.CreateSphere('tecoBody', { diameter: 0.24, segments: 8 }, scene);
+    body.scaling.set(0.9, 1.15, 0.8);
+    body.position.y = 0.22;
+    body.material = furMat;
+    body.parent = hips;
+
+    const chest = new BABYLON.TransformNode('chest', scene);
+    chest.position.y = 0.28;
+    chest.parent = hips;
+
+    const head = new BABYLON.TransformNode('head', scene);
+    head.position.y = 0.16;
+    head.parent = chest;
+
+    const skull = BABYLON.MeshBuilder.CreateSphere('tecoSkull', { diameter: 0.18, segments: 8 }, scene);
+    skull.material = furMat;
+    skull.parent = head;
+
+    const muzzle = BABYLON.MeshBuilder.CreateSphere('tecoMuzzle', { diameter: 0.1, segments: 6 }, scene);
+    muzzle.scaling.set(1, 0.8, 1.2);
+    muzzle.position.set(0, -0.02, 0.07);
+    muzzle.material = faceMat;
+    muzzle.parent = head;
+
     for (const s of [-1, 1]) {
-        const ear = new THREE.Mesh(new THREE.ConeGeometry(0.08, 0.12, 6), orange);
-        ear.position.set(-0.05, 0.24, s * 0.14);
-        head.add(ear);
-        const eye = new THREE.Mesh(new THREE.SphereGeometry(0.035, 8, 6), std(0x1a3a08, 0.3));
-        eye.position.set(0.16, 0.08, s * 0.12);
-        head.add(eye);
+        const ear = BABYLON.MeshBuilder.CreateSphere('tecoEar', { diameter: 0.07, segments: 6 }, scene);
+        ear.position.set(s * 0.08, 0.06, 0);
+        ear.material = furMat;
+        ear.parent = head;
+
+        const eye = BABYLON.MeshBuilder.CreateSphere('tecoEye', { diameter: 0.025, segments: 6 }, scene);
+        eye.position.set(s * 0.03, 0.02, 0.09);
+        eye.material = darkMat;
+        eye.parent = head;
     }
 
-    for (const [x, z] of [[-0.35, 0.22], [-0.35, -0.22], [0.35, 0.22], [0.35, -0.22]]) {
-        const leg = new THREE.Mesh(new THREE.CylinderGeometry(0.09, 0.07, 0.45, 8), orange);
-        leg.position.set(x, 0.22, z);
-        group.add(leg);
-        const paw = new THREE.Mesh(new THREE.SphereGeometry(0.1, 8, 6), black);
-        paw.scale.set(1, 0.5, 1.2);
-        paw.position.set(x, 0.04, z);
-        group.add(paw);
+    // Braços
+    const armL = new BABYLON.TransformNode('armL', scene);
+    const armR = new BABYLON.TransformNode('armR', scene);
+    armL.position.set(-0.12, 0.06, 0);
+    armR.position.set(0.12, 0.06, 0);
+    armL.parent = chest;
+    armR.parent = chest;
+
+    for (const arm of [armL, armR]) {
+        const limb = BABYLON.MeshBuilder.CreateCylinder('tecoArmMesh', { diameter: 0.045, height: 0.22 }, scene);
+        limb.position.y = -0.1;
+        limb.material = furMat;
+        limb.parent = arm;
+
+        const hand = BABYLON.MeshBuilder.CreateSphere('tecoHand', { diameter: 0.06, segments: 6 }, scene);
+        hand.position.y = -0.22;
+        hand.material = darkMat;
+        hand.parent = arm;
     }
 
-    const tail = nameBone(new THREE.Group(), 'tail');
-    tail.position.set(-0.75, 0.7, 0);
-    group.add(tail);
-    const tailM = new THREE.Mesh(new THREE.CylinderGeometry(0.05, 0.03, 0.9, 6), orange);
-    tailM.rotation.z = 0.8;
-    tailM.position.set(-0.25, 0.2, 0);
-    tail.add(tailM);
+    // Pernas
+    const legL = new BABYLON.TransformNode('legL', scene);
+    const legR = new BABYLON.TransformNode('legR', scene);
+    legL.position.set(-0.06, 0.12, 0);
+    legR.position.set(0.06, 0.12, 0);
+    legL.parent = hips;
+    legR.parent = hips;
 
-    for (let i = 0; i < 12; i++) {
-        const stripe = new THREE.Mesh(new THREE.BoxGeometry(0.06, 0.42, 0.55), black);
-        stripe.position.set(-0.4 + i * 0.12, 0.62, 0);
-        stripe.rotation.y = 0.15;
-        group.add(stripe);
+    for (const leg of [legL, legR]) {
+        const limb = BABYLON.MeshBuilder.CreateCylinder('tecoLegMesh', { diameter: 0.05, height: 0.18 }, scene);
+        limb.position.y = -0.08;
+        limb.material = furMat;
+        limb.parent = leg;
+
+        const foot = BABYLON.MeshBuilder.CreateSphere('tecoFoot', { diameter: 0.06, segments: 6 }, scene);
+        foot.scaling.set(1, 0.6, 1.4);
+        foot.position.set(0, -0.18, 0.02);
+        foot.material = darkMat;
+        foot.parent = leg;
     }
 
-    const parts = { head, tail, group };
+    // Cauda
+    const tail = new BABYLON.TransformNode('tail', scene);
+    tail.position.set(0, 0.16, -0.1);
+    tail.parent = hips;
+
+    const tailMesh = BABYLON.MeshBuilder.CreateCylinder('tecoTailMesh', {
+        diameterTop: 0.036,
+        diameterBottom: 0.02,
+        height: 0.32
+    }, scene);
+    tailMesh.rotation.x = 0.9;
+    tailMesh.position.set(0, 0.05, -0.12);
+    tailMesh.material = furMat;
+    tailMesh.parent = tail;
+
+    const parts = { hips, chest, head, armL, armR, legL, legR, tail, root };
     const clips = {
-        Idle: new THREE.AnimationClip('Idle', 2, [
-            new THREE.NumberKeyframeTrack('head.rotation[1]', [0, 1, 2], [0.1, -0.1, 0.1])
+        Idle: new ProceduralClip(2.0, [
+            { target: 'head', axis: 'y', amp: 0.15, phase: 0 },
+            { target: 'tail', axis: 'y', amp: 0.3, phase: 1 }
         ]),
-        Walk: new THREE.AnimationClip('Walk', 0.8, [
-            new THREE.NumberKeyframeTrack('head.rotation[0]', [0, 0.4, 0.8], [0.05, -0.05, 0.05])
+        Walk: new ProceduralClip(0.65, [
+            { target: 'legL', axis: 'x', amp: 0.6, phase: 0 },
+            { target: 'legR', axis: 'x', amp: 0.6, phase: Math.PI },
+            { target: 'armL', axis: 'x', amp: 0.5, phase: Math.PI },
+            { target: 'armR', axis: 'x', amp: 0.5, phase: 0 }
         ]),
-        Growl: new THREE.AnimationClip('Growl', 0.6, [
-            new THREE.NumberKeyframeTrack('head.rotation[0]', [0, 0.3, 0.6], [0, -0.25, 0])
+        Run: new ProceduralClip(0.45, [
+            { target: 'legL', axis: 'x', amp: 0.9, phase: 0 },
+            { target: 'legR', axis: 'x', amp: 0.9, phase: Math.PI },
+            { target: 'armL', axis: 'x', amp: 0.8, phase: Math.PI },
+            { target: 'armR', axis: 'x', amp: 0.8, phase: 0 }
         ]),
-        Jump: new THREE.AnimationClip('Jump', 0.5, [
-            new THREE.NumberKeyframeTrack('head.rotation[0]', [0, 0.25, 0.5], [-0.2, 0.3, -0.2])
+        Climb: new ProceduralClip(0.55, [
+            { target: 'armL', axis: 'x', amp: 0.8, phase: 0 },
+            { target: 'armR', axis: 'x', amp: 0.8, phase: Math.PI },
+            { target: 'legL', axis: 'x', amp: 0.5, phase: Math.PI }
+        ]),
+        Grab: new ProceduralClip(0.5, [
+            { target: 'armR', axis: 'x', amp: 0.6, phase: 0, base: -0.8 }
+        ]),
+        Shoulder: new ProceduralClip(2.0, [
+            { target: 'head', axis: 'y', amp: 0.2, phase: 0 }
+        ]),
+        Scared: new ProceduralClip(0.4, [
+            { target: 'head', axis: 'x', amp: 0.25, phase: 0, base: -0.2 }
+        ]),
+        Celebrate: new ProceduralClip(0.5, [
+            { target: 'armL', axis: 'x', amp: 0.6, phase: 0, base: -1.2 },
+            { target: 'armR', axis: 'x', amp: 0.6, phase: 0, base: -1.2 }
         ])
     };
-    enableShadows(group);
-    group.userData.parts = parts;
-    group.userData.clips = clips;
-    return { group, parts, clips };
+
+    root.userData = { parts, clips };
+    return { root, parts, clips };
+}
+
+export function buildTiger(scene) {
+    const root = new BABYLON.TransformNode('tigerRoot', scene);
+
+    const orangeMat = new BABYLON.StandardMaterial('tigerOrangeMat', scene);
+    orangeMat.diffuseColor = new BABYLON.Color3(0.85, 0.4, 0.1);
+
+    const whiteMat = new BABYLON.StandardMaterial('tigerWhiteMat', scene);
+    whiteMat.diffuseColor = new BABYLON.Color3(0.95, 0.92, 0.85);
+
+    const blackMat = new BABYLON.StandardMaterial('tigerBlackMat', scene);
+    blackMat.diffuseColor = new BABYLON.Color3(0.1, 0.08, 0.06);
+
+    const body = BABYLON.MeshBuilder.CreateCapsule('tigerBody', { radius: 0.38, height: 1.5 }, scene);
+    body.rotation.z = Math.PI / 2;
+    body.position.set(0, 0.55, 0);
+    body.material = orangeMat;
+    body.parent = root;
+
+    const belly = BABYLON.MeshBuilder.CreateCapsule('tigerBelly', { radius: 0.22, height: 1.1 }, scene);
+    belly.rotation.z = Math.PI / 2;
+    belly.position.set(0, 0.38, 0.05);
+    belly.material = whiteMat;
+    belly.parent = root;
+
+    const head = new BABYLON.TransformNode('head', scene);
+    head.position.set(0.85, 0.62, 0);
+    head.parent = root;
+
+    const skull = BABYLON.MeshBuilder.CreateSphere('tigerSkull', { diameter: 0.56, segments: 8 }, scene);
+    skull.scaling.set(1.15, 0.9, 0.85);
+    skull.material = orangeMat;
+    skull.parent = head;
+
+    const muzzle = BABYLON.MeshBuilder.CreateSphere('tigerMuzzle', { diameter: 0.28, segments: 6 }, scene);
+    muzzle.position.set(0.18, -0.04, 0);
+    muzzle.material = whiteMat;
+    muzzle.parent = head;
+
+    const nose = BABYLON.MeshBuilder.CreateSphere('tigerNose', { diameter: 0.1, segments: 6 }, scene);
+    nose.position.set(0.3, 0.02, 0);
+    nose.material = blackMat;
+    nose.parent = head;
+
+    for (const s of [-1, 1]) {
+        const ear = BABYLON.MeshBuilder.CreateCylinder('tigerEar', { diameterTop: 0, diameterBottom: 0.16, height: 0.12 }, scene);
+        ear.position.set(-0.05, 0.24, s * 0.14);
+        ear.material = orangeMat;
+        ear.parent = head;
+
+        const eye = BABYLON.MeshBuilder.CreateSphere('tigerEye', { diameter: 0.07, segments: 6 }, scene);
+        eye.position.set(0.16, 0.08, s * 0.12);
+        const tigerEyeMat = new BABYLON.StandardMaterial('tigerEyeMat', scene);
+        tigerEyeMat.diffuseColor = new BABYLON.Color3(0.2, 0.6, 0.1);
+        eye.material = tigerEyeMat;
+        eye.parent = head;
+    }
+
+    // 4 Patas
+    for (const [x, z] of [[-0.35, 0.22], [-0.35, -0.22], [0.35, 0.22], [0.35, -0.22]]) {
+        const leg = BABYLON.MeshBuilder.CreateCylinder('tigerLeg', { diameter: 0.16, height: 0.45 }, scene);
+        leg.position.set(x, 0.22, z);
+        leg.material = orangeMat;
+        leg.parent = root;
+
+        const paw = BABYLON.MeshBuilder.CreateSphere('tigerPaw', { diameter: 0.2, segments: 6 }, scene);
+        paw.scaling.set(1, 0.5, 1.2);
+        paw.position.set(x, 0.04, z);
+        paw.material = blackMat;
+        paw.parent = root;
+    }
+
+    // Cauda
+    const tail = new BABYLON.TransformNode('tail', scene);
+    tail.position.set(-0.75, 0.7, 0);
+    tail.parent = root;
+
+    const tailMesh = BABYLON.MeshBuilder.CreateCylinder('tigerTailMesh', { diameter: 0.08, height: 0.9 }, scene);
+    tailMesh.rotation.z = 0.8;
+    tailMesh.position.set(-0.25, 0.2, 0);
+    tailMesh.material = orangeMat;
+    tailMesh.parent = tail;
+
+    // Listras pretas
+    for (let i = 0; i < 10; i++) {
+        const stripe = BABYLON.MeshBuilder.CreateBox(`stripe_${i}`, { width: 0.06, height: 0.42, depth: 0.55 }, scene);
+        stripe.position.set(-0.4 + i * 0.12, 0.62, 0);
+        stripe.rotation.y = 0.15;
+        stripe.material = blackMat;
+        stripe.parent = root;
+    }
+
+    const parts = { head, tail, root };
+    const clips = {
+        Idle: new ProceduralClip(2.0, [
+            { target: 'head', axis: 'y', amp: 0.15, phase: 0 },
+            { target: 'tail', axis: 'z', amp: 0.25, phase: 1 }
+        ]),
+        Walk: new ProceduralClip(0.8, [
+            { target: 'head', axis: 'x', amp: 0.08, phase: 0 },
+            { target: 'tail', axis: 'z', amp: 0.4, phase: 0 }
+        ]),
+        Growl: new ProceduralClip(0.6, [
+            { target: 'head', axis: 'x', amp: 0.2, phase: 0, base: -0.15 }
+        ]),
+        Jump: new ProceduralClip(0.5, [
+            { target: 'head', axis: 'x', amp: 0.3, phase: 0, base: 0.2 }
+        ])
+    };
+
+    root.userData = { parts, clips };
+    return { root, parts, clips };
 }
 
 export function applyLocomotion(animator, speed, crouch, grounded, attacking, blocking, interacting) {

--- a/labs/guerreiro-castelo/js/core/AssetManager.js
+++ b/labs/guerreiro-castelo/js/core/AssetManager.js
@@ -1,64 +1,16 @@
 /**
- * Carrega GLB/texturas via THREE.LoadingManager.
- * Se o arquivo não existir, devolve null e o chamador usa fallback procedural.
+ * Gerenciador de assets para Babylon.js.
+ * Utiliza fallback procedural total integrado com Babylon.js.
  */
-
-import * as THREE from 'three';
-import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
-import { DRACOLoader } from 'three/addons/loaders/DRACOLoader.js';
-import { ASSETS } from './assets.js';
 
 export class AssetManager {
     constructor() {
-        this.manager = new THREE.LoadingManager();
-        this.gltf = new GLTFLoader(this.manager);
-        const draco = new DRACOLoader(this.manager);
-        draco.setDecoderPath('https://cdn.jsdelivr.net/npm/three@0.185.1/examples/jsm/libs/draco/');
-        this.gltf.setDRACOLoader(draco);
-        this.tex = new THREE.TextureLoader(this.manager);
         this.cache = new Map();
         this.progress = 0;
-        this.failed = [];
-        this.manager.onProgress = (_url, loaded, total) => {
-            this.progress = total ? loaded / total : 1;
-            this.onProgress?.(this.progress);
-        };
-        this.manager.onError = (url) => {
-            console.warn('[AssetManager] falhou:', url);
-            this.failed.push(url);
-        };
-    }
-
-    async loadTexture(url) {
-        if (this.cache.has(url)) return this.cache.get(url);
-        try {
-            const tex = await this.tex.loadAsync(url);
-            tex.colorSpace = THREE.SRGBColorSpace;
-            this.cache.set(url, tex);
-            return tex;
-        } catch (err) {
-            console.warn('[AssetManager] textura indisponível:', url, err?.message || err);
-            this.cache.set(url, null);
-            return null;
-        }
-    }
-
-    async tryGltf(key) {
-        const url = ASSETS[key];
-        if (!url) return null;
-        if (this.cache.has(url)) return this.cache.get(url);
-        try {
-            const gltf = await this.gltf.loadAsync(url);
-            this.cache.set(url, gltf);
-            return gltf;
-        } catch {
-            this.cache.set(url, null);
-            return null;
-        }
     }
 
     async preloadEssential(onProgress) {
-        this.onProgress = onProgress;
+        onProgress?.(1);
         return { waterNormals: null };
     }
 }

--- a/labs/guerreiro-castelo/js/core/AudioManager.js
+++ b/labs/guerreiro-castelo/js/core/AudioManager.js
@@ -1,9 +1,8 @@
 /**
- * Áudio procedural — categorias master/music/ambient/sfx/dialogue.
- * THREE.AudioListener é anexado à câmera; SFX posicionais usam PositionalAudio.
+ * Áudio procedural via Web Audio API puro — sem dependência de engine gráfica.
+ * Temas musicais dinâmicos por estágio, SFX táteis, passos e áudio posicional.
  */
 
-import * as THREE from 'three';
 import { clamp } from '../utils/math.js';
 
 const THEMES = {
@@ -21,7 +20,6 @@ const THEMES = {
 
 export class AudioManager {
     constructor() {
-        this.listener = new THREE.AudioListener();
         this.ctx = null;
         this.master = null;
         this.buses = {};
@@ -31,7 +29,6 @@ export class AudioManager {
         this._t = 0;
         this._step = 0;
         this._enabled = false;
-        this._ambients = [];
     }
 
     async unlock() {
@@ -41,7 +38,7 @@ export class AudioManager {
         }
         const Ctx = window.AudioContext || window.webkitAudioContext;
         if (!Ctx) return;
-        this.ctx = this.listener.context || new Ctx();
+        this.ctx = new Ctx();
         this.master = this.ctx.createGain();
         this.master.gain.value = this.muted ? 0 : this.volume.master;
         this.master.connect(this.ctx.destination);
@@ -71,14 +68,13 @@ export class AudioManager {
         this._enabled = true;
     }
 
-    attach(camera) {
-        if (this.listener.parent) this.listener.parent.remove(this.listener);
-        camera.add(this.listener);
+    attach() {
+        // Nativo Web Audio Listener
     }
 
     setMuted(muted) {
         this.muted = muted;
-        if (this.master) {
+        if (this.master && this.ctx) {
             this.master.gain.setTargetAtTime(muted ? 0 : this.volume.master, this.ctx.currentTime, 0.05);
         }
     }
@@ -132,7 +128,6 @@ export class AudioManager {
             this._step -= 1;
             this._note(theme);
         }
-        for (const amb of this._ambients) amb(this._t, dt);
     }
 
     _note(theme) {
@@ -149,7 +144,7 @@ export class AudioManager {
     }
 
     tone(freq, dur = 0.2, type = 'sine', gain = 0.12, bus = 'sfx') {
-        if (!this._enabled || this.muted) return;
+        if (!this._enabled || this.muted || !this.ctx) return;
         const osc = this.ctx.createOscillator();
         osc.type = type;
         osc.frequency.value = freq;
@@ -162,7 +157,7 @@ export class AudioManager {
     }
 
     noise(dur = 0.3, gain = 0.08, bus = 'sfx') {
-        if (!this._enabled || this.muted) return;
+        if (!this._enabled || this.muted || !this.ctx) return;
         const n = this.ctx.createBuffer(1, this.ctx.sampleRate * dur, this.ctx.sampleRate);
         const data = n.getChannelData(0);
         for (let i = 0; i < data.length; i++) data[i] = Math.random() * 2 - 1;

--- a/labs/guerreiro-castelo/js/core/Game.js
+++ b/labs/guerreiro-castelo/js/core/Game.js
@@ -1,416 +1,255 @@
 /**
- * Orquestrador: renderer, loop, estágios, fade, pause, checkpoints.
+ * Engine principal do jogo em Babylon.js.
+ * Orquestra ciclo de renderização, física, IA, áudio, HUD e transições de fases.
  */
 
-import * as THREE from 'three';
-import { EffectComposer } from 'three/addons/postprocessing/EffectComposer.js';
-import { RenderPass } from 'three/addons/postprocessing/RenderPass.js';
-import { UnrealBloomPass } from 'three/addons/postprocessing/UnrealBloomPass.js';
-import { OutputPass } from 'three/addons/postprocessing/OutputPass.js';
-
 import { QUALITY } from './QualitySettings.js';
-import { SETTINGS_KEY } from './assets.js';
 import { AssetManager } from './AssetManager.js';
-import { InputManager } from './InputManager.js';
 import { AudioManager } from './AudioManager.js';
-import { SceneManager, CHECKPOINT_STAGE } from './SceneManager.js';
-import { Player } from '../player/Player.js';
-import { ThirdPersonCamera } from '../player/ThirdPersonCamera.js';
-import { Teco } from '../characters/Teco.js';
-import { Camila } from '../characters/Camila.js';
-import { QuestManager } from '../game/QuestManager.js';
-import { InteractionSystem } from '../game/InteractionSystem.js';
-import { CombatSystem } from '../game/CombatSystem.js';
-import { CheckpointManager } from '../game/CheckpointManager.js';
-import { DialogueManager } from '../game/DialogueManager.js';
-import { CutsceneManager } from '../game/CutsceneManager.js';
-import { StoryDirector } from '../game/StoryDirector.js';
+import { InputManager } from './InputManager.js';
 import { CollisionWorld } from '../world/CollisionWorld.js';
+import { WeatherSystem } from '../world/WeatherSystem.js';
 import { Ocean } from '../world/Ocean.js';
 import { StormController } from '../world/StormController.js';
-import { WeatherSystem } from '../world/WeatherSystem.js';
 import { ArrowSystem } from '../world/ArrowSystem.js';
+import { InteractionSystem } from '../game/InteractionSystem.js';
+import { CutsceneManager } from '../game/CutsceneManager.js';
+import { DialogueManager } from '../game/DialogueManager.js';
+import { QuestManager } from '../game/QuestManager.js';
+import { CombatSystem } from '../game/CombatSystem.js';
+import { CheckpointManager } from '../game/CheckpointManager.js';
+import { StoryDirector } from '../game/StoryDirector.js';
+import { SceneManager, CHECKPOINT_STAGE } from './SceneManager.js';
+import { ThirdPersonCamera } from '../player/ThirdPersonCamera.js';
+import { Player } from '../player/Player.js';
+import { Teco } from '../characters/Teco.js';
+import { Camila } from '../characters/Camila.js';
 import { HUD } from '../ui/HUD.js';
 import { Menu } from '../ui/Menu.js';
 import { PauseMenu } from '../ui/PauseMenu.js';
-import { clamp, detectMobile, detectSoftwareGL } from '../utils/math.js';
+import { SETTINGS_KEY } from './assets.js';
 
 export class Game {
-    constructor() {
-        this.canvas = document.getElementById('scene');
-        this.hud = new HUD();
-        this.checkpoints = new CheckpointManager();
-        this.quests = new QuestManager();
-        this.dialogue = new DialogueManager();
-        this.combat = new CombatSystem();
-        this.collision = new CollisionWorld();
-        this.assets = new AssetManager();
-        this.audio = new AudioManager();
-        this.input = new InputManager(this.canvas);
-        this.story = new StoryDirector(this);
-        this.inventory = { keys: 0, cellKey: false };
-        this.settings = this.loadSettings();
-        this.state = 'boot';
+    constructor(canvas) {
+        this.canvas = canvas;
+        this.engine = null;
+        this.scene = null;
+        this.camera = null;
+        this.cameraRig = null;
+        this.quality = QUALITY.high;
         this.paused = false;
-        this.fade = 1;
-        this.fadeTarget = 1;
-        this.fadeCb = null;
-        this.clockTime = 0;
-        this.fpsAccum = 0;
-        this.fpsFrames = 0;
+        this.running = false;
+        this.inventory = { keys: 0, cellKey: false };
         this.stageId = null;
-        this.levels = [];
-        this.level = null;
-        this._failing = false;
-    }
-
-    loadSettings() {
-        const fallback = { quality: 'high', master: 0.75, music: 0.55, muted: false };
-        try {
-            const raw = localStorage.getItem(SETTINGS_KEY);
-            return raw ? { ...fallback, ...JSON.parse(raw) } : fallback;
-        } catch {
-            return fallback;
-        }
-    }
-
-    saveSettings() {
-        try {
-            localStorage.setItem(SETTINGS_KEY, JSON.stringify(this.settings));
-        } catch { /* privado */ }
-    }
-
-    resolveQuality() {
-        let id = this.settings.quality;
-        if (id === 'auto') {
-            if (detectMobile() || detectSoftwareGL()) id = 'low';
-            else id = 'high';
-        }
-        return QUALITY[id] || QUALITY.high;
+        this.lastTime = 0;
     }
 
     async init() {
-        this.hud.setLoading(0.08, 'Preparando o mar…');
-        this.quality = this.resolveQuality();
+        this._loadSettings();
 
-        this.renderer = new THREE.WebGLRenderer({
-            canvas: this.canvas,
-            antialias: this.quality.aa,
-            powerPreference: 'high-performance'
+        // Inicializar Babylon.js Engine e Scene
+        const antialias = this.quality.aa !== false;
+        this.engine = new BABYLON.Engine(this.canvas, antialias, {
+            preserveDrawingBuffer: true,
+            stencil: true,
+            adaptToDeviceRatio: true
         });
-        this.renderer.setPixelRatio(Math.min(window.devicePixelRatio, this.quality.pixelRatio));
-        this.renderer.setSize(window.innerWidth, window.innerHeight);
-        this.renderer.setClearColor(0x87b8d0, 1);
-        this.renderer.shadowMap.enabled = this.quality.id !== 'low';
-        this.renderer.shadowMap.type = THREE.PCFSoftShadowMap;
-        this.renderer.outputColorSpace = THREE.SRGBColorSpace;
-        this.renderer.toneMapping = THREE.ACESFilmicToneMapping;
-        this.renderer.toneMappingExposure = 1;
 
-        this.scene = new THREE.Scene();
-        this.camera = new THREE.PerspectiveCamera(55, window.innerWidth / window.innerHeight, 0.12, this.quality.far);
+        this.scene = new BABYLON.Scene(this.engine);
+        this.scene.clearColor = new BABYLON.Color4(0.02, 0.03, 0.05, 1);
+
+        // Câmera Universal controlada manualmente pelo ThirdPersonCamera rig
+        this.camera = new BABYLON.UniversalCamera('mainCamera', new BABYLON.Vector3(0, 2, 6), this.scene);
+        this.camera.minZ = 0.1;
+        this.camera.maxZ = this.quality.far || 500;
+        this.camera.fov = 0.95;
+        this.scene.activeCamera = this.camera;
+
         this.cameraRig = new ThirdPersonCamera(this.camera, this.scene);
-        this.cutscenes = new CutsceneManager(this.cameraRig);
-        this.interact = new InteractionSystem(this.camera);
-        this.audio.attach(this.camera);
 
-        this.weather = new WeatherSystem(this.scene, this.renderer);
-        this.weather.setShadowSize(this.quality.shadows);
-        this.hud.setLoading(0.28, 'Ondas e céu…');
-
-        const essential = await this.assets.preloadEssential((p) => this.hud.setLoading(0.28 + p * 0.4, 'Carregando…'));
-        this.ocean = new Ocean(this.scene, essential.waterNormals, this.quality);
+        // Sistemas centrais
+        this.assets = new AssetManager();
+        this.audio = new AudioManager();
+        this.input = new InputManager(this.canvas);
+        this.collision = new CollisionWorld();
+        this.weather = new WeatherSystem(this.scene, this.quality);
+        this.ocean = new Ocean(this.scene, this.quality);
         this.storm = new StormController(this.scene, this.quality);
         this.arrows = new ArrowSystem(this.scene);
+        this.interact = new InteractionSystem(this.camera);
+        this.cutscenes = new CutsceneManager(this.cameraRig);
+        this.dialogue = new DialogueManager(this);
+        this.quests = new QuestManager(this);
+        this.combat = new CombatSystem();
+        this.checkpoints = new CheckpointManager();
+        this.story = new StoryDirector(this);
+        this.sceneMgr = new SceneManager(this);
 
+        // Atores principais
         this.player = new Player(this.scene, this.collision);
         this.teco = new Teco(this.scene);
         this.camila = new Camila(this.scene);
-        this.player.root.visible = false;
-        this.teco.root.visible = false;
-        this.camila.root.visible = false;
-        this.scenes = new SceneManager(this);
 
-        this._setupComposer();
+        // UI
+        this.hud = new HUD(this);
         this.menu = new Menu(this);
         this.pauseMenu = new PauseMenu(this);
-        this._bindSettings();
-        window.addEventListener('resize', () => this.onResize());
-        this.quests.onChange = (q) => this.hud.showObjective(q.text, q.id === 'flee');
 
-        this.hud.setLoading(1, 'Pronto');
-        this.hud.hideLoading();
-        this.state = 'menu';
-        this.menu.show(true);
-        this.hud.showHud(false);
-        this.renderMenuPreview();
+        // Redimensionamento
+        window.addEventListener('resize', () => {
+            this.engine.resize();
+        });
+
+        await this.assets.preloadEssential((p) => {
+            this.menu.setProgress(p);
+        });
+
+        this.menu.show();
     }
 
-    _setupComposer() {
+    _loadSettings() {
         try {
-            this.composer = new EffectComposer(this.renderer);
-            this.composer.addPass(new RenderPass(this.scene, this.camera));
-            this.bloom = new UnrealBloomPass(
-                new THREE.Vector2(window.innerWidth, window.innerHeight),
-                this.quality.bloom ? 0.18 : 0,
-                0.4,
-                0.85
-            );
-            this.composer.addPass(this.bloom);
-            this.composer.addPass(new OutputPass());
-        } catch (err) {
-            console.warn('[Game] pós-processamento indisponível', err);
-            this.composer = null;
-            this.quality.bloom = false;
-        }
+            const raw = localStorage.getItem(SETTINGS_KEY);
+            if (raw) {
+                const s = JSON.parse(raw);
+                if (s.quality && QUALITY[s.quality]) this.quality = QUALITY[s.quality];
+            }
+        } catch { /* privado */ }
     }
 
-    _bindSettings() {
-        const q = document.getElementById('qualitySelect');
-        const vol = document.getElementById('volumeSlider');
-        q.value = this.settings.quality;
-        vol.value = Math.round(this.settings.master * 100);
-        document.getElementById('volumeValue').textContent = vol.value;
-        q.addEventListener('change', () => {
-            this.settings.quality = q.value;
-            this.saveSettings();
-            this.quality = this.resolveQuality();
-            this.renderer.setPixelRatio(Math.min(window.devicePixelRatio, this.quality.pixelRatio));
-            this.bloom.strength = this.quality.bloom ? 0.18 : 0;
-            this.weather.setShadowSize(this.quality.shadows);
-        });
-        vol.addEventListener('input', () => {
-            this.settings.master = vol.value / 100;
-            document.getElementById('volumeValue').textContent = vol.value;
-            this.audio.setBusVolume('master', this.settings.master);
-            this.saveSettings();
-        });
-        document.getElementById('btnPlayAgain')?.addEventListener('click', () => this.newGame());
-        document.getElementById('btnEndMenu')?.addEventListener('click', () => this.quitToMenu());
-    }
-
-    renderMenuPreview() {
-        this.weather.apply('dawn');
-        this.camera.position.set(8, 6, 16);
-        this.camera.lookAt(0, 2, 0);
-        this.fade = 0;
-        this.hud.setFade(0);
-    }
-
-    async newGame() {
-        await this.audio.unlock();
-        this.checkpoints.clear();
+    startNewGame() {
+        this.audio.unlock();
         this.story.resetFlags();
-        this.inventory = { keys: 0, cellKey: false };
-        this.player.heal();
-        this.menu.show(false);
-        this.hud.showHud(true);
-        this.state = 'playing';
-        this.paused = false;
-        await this.loadStage('home', 'home_intro');
-        this.input.requestLock();
+        this.checkpoints.clear();
+        this.menu.hide();
+        this.hud.show();
+        this.loadStage('home', 'home_intro');
+        this.running = true;
     }
 
-    async continueGame() {
-        await this.audio.unlock();
+    continueGame() {
+        this.audio.unlock();
         const data = this.checkpoints.load();
-        if (!data) return this.newGame();
-        this.story.applySave(data);
-        this.menu.show(false);
-        this.hud.showHud(true);
-        this.state = 'playing';
-        const stage = CHECKPOINT_STAGE[data.checkpoint] || 'home';
-        await this.loadStage(stage, data.checkpoint);
-        this.input.requestLock();
-    }
-
-    async loadStage(stageId, checkpoint) {
-        this.hud.setLoading(0.4, 'Atravessando…');
-        document.getElementById('loadingOverlay').hidden = false;
-        this.stageId = stageId;
-        this.fade = 1;
-        this.hud.setFade(1);
-        try {
-            this.player.root.visible = true;
-            this.teco.root.visible = true;
-            await this.scenes.load(stageId, checkpoint);
-        } catch (err) {
-            console.error('[Game] falha ao carregar estágio', stageId, err);
-            this.hud.showToast('Algo deu errado. Tentando de novo…');
+        this.menu.hide();
+        this.hud.show();
+        if (data && data.checkpoint) {
+            this.story.applySave(data);
+            const stage = data.level || CHECKPOINT_STAGE[data.checkpoint] || 'home';
+            this.loadStage(stage, data.checkpoint);
+        } else {
+            this.loadStage('home', 'home_intro');
         }
-        this.hud.hideLoading();
-        this.hud.setHealth(this.player.health, this.player.maxHealth);
-        if (this.quests.current) this.hud.showObjective(this.quests.current.text);
-        this.fadeTo(0);
-        this._failing = false;
+        this.running = true;
     }
 
-    fadeTo(target, cb, speed = 1.2) {
-        if (target > 1) {
-            this.fadeTarget = 1;
-            this.fadeSpeed = 1 / target;
-            this.fadeCb = cb || null;
+    async loadStage(stageId, checkpoint = null) {
+        this.stageId = stageId;
+        await this.sceneMgr.load(stageId, checkpoint);
+        this.hud.showLevelName(stageId);
+    }
+
+    fadeTo(duration, onMid, outDuration) {
+        const overlay = document.getElementById('fadeOverlay');
+        if (!overlay) {
+            onMid?.();
             return;
         }
-        this.fadeTarget = target;
-        this.fadeSpeed = speed;
-        this.fadeCb = cb || null;
+        overlay.style.transition = `opacity ${duration}s ease`;
+        overlay.classList.add('is-active');
+        setTimeout(() => {
+            onMid?.();
+            setTimeout(() => {
+                overlay.style.transition = `opacity ${outDuration || duration}s ease`;
+                overlay.classList.remove('is-active');
+            }, 60);
+        }, duration * 1000);
     }
 
     failCheckpoint(reason) {
-        if (this._failing) return;
-        this._failing = true;
         this.audio.play('fail');
         this.hud.showToast(reason || 'Tente novamente');
-        this.fadeTo(1, () => this.reloadCheckpoint(), 2.2);
-    }
-
-    async reloadCheckpoint() {
-        const cp = this.checkpoints.current || this.checkpoints.data.checkpoint || 'ship_start';
-        const stage = CHECKPOINT_STAGE[cp] || this.stageId;
-        this.player.heal();
-        await this.loadStage(stage, cp);
-    }
-
-    setPaused(v) {
-        this.paused = v;
-        this.pauseMenu.show(v);
-        this.input.enabled = !v && this.state === 'playing';
-        if (v) this.input.exitLock();
-        else this.input.requestLock();
-    }
-
-    quitToMenu() {
-        this.setPaused(false);
-        this.state = 'menu';
-        this.hud.showHud(false);
-        this.pauseMenu.show(false);
-        document.getElementById('endOverlay').hidden = true;
-        this.menu.show(true);
-        this.input.exitLock();
-        this.scenes.unload();
-        this.renderMenuPreview();
+        this.fadeTo(1.2, () => {
+            this.player.heal();
+            const cp = this.checkpoints.current || 'home_intro';
+            const stage = CHECKPOINT_STAGE[cp] || 'home';
+            this.loadStage(stage, cp);
+        });
     }
 
     showEnding() {
-        this.state = 'ending';
-        this.input.enabled = false;
+        this.running = false;
         this.input.exitLock();
-        const end = document.getElementById('endOverlay');
-        end.hidden = false;
-        this.hud.showHud(false);
-        this.audio.setTheme('ending');
+        this.hud.hide();
+        const endScreen = document.getElementById('endScreen');
+        if (endScreen) {
+            endScreen.classList.remove('is-hidden');
+            endScreen.focus();
+        }
     }
 
-    update(dt) {
-        this.clockTime += dt;
+    tick() {
+        if (!this.running || this.paused) return;
+
+        const now = performance.now();
+        const rawDt = this.lastTime ? (now - this.lastTime) / 1000 : 0.016;
+        this.lastTime = now;
+        const dt = Math.min(0.08, rawDt);
+
         this.input.update();
 
-        if (this.input.consume('pause') && this.state === 'playing') {
-            this.setPaused(!this.paused);
-        }
-        if (this.paused) {
-            this.audio.update(dt * 0.2);
-            return;
+        if (this.input.consume('pause')) {
+            this.pauseMenu.toggle();
         }
 
-        if (this.fade !== this.fadeTarget) {
-            const dir = Math.sign(this.fadeTarget - this.fade);
-            this.fade = clamp(this.fade + dir * dt * (this.fadeSpeed || 1.2), 0, 1);
-            this.hud.setFade(this.fade);
-            if (Math.abs(this.fade - this.fadeTarget) < 0.02) {
-                this.fade = this.fadeTarget;
-                this.hud.setFade(this.fade);
-                const cb = this.fadeCb;
-                this.fadeCb = null;
-                cb?.();
+        if (this.input.consume('advance')) {
+            if (this.dialogue.active) {
+                this.dialogue.advance();
             }
         }
 
-        if (this.state !== 'playing' && this.state !== 'ending') {
-            this.ocean.update(dt, this.clockTime);
-            return;
+        const lookDelta = this.input.consumeLook();
+        const zoomDelta = this.input.consumeZoom();
+
+        // Passo e movimento do jogador
+        const step = this.player.update(dt, this.input, this.cameraRig.yaw);
+        if (step) {
+            this.audio.footstep(this.player.crouching);
         }
 
+        // Câmera
+        this.cameraRig.update(dt, this.player, lookDelta, zoomDelta, this.player.sprinting);
+
+        // Companheiros
+        this.teco.update(dt, this);
+        this.camila.update(dt, this);
+
+        // Interação
+        const prompt = this.interact.update(this.player, this);
+        this.hud.setInteractPrompt(prompt);
+
+        if (this.input.consume('interact')) {
+            this.interact.tryInteract(this.player, this);
+        }
+
+        // Combate & Projéteis
+        this.combat.update(dt, this);
+        this.arrows.update(dt, this);
+
+        // Clima & Ambiente
+        this.ocean.update(dt, now * 0.001);
+        this.storm.update(dt, this);
+        this.collision.update(dt);
+        this.sceneMgr.update(dt);
         this.cutscenes.update(dt);
         this.dialogue.update(dt);
-        if (this.input.consume('advance')) {
-            this.dialogue.skip();
-            if (this.cutscenes.blocking) this.cutscenes.skip();
-        }
-
-        this.collision.update(dt);
-        this.storm.update(dt, this);
-        this.ocean.update(dt, this.clockTime);
-
-        const look = this.input.consumeLook();
-        const zoom = this.input.consumeZoom();
-
-        if (!this.cutscenes.blocking && this.player.controller.mode !== 'locked') {
-            const foot = this.player.update(dt, this.input, this.cameraRig.yaw);
-            if (foot) this.audio.footstep(this.player.crouching);
-            this.teco.update(dt, this);
-            this.camila.update(dt, this);
-            this.combat.update(dt, this);
-            this.arrows.update(dt, this);
-            const item = this.interact.update(this.player, this);
-            this.hud.setPrompt(item);
-            if (this.input.consume('interact')) {
-                if (item) {
-                    this.player.interactT = 0.4;
-                    this.audio.play('interact');
-                    this.interact.tryInteract(this.player, this);
-                }
-            }
-        } else if (this.player.controller.mode === 'helm') {
-            this.player.update(dt, this.input, this.cameraRig.yaw);
-            this.teco.update(dt, this);
-            this.camila.update(dt, this);
-            this.arrows.update(dt, this);
-        } else {
-            this.player.animator.update(dt);
-            this.teco.animator.update(dt);
-        }
-
-        this.cameraRig.update(dt, this.player, look, zoom, this.player.sprinting);
-        this.scenes.update(dt);
-        this.quests.update(dt);
         this.audio.update(dt);
-        this.hud.setDialogue(this.dialogue.current);
-        this.hud.setHealth(this.player.health, this.player.maxHealth);
         this.hud.update(dt);
-
-        if (this.input.consume('tab') && this.quests.current) {
-            this.hud.showObjective(this.quests.current.text);
-        }
-
-        if (!this.player.alive && this.state === 'playing') {
-            this.failCheckpoint('Dico caiu…');
-        }
-
-        this.fpsAccum += dt;
-        this.fpsFrames++;
-        if (this.fpsAccum > 0.5) {
-            this.hud.setFps(Math.round(this.fpsFrames / this.fpsAccum));
-            this.fpsAccum = 0;
-            this.fpsFrames = 0;
-        }
     }
 
-    render() {
-        this.renderer.toneMappingExposure = this.weather.exposure ?? 1;
-        if (this.composer && this.quality.bloom) this.composer.render();
-        else this.renderer.render(this.scene, this.camera);
-    }
-
-    onResize() {
-        const w = window.innerWidth;
-        const h = window.innerHeight;
-        this.camera.aspect = w / h;
-        this.camera.updateProjectionMatrix();
-        this.renderer.setSize(w, h);
-        this.composer?.setSize(w, h);
-        this.bloom?.setSize(w, h);
-        this.renderer.setPixelRatio(Math.min(window.devicePixelRatio, this.quality.pixelRatio));
+    start() {
+        this.engine.runRenderLoop(() => {
+            this.tick();
+            this.scene.render();
+        });
     }
 }

--- a/labs/guerreiro-castelo/js/core/SceneManager.js
+++ b/labs/guerreiro-castelo/js/core/SceneManager.js
@@ -86,7 +86,6 @@ export class SceneManager {
         this.game.cameraRig.setObstacles(obstacles);
         for (const lv of levels) lv.enter(checkpoint);
         this._applyCheckpointSpawn(checkpoint);
-        this.game.scene.updateMatrixWorld(true);
         this.game.cameraRig.snapToPlayer(this.game.player);
         return levels;
     }
@@ -103,7 +102,7 @@ export class SceneManager {
                 this.game.level.nightStarted = true;
                 this.game.weather.apply('storm');
                 this.game.storm.setIntensity(0.85);
-                this.game.level.ship.userData.rope.visible = true;
+                this.game.level.ship.userData.rope.setEnabled(true);
                 this.game.level.ropeItem.enabled = true;
                 p.spawn(0, 1.44, 5, 0);
                 break;
@@ -147,9 +146,6 @@ export class SceneManager {
     async unload() {
         for (const lv of this.levels) {
             lv.exit();
-            if (lv.group) {
-                this.game.scene.remove(lv.group);
-            }
         }
         this.levels = [];
         this.game.level = null;

--- a/labs/guerreiro-castelo/js/core/assets.js
+++ b/labs/guerreiro-castelo/js/core/assets.js
@@ -1,19 +1,5 @@
 /**
- * Manifest único de assets. Se um GLB não existir, o AssetManager
- * usa fallback procedural sem alterar a lógica de gameplay.
+ * Constantes de armazenamento e configurações em Babylon.js.
  */
-export const ASSETS = {
-    dico: './assets/models/dico.glb',
-    ravi: './assets/models/ravi.glb',
-    camila: './assets/models/camila.glb',
-    teco: './assets/models/teco.glb',
-    guard: './assets/models/guard.glb',
-    tiger: './assets/models/tiger.glb',
-    friend: './assets/models/friend.glb',
-    ship: './assets/models/ship.glb',
-    castle: './assets/models/castle.glb',
-    waterNormals: 'https://cdn.jsdelivr.net/npm/three@0.185.1/examples/textures/waternormals.jpg'
-};
-
 export const STORAGE_KEY = 'guerreiro-castelo-save-v1';
 export const SETTINGS_KEY = 'guerreiro-castelo-settings-v1';

--- a/labs/guerreiro-castelo/js/game/CutsceneManager.js
+++ b/labs/guerreiro-castelo/js/game/CutsceneManager.js
@@ -1,8 +1,7 @@
 /**
- * Cutscenes curtas: interpola câmera, bloqueia controle, dispara eventos.
+ * Cutscenes: interpolação de câmera em Babylon.js, bloqueio de controle e eventos de história.
  */
 
-import * as THREE from 'three';
 import { getEasing } from '../utils/easing.js';
 
 export class CutsceneManager {
@@ -11,17 +10,17 @@ export class CutsceneManager {
         this.blocking = false;
         this.t = 0;
         this.duration = 0;
-        this.fromPos = new THREE.Vector3();
-        this.toPos = new THREE.Vector3();
-        this.fromLook = new THREE.Vector3();
-        this.toLook = new THREE.Vector3();
+        this.fromPos = new BABYLON.Vector3();
+        this.toPos = new BABYLON.Vector3();
+        this.fromLook = new BABYLON.Vector3();
+        this.toLook = new BABYLON.Vector3();
         this.ease = getEasing('inOutCubic');
         this.midAt = 0.5;
         this.midFired = false;
         this.onMid = null;
         this.onEnd = null;
-        this._pos = new THREE.Vector3();
-        this._look = new THREE.Vector3();
+        this._pos = new BABYLON.Vector3();
+        this._look = new BABYLON.Vector3();
     }
 
     play({
@@ -32,10 +31,10 @@ export class CutsceneManager {
         this.rig.cutscene = true;
         this.t = 0;
         this.duration = duration;
-        this.fromPos.copy(from);
-        this.toPos.copy(to);
-        this.fromLook.copy(lookFrom);
-        this.toLook.copy(lookTo);
+        this.fromPos.copyFrom(from);
+        this.toPos.copyFrom(to);
+        this.fromLook.copyFrom(lookFrom);
+        this.toLook.copyFrom(lookTo);
         this.ease = getEasing(easing);
         this.onMid = onMid;
         this.onEnd = onEnd;
@@ -65,13 +64,17 @@ export class CutsceneManager {
         this.t += dt;
         const u = Math.min(1, this.t / this.duration);
         const e = this.ease(u);
-        this._pos.lerpVectors(this.fromPos, this.toPos, e);
-        this._look.lerpVectors(this.fromLook, this.toLook, e);
+
+        BABYLON.Vector3.LerpToRef(this.fromPos, this.toPos, e, this._pos);
+        BABYLON.Vector3.LerpToRef(this.fromLook, this.toLook, e, this._look);
+
         this.rig.setCutscenePose(this._pos, this._look);
+
         if (!this.midFired && u >= this.midAt) {
             this.midFired = true;
             this.onMid?.();
         }
+
         if (u >= 1) this._finish();
     }
 }

--- a/labs/guerreiro-castelo/js/game/DialogueManager.js
+++ b/labs/guerreiro-castelo/js/game/DialogueManager.js
@@ -1,11 +1,10 @@
 /**
- * Diálogos discretos na parte inferior.
- * DICO
- * Segurem firme!
+ * Gerenciador de diálogos contextuais discretos na parte inferior da tela em Babylon.js.
  */
 
 export class DialogueManager {
-    constructor() {
+    constructor(game) {
+        this.game = game;
         this.queue = [];
         this.current = null;
         this.timer = 0;
@@ -13,7 +12,11 @@ export class DialogueManager {
         this.onDone = null;
     }
 
-    say(speaker, text, duration = 3.2) {
+    get active() {
+        return Boolean(this.current);
+    }
+
+    say(speaker, text, duration = 3.4) {
         this.queue.push({ speaker, text, duration });
         if (!this.current) this._next();
     }
@@ -28,7 +31,12 @@ export class DialogueManager {
     _next() {
         this.current = this.queue.shift() || null;
         this.timer = this.current ? this.current.duration : 0;
-        if (!this.current) {
+        if (this.game && this.game.hud) {
+            this.game.hud.setDialogue(this.current);
+        }
+        if (this.current) {
+            this.game.audio?.play('speech');
+        } else {
             this.blocking = false;
             const cb = this.onDone;
             this.onDone = null;
@@ -36,7 +44,7 @@ export class DialogueManager {
         }
     }
 
-    skip() {
+    advance() {
         if (this.current) this._next();
     }
 

--- a/labs/guerreiro-castelo/js/game/InteractionSystem.js
+++ b/labs/guerreiro-castelo/js/game/InteractionSystem.js
@@ -1,19 +1,12 @@
 /**
- * Interação por raycast da câmera. Objetos implementam:
- * { interactionLabel, interactionDistance, interact(player, game) }
+ * Sistema de interação contextual por proximidade e foco da câmera em Babylon.js.
  */
-
-import * as THREE from 'three';
 
 export class InteractionSystem {
     constructor(camera) {
         this.camera = camera;
         this.items = [];
-        this.ray = new THREE.Raycaster();
-        this.ray.far = 6;
         this.prompt = null;
-        this._dir = new THREE.Vector3();
-        this._origin = new THREE.Vector3();
     }
 
     clear() {
@@ -34,8 +27,12 @@ export class InteractionSystem {
     update(player, game) {
         this.prompt = null;
         if (game.cutscenes?.blocking) return null;
-        this.camera.getWorldDirection(this._dir);
-        this._origin.copy(this.camera.position);
+
+        const camPos = this.camera.position;
+        const camTarget = this.camera.getTarget ? this.camera.getTarget() : new BABYLON.Vector3(0, 0, 0);
+        const camDir = camTarget.subtract(camPos).normalize();
+
+        const playerPos = player.position;
         let best = null;
         let bestScore = Infinity;
 
@@ -43,15 +40,23 @@ export class InteractionSystem {
             if (item.enabled === false) continue;
             const obj = item.object;
             if (!obj) continue;
-            obj.getWorldPosition(this._origin);
-            const dist = this._origin.distanceTo(player.position);
-            const maxd = item.interactionDistance ?? 2.2;
+
+            const objPos = obj.getAbsolutePosition ? obj.getAbsolutePosition() : obj.position;
+            if (!objPos) continue;
+
+            const dx = objPos.x - playerPos.x;
+            const dy = objPos.y - playerPos.y;
+            const dz = objPos.z - playerPos.z;
+            const dist = Math.hypot(dx, dy, dz);
+
+            const maxd = item.interactionDistance ?? 2.4;
             if (dist > maxd) continue;
-            const to = this._origin.clone().sub(this.camera.position).normalize();
-            this.camera.getWorldDirection(this._dir);
-            const dot = this._dir.dot(to);
-            if (dot < 0.35 && dist > 1.1) continue;
-            const score = dist * (1.4 - dot);
+
+            const toDir = objPos.subtract(camPos).normalize();
+            const dot = BABYLON.Vector3.Dot(camDir, toDir);
+            if (dot < 0.25 && dist > 1.2) continue;
+
+            const score = dist * (1.5 - dot);
             if (score < bestScore) {
                 bestScore = score;
                 best = item;

--- a/labs/guerreiro-castelo/js/game/QuestManager.js
+++ b/labs/guerreiro-castelo/js/game/QuestManager.js
@@ -1,5 +1,5 @@
 /**
- * Objetivos da aventura. O HUD mostra o atual; Tab reexibe.
+ * Objetivos da aventura. O HUD mostra o atual; atualizações exibem banner.
  */
 
 export const QUEST_ORDER = [
@@ -29,19 +29,19 @@ export const QUEST_ORDER = [
 ];
 
 export class QuestManager {
-    constructor() {
+    constructor(game) {
+        this.game = game;
         this.current = QUEST_ORDER[0];
         this.completed = new Set();
-        this.bannerT = 0;
-        this.onChange = null;
     }
 
     set(id) {
         const q = QUEST_ORDER.find((x) => x.id === id);
         if (!q) return;
         this.current = q;
-        this.bannerT = 4.2;
-        this.onChange?.(q);
+        if (this.game && this.game.hud) {
+            this.game.hud.showObjective(q.text, id === 'flee');
+        }
     }
 
     complete(id) {
@@ -50,9 +50,5 @@ export class QuestManager {
         if (i >= 0 && i + 1 < QUEST_ORDER.length && this.current.id === id) {
             this.set(QUEST_ORDER[i + 1].id);
         }
-    }
-
-    update(dt) {
-        if (this.bannerT > 0) this.bannerT -= dt;
     }
 }

--- a/labs/guerreiro-castelo/js/levels/BeachLevel.js
+++ b/labs/guerreiro-castelo/js/levels/BeachLevel.js
@@ -1,4 +1,7 @@
-import * as THREE from 'three';
+/**
+ * Capítulo 4: Desembarque na praia em Babylon.js.
+ */
+
 import { Level } from './Level.js';
 import { sandTexture, grassTexture } from '../world/Textures.js';
 import { makeRock, makeGrassInstanced, makeBush } from '../world/Environment.js';
@@ -9,70 +12,80 @@ export class BeachLevel extends Level {
     }
 
     async build() {
-        this.group = new THREE.Group();
-        this.group.position.set(0, 0, 0);
-        const sand = new THREE.Mesh(
-            new THREE.CircleGeometry(42, 32),
-            new THREE.MeshStandardMaterial({ map: sandTexture(), roughness: 0.95, color: 0xe8d2a8 })
-        );
-        sand.rotation.x = -Math.PI / 2;
-        sand.position.y = 0.02;
-        sand.receiveShadow = true;
-        this.group.add(sand);
+        const scene = this.game.scene;
+        this.group = new BABYLON.TransformNode('beachGroup', scene);
 
-        const grass = new THREE.Mesh(
-            new THREE.CircleGeometry(38, 24),
-            new THREE.MeshStandardMaterial({ map: grassTexture(), roughness: 0.92 })
-        );
-        grass.rotation.x = -Math.PI / 2;
+        // Disco de areia
+        const sand = BABYLON.MeshBuilder.CreateDisc('beachSand', { radius: 42, tessellation: 32 }, scene);
+        sand.rotation.x = Math.PI / 2;
+        sand.position.y = 0.02;
+        const sandMat = new BABYLON.StandardMaterial('sandMat', scene);
+        sandMat.diffuseTexture = sandTexture(scene, 8, 8);
+        sandMat.diffuseColor = new BABYLON.Color3(0.95, 0.88, 0.72);
+        sand.material = sandMat;
+        sand.parent = this.group;
+        sand.receiveShadows = true;
+
+        // Disco de grama interior
+        const grass = BABYLON.MeshBuilder.CreateDisc('beachGrass', { radius: 38, tessellation: 24 }, scene);
+        grass.rotation.x = Math.PI / 2;
         grass.position.set(0, 0.04, -22);
-        grass.receiveShadow = true;
-        this.group.add(grass);
+        const grassMat = new BABYLON.StandardMaterial('bGrassMat', scene);
+        grassMat.diffuseTexture = grassTexture(scene, 8, 8);
+        grass.material = grassMat;
+        grass.parent = this.group;
+        grass.receiveShadows = true;
 
         for (let i = 0; i < 10; i++) {
-            const r = makeRock(0.8 + Math.random());
+            const r = makeRock(0.8 + Math.random(), scene);
             r.position.set((Math.random() - 0.5) * 22, 0.2, 6 + Math.random() * 10);
-            this.group.add(r);
+            r.parent = this.group;
         }
-        const wood = new THREE.Mesh(
-            new THREE.BoxGeometry(1.6, 0.18, 0.35),
-            new THREE.MeshStandardMaterial({ color: 0x6a4a28, roughness: 0.9 })
-        );
+
+        const wood = BABYLON.MeshBuilder.CreateBox('driftWood', { width: 1.6, height: 0.18, depth: 0.35 }, scene);
         wood.position.set(-4, 0.12, 8);
         wood.rotation.y = 0.4;
-        this.group.add(wood);
+        const woodMat = new BABYLON.StandardMaterial('driftWoodMat', scene);
+        woodMat.diffuseColor = new BABYLON.Color3(0.4, 0.28, 0.16);
+        wood.material = woodMat;
+        wood.parent = this.group;
 
-        const grassI = makeGrassInstanced(180, 28, this.game.quality.vegetation);
+        const grassI = makeGrassInstanced(180, 28, this.game.quality?.vegetation || 1, scene);
         grassI.position.z = -8;
-        this.group.add(grassI);
+        grassI.parent = this.group;
+
         for (let i = 0; i < 8; i++) {
-            const b = makeBush();
+            const b = makeBush(scene);
             b.position.set((Math.random() - 0.5) * 18, 0.2, -8 + Math.random() * 8);
-            this.group.add(b);
+            b.parent = this.group;
         }
 
         this.game.collision.addFloor(0, -4, 70, 70, 0);
-        this.game.scene.add(this.group);
-        this.obstacles = [];
-        this.group.traverse((c) => { if (c.isMesh) this.obstacles.push(c); });
+        this.obstacles = this.group.getChildMeshes ? this.group.getChildMeshes() : [];
 
         this.gulls = [];
+        const gullMat = new BABYLON.StandardMaterial('gullMat', scene);
+        gullMat.diffuseColor = new BABYLON.Color3(0.95, 0.95, 0.92);
+
         for (let i = 0; i < 4; i++) {
-            const gull = new THREE.Mesh(
-                new THREE.ConeGeometry(0.15, 0.5, 4),
-                new THREE.MeshStandardMaterial({ color: 0xf2f0ea })
-            );
+            const gull = BABYLON.MeshBuilder.CreateCylinder(`gull_${i}`, {
+                diameterTop: 0,
+                diameterBottom: 0.3,
+                height: 0.5,
+                tessellation: 4
+            }, scene);
             gull.position.set(-8 + i * 5, 6 + i, 10);
-            this.group.add(gull);
+            gull.material = gullMat;
+            gull.parent = this.group;
             this.gulls.push({ m: gull, p: i });
         }
     }
 
     enter() {
         const g = this.game;
-        g.player.attachTo(g.scene);
-        g.teco.attachTo(g.scene);
-        g.camila.attachTo(g.scene);
+        g.player.attachTo(this.group);
+        g.teco.attachTo(this.group);
+        g.camila.attachTo(this.group);
         g.player.spawn(0, 0, 10, Math.PI);
         g.teco.spawn(0.7, 0, 9);
         g.weather.apply('dawn');

--- a/labs/guerreiro-castelo/js/levels/CastleExteriorLevel.js
+++ b/labs/guerreiro-castelo/js/levels/CastleExteriorLevel.js
@@ -1,4 +1,7 @@
-import * as THREE from 'three';
+/**
+ * Capítulo 6: Aproximação do Castelo e Reconhecimento com Teco em Babylon.js.
+ */
+
 import { Level } from './Level.js';
 import { buildCastle, addCastleColliders } from '../world/Castle.js';
 import { makeTree } from '../world/Environment.js';
@@ -11,33 +14,37 @@ export class CastleExteriorLevel extends Level {
     }
 
     async build() {
-        this.group = new THREE.Group();
+        const scene = this.game.scene;
+        this.group = new BABYLON.TransformNode('castleExtGroup', scene);
         this.group.position.set(0, 0, -88);
-        const ground = new THREE.Mesh(
-            new THREE.PlaneGeometry(90, 70),
-            new THREE.MeshStandardMaterial({ map: grassTexture(), roughness: 0.9, color: 0x8a8a70 })
-        );
-        ground.rotation.x = -Math.PI / 2;
-        ground.receiveShadow = true;
-        this.group.add(ground);
 
-        this.castle = buildCastle();
-        this.group.add(this.castle);
+        const ground = BABYLON.MeshBuilder.CreateGround('castleExtGround', { width: 90, height: 70 }, scene);
+        ground.position.y = 0.02;
+        const gMat = new BABYLON.StandardMaterial('castleExtGMat', scene);
+        gMat.diffuseTexture = grassTexture(scene, 12, 10);
+        gMat.diffuseColor = new BABYLON.Color3(0.55, 0.55, 0.45);
+        ground.material = gMat;
+        ground.parent = this.group;
+        ground.receiveShadows = true;
+
+        this.castle = buildCastle(scene);
+        this.castle.parent = this.group;
         addCastleColliders(this.game.collision, 0, -88);
 
-        this.lookout = makeTree();
+        this.lookout = makeTree(Math.random, scene);
         this.lookout.position.set(-18, 0, 4);
-        this.group.add(this.lookout);
+        this.lookout.parent = this.group;
 
-        const gateProxy = new THREE.Object3D();
+        const gateProxy = new BABYLON.TransformNode('gateProxy', scene);
         gateProxy.position.set(0, 1, 16);
-        this.group.add(gateProxy);
+        gateProxy.parent = this.group;
+
         this.addInteract({
             object: gateProxy,
             interactionLabel: 'Portão (protegido)',
             interactionDistance: 4,
             interact: (_p, game) => {
-                game.dialogue.say('DICO', 'Não por aqui. Há arqueiros demais.');
+                game.dialogue.say('DICO', 'Não por aqui. Há arqueiros demais no portão.');
                 if (!this._viewed) {
                     this._viewed = true;
                     game.story.notify('castle_view');
@@ -48,7 +55,7 @@ export class CastleExteriorLevel extends Level {
         this.addInteract({
             object: this.lookout,
             interactionLabel: 'Mandar Teco',
-            interactionDistance: 3,
+            interactionDistance: 3.5,
             interact: (_p, game) => this.sendTecoTree(game)
         });
 
@@ -65,15 +72,13 @@ export class CastleExteriorLevel extends Level {
 
         this.archers = [];
         for (let i = -2; i <= 2; i++) {
-            const a = buildGuard({ archer: true });
-            a.group.position.set(i * 3.2, 18.2, 14.2);
-            this.castle.add(a.group);
-            this.archers.push(new CharacterAnimator(a.group, a.clips));
+            const a = buildGuard(scene, { archer: true });
+            a.root.position.set(i * 3.2, 18.2, 14.2);
+            a.root.parent = this.castle;
+            this.archers.push(new CharacterAnimator(a.root, a.clips));
         }
 
-        this.game.scene.add(this.group);
-        this.obstacles = [];
-        this.group.traverse((c) => { if (c.isMesh) this.obstacles.push(c); });
+        this.obstacles = this.group.getChildMeshes ? this.group.getChildMeshes() : [];
         this.tecoSent = false;
         this.nearCastle = false;
     }
@@ -81,23 +86,19 @@ export class CastleExteriorLevel extends Level {
     sendTecoTree(game) {
         if (this.tecoSent) return;
         this.tecoSent = true;
-        const base = this.lookout.getWorldPosition(new THREE.Vector3());
-        const local = (x, y, z) => {
-            const v = new THREE.Vector3(x, y, z);
-            game.teco.root.parent.worldToLocal(v);
-            return v;
-        };
+        const base = this.lookout.getAbsolutePosition();
         const path = [
-            local(base.x, 1.2, base.z),
-            local(base.x, 4.2, base.z),
-            local(base.x, 6.5, base.z)
+            new BABYLON.Vector3(base.x, 1.2, base.z),
+            new BABYLON.Vector3(base.x, 4.2, base.z),
+            new BABYLON.Vector3(base.x, 6.5, base.z)
         ];
         game.teco.ai.command(path, {
             climb: true,
+            celebrate: true,
             onComplete: () => {
                 game.story.notify('teco_tree');
                 game.teco.ai.command([
-                    local(game.player.position.x, game.player.position.y, game.player.position.z)
+                    new BABYLON.Vector3(game.player.position.x, game.player.position.y, game.player.position.z)
                 ], { onComplete: () => {} });
             }
         });
@@ -106,21 +107,23 @@ export class CastleExteriorLevel extends Level {
     update(dt) {
         this.time += dt;
         for (const a of this.archers) a.update(dt);
-        const p = this.game.player.worldPosition();
+
+        const p = this.game.player.position;
         if (!this.nearCastle && p.z < -70) {
             this.nearCastle = true;
             this.game.story.notify('castle_view');
             this.game.cutscenes.play({
-                from: new THREE.Vector3(p.x + 4, p.y + 8, p.z + 10),
-                to: new THREE.Vector3(p.x + 8, p.y + 16, p.z + 6),
-                lookFrom: new THREE.Vector3(0, 12, -88),
-                lookTo: new THREE.Vector3(0, 20, -100),
+                from: new BABYLON.Vector3(p.x + 4, p.y + 8, p.z + 10),
+                to: new BABYLON.Vector3(p.x + 8, p.y + 16, p.z + 6),
+                lookFrom: new BABYLON.Vector3(0, 12, -88),
+                lookTo: new BABYLON.Vector3(0, 20, -100),
                 duration: 3.6
             });
         }
+
         const door = this.castle.userData.secretDoor;
-        door.getWorldPosition(this._wp || (this._wp = new THREE.Vector3()));
-        if (!this._atDoor && this._wp.distanceTo(p) < 3.2) {
+        const doorPos = door.getAbsolutePosition ? door.getAbsolutePosition() : door.position;
+        if (!this._atDoor && BABYLON.Vector3.Distance(doorPos, p) < 3.2) {
             this._atDoor = true;
             this.game.story.notify('at_secret');
         }

--- a/labs/guerreiro-castelo/js/levels/CastleInteriorLevel.js
+++ b/labs/guerreiro-castelo/js/levels/CastleInteriorLevel.js
@@ -1,12 +1,11 @@
-import * as THREE from 'three';
+/**
+ * Capítulo 8: Calabouço, Furtividade & Guarda Dorminhoco em Babylon.js.
+ */
+
 import { Level } from './Level.js';
 import { castleStoneTexture, woodTexture } from '../world/Textures.js';
-import { std } from '../characters/builders.js';
 import { makeTorch, EnvironmentFX } from '../world/Environment.js';
 import { Guard } from '../characters/Guard.js';
-function stoneMat() {
-    return new THREE.MeshStandardMaterial({ map: castleStoneTexture(), roughness: 0.9, color: 0x8a8478 });
-}
 
 export class CastleInteriorLevel extends Level {
     get id() {
@@ -14,90 +13,103 @@ export class CastleInteriorLevel extends Level {
     }
 
     async build() {
-        this.group = new THREE.Group();
+        const scene = this.game.scene;
+        this.group = new BABYLON.TransformNode('interiorGroup', scene);
         this.fx = new EnvironmentFX();
-        const stone = stoneMat();
-        const wood = new THREE.MeshStandardMaterial({ map: woodTexture(), roughness: 0.85 });
 
-        const room = (w, h, d, x, y, z, open = []) => {
-            const floor = new THREE.Mesh(new THREE.BoxGeometry(w, 0.2, d), stone);
+        const stoneMat = new BABYLON.StandardMaterial('dungeonStoneMat', scene);
+        stoneMat.diffuseTexture = castleStoneTexture(scene, 6, 8);
+        stoneMat.diffuseColor = new BABYLON.Color3(0.7, 0.68, 0.65);
+
+        const woodMat = new BABYLON.StandardMaterial('dungeonWoodMat', scene);
+        woodMat.diffuseTexture = woodTexture(scene, 2, 2);
+
+        const darkHoleMat = new BABYLON.StandardMaterial('dungeonDarkMat', scene);
+        darkHoleMat.diffuseColor = new BABYLON.Color3(0.05, 0.04, 0.03);
+
+        const room = (name, w, h, d, x, y, z, open = []) => {
+            const floor = BABYLON.MeshBuilder.CreateBox(`${name}_floor`, { width: w, height: 0.2, depth: d }, scene);
             floor.position.set(x, y - 0.1, z);
-            floor.receiveShadow = true;
-            this.group.add(floor);
+            floor.material = stoneMat;
+            floor.parent = this.group;
+            floor.receiveShadows = true;
             this.game.collision.addFloor(x, z, w, d, y);
-            const ceil = new THREE.Mesh(new THREE.BoxGeometry(w, 0.2, d), stone);
+
+            const ceil = BABYLON.MeshBuilder.CreateBox(`${name}_ceil`, { width: w, height: 0.2, depth: d }, scene);
             ceil.position.set(x, y + h, z);
-            this.group.add(ceil);
+            ceil.material = stoneMat;
+            ceil.parent = this.group;
+
             if (!open.includes('-z')) this.game.collision.addWall(x, z - d / 2, w, 0.3, h, y);
             if (!open.includes('+z')) this.game.collision.addWall(x, z + d / 2, w, 0.3, h, y);
             if (!open.includes('-x')) this.game.collision.addWall(x - w / 2, z, 0.3, d, h, y);
             if (!open.includes('+x')) this.game.collision.addWall(x + w / 2, z, 0.3, d, h, y);
         };
 
-        room(6, 3.4, 10, 0, 0, 0, ['-z']);
-        const stairs = new THREE.Group();
+        // Salas do calabouço
+        room('roomEntry', 6, 3.4, 10, 0, 0, 0, ['-z']);
+
+        // Escadaria de pedra
+        const stairs = new BABYLON.TransformNode('dungeonStairs', scene);
+        stairs.parent = this.group;
         for (let i = 0; i < 10; i++) {
-            const st = new THREE.Mesh(new THREE.BoxGeometry(2.2, 0.22, 0.7), stone);
+            const st = BABYLON.MeshBuilder.CreateBox(`stair_${i}`, { width: 2.2, height: 0.22, depth: 0.7 }, scene);
             st.position.set(0, 0.11 + i * 0.32, -6 - i * 0.55);
-            stairs.add(st);
+            st.material = stoneMat;
+            st.parent = stairs;
             this.game.collision.addFloor(0, -6 - i * 0.55, 2.2, 0.7, 0.22 + i * 0.32);
         }
-        this.group.add(stairs);
 
-        room(10, 3.6, 12, 0, 3.2, -18, ['+z', '-z', '-x', '+x']);
-        room(8, 3.4, 10, 0, 3.2, -32, ['+z', '-z']);
-        room(6, 3.2, 6, -10, 3.2, -18, ['+x']);
-        room(6, 3.2, 6, 12, 3.2, -18, ['-x']);
+        room('roomCorridor', 10, 3.6, 12, 0, 3.2, -18, ['+z', '-z', '-x', '+x']);
+        room('roomCell', 8, 3.4, 10, 0, 3.2, -32, ['+z', '-z']);
+        room('roomSideLeft', 6, 3.2, 6, -10, 3.2, -18, ['+x']);
+        room('roomSideRight', 6, 3.2, 6, 12, 3.2, -18, ['-x']);
 
-        const openings = [
-            [0, 1.6, -5, 2, 2.4, 0.4],
-            [0, 4.6, -24, 2.2, 2.6, 0.4],
-            [-5, 4.6, -18, 0.4, 2.4, 2],
-            [5.2, 4.6, -18, 0.4, 2.4, 2]
-        ];
-        for (const o of openings) {
-            const hole = new THREE.Mesh(new THREE.BoxGeometry(o[3], o[4], o[5]), std(0x080604, 1));
-            hole.position.set(o[0], o[1], o[2]);
-            this.group.add(hole);
-        }
-
-        this.cellDoor = new THREE.Mesh(new THREE.BoxGeometry(1.6, 2.4, 0.12), wood);
+        // Porta da cela e barras de ferro
+        this.cellDoor = BABYLON.MeshBuilder.CreateBox('cellDoor', { width: 1.6, height: 2.4, depth: 0.12 }, scene);
         this.cellDoor.position.set(0, 4.4, -37.1);
-        this.group.add(this.cellDoor);
-        const bars = new THREE.Group();
+        this.cellDoor.material = woodMat;
+        this.cellDoor.parent = this.group;
+
+        const ironMat = new BABYLON.StandardMaterial('ironBarsMat', scene);
+        ironMat.diffuseColor = new BABYLON.Color3(0.35, 0.35, 0.35);
+
+        const bars = new BABYLON.TransformNode('cellBarsGroup', scene);
+        bars.parent = this.group;
         for (let i = 0; i < 6; i++) {
-            const b = new THREE.Mesh(new THREE.CylinderGeometry(0.03, 0.03, 2.2, 5), std(0x555555, 0.4, 0.7));
+            const b = BABYLON.MeshBuilder.CreateCylinder(`cellBar_${i}`, { diameter: 0.06, height: 2.2 }, scene);
             b.position.set(-0.6 + i * 0.24, 4.4, -37);
-            bars.add(b);
+            b.material = ironMat;
+            b.parent = bars;
         }
-        this.group.add(bars);
         this.bars = bars;
 
-        const torch1 = makeTorch();
+        // Tochas do calabouço
+        const torch1 = makeTorch(scene);
         torch1.position.set(-2.4, 1.4, -2);
-        this.group.add(torch1);
+        torch1.parent = this.group;
         this.fx.addFire(torch1);
-        const torch2 = makeTorch();
+
+        const torch2 = makeTorch(scene);
         torch2.position.set(2.6, 4.6, -18);
-        this.group.add(torch2);
+        torch2.parent = this.group;
         this.fx.addFire(torch2);
 
-        for (let i = 0; i < 4; i++) {
-            const rat = new THREE.Mesh(new THREE.SphereGeometry(0.08, 6, 5), std(0x3a3a32, 0.9));
-            rat.scale.set(1.4, 0.7, 2);
-            rat.position.set(-1 + i * 0.7, 0.08, -1 + (i % 2));
-            this.group.add(rat);
-            this._rats = this._rats || [];
-            this._rats.push(rat);
-        }
-
-        const vase = new THREE.Mesh(new THREE.CylinderGeometry(0.12, 0.16, 0.4, 8), std(0x6a4a2a, 0.7));
+        // Vaso de cerâmica que pode ser derrubado
+        const vase = BABYLON.MeshBuilder.CreateCylinder('dungeonVase', {
+            diameterTop: 0.24,
+            diameterBottom: 0.32,
+            height: 0.45
+        }, scene);
         vase.position.set(3.2, 3.42, -14);
-        vase.name = 'vase';
-        this.group.add(vase);
+        const vaseMat = new BABYLON.StandardMaterial('vaseMat', scene);
+        vaseMat.diffuseColor = new BABYLON.Color3(0.55, 0.32, 0.18);
+        vase.material = vaseMat;
+        vase.parent = this.group;
+
         this.addInteract({
             object: vase,
-            interactionLabel: 'Não tocar',
+            interactionLabel: 'Não tocar no vaso',
             interactionDistance: 1.6,
             interact: (_p, game) => {
                 vase.rotation.z = 1.2;
@@ -108,6 +120,7 @@ export class CastleInteriorLevel extends Level {
             }
         });
 
+        // Guarda dorminhoco
         this.sleeping = new Guard(this.group, { fat: true, sleep: true });
         this.sleeping.spawn(1.4, 3.2, -16.5, 1.2);
         this.game.combat.setGuards([this.sleeping]);
@@ -115,23 +128,25 @@ export class CastleInteriorLevel extends Level {
         this.addInteract({
             object: this.sleeping.root,
             interactionLabel: 'Pegar chaves',
-            interactionDistance: 1.7,
+            interactionDistance: 1.8,
             interact: (_p, game) => this.stealKeys(game)
         });
 
+        // Camila na cela
         this.game.camila.attachTo(this.group);
         this.game.camila.spawn(0, 3.2, -39.5);
         this.game.camila.setShackles(true);
         this.game.camila.ai.state = 'WAIT';
-        this.game.camila.root.visible = true;
+        this.game.camila.root.setEnabled(true);
         this.game.camila.active = true;
 
         this.addInteract({
             object: this.game.camila.root,
-            interactionLabel: 'Conversar',
+            interactionLabel: 'Conversar com Camila',
             interactionDistance: 2.4,
             interact: (_p, game) => this.talkCamila(game)
         });
+
         this.addInteract({
             object: this.cellDoor,
             interactionLabel: 'Usar chave',
@@ -139,15 +154,14 @@ export class CastleInteriorLevel extends Level {
             interact: (_p, game) => this.tryCell(game)
         });
 
-        const drip = new THREE.PointLight(0x6688aa, 0.15, 6);
-        drip.position.set(2, 2, -4);
-        this.group.add(drip);
-        this.torchLight = new THREE.PointLight(0xff9030, 1.1, 8);
-        this.group.add(this.torchLight);
+        // Luz de tocha móvel com Dico
+        this.torchLight = new BABYLON.PointLight('dicoTorchLight', new BABYLON.Vector3(0, 0, 0), scene);
+        this.torchLight.diffuse = new BABYLON.Color3(1.0, 0.6, 0.2);
+        this.torchLight.intensity = 1.1;
+        this.torchLight.range = 8;
+        this.torchLight.parent = this.group;
 
-        this.game.scene.add(this.group);
-        this.obstacles = [];
-        this.group.traverse((c) => { if (c.isMesh) this.obstacles.push(c); });
+        this.obstacles = this.group.getChildMeshes ? this.group.getChildMeshes() : [];
         this.keysTaken = false;
         this.cellTried = 0;
         this.alarmArmed = false;
@@ -164,9 +178,9 @@ export class CastleInteriorLevel extends Level {
         g.weather.apply('interior');
         g.audio.setTheme('stealth');
         g.storm.setIntensity(0);
-        g.ocean.water.visible = false;
+        g.ocean.visible = false;
         g.quests.set('stealth_up');
-        g.dialogue.say('DICO', 'Devagar…');
+        g.dialogue.say('DICO', 'Devagar… não faça barulho.');
         g.teco.ai.state = 'PERCHED';
         g.cameraRig.setObstacles(this.obstacles);
         g.input.enabled = true;
@@ -180,7 +194,7 @@ export class CastleInteriorLevel extends Level {
         this.keysTaken = true;
         this.sleeping.hasKeys = false;
         game.audio.play('clink');
-        game.dialogue.say('GUARDA', '…hmm…');
+        game.dialogue.say('GUARDA', '…hmm… quem está aí…');
         game.hud.showStealth(true, 0.7);
         game.story.notify('keys');
         this.sleeping.ai.suspicion = 0.4;
@@ -209,7 +223,7 @@ export class CastleInteriorLevel extends Level {
         if (game.story.flags.cellOpen) return;
         if (game.inventory.cellKey) {
             this.cellDoor.rotation.y = 1.5;
-            this.bars.visible = false;
+            this.bars.setEnabled(false);
             game.audio.play('click');
             game.audio.play('door');
             game.story.notify('cell_open');
@@ -226,12 +240,12 @@ export class CastleInteriorLevel extends Level {
         const n = this.cellTried;
         if (n === 1) game.dialogue.say('DICO', 'Não é esta…');
         else if (n === 2) game.dialogue.say('DICO', 'Tampouco esta.');
-        else game.dialogue.say('DICO', 'Nenhuma das três. Teco, a fechadura é outra.');
+        else game.dialogue.say('DICO', 'Nenhuma das três. Teco, a fechadura é outra. Deve estar na outra sala.');
     }
 
     tryShackles(game) {
         game.audio.play('fail');
-        game.dialogue.say('DICO', 'Primeira… não. Segunda… nada.');
+        game.dialogue.say('DICO', 'Tentando os grilhões…');
         setTimeout(() => {
             game.audio.play('click');
             game.story.notify('shackles');
@@ -243,16 +257,12 @@ export class CastleInteriorLevel extends Level {
         this.time += dt;
         this.fx.update(this.time);
         this.sleeping.update(dt, this.game);
-        if (this._rats) {
-            for (let i = 0; i < this._rats.length; i++) {
-                this._rats[i].position.x = Math.sin(this.time * 1.5 + i) * 1.4 - 1;
-            }
-        }
+
         const p = this.game.player.position;
         this.torchLight.position.set(p.x + 0.3, p.y + 1.5, p.z + 0.2);
-        this.torchLight.intensity = 1 + Math.sin(this.time * 10) * 0.15;
+        this.torchLight.intensity = 1.0 + Math.sin(this.time * 10) * 0.15;
 
-        const noise = this.game.player.noise;
+        const noise = this.game.player.noise || 0;
         this.game.hud.showStealth(true, Math.min(1, this.sleeping.ai.suspicion + noise * 0.3));
 
         if (this.alarmArmed && p.z > -22 && p.y > 2.5 && !this.game.story.flags.alarm) {
@@ -265,6 +275,6 @@ export class CastleInteriorLevel extends Level {
         super.exit();
         this.game.player.setTorch(false);
         this.game.hud.showStealth(false);
-        this.game.ocean.water.visible = true;
+        this.game.ocean.visible = true;
     }
 }

--- a/labs/guerreiro-castelo/js/levels/EndingLevel.js
+++ b/labs/guerreiro-castelo/js/levels/EndingLevel.js
@@ -1,4 +1,7 @@
-import * as THREE from 'three';
+/**
+ * Capítulo 12: Celebração e Pôr do Sol no Mar em Babylon.js.
+ */
+
 import { Level } from './Level.js';
 import { buildShip } from '../world/Ship.js';
 import { buildFriend, CharacterAnimator } from '../characters/builders.js';
@@ -9,20 +12,20 @@ export class EndingLevel extends Level {
     }
 
     async build() {
-        this.group = new THREE.Group();
-        this.ship = buildShip();
-        this.group.add(this.ship);
-        this.game.scene.add(this.group);
+        const scene = this.game.scene;
+        this.group = new BABYLON.TransformNode('endingLevelGroup', scene);
+        this.ship = buildShip(scene);
+        this.ship.parent = this.group;
 
         this.friends = [];
         for (let i = 0; i < 3; i++) {
-            const f = buildFriend(i);
-            f.group.position.set(-1.4 + i, 1.44, 1.5);
-            this.ship.add(f.group);
-            this.friends.push(new CharacterAnimator(f.group, f.clips));
+            const f = buildFriend(scene, i);
+            f.root.position.set(-1.4 + i * 1.4, 1.44, 1.2);
+            f.root.parent = this.ship;
+            this.friends.push(new CharacterAnimator(f.root, f.clips));
         }
-        this.phase = 'sail';
-        this.t = 0;
+
+        this.obstacles = this.ship.getChildMeshes ? this.ship.getChildMeshes() : [];
     }
 
     enter() {
@@ -30,56 +33,44 @@ export class EndingLevel extends Level {
         g.player.attachTo(this.ship);
         g.teco.attachTo(this.ship);
         g.camila.attachTo(this.ship);
-        g.player.spawn(0.4, 1.44, 3, Math.PI);
-        g.teco.spawn(0.6, 1.52, 3);
-        g.teco.ai.state = 'PERCHED';
-        g.camila.spawn(-0.8, 1.44, 2.4);
+        g.player.spawn(0, 1.44, 4.5, 0);
+        g.teco.spawn(0.8, 1.5, 3.8);
+        g.camila.spawn(-0.6, 1.44, 3.6);
+        g.camila.setShackles(false);
         g.camila.active = true;
-        g.camila.root.visible = true;
-        g.camila.ai.state = 'WAIT';
+        g.camila.root.setEnabled(true);
         g.player.controller.setMode('locked');
-        g.input.enabled = false;
-        g.weather.apply('day');
+        g.weather.apply('sunset');
         g.audio.setTheme('calm');
-        g.storm.setIntensity(0);
-        g.ocean.water.visible = true;
-        g.ocean.setStorm(0.12);
+        g.ocean.visible = true;
 
-        g.dialogue.play(
-            [
-                { speaker: 'CAMILA', text: 'Eu achei que nunca sairia daquele lugar.', duration: 4 },
-                { speaker: 'CAMILA', text: 'Obrigada. A todos vocês.', duration: 3.2 }
-            ],
-            () => this.pullBack()
-        );
-    }
-
-    pullBack() {
-        const g = this.game;
         g.cutscenes.play({
-            from: new THREE.Vector3(2, 3, 8),
-            to: new THREE.Vector3(18, 22, 40),
-            lookFrom: new THREE.Vector3(0, 2, 0),
-            lookTo: new THREE.Vector3(0, 4, -10),
-            duration: 6,
+            from: new BABYLON.Vector3(0, 4, 14),
+            to: new BABYLON.Vector3(0, 7, 24),
+            lookFrom: new BABYLON.Vector3(0, 2.4, 0),
+            lookTo: new BABYLON.Vector3(0, 3.4, -6),
+            duration: 7.5,
+            onMid: () => {
+                g.dialogue.play([
+                    { speaker: 'CAMILA', text: 'Obrigada, guerreiro. Achei que nunca mais veria o pôr do sol assim.', duration: 4.2 },
+                    { speaker: 'DICO', text: 'Nós sempre cumprimos uma promessa.', duration: 3.6 },
+                    { speaker: 'TECO', text: '*Teco pula no mastro e comemora*', duration: 3.2 }
+                ]);
+            },
             onEnd: () => {
-                g.fadeTo(1.6, () => g.loadStage('homeEnd', 'ending'));
+                g.fadeTo(1.6, () => {
+                    g.loadStage('home', 'ending');
+                });
             }
         });
     }
 
     update(dt) {
-        this.t += dt;
-        this.group.position.z -= dt * 2.2;
-        const wave = this.game.ocean.sample(0, this.group.position.z, this.t);
-        this.ship.position.y = wave.y * 0.3;
+        this.time += dt;
+        const wave = this.game.ocean.sample(0, 0, this.time);
+        this.ship.position.y = wave.y * 0.25;
         this.ship.rotation.x = wave.pitch * 0.3;
         this.ship.rotation.z = wave.roll * 0.3;
-        for (const a of this.friends) a.update(dt);
-    }
-
-    exit() {
-        super.exit();
-        this.game.input.enabled = true;
+        for (const f of this.friends) f.update(dt);
     }
 }

--- a/labs/guerreiro-castelo/js/levels/EscapeLevel.js
+++ b/labs/guerreiro-castelo/js/levels/EscapeLevel.js
@@ -1,4 +1,7 @@
-import * as THREE from 'three';
+/**
+ * Capítulo 10: Fuga do Castelo sob Saraivada de Flechas em Babylon.js.
+ */
+
 import { Level } from './Level.js';
 import { makeTree, makeGrassInstanced } from '../world/Environment.js';
 import { grassTexture, sandTexture } from '../world/Textures.js';
@@ -11,52 +14,55 @@ export class EscapeLevel extends Level {
     }
 
     async build() {
-        this.group = new THREE.Group();
-        const grass = new THREE.Mesh(
-            new THREE.PlaneGeometry(50, 90),
-            new THREE.MeshStandardMaterial({ map: grassTexture(), roughness: 0.92 })
-        );
-        grass.rotation.x = -Math.PI / 2;
-        grass.receiveShadow = true;
-        this.group.add(grass);
-        const sand = new THREE.Mesh(
-            new THREE.CircleGeometry(22, 24),
-            new THREE.MeshStandardMaterial({ map: sandTexture(), roughness: 0.95 })
-        );
-        sand.rotation.x = -Math.PI / 2;
-        sand.position.set(0, 0.03, 38);
-        this.group.add(sand);
+        const scene = this.game.scene;
+        this.group = new BABYLON.TransformNode('escapeGroup', scene);
+
+        const grass = BABYLON.MeshBuilder.CreateGround('escapeGrass', { width: 50, height: 90 }, scene);
+        grass.position.y = 0.02;
+        const gMat = new BABYLON.StandardMaterial('eGrassMat', scene);
+        gMat.diffuseTexture = grassTexture(scene, 10, 15);
+        grass.material = gMat;
+        grass.parent = this.group;
+        grass.receiveShadows = true;
+
+        const sand = BABYLON.MeshBuilder.CreateDisc('escapeSand', { radius: 22, tessellation: 24 }, scene);
+        sand.rotation.x = Math.PI / 2;
+        sand.position.set(0, 0.04, 38);
+        const sMat = new BABYLON.StandardMaterial('eSandMat', scene);
+        sMat.diffuseTexture = sandTexture(scene, 5, 5);
+        sand.material = sMat;
+        sand.parent = this.group;
+        sand.receiveShadows = true;
 
         const rng = seeded(9);
         this.trees = [];
         for (let i = 0; i < 22; i++) {
-            const t = makeTree(rng);
+            const t = makeTree(rng, scene);
             t.position.set((rng() - 0.5) * 28, 0, -20 + rng() * 50);
-            this.group.add(t);
+            t.parent = this.group;
             this.trees.push(t);
         }
-        this.group.add(makeGrassInstanced(160, 40, this.game.quality.vegetation));
+
+        const grassI = makeGrassInstanced(160, 40, this.game.quality?.vegetation || 1, scene);
+        grassI.parent = this.group;
 
         this.archers = [];
         for (let i = 0; i < 3; i++) {
-            const a = buildGuard({ archer: true });
-            a.group.position.set(-8 + i * 8, 10, -28);
-            this.group.add(a.group);
-            this.archers.push({ root: a.group, anim: new CharacterAnimator(a.group, a.clips), t: i * 0.4 });
+            const a = buildGuard(scene, { archer: true });
+            a.root.position.set(-8 + i * 8, 10, -28);
+            a.root.parent = this.group;
+            this.archers.push({ root: a.root, anim: new CharacterAnimator(a.root, a.clips), t: i * 0.4 });
         }
 
-        const shipHint = new THREE.Mesh(
-            new THREE.BoxGeometry(6, 3, 14),
-            new THREE.MeshStandardMaterial({ color: 0x8a6238, roughness: 0.85 })
-        );
+        const shipHint = BABYLON.MeshBuilder.CreateBox('shipEscapeHint', { width: 6, height: 3, depth: 14 }, scene);
         shipHint.position.set(0, 1.6, 46);
-        this.group.add(shipHint);
-        this.shipHint = shipHint;
+        const shipMat = new BABYLON.StandardMaterial('sHintMat', scene);
+        shipMat.diffuseColor = new BABYLON.Color3(0.5, 0.35, 0.2);
+        shipHint.material = shipMat;
+        shipHint.parent = this.group;
 
         this.game.collision.addFloor(0, 10, 60, 100, 0);
-        this.game.scene.add(this.group);
-        this.obstacles = [];
-        this.group.traverse((c) => { if (c.isMesh) this.obstacles.push(c); });
+        this.obstacles = this.group.getChildMeshes ? this.group.getChildMeshes() : [];
         this.game.arrows.setColliders(this.obstacles);
         this.fireT = 0;
         this.called = false;
@@ -64,23 +70,24 @@ export class EscapeLevel extends Level {
 
     enter() {
         const g = this.game;
-        g.player.attachTo(g.scene);
-        g.teco.attachTo(g.scene);
-        g.camila.attachTo(g.scene);
+        g.player.attachTo(this.group);
+        g.teco.attachTo(this.group);
+        g.camila.attachTo(this.group);
         g.player.spawn(0, 0, -24, 0);
         g.teco.spawn(0.5, 0, -23);
         g.camila.spawn(-0.8, 0, -25);
         g.camila.active = true;
-        g.camila.root.visible = true;
+        g.camila.root.setEnabled(true);
         g.camila.ai.run();
         g.weather.apply('day');
         g.audio.setTheme('chase');
         g.quests.set('reach_ship');
         g.hud.showObjective('Chegue ao navio', true);
-        g.dialogue.say('ARQUEIRO', 'Ali estão eles!');
+        g.dialogue.say('ARQUEIRO', 'Ali estão eles! Não os deixem escapar!');
         g.input.enabled = true;
         g.player.controller.setMode('walk');
         g.cameraRig.setObstacles(this.obstacles);
+
         g.arrows.onHitPlayer = () => {
             if (g.player.hurt(1)) {
                 g.audio.play('hit');
@@ -88,34 +95,41 @@ export class EscapeLevel extends Level {
                 if (!g.player.alive) g.failCheckpoint('Uma flecha…');
             }
         };
+
         g.input.requestLock();
     }
 
     update(dt) {
         this.time += dt;
         this.fireT += dt;
+
         for (const a of this.archers) {
             a.anim.update(dt);
             a.t += dt;
             if (a.t > 1.15) {
                 a.t = 0;
-                const origin = a.root.getWorldPosition(new THREE.Vector3()).add(new THREE.Vector3(0, 1.4, 0));
-                const target = this.game.player.worldPosition().clone();
-                target.x += (Math.random() - 0.5) * 4;
-                target.z += (Math.random() - 0.5) * 3;
-                target.y += 1;
-                const dir = target.sub(origin).normalize();
+                const archerPos = a.root.position;
+                const origin = new BABYLON.Vector3(archerPos.x, archerPos.y + 1.4, archerPos.z);
+                const p = this.game.player.position;
+                const target = new BABYLON.Vector3(
+                    p.x + (Math.random() - 0.5) * 4,
+                    p.y + 1,
+                    p.z + (Math.random() - 0.5) * 3
+                );
+                const dir = target.subtract(origin).normalize();
                 this.game.arrows.fire(origin, dir, 26 + Math.random() * 8);
                 this.game.audio.play('arrow');
             }
         }
+
         const p = this.game.player.position;
         if (p.z > 8 && !this.called) {
             this.called = true;
-            this.game.dialogue.say('DICO', 'Não parem!');
+            this.game.dialogue.say('DICO', 'Não parem! O navio está logo à frente!');
             this.game.teco.ai.state = 'SCARED';
             this.game.teco.ai.timer = 0;
         }
+
         if (p.z > 40) {
             this.game.story.notify('reach_ship');
         }

--- a/labs/guerreiro-castelo/js/levels/ForestLevel.js
+++ b/labs/guerreiro-castelo/js/levels/ForestLevel.js
@@ -1,4 +1,7 @@
-import * as THREE from 'three';
+/**
+ * Capítulo 5: Travessia pela Floresta em Babylon.js.
+ */
+
 import { Level } from './Level.js';
 import { makeTree, makeBush, makeRock, makeGrassInstanced } from '../world/Environment.js';
 import { grassTexture } from '../world/Textures.js';
@@ -10,47 +13,55 @@ export class ForestLevel extends Level {
     }
 
     async build() {
-        this.group = new THREE.Group();
+        const scene = this.game.scene;
+        this.group = new BABYLON.TransformNode('forestGroup', scene);
         this.group.position.set(0, 0, -36);
+
         const rng = seeded(42);
-        const ground = new THREE.Mesh(
-            new THREE.PlaneGeometry(48, 50),
-            new THREE.MeshStandardMaterial({ map: grassTexture(), roughness: 0.92 })
-        );
-        ground.rotation.x = -Math.PI / 2;
-        ground.receiveShadow = true;
-        this.group.add(ground);
+        const ground = BABYLON.MeshBuilder.CreateGround('forestGround', { width: 48, height: 50 }, scene);
+        ground.position.y = 0.02;
+        const gMat = new BABYLON.StandardMaterial('forestGroundMat', scene);
+        gMat.diffuseTexture = grassTexture(scene, 10, 10);
+        ground.material = gMat;
+        ground.parent = this.group;
+        ground.receiveShadows = true;
 
         this.trees = [];
-        for (let i = 0; i < 28 * this.game.quality.vegetation; i++) {
-            const t = makeTree(rng);
+        const treeCount = Math.floor(28 * (this.game.quality?.vegetation || 1));
+        for (let i = 0; i < treeCount; i++) {
+            const t = makeTree(rng, scene);
             let x = (rng() - 0.5) * 36;
             let z = (rng() - 0.5) * 42;
             if (Math.abs(x) < 2.4) x += x < 0 ? -3 : 3;
             t.position.set(x, 0, z);
-            this.group.add(t);
+            t.parent = this.group;
             this.trees.push(t);
             this.game.collision.addWall(x, z - 36, 0.8, 0.8, 4);
         }
-        for (let i = 0; i < 12; i++) {
-            const b = makeBush();
-            b.position.set((rng() - 0.5) * 20, 0.2, (rng() - 0.5) * 30);
-            this.group.add(b);
-        }
-        const rocks = makeRock(1.2);
-        rocks.position.set(3, 0.2, 8);
-        this.group.add(rocks);
-        this.group.add(makeGrassInstanced(220, 40, this.game.quality.vegetation));
 
-        this.game.scene.add(this.group);
-        this.obstacles = [];
-        this.group.traverse((c) => { if (c.isMesh) this.obstacles.push(c); });
+        for (let i = 0; i < 12; i++) {
+            const b = makeBush(scene);
+            b.position.set((rng() - 0.5) * 20, 0.2, (rng() - 0.5) * 30);
+            b.parent = this.group;
+        }
+
+        const rocks = makeRock(1.2, scene);
+        rocks.position.set(3, 0.2, 8);
+        rocks.parent = this.group;
+
+        const grassI = makeGrassInstanced(220, 40, this.game.quality?.vegetation || 1, scene);
+        grassI.parent = this.group;
+
+        this.obstacles = this.group.getChildMeshes ? this.group.getChildMeshes() : [];
     }
 
-    update() {
+    update(dt) {
+        this.time += dt;
         for (const t of this.trees) {
-            const c = t.children[1];
-            if (c) c.rotation.y = Math.sin(this.game.clockTime * 0.4) * 0.04;
+            const foliage = t.getChildren ? t.getChildren()[1] : null;
+            if (foliage) {
+                foliage.rotation.y = Math.sin(this.time * 0.4) * 0.04;
+            }
         }
     }
 }

--- a/labs/guerreiro-castelo/js/levels/HomeLevel.js
+++ b/labs/guerreiro-castelo/js/levels/HomeLevel.js
@@ -1,4 +1,7 @@
-import * as THREE from 'three';
+/**
+ * Capítulo 1 & Epílogo: Sala da Lareira em Babylon.js.
+ */
+
 import { Level } from './Level.js';
 import { buildHomeInterior, addHomeColliders } from '../world/Home.js';
 import { buildRavi, CharacterAnimator } from '../characters/builders.js';
@@ -10,47 +13,48 @@ export class HomeLevel extends Level {
     }
 
     async build() {
-        const g = buildHomeInterior();
+        const scene = this.game.scene;
+        const g = buildHomeInterior(scene);
         this.group = g;
         this.fx = new EnvironmentFX();
         this.fx.addFire(g.userData.fire);
         addHomeColliders(this.game.collision);
 
-        const ravi = buildRavi();
-        ravi.group.position.set(0.55, 0, 1.55);
-        ravi.group.rotation.y = -0.6;
-        g.add(ravi.group);
+        const ravi = buildRavi(scene);
+        ravi.root.position.set(0.55, 0, 1.55);
+        ravi.root.rotation.y = -0.6;
+        ravi.root.parent = g;
         this.ravi = ravi;
-        this.raviAnim = new CharacterAnimator(ravi.group, ravi.clips);
+        this.raviAnim = new CharacterAnimator(ravi.root, ravi.clips);
 
-        const lamp = new THREE.PointLight(0xff9030, 1.35, 7);
-        lamp.position.set(0, 1.1, -2.8);
-        g.add(lamp);
+        const lamp = new BABYLON.PointLight('hearthPointLight', new BABYLON.Vector3(0, 1.1, -2.8), scene);
+        lamp.diffuse = new BABYLON.Color3(1.0, 0.55, 0.2);
+        lamp.intensity = 1.35;
+        lamp.range = 8;
+        lamp.parent = g;
         this.hearthLight = lamp;
 
-        const fill = new THREE.PointLight(0xffc8a0, 0.35, 10);
-        fill.position.set(1.5, 2.2, 1);
-        g.add(fill);
+        const fill = new BABYLON.PointLight('homeFillLight', new BABYLON.Vector3(1.5, 2.2, 1), scene);
+        fill.diffuse = new BABYLON.Color3(1.0, 0.78, 0.62);
+        fill.intensity = 0.35;
+        fill.range = 10;
+        fill.parent = g;
 
-        this.game.scene.add(g);
-        this.obstacles = [];
-        g.traverse((c) => {
-            if (c.isMesh) this.obstacles.push(c);
-        });
+        this.obstacles = g.getChildMeshes ? g.getChildMeshes() : [];
     }
 
     enter(checkpoint) {
         const g = this.game;
         g.player.attachTo(this.group);
         g.teco.attachTo(this.group);
-        g.teco.root.visible = false;
+        g.teco.root.setEnabled(false);
         g.player.spawn(0.15, 0, 1.7, Math.PI);
         g.player.controller.setMode('locked');
         g.input.enabled = false;
         g.weather.apply('night');
         g.audio.setTheme('home');
         g.storm.setIntensity(0);
-        g.ocean.water.visible = false;
+        g.ocean.visible = false;
         g.cameraRig.setObstacles(this.obstacles);
 
         if (checkpoint === 'ending') {
@@ -59,10 +63,10 @@ export class HomeLevel extends Level {
         }
 
         g.cutscenes.play({
-            from: new THREE.Vector3(2.8, 1.6, 3.2),
-            to: new THREE.Vector3(1.4, 1.45, 2.6),
-            lookFrom: new THREE.Vector3(0, 1.1, 1.2),
-            lookTo: new THREE.Vector3(0.2, 1.2, 1.5),
+            from: new BABYLON.Vector3(2.8, 1.6, 3.2),
+            to: new BABYLON.Vector3(1.4, 1.45, 2.6),
+            lookFrom: new BABYLON.Vector3(0, 1.1, 1.2),
+            lookTo: new BABYLON.Vector3(0.2, 1.2, 1.5),
             duration: 4.2,
             onEnd: () => this._introDialogue()
         });
@@ -85,12 +89,12 @@ export class HomeLevel extends Level {
     _intoFire() {
         const g = this.game;
         g.cutscenes.play({
-            from: new THREE.Vector3(1.2, 1.4, 2.4),
-            to: new THREE.Vector3(0.1, 0.9, -2.2),
-            lookFrom: new THREE.Vector3(0, 1.1, 0.4),
-            lookTo: new THREE.Vector3(0, 0.7, -3.1),
+            from: new BABYLON.Vector3(1.2, 1.4, 2.4),
+            to: new BABYLON.Vector3(0.1, 0.9, -2.2),
+            lookFrom: new BABYLON.Vector3(0, 1.1, 0.4),
+            lookTo: new BABYLON.Vector3(0, 0.7, -3.1),
             duration: 3.6,
-            onMid: () => g.hud.showChapter('', ''),
+            onMid: () => g.hud.showChapter('A Travessia', 'rumo ao outro lado do mar'),
             onEnd: () => {
                 g.audio.play('wave');
                 g.fadeTo(1.4, () => {
@@ -104,12 +108,12 @@ export class HomeLevel extends Level {
         const g = this.game;
         g.player.spawn(0.15, 0, 1.7, Math.PI);
         g.player.controller.setMode('locked');
-        g.teco.root.visible = false;
+        g.teco.root.setEnabled(false);
         g.cutscenes.play({
-            from: new THREE.Vector3(2.2, 1.5, 3),
-            to: new THREE.Vector3(1.3, 1.4, 2.5),
-            lookFrom: new THREE.Vector3(0.2, 1.2, 1.4),
-            lookTo: new THREE.Vector3(0.2, 1.2, 1.5),
+            from: new BABYLON.Vector3(2.2, 1.5, 3),
+            to: new BABYLON.Vector3(1.3, 1.4, 2.5),
+            lookFrom: new BABYLON.Vector3(0.2, 1.2, 1.4),
+            lookTo: new BABYLON.Vector3(0.2, 1.2, 1.5),
             duration: 2.5,
             onEnd: () => {
                 g.dialogue.play(
@@ -129,17 +133,18 @@ export class HomeLevel extends Level {
         const shiny = this.group.userData.shiny;
         g.audio.play('click');
         if (shiny) {
-            const start = shiny.position.clone();
+            const startX = shiny.position.x;
+            const startY = shiny.position.y;
             let t = 0;
             this._fly = (dt) => {
                 t += dt;
-                shiny.position.x = start.x + t * 1.8;
-                shiny.position.y = start.y + Math.sin(t * 6) * 0.1 + t * 0.2;
+                shiny.position.x = startX + t * 1.8;
+                shiny.position.y = startY + Math.sin(t * 6) * 0.1 + t * 0.2;
                 if (t > 1.2) {
-                    shiny.visible = false;
+                    shiny.setEnabled(false);
                     this._fly = null;
-                    g.dialogue.say('DICO', '…', 1.2);
-                    setTimeout(() => g.story.notify('the_end'), 1600);
+                    g.dialogue.say('DICO', '… Teco levou o brinquedo de novo.', 2.4);
+                    setTimeout(() => g.story.notify('the_end'), 2000);
                 }
             };
         } else {
@@ -152,16 +157,16 @@ export class HomeLevel extends Level {
         this.fx.update(this.time);
         this.raviAnim?.update(dt);
         if (this.hearthLight) {
-            this.hearthLight.intensity = 1.2 + Math.sin(this.time * 9) * 0.2;
+            this.hearthLight.intensity = 1.2 + Math.sin(this.time * 9) * 0.25;
         }
         this._fly?.(dt);
     }
 
     exit() {
         super.exit();
-        this.game.ocean.water.visible = true;
+        this.game.ocean.visible = true;
         this.game.player.controller.setMode('walk');
         this.game.input.enabled = true;
-        this.game.teco.root.visible = true;
+        this.game.teco.root.setEnabled(true);
     }
 }

--- a/labs/guerreiro-castelo/js/levels/Level.js
+++ b/labs/guerreiro-castelo/js/levels/Level.js
@@ -1,4 +1,6 @@
-/** Nível base — grupo, colisão e ciclo de vida. */
+/**
+ * Nível base em Babylon.js — transformNode raiz, obstáculos, ciclo de vida e interação.
+ */
 
 export class Level {
     constructor(game) {
@@ -19,7 +21,18 @@ export class Level {
     enter() {}
 
     exit() {
+        for (const item of this.interactables) {
+            this.game.interact.remove(item);
+        }
         this.interactables.length = 0;
+        this.obstacles.length = 0;
+        this.npcs.length = 0;
+        if (this.group) {
+            try {
+                this.group.dispose(false, true);
+            } catch { /* ignore */ }
+            this.group = null;
+        }
     }
 
     update() {}

--- a/labs/guerreiro-castelo/js/levels/SecretEntranceLevel.js
+++ b/labs/guerreiro-castelo/js/levels/SecretEntranceLevel.js
@@ -1,7 +1,9 @@
-import * as THREE from 'three';
+/**
+ * Capítulo 7: Entrada Secreta do Castelo em Babylon.js.
+ */
+
 import { Level } from './Level.js';
 import { woodTexture, mossTexture, rustTexture } from '../world/Textures.js';
-import { std } from '../characters/builders.js';
 
 export class SecretEntranceLevel extends Level {
     get id() {
@@ -9,40 +11,56 @@ export class SecretEntranceLevel extends Level {
     }
 
     async build() {
-        this.group = new THREE.Group();
+        const scene = this.game.scene;
+        this.group = new BABYLON.TransformNode('secretEntranceGroup', scene);
         this.group.position.set(-18, 0, -94);
-        const wood = new THREE.MeshStandardMaterial({ map: woodTexture(), roughness: 0.85 });
-        const frame = new THREE.Mesh(new THREE.BoxGeometry(2.2, 3.2, 0.4), wood);
+
+        const woodMat = new BABYLON.StandardMaterial('secretWoodMat', scene);
+        woodMat.diffuseTexture = woodTexture(scene, 2, 2);
+
+        const frame = BABYLON.MeshBuilder.CreateBox('doorFrame', { width: 2.2, height: 3.2, depth: 0.4 }, scene);
         frame.position.y = 1.6;
-        this.group.add(frame);
-        this.door = new THREE.Mesh(new THREE.BoxGeometry(1.4, 2.4, 0.16), wood);
+        frame.material = woodMat;
+        frame.parent = this.group;
+
+        this.door = BABYLON.MeshBuilder.CreateBox('secretDoorMesh', { width: 1.4, height: 2.4, depth: 0.16 }, scene);
         this.door.position.set(0, 1.25, 0.1);
-        this.group.add(this.door);
-        const lock = new THREE.Mesh(
-            new THREE.BoxGeometry(0.2, 0.24, 0.12),
-            new THREE.MeshStandardMaterial({ map: rustTexture(), color: 0x8a4a18, metalness: 0.6, roughness: 0.5 })
-        );
+        this.door.material = woodMat;
+        this.door.parent = this.group;
+
+        const lock = BABYLON.MeshBuilder.CreateBox('secretLockMesh', { width: 0.2, height: 0.24, depth: 0.12 }, scene);
         lock.position.set(0.45, 1.2, 0.22);
-        this.group.add(lock);
-        const moss = new THREE.Mesh(
-            new THREE.PlaneGeometry(2.6, 3.4),
-            new THREE.MeshStandardMaterial({ map: mossTexture(), side: THREE.DoubleSide, roughness: 0.9 })
-        );
+        const rustMat = new BABYLON.StandardMaterial('secretRustMat', scene);
+        rustMat.diffuseTexture = rustTexture(scene, 1, 1);
+        rustMat.diffuseColor = new BABYLON.Color3(0.6, 0.35, 0.15);
+        lock.material = rustMat;
+        lock.parent = this.group;
+
+        const moss = BABYLON.MeshBuilder.CreatePlane('secretMossMesh', { width: 2.6, height: 3.4 }, scene);
         moss.position.set(0, 1.5, -0.25);
-        this.group.add(moss);
-        const roots = new THREE.Mesh(new THREE.CylinderGeometry(0.05, 0.08, 2.2, 5), std(0x3a2a14, 0.9));
+        const mossMat = new BABYLON.StandardMaterial('sMossMat', scene);
+        mossMat.diffuseTexture = mossTexture(scene, 2, 2);
+        mossMat.backFaceCulling = false;
+        moss.material = mossMat;
+        moss.parent = this.group;
+
+        const roots = BABYLON.MeshBuilder.CreateCylinder('secretRoots', { diameter: 0.08, height: 2.2 }, scene);
         roots.rotation.z = 0.6;
         roots.position.set(-0.8, 0.8, 0.2);
-        this.group.add(roots);
+        const rootMat = new BABYLON.StandardMaterial('rootMat', scene);
+        rootMat.diffuseColor = new BABYLON.Color3(0.25, 0.18, 0.1);
+        roots.material = rootMat;
+        roots.parent = this.group;
 
         this.addInteract({
             object: this.door,
             interactionLabel: 'Abrir',
             interactionDistance: 2.2,
             interact: (_p, game) => {
-                game.dialogue.say('DICO', 'Trancada.');
+                game.dialogue.say('DICO', 'Trancada por dentro.');
             }
         });
+
         this.addInteract({
             object: lock,
             interactionLabel: 'Pedir ajuda a Teco',
@@ -50,17 +68,17 @@ export class SecretEntranceLevel extends Level {
             interact: (_p, game) => this.sendTeco(game)
         });
 
-        this.game.scene.add(this.group);
         this.opened = false;
     }
 
     sendTeco(game) {
         if (this.opened) return;
-        const dest = this.lockWorld || this.door.getWorldPosition(new THREE.Vector3());
+        const dest = this.door.getAbsolutePosition();
         dest.y += 0.4;
-        const local = dest.clone();
-        game.teco.root.parent.worldToLocal(local);
-        game.teco.ai.command([game.teco.position.clone(), local], {
+
+        game.teco.ai.command([game.teco.position.clone(), dest], {
+            climb: true,
+            celebrate: true,
             onComplete: () => {
                 this.opened = true;
                 game.audio.play('click');

--- a/labs/guerreiro-castelo/js/levels/ShipEscapeLevel.js
+++ b/labs/guerreiro-castelo/js/levels/ShipEscapeLevel.js
@@ -1,4 +1,7 @@
-import * as THREE from 'three';
+/**
+ * Capítulo 11: Zarpando e Fuga de Navio em Babylon.js.
+ */
+
 import { Level } from './Level.js';
 import { buildShip, addShipColliders } from '../world/Ship.js';
 import { makeRock } from '../world/Environment.js';
@@ -10,18 +13,19 @@ export class ShipEscapeLevel extends Level {
     }
 
     async build() {
-        this.group = new THREE.Group();
-        this.ship = buildShip();
-        this.group.add(this.ship);
-        this.game.scene.add(this.group);
+        const scene = this.game.scene;
+        this.group = new BABYLON.TransformNode('shipEscapeGroup', scene);
+        this.ship = buildShip(scene);
+        this.ship.parent = this.group;
+
         addShipColliders(this.game.collision);
 
         this.friends = [];
         for (let i = 0; i < 3; i++) {
-            const f = buildFriend(i);
-            f.group.position.set(-1.5 + i * 1.4, 1.44, 2);
-            this.ship.add(f.group);
-            this.friends.push(new CharacterAnimator(f.group, f.clips));
+            const f = buildFriend(scene, i);
+            f.root.position.set(-1.5 + i * 1.4, 1.44, 2);
+            f.root.parent = this.ship;
+            this.friends.push(new CharacterAnimator(f.root, f.clips));
         }
 
         this.addInteract({
@@ -31,11 +35,12 @@ export class ShipEscapeLevel extends Level {
             interact: (_p, game) => {
                 if (this.untied) return;
                 this.untied = true;
-                this.ship.userData.mooring.visible = false;
+                this.ship.userData.mooring.setEnabled(false);
                 game.audio.play('interact');
                 game.story.notify('untie');
             }
         });
+
         this.addInteract({
             object: this.ship.userData.sail,
             interactionLabel: 'Levantar a vela',
@@ -47,6 +52,7 @@ export class ShipEscapeLevel extends Level {
                 game.story.notify('sail');
             }
         });
+
         this.addInteract({
             object: this.ship.userData.helm,
             interactionLabel: 'Assumir o leme',
@@ -62,16 +68,15 @@ export class ShipEscapeLevel extends Level {
 
         this.rocks = [];
         for (const [x, z] of [[-8, -18], [9, -28], [0, -40]]) {
-            const r = makeRock(5);
-            r.scale.set(3, 6, 4);
+            const r = makeRock(5, scene);
+            r.scaling.set(3, 6, 4);
             r.position.set(x, 1.5, z);
-            this.game.scene.add(r);
             this.rocks.push(r);
         }
 
-        this.obstacles = [];
-        this.ship.traverse((c) => { if (c.isMesh) this.obstacles.push(c); });
+        this.obstacles = this.ship.getChildMeshes ? this.ship.getChildMeshes() : [];
         this.game.arrows.setColliders(this.obstacles.concat(this.rocks));
+
         this.phase = 'prep';
         this.steer = 0;
         this.shipX = 0;
@@ -92,14 +97,16 @@ export class ShipEscapeLevel extends Level {
         g.camila.ai.state = 'WAIT';
         g.weather.apply('day');
         g.audio.setTheme('chase');
-        g.ocean.water.visible = true;
+        g.ocean.visible = true;
         g.quests.set('untie');
         g.input.enabled = true;
         g.player.controller.setMode('walk');
         g.cameraRig.setObstacles(this.obstacles);
+
         g.arrows.onHitPlayer = () => {
             if (g.player.hurt(0.5)) g.cameraRig.addShake(0.1, 0.2);
         };
+
         g.input.requestLock();
         g.dialogue.say('DICO', 'Soltem as amarras!');
     }
@@ -108,8 +115,8 @@ export class ShipEscapeLevel extends Level {
         this.phase = 'helm';
         this.game.player.controller.setMode('helm');
         this.game.player.spawn(0, 2.23, 7.1, Math.PI);
-        this.game.hud.showObjective('Saia da costa sem bater');
-        this.game.dialogue.say('DICO', 'Vento nas velas!');
+        this.game.hud.showObjective('Saia da costa sem bater nos recifes');
+        this.game.dialogue.say('DICO', 'Vento nas velas! Segurem-se!');
     }
 
     update(dt) {
@@ -119,13 +126,14 @@ export class ShipEscapeLevel extends Level {
         this.ship.rotation.x = wave.pitch * 0.4;
         this.ship.rotation.z = wave.roll * 0.4;
         this.ship.userData.helm.rotation.z = this.steer * 0.5;
+
         for (const a of this.friends) a.update(dt);
 
         this.arrowT += dt;
         if (this.phase !== 'done' && this.arrowT > 0.9 && this.shipZ > -25) {
             this.arrowT = 0;
-            const origin = new THREE.Vector3((Math.random() - 0.5) * 16, 8, 18);
-            const dir = new THREE.Vector3((Math.random() - 0.5) * 0.3, -0.1, -1).normalize();
+            const origin = new BABYLON.Vector3((Math.random() - 0.5) * 16, 8, 18);
+            const dir = new BABYLON.Vector3((Math.random() - 0.5) * 0.3, -0.1, -1).normalize();
             this.game.arrows.fire(origin, dir, 22);
             this.game.audio.play('arrow');
         }
@@ -137,6 +145,7 @@ export class ShipEscapeLevel extends Level {
             this.shipX += this.steer * 8 * dt;
             this.shipZ -= 14 * dt;
             this.group.position.set(this.shipX, 0, this.shipZ);
+
             for (const r of this.rocks) {
                 if (Math.hypot(this.shipX - r.position.x, this.shipZ - r.position.z) < 6.5) {
                     this.game.failCheckpoint('Pedras na costa…');
@@ -144,6 +153,7 @@ export class ShipEscapeLevel extends Level {
                     return;
                 }
             }
+
             if (this.shipZ < -55) {
                 this.phase = 'done';
                 this.game.player.controller.setMode('locked');
@@ -154,7 +164,9 @@ export class ShipEscapeLevel extends Level {
 
     exit() {
         super.exit();
-        for (const r of this.rocks) this.game.scene.remove(r);
+        for (const r of this.rocks) {
+            try { r.dispose(); } catch { /* ignore */ }
+        }
         this.game.arrows.clear();
         this.game.arrows.onHitPlayer = null;
         this.game.player.controller.setMode('walk');

--- a/labs/guerreiro-castelo/js/levels/ShipLevel.js
+++ b/labs/guerreiro-castelo/js/levels/ShipLevel.js
@@ -1,4 +1,7 @@
-import * as THREE from 'three';
+/**
+ * Capítulos 2 e 3: Exploração marítima & Tempestade no mar em Babylon.js.
+ */
+
 import { Level } from './Level.js';
 import { buildShip, addShipColliders } from '../world/Ship.js';
 import { buildFriend, CharacterAnimator } from '../characters/builders.js';
@@ -10,12 +13,10 @@ export class ShipLevel extends Level {
     }
 
     async build() {
-        this.group = new THREE.Group();
-        this.ship = buildShip();
-        this.group.add(this.ship);
-        this.game.scene.add(this.group);
-        const fill = new THREE.HemisphereLight(0xc8e4ff, 0x3a2a18, 0.4);
-        this.ship.add(fill);
+        const scene = this.game.scene;
+        this.group = new BABYLON.TransformNode('shipLevelRoot', scene);
+        this.ship = buildShip(scene);
+        this.ship.parent = this.group;
 
         addShipColliders(this.game.collision);
 
@@ -25,15 +26,17 @@ export class ShipLevel extends Level {
             { x: 1.8, z: 1.4, y: 1.44, yaw: -0.8, line: ['AMIGO', 'Espadas, cordas, água… está tudo a bordo.'] },
             { x: -1.4, z: 4.6, y: 1.44, yaw: 2.4, line: ['AMIGO', 'Teco já subiu em três barris hoje.'] }
         ];
+
         spots.forEach((s, i) => {
-            const f = buildFriend(i);
-            f.group.position.set(s.x, s.y, s.z);
-            f.group.rotation.y = s.yaw;
-            this.ship.add(f.group);
-            const anim = new CharacterAnimator(f.group, f.clips);
-            this.friends.push({ root: f.group, anim, line: s.line });
+            const f = buildFriend(scene, i);
+            f.root.position.set(s.x, s.y, s.z);
+            f.root.rotation.y = s.yaw;
+            f.root.parent = this.ship;
+            const anim = new CharacterAnimator(f.root, f.clips);
+            this.friends.push({ root: f.root, anim, line: s.line });
+
             this.addInteract({
-                object: f.group,
+                object: f.root,
                 interactionLabel: 'Conversar',
                 interactionDistance: 2.4,
                 interact: (_p, game) => {
@@ -45,15 +48,15 @@ export class ShipLevel extends Level {
             });
         });
 
-        const horizon = new THREE.Object3D();
+        const horizon = new BABYLON.TransformNode('horizonProxy', scene);
         horizon.position.set(0, 1.8, -7.5);
-        this.ship.add(horizon);
+        horizon.parent = this.ship;
         this.addInteract({
             object: horizon,
             interactionLabel: 'Observar o horizonte',
             interactionDistance: 2.8,
             interact: (_p, game) => {
-                game.dialogue.say('DICO', 'Do outro lado do mar… uma cidade, e um castelo.');
+                game.dialogue.say('DICO', 'Do outro lado do mar… uma ilha, e um castelo.');
                 game.story.notify('horizon');
             }
         });
@@ -93,16 +96,12 @@ export class ShipLevel extends Level {
             interact: (_p, game) => this.sendTecoRope(game)
         });
 
-        this.rock = makeRock(6);
-        this.rock.scale.set(4.5, 8, 5);
+        this.rock = makeRock(6, scene);
+        this.rock.scaling.set(4.5, 8, 5);
         this.rock.position.set(2, 2, -70);
-        this.game.scene.add(this.rock);
-        this.rock.visible = false;
+        this.rock.setEnabled(false);
 
-        this.obstacles = [];
-        this.ship.traverse((c) => {
-            if (c.isMesh) this.obstacles.push(c);
-        });
+        this.obstacles = this.ship.getChildMeshes ? this.ship.getChildMeshes() : [];
 
         this.phase = 'explore';
         this.steer = 0;
@@ -123,20 +122,14 @@ export class ShipLevel extends Level {
         g.weather.apply('day');
         g.audio.setTheme('sea');
         g.storm.setIntensity(0);
-        g.ocean.water.visible = true;
+        g.ocean.visible = true;
         g.quests.set('explore_ship');
         g.checkpoints.save('ship_start', g.story._saveBlob());
         g.cameraRig.setObstacles(this.obstacles);
         g.cameraRig.yaw = Math.PI;
         g.cameraRig.pitch = 0.28;
         g.cameraRig.cutscene = false;
-        this.ship.updateMatrixWorld(true);
-        g.player.root.updateMatrixWorld(true);
         g.cameraRig.snapToPlayer(g.player);
-        g.camera.position.set(0, 6.5, 9.5);
-        g.camera.lookAt(0, 2, 1);
-        g.cameraRig.currentPos.copy(g.camera.position);
-        g.cameraRig.smoothLook.set(0, 2, 1);
         g.hud.showObjective('Explore o navio');
         g.input.requestLock();
     }
@@ -145,7 +138,7 @@ export class ShipLevel extends Level {
         if (this.nightStarted) return;
         this.nightStarted = true;
         const g = this.game;
-        g.hud.showChapter('Terceira noite', '');
+        g.hud.showChapter('A Tempestade', 'ondas ferozes na escuridão');
         g.fadeTo(1.2, () => {
             this.phase = 'storm';
             g.weather.apply('storm');
@@ -154,9 +147,9 @@ export class ShipLevel extends Level {
             g.dialogue.say('DICO', 'Segurem firme!');
             g.quests.set('free_helm');
             g.checkpoints.save('storm_start', g.story._saveBlob());
-            this.ship.userData.rope.visible = true;
+            this.ship.userData.rope.setEnabled(true);
             this.ropeItem.enabled = true;
-            this.rock.visible = true;
+            this.rock.setEnabled(true);
             g.cameraRig.addShake(0.04, 8);
             g.player.spawn(0, 1.44, 4.5, 0);
             g.fadeTo(0, null, 0.9);
@@ -167,15 +160,15 @@ export class ShipLevel extends Level {
         this.ropeItem.enabled = false;
         game.dialogue.say('DICO', 'Cuidado, Teco!');
         const path = [
-            new THREE.Vector3(1.8, 1.7, 2),
-            new THREE.Vector3(2.1, 2.1, 4.2),
-            new THREE.Vector3(1.2, 2.6, 6.4),
-            new THREE.Vector3(0.3, 2.7, 7.4)
+            new BABYLON.Vector3(1.8, 1.7, 2),
+            new BABYLON.Vector3(2.1, 2.1, 4.2),
+            new BABYLON.Vector3(1.2, 2.6, 6.4),
+            new BABYLON.Vector3(0.3, 2.7, 7.4)
         ];
         game.teco.ai.command(path, {
             climb: true,
             onComplete: () => {
-                this.ship.userData.rope.visible = false;
+                this.ship.userData.rope.setEnabled(false);
                 game.audio.play('success');
                 game.story.notify('rope_freed');
             }
@@ -192,7 +185,7 @@ export class ShipLevel extends Level {
         this.shipX = 0;
         this.steer = 0;
         this.rock.position.set(3, 2, -55);
-        this.rock.visible = true;
+        this.rock.setEnabled(true);
     }
 
     endStorm() {
@@ -202,18 +195,19 @@ export class ShipLevel extends Level {
         g.storm.setIntensity(0.15);
         g.weather.apply('dawn');
         g.audio.setTheme('land');
-        const castleHint = new THREE.Mesh(
-            new THREE.BoxGeometry(18, 28, 18),
-            new THREE.MeshStandardMaterial({ color: 0x8a8070, roughness: 0.9 })
-        );
+
+        const castleHint = BABYLON.MeshBuilder.CreateBox('castleHint', { width: 18, height: 28, depth: 18 }, this.game.scene);
+        const cMat = new BABYLON.StandardMaterial('cHintMat', this.game.scene);
+        cMat.diffuseColor = new BABYLON.Color3(0.55, 0.5, 0.45);
+        castleHint.material = cMat;
         castleHint.position.set(8, 16, -160);
-        this.game.scene.add(castleHint);
         this._hint = castleHint;
+
         g.cutscenes.play({
-            from: new THREE.Vector3(4, 8, 16),
-            to: new THREE.Vector3(10, 14, 6),
-            lookFrom: new THREE.Vector3(8, 10, -40),
-            lookTo: new THREE.Vector3(8, 18, -160),
+            from: new BABYLON.Vector3(4, 8, 16),
+            to: new BABYLON.Vector3(10, 14, 6),
+            lookFrom: new BABYLON.Vector3(8, 10, -40),
+            lookTo: new BABYLON.Vector3(8, 18, -160),
             duration: 5.2,
             onEnd: () => {}
         });
@@ -261,14 +255,18 @@ export class ShipLevel extends Level {
 
         if (this.phase === 'storm') {
             this.game.cameraRig.addShake(0.015, 0.2);
-            this.game.storm.follow(this.ship.getWorldPosition(new THREE.Vector3()));
+            this.game.storm.follow(this.ship.position);
         }
     }
 
     exit() {
         super.exit();
-        this.game.scene.remove(this.rock);
-        if (this._hint) this.game.scene.remove(this._hint);
+        if (this.rock) {
+            try { this.rock.dispose(); } catch { /* ignore */ }
+        }
+        if (this._hint) {
+            try { this._hint.dispose(); } catch { /* ignore */ }
+        }
         this.game.player.controller.setMode('walk');
     }
 }

--- a/labs/guerreiro-castelo/js/levels/TigerRoomLevel.js
+++ b/labs/guerreiro-castelo/js/levels/TigerRoomLevel.js
@@ -1,7 +1,9 @@
-import * as THREE from 'three';
+/**
+ * Capítulo 9: Sala do Tigre & Puzzle Aéreo com Teco em Babylon.js.
+ */
+
 import { Level } from './Level.js';
 import { castleStoneTexture, woodTexture } from '../world/Textures.js';
-import { std } from '../characters/builders.js';
 import { Tiger } from '../characters/Tiger.js';
 
 export class TigerRoomLevel extends Level {
@@ -10,56 +12,74 @@ export class TigerRoomLevel extends Level {
     }
 
     async build() {
-        this.group = new THREE.Group();
+        const scene = this.game.scene;
+        this.group = new BABYLON.TransformNode('tigerRoomGroup', scene);
         this.group.position.set(12, 3.2, -18);
-        const stone = new THREE.MeshStandardMaterial({ map: castleStoneTexture(), roughness: 0.9 });
-        const floor = new THREE.Mesh(new THREE.BoxGeometry(12, 0.2, 12), stone);
+
+        const stoneMat = new BABYLON.StandardMaterial('tigerStoneMat', scene);
+        stoneMat.diffuseTexture = castleStoneTexture(scene, 4, 4);
+
+        const woodMat = new BABYLON.StandardMaterial('tigerWoodMat', scene);
+        woodMat.diffuseTexture = woodTexture(scene, 2, 2);
+
+        // Piso
+        const floor = BABYLON.MeshBuilder.CreateBox('tigerFloor', { width: 12, height: 0.2, depth: 12 }, scene);
         floor.position.y = -0.1;
-        floor.receiveShadow = true;
-        this.group.add(floor);
+        floor.material = stoneMat;
+        floor.parent = this.group;
+        floor.receiveShadows = true;
         this.game.collision.addFloor(12, -18, 12, 12, 3.2);
 
+        // 4 Paredes
         const walls = [
-            [0, 2, -6, 12, 4.2, 0.3],
-            [0, 2, 6, 12, 4.2, 0.3],
-            [-6, 2, 0, 0.3, 4.2, 12],
-            [6, 2, 0, 0.3, 4.2, 12]
+            { name: 'tWallN', w: 12, h: 4.2, d: 0.3, x: 0, y: 2, z: -6 },
+            { name: 'tWallS', w: 12, h: 4.2, d: 0.3, x: 0, y: 2, z: 6 },
+            { name: 'tWallW', w: 0.3, h: 4.2, d: 12, x: -6, y: 2, z: 0 },
+            { name: 'tWallE', w: 0.3, h: 4.2, d: 12, x: 6, y: 2, z: 0 }
         ];
+
         for (const w of walls) {
-            const m = new THREE.Mesh(new THREE.BoxGeometry(w[3], w[4], w[5]), stone);
-            m.position.set(w[0], w[1], w[2]);
-            this.group.add(m);
+            const m = BABYLON.MeshBuilder.CreateBox(w.name, { width: w.w, height: w.h, depth: w.d }, scene);
+            m.position.set(w.x, w.y, w.z);
+            m.material = stoneMat;
+            m.parent = this.group;
         }
+
         this.game.collision.addWall(12, -24, 12, 0.4, 4, 3.2);
         this.game.collision.addWall(12, -12, 12, 0.4, 4, 3.2);
         this.game.collision.addWall(6, -18, 0.4, 12, 4, 3.2);
         this.game.collision.addWall(18, -18, 0.4, 12, 4, 3.2);
 
-        const doorHole = new THREE.Mesh(new THREE.BoxGeometry(0.5, 2.6, 2.2), std(0x0a0806, 1));
-        doorHole.position.set(-5.8, 1.3, 0);
-        this.group.add(doorHole);
-
-        for (const [x, y, z] of [
-            [-3, 2.6, -2], [0, 3.1, 1], [2.4, 3.4, -1], [4, 3.6, 2]
-        ]) {
-            const beam = new THREE.Mesh(
-                new THREE.BoxGeometry(0.7, 0.25, 2.2),
-                new THREE.MeshStandardMaterial({ map: woodTexture(), roughness: 0.85 })
-            );
+        // Vigas de madeira no alto
+        const beamCoords = [
+            [-3, 2.6, -2],
+            [0, 3.1, 1],
+            [2.4, 3.4, -1],
+            [4, 3.6, 2]
+        ];
+        for (const [x, y, z] of beamCoords) {
+            const beam = BABYLON.MeshBuilder.CreateBox('beam', { width: 0.7, height: 0.25, depth: 2.2 }, scene);
             beam.position.set(x, y, z);
-            this.group.add(beam);
+            beam.material = woodMat;
+            beam.parent = this.group;
         }
-        const ledge = new THREE.Mesh(new THREE.BoxGeometry(1.2, 0.3, 1.2), stone);
+
+        const ledge = BABYLON.MeshBuilder.CreateBox('ledge', { width: 1.2, height: 0.3, depth: 1.2 }, scene);
         ledge.position.set(-4, 2.2, 3.4);
-        this.group.add(ledge);
+        ledge.material = stoneMat;
+        ledge.parent = this.group;
 
-        this.keyMesh = new THREE.Mesh(
-            new THREE.BoxGeometry(0.12, 0.35, 0.06),
-            new THREE.MeshStandardMaterial({ color: 0xd4b45a, metalness: 0.8, roughness: 0.3, emissive: 0x553300, emissiveIntensity: 0.5 })
-        );
+        // Chave dourada suspensa na viga alta
+        this.keyMesh = BABYLON.MeshBuilder.CreateBox('cellKeyGold', { width: 0.12, height: 0.35, depth: 0.06 }, scene);
         this.keyMesh.position.set(4.6, 2.4, -4.4);
-        this.group.add(this.keyMesh);
+        const goldMat = new BABYLON.StandardMaterial('goldKeyCellMat', scene);
+        goldMat.diffuseColor = new BABYLON.Color3(0.95, 0.8, 0.2);
+        goldMat.specularColor = new BABYLON.Color3(1, 1, 0.8);
+        goldMat.emissiveColor = new BABYLON.Color3(0.4, 0.3, 0.05);
+        this.keyMesh.material = goldMat;
+        this.keyMesh.parent = this.group;
 
+        // Tigre patrulhando
         this.tiger = new Tiger(this.group);
         this.tiger.spawn(1.2, 0, -1.5, Math.PI);
         this.tiger.ai.setBounds(-4, 4, -4, 4);
@@ -72,11 +92,13 @@ export class TigerRoomLevel extends Level {
             interact: (_p, game) => this.sendTeco(game)
         });
 
-        const dim = new THREE.PointLight(0xffaa66, 0.45, 10);
-        dim.position.set(0, 3, 0);
-        this.group.add(dim);
+        const dim = new BABYLON.PointLight('tigerRoomLight', new BABYLON.Vector3(0, 3, 0), scene);
+        dim.diffuse = new BABYLON.Color3(1.0, 0.7, 0.4);
+        dim.intensity = 0.55;
+        dim.range = 12;
+        dim.parent = this.group;
 
-        this.game.scene.add(this.group);
+        this.obstacles = this.group.getChildMeshes ? this.group.getChildMeshes() : [];
         this.sent = false;
         this.greeted = false;
     }
@@ -84,14 +106,11 @@ export class TigerRoomLevel extends Level {
     sendTeco(game) {
         if (this.sent || game.inventory.cellKey) return;
         this.sent = true;
-        game.dialogue.say('DICO', 'Teco… consegue pegar aquela chave?');
-        const parent = game.teco.root.parent;
-        const wp = (x, y, z) => {
-            const v = new THREE.Vector3(x, y, z);
-            this.group.localToWorld(v);
-            parent.worldToLocal(v);
-            return v;
-        };
+        game.dialogue.say('DICO', 'Teco… consegue alcançar aquela chave dourada nas vigas?');
+
+        const roomPos = this.group.position;
+        const wp = (x, y, z) => new BABYLON.Vector3(roomPos.x + x, roomPos.y + y, roomPos.z + z);
+
         const path = [
             wp(-4, 2.4, 3.4),
             wp(-3, 2.8, -2),
@@ -100,17 +119,18 @@ export class TigerRoomLevel extends Level {
             wp(4.2, 3.8, 2),
             wp(4.6, 2.6, -4.2)
         ];
+
         game.teco.ai.command(path, {
             climb: true,
             scared: true,
             celebrate: true,
             onComplete: () => {
-                this.keyMesh.visible = false;
+                this.keyMesh.setEnabled(false);
                 game.audio.play('pickup');
                 game.dialogue.say('TECO', 'Consegui!');
                 game.dialogue.say('DICO', 'Muito bem!');
                 game.story.notify('cell_key');
-                const back = wp(game.player.position.x, game.player.position.y + 0.2, game.player.position.z);
+                const back = new BABYLON.Vector3(game.player.position.x, game.player.position.y + 0.2, game.player.position.z);
                 game.teco.ai.command([back], { onComplete: () => {} });
             }
         });
@@ -118,9 +138,10 @@ export class TigerRoomLevel extends Level {
 
     update(dt) {
         this.tiger.update(dt, this.game);
-        const p = this.game.player.worldPosition();
+        const p = this.game.player.position;
         const room = this.group.position;
         const inside = Math.abs(p.x - room.x) < 5.5 && Math.abs(p.z - room.z) < 5.5;
+
         if (inside && !this.greeted) {
             this.greeted = true;
             this.game.audio.setTheme('tiger');
@@ -129,6 +150,7 @@ export class TigerRoomLevel extends Level {
             this.tiger.ai.state = 'THREATEN';
             this.game.checkpoints.save('tiger_room', this.game.story._saveBlob());
         }
+
         this.keyMesh.rotation.y += dt * 1.2;
     }
 }

--- a/labs/guerreiro-castelo/js/main.js
+++ b/labs/guerreiro-castelo/js/main.js
@@ -1,18 +1,16 @@
-import * as THREE from 'three';
+/**
+ * Ponto de entrada do jogo O Guerreiro e o Castelo com Babylon.js.
+ */
+
 import { Game } from './core/Game.js';
 
-const game = new Game();
-const clock = new THREE.Clock();
-
-function animate() {
-    requestAnimationFrame(animate);
-    const delta = Math.min(clock.getDelta(), 0.05);
-    game.update(delta);
-    game.render();
-}
+const canvas = document.getElementById('scene') || document.getElementById('gameCanvas');
+const game = new Game(canvas);
 
 game.init()
-    .then(() => animate())
+    .then(() => {
+        game.start();
+    })
     .catch((err) => {
         console.error('[Guerreiro] falha na inicialização', err);
         const el = document.getElementById('loadingText');

--- a/labs/guerreiro-castelo/js/player/Player.js
+++ b/labs/guerreiro-castelo/js/player/Player.js
@@ -1,8 +1,7 @@
 /**
- * Dico jogável — vida, tocha, combate leve, animação.
+ * Dico jogável: movimentação física, animação, combate, tocha e vida em Babylon.js.
  */
 
-import * as THREE from 'three';
 import { CapsuleCollider } from './CapsuleCollider.js';
 import { PlayerController } from './PlayerController.js';
 import { buildDico, CharacterAnimator, applyLocomotion } from '../characters/builders.js';
@@ -10,14 +9,13 @@ import { angleDamp } from '../utils/math.js';
 
 export class Player {
     constructor(scene, collision) {
-        const built = buildDico();
-        this.root = built.group;
+        this.scene = scene;
+        const built = buildDico(scene);
+        this.root = built.root;
         this.parts = built.parts;
-        this.animator = new CharacterAnimator(built.group, built.clips);
-        scene.add(this.root);
-        this.root.traverse((c) => { if (c.isMesh) c.userData.ignoreCamera = true; });
+        this.animator = new CharacterAnimator(built.root, built.clips);
 
-        this.position = new THREE.Vector3(0, 0, 0);
+        this.position = new BABYLON.Vector3(0, 0, 0);
         this.facing = 0;
         this.yaw = 0;
         this.speed = 0;
@@ -36,14 +34,11 @@ export class Player {
         this.collider = new CapsuleCollider({ radius: 0.32, height: 1.78 });
         this.controller = new PlayerController(this, collision);
         this.footTimer = 0;
-        this.parent = scene;
-        this._worldPos = new THREE.Vector3();
+        this._worldPos = new BABYLON.Vector3();
     }
 
     attachTo(parent) {
-        if (this.root.parent) this.root.parent.remove(this.root);
-        parent.add(this.root);
-        this.parent = parent;
+        this.root.parent = parent;
     }
 
     spawn(x, y, z, yaw = 0) {
@@ -61,7 +56,9 @@ export class Player {
 
     setTorch(on) {
         this.torchOn = on;
-        if (this.parts.torch) this.parts.torch.visible = on;
+        if (this.parts.torch) {
+            this.parts.torch.setEnabled(on);
+        }
     }
 
     hurt(amount = 1) {
@@ -82,14 +79,14 @@ export class Player {
     }
 
     worldPosition() {
-        this.root.getWorldPosition(this._worldPos);
-        return this._worldPos;
+        return this.root.getAbsolutePosition();
     }
 
     sync() {
-        this.root.position.copy(this.position);
+        this.root.position.copyFrom(this.position);
         this.root.rotation.y = this.facing;
-        this.root.scale.setScalar(this.crouching ? 0.92 : 1);
+        const scale = this.crouching ? 0.92 : 1.0;
+        this.root.scaling.set(scale, scale, scale);
     }
 
     update(dt, input, camYaw) {
@@ -105,7 +102,7 @@ export class Player {
         if (input.block) this.blockT = 0.1;
 
         const speed = this.controller.update(dt, input, camYaw) ?? 0;
-        this.facing = angleDamp(this.facing, this.controller.mode === 'walk' ? this.facing : this.facing, 10, dt);
+        this.facing = angleDamp(this.facing, this.facing, 10, dt);
         if (speed > 0.25 && this.controller.mode === 'walk') {
             this.facing = angleDamp(this.facing, Math.atan2(this.controller.vx, this.controller.vz), 12, dt);
         }
@@ -131,8 +128,9 @@ export class Player {
 
         if (this.parts.torchFlame) {
             const s = 0.9 + Math.sin(performance.now() * 0.012) * 0.15;
-            this.parts.torchFlame.scale.setScalar(s);
+            this.parts.torchFlame.scaling.set(s, s, s);
         }
+
         this.sync();
         return this._footstep ? (this._footstep = false, true) : false;
     }

--- a/labs/guerreiro-castelo/js/player/PlayerController.js
+++ b/labs/guerreiro-castelo/js/player/PlayerController.js
@@ -1,5 +1,5 @@
 /**
- * Controlador de movimento: aceleração, gravidade, pulo, sprint, agachar.
+ * Controlador de movimento do guerreiro: aceleração, física de gravidade, pulo, corrida e agachar.
  */
 
 import { clamp } from '../utils/math.js';
@@ -35,7 +35,7 @@ export class PlayerController {
             return;
         }
 
-        const crouch = input.move.crouch && p.grounded;
+        const crouch = Boolean(input.move.crouch && p.grounded);
         p.collider.setCrouch(crouch);
         p.crouching = crouch;
 
@@ -72,7 +72,7 @@ export class PlayerController {
         const res = this.collision.resolveCapsule(
             p.position.x, y, p.position.z,
             p.collider.radius, p.collider.height,
-            this.vx, this.vz, 1, 0.4
+            this.vx, this.vz, dt, 0.4
         );
 
         p.position.set(res.x, res.y, res.z);

--- a/labs/guerreiro-castelo/js/player/ThirdPersonCamera.js
+++ b/labs/guerreiro-castelo/js/player/ThirdPersonCamera.js
@@ -1,17 +1,8 @@
 /**
- * Câmera em terceira pessoa — ombro, órbita, zoom, raycast contra paredes.
- * Nunca é parenteda no personagem.
+ * Câmera em terceira pessoa em Babylon.js — órbita, ombro, zoom, raycast contra paredes e screen shake.
  */
 
-import * as THREE from 'three';
 import { clamp, damp } from '../utils/math.js';
-
-const _from = new THREE.Vector3();
-const _to = new THREE.Vector3();
-const _desired = new THREE.Vector3();
-const _look = new THREE.Vector3();
-const _up = new THREE.Vector3(0, 1, 0);
-const _hit = new THREE.Vector3();
 
 export class ThirdPersonCamera {
     constructor(camera, scene) {
@@ -27,24 +18,21 @@ export class ThirdPersonCamera {
         this.pitchMax = 1.15;
         this.shoulder = 0.55;
         this.lookHeight = 1.55;
-        this.fov = 55;
-        this.targetFov = 55;
+        this.fov = 0.95; // radianos (~55 deg)
+        this.targetFov = 0.95;
         this.shake = 0;
         this.shakeAmp = 0;
-        this.locked = false;
-        this.ray = new THREE.Raycaster();
-        this.ray.far = 12;
         this._obstacles = [];
-        this.currentPos = new THREE.Vector3(0, 2, 6);
-        this.smoothLook = new THREE.Vector3();
+        this.currentPos = new BABYLON.Vector3(0, 2, 6);
+        this.smoothLook = new BABYLON.Vector3(0, 1.5, 0);
         this.cutscene = false;
     }
 
     setObstacles(meshes) {
-        this._obstacles = meshes.filter((m) => {
-            if (!m || !m.isMesh) return false;
-            if (m.userData.ignoreCamera) return false;
-            if (m.name === 'sail') return false;
+        this._obstacles = (meshes || []).filter((m) => {
+            if (!m) return false;
+            if (m.userData?.ignoreCamera) return false;
+            if (m.name === 'shipSail') return false;
             return true;
         });
     }
@@ -58,23 +46,20 @@ export class ThirdPersonCamera {
         this.cutscene = false;
         const origin = player.worldPosition ? player.worldPosition() : player.position;
         this.smoothLook.set(origin.x, origin.y + this.lookHeight, origin.z);
+
         const cosP = Math.cos(this.pitch);
         const sinP = Math.sin(this.pitch);
         const sinY = Math.sin(this.yaw);
         const cosY = Math.cos(this.yaw);
+
         this.currentPos.set(
             origin.x + sinY * cosP * this.distance + cosY * this.shoulder,
             origin.y + this.lookHeight + sinP * this.distance,
             origin.z + cosY * cosP * this.distance - sinY * this.shoulder
         );
-        this.camera.position.copy(this.currentPos);
-        this.camera.lookAt(this.smoothLook);
-        this.camera.updateMatrixWorld();
-    }
 
-    lookAtImmediate(target) {
-        this.smoothLook.copy(target);
-        this.currentPos.copy(this.camera.position);
+        this.camera.position.copyFrom(this.currentPos);
+        this.camera.setTarget(this.smoothLook);
     }
 
     update(dt, player, lookDelta, zoomDelta, sprinting) {
@@ -85,14 +70,13 @@ export class ThirdPersonCamera {
         this.targetDistance = clamp(this.targetDistance + zoomDelta * 0.45, this.minDistance, this.maxDistance);
         this.distance = damp(this.distance, this.targetDistance, 8, dt);
 
-        this.targetFov = sprinting ? 62 : 55;
+        this.targetFov = sprinting ? 1.08 : 0.95;
         this.fov = damp(this.fov, this.targetFov, 4, dt);
         this.camera.fov = this.fov;
-        this.camera.updateProjectionMatrix();
 
         const origin = player.worldPosition ? player.worldPosition() : player.position;
         const lookY = origin.y + (player.crouching ? 1.15 : this.lookHeight);
-        _look.set(origin.x, lookY, origin.z);
+        const targetLook = new BABYLON.Vector3(origin.x, lookY, origin.z);
 
         const cosP = Math.cos(this.pitch);
         const sinP = Math.sin(this.pitch);
@@ -104,35 +88,41 @@ export class ThirdPersonCamera {
         const rightX = cosY;
         const rightZ = -sinY;
 
-        _desired.set(
-            _look.x + backX * this.distance + rightX * this.shoulder,
-            _look.y + sinP * this.distance,
-            _look.z + backZ * this.distance + rightZ * this.shoulder
+        const desired = new BABYLON.Vector3(
+            targetLook.x + backX * this.distance + rightX * this.shoulder,
+            targetLook.y + sinP * this.distance,
+            targetLook.z + backZ * this.distance + rightZ * this.shoulder
         );
 
-        let dist = this.distance;
+        // Raycast contra obstáculos
         if (this._obstacles.length) {
-            _from.copy(_look);
-            _to.copy(_desired).sub(_from);
-            const len = _to.length();
-            if (len > 0.01) {
-                this.ray.set(_from, _to.normalize());
-                this.ray.far = len;
-                const hits = this.ray.intersectObjects(this._obstacles, true);
-                if (hits.length) {
-                    const h = hits[0];
-                    dist = Math.max(0.6, h.distance - 0.28);
-                    _desired.copy(_from).addScaledVector(this.ray.ray.direction, dist);
+            const rayDir = desired.subtract(targetLook);
+            const rayLen = rayDir.length();
+            if (rayLen > 0.01) {
+                rayDir.normalize();
+                const ray = new BABYLON.Ray(targetLook, rayDir, rayLen);
+                let hit = null;
+                for (const obs of this._obstacles) {
+                    if (!obs || !obs.isEnabled?.()) continue;
+                    const pick = ray.intersectsMesh(obs, false);
+                    if (pick.hit && (!hit || pick.distance < hit.distance)) {
+                        hit = pick;
+                    }
+                }
+                if (hit) {
+                    const safeDist = Math.max(0.6, hit.distance - 0.28);
+                    desired.copyFrom(targetLook.add(rayDir.scale(safeDist)));
                 }
             }
         }
 
-        this.currentPos.x = damp(this.currentPos.x, _desired.x, 14, dt);
-        this.currentPos.y = damp(this.currentPos.y, _desired.y, 12, dt);
-        this.currentPos.z = damp(this.currentPos.z, _desired.z, 14, dt);
-        this.smoothLook.x = damp(this.smoothLook.x, _look.x, 16, dt);
-        this.smoothLook.y = damp(this.smoothLook.y, _look.y, 16, dt);
-        this.smoothLook.z = damp(this.smoothLook.z, _look.z, 16, dt);
+        this.currentPos.x = damp(this.currentPos.x, desired.x, 14, dt);
+        this.currentPos.y = damp(this.currentPos.y, desired.y, 12, dt);
+        this.currentPos.z = damp(this.currentPos.z, desired.z, 14, dt);
+
+        this.smoothLook.x = damp(this.smoothLook.x, targetLook.x, 16, dt);
+        this.smoothLook.y = damp(this.smoothLook.y, targetLook.y, 16, dt);
+        this.smoothLook.z = damp(this.smoothLook.z, targetLook.z, 16, dt);
 
         if (this.shake > 0) {
             this.shake -= dt;
@@ -141,19 +131,14 @@ export class ThirdPersonCamera {
             this.currentPos.y += (Math.random() - 0.5) * a * 0.6;
         }
 
-        this.camera.position.copy(this.currentPos);
-        this.camera.up.copy(_up);
-        this.camera.lookAt(this.smoothLook);
-        _hit.copy(_desired);
+        this.camera.position.copyFrom(this.currentPos);
+        this.camera.setTarget(this.smoothLook);
     }
 
-    /**
-     * Cutscene: interpola posição e lookAt. Chamado pelo CutsceneManager.
-     */
     setCutscenePose(pos, look) {
-        this.camera.position.copy(pos);
-        this.camera.lookAt(look);
-        this.currentPos.copy(pos);
-        this.smoothLook.copy(look);
+        this.camera.position.copyFrom(pos);
+        this.camera.setTarget(look);
+        this.currentPos.copyFrom(pos);
+        this.smoothLook.copyFrom(look);
     }
 }

--- a/labs/guerreiro-castelo/js/ui/HUD.js
+++ b/labs/guerreiro-castelo/js/ui/HUD.js
@@ -1,9 +1,10 @@
 /**
- * HUD cinematográfico: vida, objetivo, interação, diálogo, stealth.
+ * HUD cinematográfico em Babylon.js: vida, objetivo, interação, diálogo, stealth, FPS.
  */
 
 export class HUD {
-    constructor() {
+    constructor(game) {
+        this.game = game;
         this.el = {
             hud: document.getElementById('hud'),
             hearts: document.getElementById('hearts'),
@@ -17,6 +18,7 @@ export class HUD {
             toast: document.getElementById('toast'),
             chapter: document.getElementById('chapterCard'),
             chapterTitle: document.getElementById('chapterTitle'),
+            chapterSub: document.getElementById('chapterSub'),
             fade: document.getElementById('fade'),
             loading: document.getElementById('loadingOverlay'),
             loadingFill: document.getElementById('loadingFill'),
@@ -25,8 +27,16 @@ export class HUD {
         };
         this._toastT = 0;
         this._chapterT = 0;
-        /* Em telas de toque o prompt aponta o botão da tela, não a tecla E. */
         this.isTouch = Boolean(window.matchMedia?.('(pointer: coarse)').matches);
+        this.lastHp = -1;
+    }
+
+    show() {
+        if (this.el.hud) this.el.hud.hidden = false;
+    }
+
+    hide() {
+        if (this.el.hud) this.el.hud.hidden = true;
     }
 
     setLoading(p, text) {
@@ -39,14 +49,13 @@ export class HUD {
     }
 
     hideLoading() {
-        this.el.loading.hidden = true;
+        if (this.el.loading) this.el.loading.hidden = true;
     }
 
-    showHud(v) {
-        this.el.hud.hidden = !v;
-    }
-
-    setHealth(hp, max) {
+    setHealth(hp, max = 5) {
+        if (this.lastHp === hp) return;
+        this.lastHp = hp;
+        if (!this.el.hearts) return;
         this.el.hearts.innerHTML = '';
         for (let i = 0; i < max; i++) {
             const s = document.createElement('span');
@@ -57,13 +66,18 @@ export class HUD {
     }
 
     showObjective(text, urgent = false) {
+        if (!this.el.objective) return;
         this.el.objective.textContent = text;
         this.el.objective.dataset.urgent = urgent ? 'true' : 'false';
-        this.el.objective.parentElement.classList.add('is-flash');
-        setTimeout(() => this.el.objective.parentElement.classList.remove('is-flash'), 2400);
+        const parent = this.el.objective.parentElement;
+        if (parent) {
+            parent.classList.add('is-flash');
+            setTimeout(() => parent.classList.remove('is-flash'), 2400);
+        }
     }
 
-    setPrompt(item) {
+    setInteractPrompt(item) {
+        if (!this.el.prompt) return;
         if (!item) {
             this.el.prompt.hidden = true;
             return;
@@ -74,55 +88,78 @@ export class HUD {
     }
 
     setDialogue(line) {
+        if (!this.el.dialogue) return;
         if (!line) {
             this.el.dialogue.hidden = true;
             return;
         }
         this.el.dialogue.hidden = false;
-        this.el.speaker.textContent = line.speaker;
-        this.el.line.textContent = line.text;
+        if (this.el.speaker) this.el.speaker.textContent = line.speaker;
+        if (this.el.line) this.el.line.textContent = line.text;
     }
 
     showStealth(on, amount = 0) {
+        if (!this.el.stealth) return;
         this.el.stealth.hidden = !on;
         if (this.el.stealthFill) this.el.stealthFill.style.width = `${Math.round(amount * 100)}%`;
         this.el.stealth.dataset.danger = amount > 0.65 ? 'true' : 'false';
     }
 
     showToast(text) {
+        if (!this.el.toast) return;
         this.el.toast.hidden = false;
         this.el.toast.textContent = text;
         this._toastT = 3.2;
     }
 
     showChapter(title, sub) {
+        if (!this.el.chapter) return;
         this.el.chapter.hidden = false;
-        this.el.chapterTitle.textContent = title;
-        const s = document.getElementById('chapterSub');
-        if (s) s.textContent = sub || '';
-        this._chapterT = 3.5;
+        if (this.el.chapterTitle) this.el.chapterTitle.textContent = title;
+        if (this.el.chapterSub) this.el.chapterSub.textContent = sub || '';
+        this._chapterT = 3.8;
     }
 
-    setFade(v) {
-        this.el.fade.style.opacity = String(v);
-    }
-
-    setFps(n) {
-        if (this.el.fps) this.el.fps.textContent = `${n} fps`;
+    showLevelName(stageId) {
+        const names = {
+            home: ['A Sala da Lareira', 'onde toda história começa'],
+            ship: ['O Mar Aberto', 'rumo ao outro lado do oceano'],
+            island: ['A Ilha do Castelo', 'desembarque e reconhecimento'],
+            interior: ['As Profundezas', 'sombras e grades de ferro'],
+            escape: ['A Fuga', 'correndo pelas flechas'],
+            shipEscape: ['Zarpando', 'mar adentro contra o vento'],
+            ending: ['O Retorno', 'uma promessa cumprida']
+        };
+        if (names[stageId]) {
+            this.showChapter(names[stageId][0], names[stageId][1]);
+        }
     }
 
     flashStealth(text) {
         if (text) this.showToast(text);
     }
 
+    setFps(n) {
+        if (this.el.fps) this.el.fps.textContent = `${n} fps`;
+    }
+
     update(dt) {
         if (this._toastT > 0) {
             this._toastT -= dt;
-            if (this._toastT <= 0) this.el.toast.hidden = true;
+            if (this._toastT <= 0 && this.el.toast) this.el.toast.hidden = true;
         }
         if (this._chapterT > 0) {
             this._chapterT -= dt;
-            if (this._chapterT <= 0) this.el.chapter.hidden = true;
+            if (this._chapterT <= 0 && this.el.chapter) this.el.chapter.hidden = true;
+        }
+
+        if (this.game && this.game.player) {
+            this.setHealth(this.game.player.health, this.game.player.maxHealth);
+        }
+
+        if (this.game && this.game.engine) {
+            const fps = Math.round(this.game.engine.getFps() || 60);
+            this.setFps(fps);
         }
     }
 }

--- a/labs/guerreiro-castelo/js/ui/Menu.js
+++ b/labs/guerreiro-castelo/js/ui/Menu.js
@@ -1,33 +1,96 @@
+/**
+ * Menu principal, overlay de controles, opções de qualidade e volume.
+ */
+
+import { QUALITY } from '../core/QualitySettings.js';
+import { SETTINGS_KEY } from '../core/assets.js';
+
 export class Menu {
     constructor(game) {
         this.game = game;
         this.root = document.getElementById('menuOverlay');
         this.controls = document.getElementById('controlsOverlay');
         this.settings = document.getElementById('settingsOverlay');
-        document.getElementById('btnNewGame').addEventListener('click', () => game.newGame());
-        document.getElementById('btnContinue').addEventListener('click', () => game.continueGame());
-        document.getElementById('btnControls').addEventListener('click', () => this.showControls(true));
-        document.getElementById('btnSettings').addEventListener('click', () => this.showSettings(true));
-        document.getElementById('btnCloseControls').addEventListener('click', () => this.showControls(false));
-        document.getElementById('btnCloseSettings').addEventListener('click', () => this.showSettings(false));
+        this.loading = document.getElementById('loadingOverlay');
+
+        document.getElementById('btnNewGame')?.addEventListener('click', () => game.startNewGame());
+        document.getElementById('btnContinue')?.addEventListener('click', () => game.continueGame());
+        document.getElementById('btnControls')?.addEventListener('click', () => this.showControls(true));
+        document.getElementById('btnSettings')?.addEventListener('click', () => this.showSettings(true));
+        document.getElementById('btnCloseControls')?.addEventListener('click', () => this.showControls(false));
+        document.getElementById('btnCloseSettings')?.addEventListener('click', () => this.showSettings(false));
+
+        document.getElementById('btnPlayAgain')?.addEventListener('click', () => {
+            document.getElementById('endOverlay').hidden = true;
+            game.startNewGame();
+        });
+        document.getElementById('btnEndMenu')?.addEventListener('click', () => {
+            document.getElementById('endOverlay').hidden = true;
+            this.show();
+        });
+
+        // Configurações
+        const qSel = document.getElementById('qualitySelect');
+        if (qSel) {
+            qSel.value = game.quality.id;
+            qSel.addEventListener('change', (e) => {
+                const q = QUALITY[e.target.value];
+                if (q) {
+                    game.quality = q;
+                    this._saveSettings();
+                }
+            });
+        }
+
+        const volSlider = document.getElementById('volumeSlider');
+        const volVal = document.getElementById('volumeValue');
+        if (volSlider) {
+            volSlider.addEventListener('input', (e) => {
+                const v = parseInt(e.target.value, 10) / 100;
+                game.audio.setBusVolume('master', v);
+                if (volVal) volVal.textContent = e.target.value;
+                this._saveSettings();
+            });
+        }
+
         this.syncContinue();
+    }
+
+    _saveSettings() {
+        try {
+            const data = {
+                quality: this.game.quality.id,
+                volume: document.getElementById('volumeSlider')?.value || 75
+            };
+            localStorage.setItem(SETTINGS_KEY, JSON.stringify(data));
+        } catch { /* ignore */ }
     }
 
     syncContinue() {
         const btn = document.getElementById('btnContinue');
-        btn.disabled = !this.game.checkpoints.hasSave();
+        if (btn) btn.disabled = !this.game.checkpoints.hasSave();
     }
 
-    show(v) {
-        this.root.hidden = !v;
-        if (v) this.syncContinue();
+    setProgress(p) {
+        this.game.hud?.setLoading(p);
+    }
+
+    show() {
+        if (this.loading) this.loading.hidden = true;
+        if (this.root) this.root.hidden = false;
+        this.syncContinue();
+    }
+
+    hide() {
+        if (this.root) this.root.hidden = true;
+        if (this.loading) this.loading.hidden = true;
     }
 
     showControls(v) {
-        this.controls.hidden = !v;
+        if (this.controls) this.controls.hidden = !v;
     }
 
     showSettings(v) {
-        this.settings.hidden = !v;
+        if (this.settings) this.settings.hidden = !v;
     }
 }

--- a/labs/guerreiro-castelo/js/ui/PauseMenu.js
+++ b/labs/guerreiro-castelo/js/ui/PauseMenu.js
@@ -1,20 +1,45 @@
+/**
+ * Menu de pausa em Babylon.js.
+ */
+
+import { CHECKPOINT_STAGE } from '../core/SceneManager.js';
+
 export class PauseMenu {
     constructor(game) {
         this.game = game;
         this.root = document.getElementById('pauseOverlay');
-        document.getElementById('btnResume').addEventListener('click', () => game.setPaused(false));
-        document.getElementById('btnRestartCp').addEventListener('click', () => {
-            game.setPaused(false);
-            game.reloadCheckpoint();
+
+        document.getElementById('btnResume')?.addEventListener('click', () => this.toggle(false));
+        document.getElementById('btnRestartCp')?.addEventListener('click', () => {
+            this.toggle(false);
+            const cp = game.checkpoints.current || 'home_intro';
+            const stage = CHECKPOINT_STAGE[cp] || 'home';
+            game.loadStage(stage, cp);
         });
-        document.getElementById('btnPauseSettings').addEventListener('click', () => {
-            this.root.hidden = true;
-            document.getElementById('settingsOverlay').hidden = false;
+        document.getElementById('btnPauseSettings')?.addEventListener('click', () => {
+            this.show(false);
+            game.menu.showSettings(true);
         });
-        document.getElementById('btnQuitMenu').addEventListener('click', () => game.quitToMenu());
+        document.getElementById('btnQuitMenu')?.addEventListener('click', () => {
+            this.toggle(false);
+            game.running = false;
+            game.hud.hide();
+            game.menu.show();
+        });
+    }
+
+    toggle(force) {
+        const next = force !== undefined ? force : !this.game.paused;
+        this.game.paused = next;
+        this.show(next);
+        if (next) {
+            this.game.input.exitLock();
+        } else {
+            this.game.input.requestLock();
+        }
     }
 
     show(v) {
-        this.root.hidden = !v;
+        if (this.root) this.root.hidden = !v;
     }
 }

--- a/labs/guerreiro-castelo/js/world/ArrowSystem.js
+++ b/labs/guerreiro-castelo/js/world/ArrowSystem.js
@@ -1,8 +1,7 @@
 /**
- * Pool de flechas: trajetória, gravidade, colisão, impacto, reciclagem.
+ * Pool de flechas físicas disparadas por arqueiros em Babylon.js.
  */
 
-import * as THREE from 'three';
 import { Pool } from '../utils/pool.js';
 
 export class ArrowSystem {
@@ -13,89 +12,126 @@ export class ArrowSystem {
         this.gravity = 18;
         this.colliders = [];
         this.onHitPlayer = null;
-        this.geo = new THREE.CylinderGeometry(0.015, 0.015, 0.55, 5);
-        this.mat = new THREE.MeshStandardMaterial({ color: 0x5a3a18, roughness: 0.6 });
-        this.tipMat = new THREE.MeshStandardMaterial({ color: 0xb0b8c0, metalness: 0.8, roughness: 0.3 });
-        this._n = new THREE.Vector3();
     }
 
     _make() {
-        const g = new THREE.Group();
-        const shaft = new THREE.Mesh(this.geo, this.mat);
+        const root = new BABYLON.TransformNode('arrowRoot', this.scene);
+
+        const shaft = BABYLON.MeshBuilder.CreateCylinder('arrowShaft', {
+            diameter: 0.03,
+            height: 0.6,
+            tessellation: 6
+        }, this.scene);
         shaft.rotation.x = Math.PI / 2;
-        g.add(shaft);
-        const tip = new THREE.Mesh(new THREE.ConeGeometry(0.03, 0.1, 5), this.tipMat);
+        shaft.parent = root;
+
+        const shaftMat = new BABYLON.StandardMaterial('shaftMat', this.scene);
+        shaftMat.diffuseColor = new BABYLON.Color3(0.35, 0.22, 0.1);
+        shaft.material = shaftMat;
+
+        const tip = BABYLON.MeshBuilder.CreateCylinder('arrowTip', {
+            diameterTop: 0,
+            diameterBottom: 0.08,
+            height: 0.14,
+            tessellation: 5
+        }, this.scene);
         tip.rotation.x = Math.PI / 2;
-        tip.position.z = 0.3;
-        g.add(tip);
-        g.visible = false;
-        this.scene.add(g);
+        tip.position.z = 0.35;
+        tip.parent = root;
+
+        const tipMat = new BABYLON.StandardMaterial('tipMat', this.scene);
+        tipMat.diffuseColor = new BABYLON.Color3(0.7, 0.75, 0.8);
+        tipMat.specularColor = new BABYLON.Color3(0.8, 0.8, 0.8);
+        tip.material = tipMat;
+
+        root.setEnabled(false);
+
         return {
-            mesh: g,
-            vel: new THREE.Vector3(),
+            root,
+            vel: new BABYLON.Vector3(),
             alive: false,
-            stuck: 0,
-            from: 'world'
+            stuck: 0
         };
     }
 
     setColliders(meshes) {
-        this.colliders = meshes;
+        this.colliders = meshes || [];
     }
 
     fire(origin, direction, speed = 28) {
         const a = this.pool.obtain();
-        a.mesh.position.copy(origin);
-        a.mesh.visible = true;
-        a.vel.copy(direction).normalize().multiplyScalar(speed);
+        a.root.position.copyFrom(origin);
+        a.root.setEnabled(true);
+        a.vel.copyFrom(direction).normalize().scaleInPlace(speed);
         a.alive = true;
         a.stuck = 0;
-        a.mesh.lookAt(origin.clone().add(a.vel));
+
+        const lookTarget = a.root.position.add(a.vel);
+        a.root.lookAt(lookTarget);
+
         this.active.push(a);
         return a;
     }
 
     update(dt, game) {
-        const ray = game._arrowRay || (game._arrowRay = new THREE.Raycaster());
         for (let i = this.active.length - 1; i >= 0; i--) {
             const a = this.active[i];
             if (a.stuck > 0) {
                 a.stuck -= dt;
                 if (a.stuck <= 0) {
-                    a.mesh.visible = false;
+                    a.root.setEnabled(false);
                     this.active.splice(i, 1);
                     this.pool.release(a);
                 }
                 continue;
             }
+
             a.vel.y -= this.gravity * dt;
-            const next = a.mesh.position.clone().addScaledVector(a.vel, dt);
-            const dist = a.mesh.position.distanceTo(next);
-            ray.set(a.mesh.position, this._n.copy(a.vel).normalize());
-            ray.far = dist + 0.1;
+            const delta = a.vel.scale(dt);
+            const currentPos = a.root.position.clone();
+            const nextPos = currentPos.add(delta);
+
+            // Raycast check against colliders
+            const rayDir = delta.normalizeToNew();
+            const rayDist = BABYLON.Vector3.Distance(currentPos, nextPos);
+            const ray = new BABYLON.Ray(currentPos, rayDir, rayDist + 0.1);
+
             let hit = null;
             if (this.colliders.length) {
-                const hits = ray.intersectObjects(this.colliders, true);
-                if (hits.length) hit = hits[0];
+                for (const col of this.colliders) {
+                    if (!col || !col.isEnabled?.()) continue;
+                    const pick = ray.intersectsMesh(col, false);
+                    if (pick.hit && (!hit || pick.distance < hit.distance)) {
+                        hit = pick;
+                    }
+                }
             }
-            const p = game.player.position;
-            const toP = Math.hypot(next.x - p.x, next.y - (p.y + 1), next.z - p.z);
-            if (toP < 0.45) {
+
+            // Check hit player
+            const playerPos = game.player.position;
+            const playerCenter = new BABYLON.Vector3(playerPos.x, playerPos.y + 0.9, playerPos.z);
+            const distToPlayer = BABYLON.Vector3.Distance(nextPos, playerCenter);
+
+            if (distToPlayer < 0.65) {
                 this.onHitPlayer?.(1);
                 a.stuck = 0.01;
-                a.mesh.visible = false;
+                a.root.setEnabled(false);
                 continue;
             }
-            if (hit || next.y < 0.02) {
-                a.mesh.position.copy(hit ? hit.point : next);
-                a.stuck = 2.4;
-                game.audio.play('impact');
+
+            if (hit || nextPos.y < 0.02) {
+                a.root.position.copyFrom(hit ? hit.pickedPoint : nextPos);
+                a.stuck = 2.0;
+                game.audio?.play('impact');
                 continue;
             }
-            a.mesh.position.copy(next);
-            a.mesh.lookAt(next.clone().add(a.vel));
-            if (a.mesh.position.length() > 400) {
-                a.mesh.visible = false;
+
+            a.root.position.copyFrom(nextPos);
+            const lookTarget = a.root.position.add(a.vel);
+            a.root.lookAt(lookTarget);
+
+            if (a.root.position.length() > 400) {
+                a.root.setEnabled(false);
                 this.active.splice(i, 1);
                 this.pool.release(a);
             }
@@ -104,7 +140,7 @@ export class ArrowSystem {
 
     clear() {
         for (const a of this.active) {
-            a.mesh.visible = false;
+            a.root.setEnabled(false);
             this.pool.release(a);
         }
         this.active.length = 0;

--- a/labs/guerreiro-castelo/js/world/Castle.js
+++ b/labs/guerreiro-castelo/js/world/Castle.js
@@ -1,136 +1,194 @@
 /**
- * Castelo em escala — muralhas, torres, ameias, portão, bandeiras, musgo.
+ * Castelo em escala: muralhas, 4 torres, ameias, portão maciço, bandeiras e porta secreta em Babylon.js.
  */
 
-import * as THREE from 'three';
 import { castleStoneTexture, mossTexture, flagTexture, woodTexture } from './Textures.js';
-import { std } from '../characters/builders.js';
 import { makeTorch } from './Environment.js';
 
-export function buildCastle() {
-    const root = new THREE.Group();
-    root.name = 'castle';
-    const stone = new THREE.MeshStandardMaterial({
-        map: castleStoneTexture(),
-        roughness: 0.88,
-        color: 0xc8c0b0
-    });
-    const moss = new THREE.MeshStandardMaterial({ map: mossTexture(), roughness: 0.92, color: 0x5a7a40 });
-    const wood = new THREE.MeshStandardMaterial({ map: woodTexture(), roughness: 0.84 });
+export function buildCastle(scene) {
+    const root = new BABYLON.TransformNode('castleRoot', scene);
+
+    const stoneMat = new BABYLON.StandardMaterial('castleStoneMat', scene);
+    stoneMat.diffuseTexture = castleStoneTexture(scene, 6, 8);
+    stoneMat.diffuseColor = new BABYLON.Color3(0.85, 0.82, 0.78);
+
+    const mossMat = new BABYLON.StandardMaterial('castleMossMat', scene);
+    mossMat.diffuseTexture = mossTexture(scene, 4, 4);
+
+    const woodMat = new BABYLON.StandardMaterial('castleWoodMat', scene);
+    woodMat.diffuseTexture = woodTexture(scene, 3, 3);
 
     const wallH = 18;
     const wallT = 2.4;
     const court = 28;
 
-    const mkWall = (w, d, x, z) => {
-        const m = new THREE.Mesh(new THREE.BoxGeometry(w, wallH, d), stone);
+    const mkWall = (name, w, d, x, z) => {
+        const m = BABYLON.MeshBuilder.CreateBox(name, { width: w, height: wallH, depth: d }, scene);
         m.position.set(x, wallH / 2, z);
-        m.castShadow = true;
-        m.receiveShadow = true;
-        root.add(m);
-        const mossBand = new THREE.Mesh(new THREE.BoxGeometry(w * 0.98, 2.2, d * 1.02), moss);
+        m.material = stoneMat;
+        m.parent = root;
+        m.receiveShadows = true;
+
+        const mossBand = BABYLON.MeshBuilder.CreateBox(`${name}_moss`, { width: w * 0.98, height: 2.2, depth: d * 1.02 }, scene);
         mossBand.position.set(x, 1.1, z);
-        root.add(mossBand);
-        addCrenels(root, stone, x, z, w, d, wallH);
+        mossBand.material = mossMat;
+        mossBand.parent = root;
+
+        addCrenels(root, stoneMat, x, z, w, d, wallH, scene);
     };
 
-    mkWall(court + wallT, wallT, 0, -court / 2);
-    mkWall(court + wallT, wallT, 0, court / 2);
-    mkWall(wallT, court, -court / 2, 0);
-    mkWall(wallT, court, court / 2, 0);
+    mkWall('castleWallBack', court + wallT, wallT, 0, -court / 2);
+    mkWall('castleWallFront', court + wallT, wallT, 0, court / 2);
+    mkWall('castleWallLeft', wallT, court, -court / 2, 0);
+    mkWall('castleWallRight', wallT, court, court / 2, 0);
 
-    for (const [x, z] of [
+    // 4 Torres cilíndricas nos cantos
+    const roofMat = new BABYLON.StandardMaterial('towerRoofMat', scene);
+    roofMat.diffuseColor = new BABYLON.Color3(0.45, 0.15, 0.15);
+
+    const towerPositions = [
         [-court / 2, -court / 2],
         [court / 2, -court / 2],
         [-court / 2, court / 2],
         [court / 2, court / 2]
-    ]) {
-        const tower = new THREE.Mesh(new THREE.CylinderGeometry(3.2, 3.6, 26, 10), stone);
+    ];
+
+    towerPositions.forEach(([x, z], i) => {
+        const tower = BABYLON.MeshBuilder.CreateCylinder(`tower_${i}`, {
+            diameterTop: 6.4,
+            diameterBottom: 7.2,
+            height: 26,
+            tessellation: 12
+        }, scene);
         tower.position.set(x, 13, z);
-        tower.castShadow = true;
-        root.add(tower);
-        const roof = new THREE.Mesh(new THREE.ConeGeometry(3.8, 4.5, 10), std(0x5a1c1c, 0.75));
+        tower.material = stoneMat;
+        tower.parent = root;
+        tower.receiveShadows = true;
+
+        const roof = BABYLON.MeshBuilder.CreateCylinder(`towerRoof_${i}`, {
+            diameterTop: 0,
+            diameterBottom: 7.6,
+            height: 4.5,
+            tessellation: 12
+        }, scene);
         roof.position.set(x, 28, z);
-        root.add(roof);
-        const flag = makeFlag();
+        roof.material = roofMat;
+        roof.parent = root;
+
+        const flag = makeFlag(scene);
         flag.position.set(x, 31, z);
-        root.add(flag);
-    }
+        flag.parent = root;
+    });
 
-    const keep = new THREE.Mesh(new THREE.BoxGeometry(12, 22, 12), stone);
+    // Torre de menagem central (Keep)
+    const keep = BABYLON.MeshBuilder.CreateBox('castleKeep', { width: 12, height: 22, depth: 12 }, scene);
     keep.position.set(0, 11, -2);
-    keep.castShadow = true;
-    root.add(keep);
-    const keepRoof = new THREE.Mesh(new THREE.BoxGeometry(13, 1.2, 13), std(0x4a1818, 0.7));
+    keep.material = stoneMat;
+    keep.parent = root;
+    keep.receiveShadows = true;
+
+    const keepRoof = BABYLON.MeshBuilder.CreateBox('keepRoof', { width: 13, height: 1.2, depth: 13 }, scene);
     keepRoof.position.set(0, 22.4, -2);
-    root.add(keepRoof);
+    keepRoof.material = roofMat;
+    keepRoof.parent = root;
 
-    const gate = new THREE.Mesh(new THREE.BoxGeometry(7, 10, 1.2), wood);
+    // Portão principal
+    const gate = BABYLON.MeshBuilder.CreateBox('mainGate', { width: 7, height: 10, depth: 1.2 }, scene);
     gate.position.set(0, 5, court / 2 + 0.4);
-    gate.name = 'mainGate';
-    root.add(gate);
-    const arch = new THREE.Mesh(new THREE.TorusGeometry(3.6, 0.7, 8, 16, Math.PI), stone);
+    gate.material = woodMat;
+    gate.parent = root;
+
+    const arch = BABYLON.MeshBuilder.CreateTorus('gateArch', {
+        diameter: 7.2,
+        thickness: 1.4,
+        tessellation: 16
+    }, scene);
     arch.position.set(0, 9.5, court / 2 + 0.5);
-    arch.rotation.y = Math.PI;
-    root.add(arch);
+    arch.material = stoneMat;
+    arch.parent = root;
 
-    const walk = new THREE.Mesh(new THREE.BoxGeometry(court, 0.4, 2), stone);
+    // Passadiço dos arqueiros
+    const walk = BABYLON.MeshBuilder.CreateBox('archerWalk', { width: court, height: 0.4, depth: 2 }, scene);
     walk.position.set(0, wallH - 0.5, court / 2 - 0.2);
-    walk.name = 'archerWalk';
-    root.add(walk);
+    walk.material = stoneMat;
+    walk.parent = root;
 
+    // Tochas no muro frontal
     for (let i = -3; i <= 3; i++) {
-        const torch = makeTorch();
+        const torch = makeTorch(scene);
         torch.position.set(i * 3.2, 6, court / 2 + 1.3);
-        root.add(torch);
+        torch.parent = root;
     }
 
-    const secret = new THREE.Group();
-    secret.name = 'secretDoor';
-    const door = new THREE.Mesh(new THREE.BoxGeometry(1.3, 2.2, 0.18), wood);
-    secret.add(door);
-    const lock = new THREE.Mesh(new THREE.BoxGeometry(0.18, 0.22, 0.1), std(0x6a3a12, 0.5, 0.6));
-    lock.position.set(0.4, 0, 0.12);
-    secret.add(lock);
-    secret.position.set(-court / 2 - 1.3, 1.15, -6);
-    root.add(secret);
+    // Porta secreta coberta de musgo
+    const secretRoot = new BABYLON.TransformNode('secretDoorRoot', scene);
+    secretRoot.position.set(-court / 2 - 1.3, 1.15, -6);
+    secretRoot.parent = root;
 
-    const vine = new THREE.Mesh(new THREE.PlaneGeometry(2.4, 4.2), moss);
+    const door = BABYLON.MeshBuilder.CreateBox('secretDoorMesh', { width: 1.3, height: 2.2, depth: 0.18 }, scene);
+    door.material = woodMat;
+    door.parent = secretRoot;
+
+    const lock = BABYLON.MeshBuilder.CreateBox('secretLock', { width: 0.18, height: 0.22, depth: 0.1 }, scene);
+    lock.position.set(0.4, 0, 0.12);
+    const rustMat = new BABYLON.StandardMaterial('lockRustMat', scene);
+    rustMat.diffuseColor = new BABYLON.Color3(0.5, 0.3, 0.1);
+    lock.material = rustMat;
+    lock.parent = secretRoot;
+
+    const vine = BABYLON.MeshBuilder.CreatePlane('secretVine', { width: 2.4, height: 4.2 }, scene);
     vine.position.set(-court / 2 - 1.35, 2.2, -6);
     vine.rotation.y = Math.PI / 2;
-    root.add(vine);
+    vine.material = mossMat;
+    vine.parent = root;
 
-    root.userData.secretDoor = secret;
-    root.userData.gate = gate;
-    root.userData.court = court;
+    root.userData = {
+        secretDoor: secretRoot,
+        doorMesh: door,
+        gate,
+        court
+    };
+
     return root;
 }
 
-function addCrenels(root, mat, x, z, w, d, h) {
+function addCrenels(root, mat, x, z, w, d, h, scene) {
     const alongX = w > d;
     const len = alongX ? w : d;
     const n = Math.floor(len / 2.2);
     for (let i = 0; i < n; i++) {
         const t = (i / n - 0.5) * len;
-        const c = new THREE.Mesh(new THREE.BoxGeometry(alongX ? 1.1 : d + 0.4, 1.4, alongX ? d + 0.4 : 1.1), mat);
+        const c = BABYLON.MeshBuilder.CreateBox(`crenel_${x}_${z}_${i}`, {
+            width: alongX ? 1.1 : d + 0.4,
+            height: 1.4,
+            depth: alongX ? d + 0.4 : 1.1
+        }, scene);
         c.position.set(alongX ? x + t : x, h + 0.7, alongX ? z : z + t);
-        root.add(c);
+        c.material = mat;
+        c.parent = root;
     }
 }
 
-function makeFlag() {
-    const g = new THREE.Group();
-    const pole = new THREE.Mesh(new THREE.CylinderGeometry(0.04, 0.04, 3.2, 5), std(0x3a2a18, 0.8));
+function makeFlag(scene) {
+    const root = new BABYLON.TransformNode('flagRoot', scene);
+
+    const pole = BABYLON.MeshBuilder.CreateCylinder('flagPole', {
+        diameter: 0.08,
+        height: 3.2,
+        tessellation: 6
+    }, scene);
     pole.position.y = 1.6;
-    g.add(pole);
-    const cloth = new THREE.Mesh(
-        new THREE.PlaneGeometry(1.6, 0.9, 4, 2),
-        new THREE.MeshStandardMaterial({ map: flagTexture('#6b1c1c'), side: THREE.DoubleSide, roughness: 0.8 })
-    );
+    pole.parent = root;
+
+    const cloth = BABYLON.MeshBuilder.CreatePlane('flagCloth', { width: 1.6, height: 0.9 }, scene);
     cloth.position.set(0.8, 2.7, 0);
-    cloth.name = 'flag';
-    g.add(cloth);
-    return g;
+    const fMat = new BABYLON.StandardMaterial('flagMat', scene);
+    fMat.diffuseTexture = flagTexture(scene, '#6b1c1c');
+    fMat.backFaceCulling = false;
+    cloth.material = fMat;
+    cloth.parent = root;
+
+    return root;
 }
 
 export function addCastleColliders(collision, ox, oz) {

--- a/labs/guerreiro-castelo/js/world/CollisionWorld.js
+++ b/labs/guerreiro-castelo/js/world/CollisionWorld.js
@@ -1,13 +1,9 @@
 /**
- * Mundo de colisão sem engine externa.
- * Caixas AABB, chão, degraus pequenos e rampas até o limite.
+ * Mundo de colisão geométrico sem dependência externa.
+ * Caixas AABB, pisos, paredes e resolução de cápsula com step-up e rampas.
  */
 
-import * as THREE from 'three';
 import { clamp } from '../utils/math.js';
-
-const _center = new THREE.Vector3();
-const _size = new THREE.Vector3();
 
 export class CollisionWorld {
     constructor() {
@@ -24,8 +20,8 @@ export class CollisionWorld {
 
     addBox(minx, miny, minz, maxx, maxy, maxz, opts = {}) {
         this.boxes.push({
-            min: new THREE.Vector3(minx, miny, minz),
-            max: new THREE.Vector3(maxx, maxy, maxz),
+            min: { x: minx, y: miny, z: minz },
+            max: { x: maxx, y: maxy, z: maxz },
             solid: opts.solid !== false,
             climb: Boolean(opts.climb),
             oneWay: Boolean(opts.oneWay),
@@ -44,8 +40,8 @@ export class CollisionWorld {
     addTrigger(id, minx, miny, minz, maxx, maxy, maxz) {
         this.triggers.push({
             id,
-            min: new THREE.Vector3(minx, miny, minz),
-            max: new THREE.Vector3(maxx, maxy, maxz),
+            min: { x: minx, y: miny, z: minz },
+            max: { x: maxx, y: maxy, z: maxz },
             inside: false
         });
     }
@@ -131,11 +127,5 @@ export class CollisionWorld {
             if (inside) hits.push(t.id);
         }
         return hits;
-    }
-
-    debugBox(box) {
-        box.getCenter(_center);
-        box.getSize(_size);
-        return { center: _center, size: _size };
     }
 }

--- a/labs/guerreiro-castelo/js/world/Environment.js
+++ b/labs/guerreiro-castelo/js/world/Environment.js
@@ -1,133 +1,192 @@
 /**
- * Fogo, fumaça, tochas e instâncias de vegetação.
+ * Elementos do cenário: árvores, rochas, arbustos, tochas e fogo em Babylon.js.
  */
 
-import * as THREE from 'three';
-import { barkTexture, leafTexture, grassTexture, mossTexture } from './Textures.js';
-import { std } from '../characters/builders.js';
+import { barkTexture, leafTexture, stoneTexture, woodTexture } from './Textures.js';
 
-export function makeTorch() {
-    const g = new THREE.Group();
-    const stick = new THREE.Mesh(new THREE.CylinderGeometry(0.03, 0.04, 0.5, 6), std(0x4a3218, 0.9));
-    stick.position.y = 0.25;
-    g.add(stick);
-    const flame = new THREE.Mesh(
-        new THREE.ConeGeometry(0.07, 0.22, 6),
-        new THREE.MeshStandardMaterial({ color: 0xffaa33, emissive: 0xff6611, emissiveIntensity: 2.4 })
-    );
-    flame.position.y = 0.58;
-    g.add(flame);
-    g.userData.flame = flame;
-    return g;
-}
+export function makeTree(rng = Math.random, scene) {
+    const root = new BABYLON.TransformNode('treeRoot', scene);
 
-export function makeFire(size = 1) {
-    const g = new THREE.Group();
-    const logs = new THREE.Mesh(new THREE.CylinderGeometry(0.08 * size, 0.08 * size, 0.7 * size, 6), std(0x3a2414, 0.9));
-    logs.rotation.z = Math.PI / 2;
-    g.add(logs);
-    const logs2 = logs.clone();
-    logs2.rotation.y = 1.1;
-    g.add(logs2);
-    const flame = new THREE.Mesh(
-        new THREE.ConeGeometry(0.22 * size, 0.7 * size, 7),
-        new THREE.MeshStandardMaterial({
-            color: 0xff8020,
-            emissive: 0xff5500,
-            emissiveIntensity: 2.8,
-            transparent: true,
-            opacity: 0.92
-        })
-    );
-    flame.position.y = 0.35 * size;
-    g.add(flame);
-    const glow = new THREE.PointLight(0xff6a22, 1.6 * size, 8 * size);
-    glow.position.y = 0.4 * size;
-    glow.castShadow = false;
-    g.add(glow);
-    g.userData.flame = flame;
-    g.userData.glow = glow;
-    return g;
-}
+    const trunkH = 4 + rng() * 2;
+    const trunk = BABYLON.MeshBuilder.CreateCylinder('treeTrunk', {
+        diameterTop: 0.35,
+        diameterBottom: 0.55,
+        height: trunkH,
+        tessellation: 7
+    }, scene);
+    trunk.position.y = trunkH / 2;
+    trunk.parent = root;
 
-export function updateFire(group, t) {
-    if (!group?.userData.flame) return;
-    const s = 0.85 + Math.sin(t * 11) * 0.12 + Math.sin(t * 17) * 0.06;
-    group.userData.flame.scale.set(s, 0.9 + Math.sin(t * 9) * 0.15, s);
-    if (group.userData.glow) group.userData.glow.intensity = 1.3 + Math.sin(t * 13) * 0.35;
-}
+    const trunkMat = new BABYLON.StandardMaterial('trunkMat', scene);
+    trunkMat.diffuseTexture = barkTexture(scene, 1, 2);
+    trunkMat.specularColor = new BABYLON.Color3(0.05, 0.05, 0.05);
+    trunk.material = trunkMat;
 
-export function makeTree(rng = Math.random) {
-    const g = new THREE.Group();
-    const h = 3.2 + rng() * 2.4;
-    const trunk = new THREE.Mesh(
-        new THREE.CylinderGeometry(0.16, 0.22, h, 7),
-        new THREE.MeshStandardMaterial({ map: barkTexture(), roughness: 0.92 })
-    );
-    trunk.position.y = h / 2;
-    trunk.castShadow = true;
-    g.add(trunk);
-    const canopy = new THREE.Mesh(
-        new THREE.SphereGeometry(1.3 + rng() * 0.6, 10, 8),
-        new THREE.MeshStandardMaterial({ map: leafTexture(), color: 0x3a7a28, roughness: 0.85 })
-    );
-    canopy.position.y = h + 0.4;
-    canopy.castShadow = true;
-    g.add(canopy);
-    const c2 = canopy.clone();
-    c2.scale.setScalar(0.7);
-    c2.position.set((rng() - 0.5) * 0.8, h + 0.8, (rng() - 0.5) * 0.8);
-    g.add(c2);
-    return g;
-}
+    const foliage = new BABYLON.TransformNode('treeFoliage', scene);
+    foliage.parent = root;
+    foliage.position.y = trunkH * 0.75;
 
-export function makeBush() {
-    const m = new THREE.Mesh(
-        new THREE.SphereGeometry(0.45, 8, 6),
-        new THREE.MeshStandardMaterial({ map: mossTexture(), color: 0x3a6a28, roughness: 0.9 })
-    );
-    m.scale.set(1.2, 0.7, 1);
-    m.castShadow = true;
-    return m;
-}
+    const leafMat = new BABYLON.StandardMaterial('leafMat', scene);
+    leafMat.diffuseTexture = leafTexture(scene, 2, 2);
+    leafMat.specularColor = new BABYLON.Color3(0.02, 0.02, 0.02);
 
-export function makeRock(s = 1) {
-    const m = new THREE.Mesh(
-        new THREE.DodecahedronGeometry(0.5 * s, 0),
-        new THREE.MeshStandardMaterial({ color: 0x6a665c, roughness: 0.95 })
-    );
-    m.scale.set(1 + Math.random() * 0.4, 0.6 + Math.random() * 0.5, 1 + Math.random() * 0.3);
-    m.castShadow = true;
-    m.receiveShadow = true;
-    return m;
-}
-
-export function grassBladeGeo() {
-    return new THREE.PlaneGeometry(0.12, 0.45);
-}
-
-export function makeGrassInstanced(count, spread, qualityScale = 1) {
-    const n = Math.floor(count * qualityScale);
-    const mesh = new THREE.InstancedMesh(
-        grassBladeGeo(),
-        new THREE.MeshStandardMaterial({
-            map: grassTexture(),
-            color: 0x4a8a30,
-            side: THREE.DoubleSide,
-            roughness: 0.9
-        }),
-        n
-    );
-    const dummy = new THREE.Object3D();
-    for (let i = 0; i < n; i++) {
-        dummy.position.set((Math.random() - 0.5) * spread, 0.2, (Math.random() - 0.5) * spread);
-        dummy.rotation.y = Math.random() * Math.PI;
-        dummy.scale.setScalar(0.7 + Math.random() * 0.8);
-        dummy.updateMatrix();
-        mesh.setMatrixAt(i, dummy.matrix);
+    const layers = 3;
+    for (let i = 0; i < layers; i++) {
+        const cone = BABYLON.MeshBuilder.CreateCylinder(`treeCone_${i}`, {
+            diameterTop: 0,
+            diameterBottom: 3.2 - i * 0.7 + rng() * 0.4,
+            height: 2.2,
+            tessellation: 7
+        }, scene);
+        cone.position.y = i * 1.3;
+        cone.material = leafMat;
+        cone.parent = foliage;
     }
-    mesh.instanceMatrix.needsUpdate = true;
+
+    return root;
+}
+
+export function makeRock(scale = 1, scene) {
+    const mesh = BABYLON.MeshBuilder.CreateSphere('rockMesh', {
+        diameter: scale * 2,
+        segments: 6
+    }, scene);
+    mesh.scaling = new BABYLON.Vector3(1 + Math.random() * 0.3, 0.7 + Math.random() * 0.4, 1 + Math.random() * 0.3);
+    mesh.rotation.y = Math.random() * Math.PI * 2;
+    mesh.rotation.x = (Math.random() - 0.5) * 0.4;
+
+    const rockMat = new BABYLON.StandardMaterial('rockMat', scene);
+    rockMat.diffuseTexture = stoneTexture(scene, 2, 2);
+    rockMat.specularColor = new BABYLON.Color3(0.08, 0.08, 0.08);
+    mesh.material = rockMat;
+
     return mesh;
+}
+
+export function makeBush(scene) {
+    const root = new BABYLON.TransformNode('bushRoot', scene);
+    const leafMat = new BABYLON.StandardMaterial('bushLeafMat', scene);
+    leafMat.diffuseTexture = leafTexture(scene, 1, 1);
+
+    for (let i = 0; i < 4; i++) {
+        const b = BABYLON.MeshBuilder.CreateSphere(`bushPart_${i}`, {
+            diameter: 0.9 + Math.random() * 0.5,
+            segments: 6
+        }, scene);
+        b.position.set((Math.random() - 0.5) * 0.6, 0.35 + Math.random() * 0.3, (Math.random() - 0.5) * 0.6);
+        b.material = leafMat;
+        b.parent = root;
+    }
+    return root;
+}
+
+export function makeGrassInstanced(count, radius, quality = 1, scene) {
+    const root = new BABYLON.TransformNode('grassGroup', scene);
+    const actualCount = Math.floor(count * quality);
+    if (actualCount <= 0) return root;
+
+    const blade = BABYLON.MeshBuilder.CreatePlane('grassBlade', {
+        width: 0.35,
+        height: 0.7
+    }, scene);
+    const gMat = new BABYLON.StandardMaterial('grassBladeMat', scene);
+    gMat.diffuseColor = new BABYLON.Color3(0.24, 0.46, 0.16);
+    gMat.backFaceCulling = false;
+    blade.material = gMat;
+    blade.parent = root;
+    blade.isVisible = false;
+
+    for (let i = 0; i < actualCount; i++) {
+        const inst = blade.createInstance(`grass_${i}`);
+        const r = Math.sqrt(Math.random()) * radius;
+        const theta = Math.random() * Math.PI * 2;
+        inst.position.set(Math.cos(theta) * r, 0.35, Math.sin(theta) * r);
+        inst.rotation.y = Math.random() * Math.PI * 2;
+        inst.scaling.setScalar(0.7 + Math.random() * 0.6);
+        inst.parent = root;
+    }
+
+    return root;
+}
+
+export function makeTorch(scene) {
+    const root = new BABYLON.TransformNode('torchRoot', scene);
+
+    const stick = BABYLON.MeshBuilder.CreateCylinder('torchStick', {
+        diameterTop: 0.06,
+        diameterBottom: 0.04,
+        height: 0.5,
+        tessellation: 6
+    }, scene);
+    stick.position.y = 0.25;
+    stick.parent = root;
+
+    const stickMat = new BABYLON.StandardMaterial('torchWoodMat', scene);
+    stickMat.diffuseTexture = woodTexture(scene, 1, 1);
+    stick.material = stickMat;
+
+    const head = BABYLON.MeshBuilder.CreateCylinder('torchHead', {
+        diameterTop: 0.12,
+        diameterBottom: 0.08,
+        height: 0.14,
+        tessellation: 6
+    }, scene);
+    head.position.y = 0.5;
+    head.parent = root;
+
+    const headMat = new BABYLON.StandardMaterial('torchHeadMat', scene);
+    headMat.diffuseColor = new BABYLON.Color3(0.2, 0.15, 0.1);
+    head.material = headMat;
+
+    const light = new BABYLON.PointLight('torchLight', new BABYLON.Vector3(0, 0.6, 0), scene);
+    light.diffuse = new BABYLON.Color3(1.0, 0.6, 0.2);
+    light.intensity = 1.2;
+    light.range = 8;
+    light.parent = root;
+
+    root.userData = { light };
+    return root;
+}
+
+export function makeFire(scale = 1, scene) {
+    const root = new BABYLON.TransformNode('fireRoot', scene);
+
+    const fireSystem = new BABYLON.ParticleSystem('fireParticles', Math.floor(100 * scale), scene);
+
+    const c = document.createElement('canvas');
+    c.width = 32;
+    c.height = 32;
+    const ctx = c.getContext('2d');
+    const rad = ctx.createRadialGradient(16, 16, 0, 16, 16, 16);
+    rad.addColorStop(0, 'rgba(255, 220, 120, 1)');
+    rad.addColorStop(0.4, 'rgba(255, 120, 30, 0.8)');
+    rad.addColorStop(1, 'rgba(200, 40, 10, 0)');
+    ctx.fillStyle = rad;
+    ctx.fillRect(0, 0, 32, 32);
+
+    fireSystem.particleTexture = new BABYLON.DynamicTexture('fireTex', c, scene, false);
+    fireSystem.emitter = root;
+    fireSystem.minEmitBox = new BABYLON.Vector3(-0.15 * scale, 0, -0.15 * scale);
+    fireSystem.maxEmitBox = new BABYLON.Vector3(0.15 * scale, 0.1 * scale, 0.15 * scale);
+
+    fireSystem.color1 = new BABYLON.Color4(1.0, 0.7, 0.2, 1.0);
+    fireSystem.color2 = new BABYLON.Color4(1.0, 0.3, 0.1, 0.8);
+    fireSystem.colorDead = new BABYLON.Color4(0.3, 0.05, 0.0, 0.0);
+
+    fireSystem.minSize = 0.25 * scale;
+    fireSystem.maxSize = 0.55 * scale;
+    fireSystem.minLifeTime = 0.35;
+    fireSystem.maxLifeTime = 0.7;
+
+    fireSystem.emitRate = Math.floor(45 * scale);
+    fireSystem.blendMode = BABYLON.ParticleSystem.BLENDMODE_ONEONE;
+    fireSystem.gravity = new BABYLON.Vector3(0, 4.5, 0);
+    fireSystem.direction1 = new BABYLON.Vector3(-0.3, 1.8, -0.3);
+    fireSystem.direction2 = new BABYLON.Vector3(0.3, 2.4, 0.3);
+    fireSystem.start();
+
+    root.userData = { fireSystem };
+    return root;
 }
 
 export class EnvironmentFX {
@@ -135,15 +194,17 @@ export class EnvironmentFX {
         this.fires = [];
     }
 
-    addFire(f) {
-        this.fires.push(f);
+    addFire(fireNode) {
+        if (fireNode) this.fires.push(fireNode);
     }
 
-    update(t) {
-        for (const f of this.fires) updateFire(f, t);
-    }
-
-    clear() {
-        this.fires.length = 0;
+    update(time) {
+        // Jitter luzes das tochas/lareira
+        for (const f of this.fires) {
+            const light = f.userData?.light;
+            if (light) {
+                light.intensity = 1.0 + Math.sin(time * 12 + light.uniqueId) * 0.25;
+            }
+        }
     }
 }

--- a/labs/guerreiro-castelo/js/world/Home.js
+++ b/labs/guerreiro-castelo/js/world/Home.js
@@ -1,142 +1,158 @@
 /**
- * Sala rústica da casa — lareira, sofá, tapete, estante, brinquedos.
+ * Sala rústica da casa inicial (Lareira, sofá, estante, brinquedos) em Babylon.js.
  */
 
-import * as THREE from 'three';
 import {
     woodTexture, darkWoodTexture, plasterTexture, rugTexture, clothTexture
 } from './Textures.js';
-import { std } from '../characters/builders.js';
 import { makeFire } from './Environment.js';
 
-export function buildHomeInterior() {
-    const g = new THREE.Group();
-    const plaster = new THREE.MeshStandardMaterial({ map: plasterTexture(), roughness: 0.9, color: 0xe8d8c0 });
-    const wood = new THREE.MeshStandardMaterial({ map: woodTexture(), roughness: 0.8 });
-    const dark = new THREE.MeshStandardMaterial({ map: darkWoodTexture(), roughness: 0.85 });
+export function buildHomeInterior(scene) {
+    const root = new BABYLON.TransformNode('homeRoot', scene);
 
-    const floor = new THREE.Mesh(new THREE.BoxGeometry(10, 0.2, 8), dark);
+    const plasterMat = new BABYLON.StandardMaterial('plasterMat', scene);
+    plasterMat.diffuseTexture = plasterTexture(scene, 3, 3);
+    plasterMat.diffuseColor = new BABYLON.Color3(0.9, 0.85, 0.75);
+
+    const woodMat = new BABYLON.StandardMaterial('woodMat', scene);
+    woodMat.diffuseTexture = woodTexture(scene, 4, 4);
+
+    const darkWoodMat = new BABYLON.StandardMaterial('darkWoodMat', scene);
+    darkWoodMat.diffuseTexture = darkWoodTexture(scene, 3, 3);
+
+    // Piso
+    const floor = BABYLON.MeshBuilder.CreateBox('homeFloor', { width: 10, height: 0.2, depth: 8 }, scene);
     floor.position.y = -0.1;
-    floor.receiveShadow = true;
-    g.add(floor);
+    floor.material = darkWoodMat;
+    floor.parent = root;
+    floor.receiveShadows = true;
 
-    const ceil = new THREE.Mesh(new THREE.BoxGeometry(10, 0.2, 8), wood);
+    // Teto
+    const ceil = BABYLON.MeshBuilder.CreateBox('homeCeil', { width: 10, height: 0.2, depth: 8 }, scene);
     ceil.position.y = 3.4;
-    g.add(ceil);
+    ceil.material = woodMat;
+    ceil.parent = root;
 
-    const wall = (w, h, d, x, y, z) => {
-        const m = new THREE.Mesh(new THREE.BoxGeometry(w, h, d), plaster);
+    // Paredes
+    const mkWall = (name, w, h, d, x, y, z) => {
+        const m = BABYLON.MeshBuilder.CreateBox(name, { width: w, height: h, depth: d }, scene);
         m.position.set(x, y, z);
-        m.castShadow = true;
-        m.receiveShadow = true;
-        g.add(m);
+        m.material = plasterMat;
+        m.parent = root;
+        m.receiveShadows = true;
         return m;
     };
-    wall(10, 3.6, 0.25, 0, 1.7, -4);
-    wall(10, 3.6, 0.25, 0, 1.7, 4);
-    wall(0.25, 3.6, 8, -5, 1.7, 0);
-    wall(0.25, 3.6, 8, 5, 1.7, 0);
 
-    const fireplace = new THREE.Mesh(new THREE.BoxGeometry(2.4, 2.2, 0.7), dark);
+    mkWall('wallBack', 10, 3.6, 0.25, 0, 1.7, -4);
+    mkWall('wallFront', 10, 3.6, 0.25, 0, 1.7, 4);
+    mkWall('wallLeft', 0.25, 3.6, 8, -5, 1.7, 0);
+    mkWall('wallRight', 0.25, 3.6, 8, 5, 1.7, 0);
+
+    // Lareira
+    const fireplace = BABYLON.MeshBuilder.CreateBox('fireplace', { width: 2.4, height: 2.2, depth: 0.7 }, scene);
     fireplace.position.set(0, 1.1, -3.55);
-    g.add(fireplace);
-    const opening = new THREE.Mesh(new THREE.BoxGeometry(1.5, 1.2, 0.4), std(0x1a1008, 1));
+    fireplace.material = darkWoodMat;
+    fireplace.parent = root;
+
+    const opening = BABYLON.MeshBuilder.CreateBox('fireplaceOpening', { width: 1.5, height: 1.2, depth: 0.4 }, scene);
     opening.position.set(0, 0.75, -3.2);
-    g.add(opening);
-    const fire = makeFire(0.85);
+    const darkMat = new BABYLON.StandardMaterial('fpDarkMat', scene);
+    darkMat.diffuseColor = new BABYLON.Color3(0.08, 0.05, 0.03);
+    opening.material = darkMat;
+    opening.parent = root;
+
+    const fire = makeFire(0.85, scene);
     fire.position.set(0, 0.15, -3.15);
-    fire.name = 'hearth';
-    g.add(fire);
+    fire.parent = root;
 
-    const mantel = new THREE.Mesh(new THREE.BoxGeometry(2.6, 0.12, 0.5), wood);
+    const mantel = BABYLON.MeshBuilder.CreateBox('mantel', { width: 2.6, height: 0.12, depth: 0.5 }, scene);
     mantel.position.set(0, 2.15, -3.45);
-    g.add(mantel);
+    mantel.material = woodMat;
+    mantel.parent = root;
 
-    const rug = new THREE.Mesh(
-        new THREE.BoxGeometry(3.2, 0.04, 2.4),
-        new THREE.MeshStandardMaterial({ map: rugTexture(), roughness: 0.9 })
-    );
+    // Tapete
+    const rug = BABYLON.MeshBuilder.CreateBox('rug', { width: 3.2, height: 0.04, depth: 2.4 }, scene);
     rug.position.set(0, 0.03, 0.3);
-    rug.receiveShadow = true;
-    g.add(rug);
+    const rugMat = new BABYLON.StandardMaterial('rugMat', scene);
+    rugMat.diffuseTexture = rugTexture(scene, 1, 1);
+    rug.material = rugMat;
+    rug.parent = root;
 
-    const sofa = new THREE.Group();
-    const seat = new THREE.Mesh(
-        new THREE.BoxGeometry(2.4, 0.4, 0.9),
-        new THREE.MeshStandardMaterial({ map: clothTexture(), color: 0x6a3a28, roughness: 0.88 })
-    );
-    seat.position.y = 0.4;
-    sofa.add(seat);
-    const back = new THREE.Mesh(new THREE.BoxGeometry(2.4, 0.9, 0.2), std(0x5a3222, 0.88));
-    back.position.set(0, 0.85, -0.4);
-    sofa.add(back);
-    const frame = new THREE.Mesh(new THREE.BoxGeometry(2.5, 0.18, 1), wood);
-    frame.position.y = 0.18;
-    sofa.add(frame);
+    // Sofá
+    const sofa = new BABYLON.TransformNode('sofa', scene);
     sofa.position.set(0, 0, 1.4);
-    sofa.name = 'sofa';
-    g.add(sofa);
+    sofa.parent = root;
 
-    const shelf = new THREE.Mesh(new THREE.BoxGeometry(1.4, 2.2, 0.35), wood);
+    const sofaClothMat = new BABYLON.StandardMaterial('sofaClothMat', scene);
+    sofaClothMat.diffuseTexture = clothTexture(scene, 2, 2);
+    sofaClothMat.diffuseColor = new BABYLON.Color3(0.55, 0.3, 0.2);
+
+    const seat = BABYLON.MeshBuilder.CreateBox('sofaSeat', { width: 2.4, height: 0.4, depth: 0.9 }, scene);
+    seat.position.y = 0.4;
+    seat.material = sofaClothMat;
+    seat.parent = sofa;
+
+    const back = BABYLON.MeshBuilder.CreateBox('sofaBack', { width: 2.4, height: 0.9, depth: 0.2 }, scene);
+    back.position.set(0, 0.85, -0.4);
+    back.material = sofaClothMat;
+    back.parent = sofa;
+
+    const sofaFrame = BABYLON.MeshBuilder.CreateBox('sofaFrame', { width: 2.5, height: 0.18, depth: 1.0 }, scene);
+    sofaFrame.position.y = 0.18;
+    sofaFrame.material = woodMat;
+    sofaFrame.parent = sofa;
+
+    // Estante com livros
+    const shelf = BABYLON.MeshBuilder.CreateBox('bookshelf', { width: 1.4, height: 2.2, depth: 0.35 }, scene);
     shelf.position.set(-4.2, 1.2, -2.4);
-    g.add(shelf);
+    shelf.material = woodMat;
+    shelf.parent = root;
+
+    const bookColors = [
+        new BABYLON.Color3(0.5, 0.15, 0.15),
+        new BABYLON.Color3(0.15, 0.25, 0.5),
+        new BABYLON.Color3(0.2, 0.45, 0.15),
+        new BABYLON.Color3(0.45, 0.3, 0.15)
+    ];
     for (let i = 0; i < 12; i++) {
-        const book = new THREE.Mesh(
-            new THREE.BoxGeometry(0.12, 0.28, 0.22),
-            std([0x6b1c1c, 0x1c3a6b, 0x3a5a1c, 0x5a3a1c][i % 4], 0.8)
-        );
+        const book = BABYLON.MeshBuilder.CreateBox(`book_${i}`, { width: 0.12, height: 0.28, depth: 0.22 }, scene);
         book.position.set(-4.2 + (i % 6) * 0.16 - 0.4, 0.55 + Math.floor(i / 6) * 0.7, -2.4);
-        g.add(book);
+        const bMat = new BABYLON.StandardMaterial(`bookMat_${i}`, scene);
+        bMat.diffuseColor = bookColors[i % 4];
+        book.material = bMat;
+        book.parent = root;
     }
 
-    const table = new THREE.Mesh(new THREE.BoxGeometry(0.8, 0.5, 0.8), wood);
+    // Mesinha lateral com o brinquedo brilhante
+    const table = BABYLON.MeshBuilder.CreateBox('sideTable', { width: 0.8, height: 0.5, depth: 0.8 }, scene);
     table.position.set(3.2, 0.28, 1.2);
-    table.name = 'sideTable';
-    g.add(table);
-    const shiny = new THREE.Mesh(
-        new THREE.SphereGeometry(0.08, 10, 8),
-        new THREE.MeshStandardMaterial({ color: 0xd4b45a, metalness: 0.9, roughness: 0.25, emissive: 0x332200, emissiveIntensity: 0.4 })
-    );
+    table.material = woodMat;
+    table.parent = root;
+
+    const shiny = BABYLON.MeshBuilder.CreateSphere('shinyToy', { diameter: 0.18, segments: 10 }, scene);
     shiny.position.set(3.2, 0.62, 1.2);
-    shiny.name = 'shinyToy';
-    g.add(shiny);
+    const shinyMat = new BABYLON.StandardMaterial('shinyMat', scene);
+    shinyMat.diffuseColor = new BABYLON.Color3(0.9, 0.75, 0.3);
+    shinyMat.specularColor = new BABYLON.Color3(1, 1, 0.8);
+    shinyMat.emissiveColor = new BABYLON.Color3(0.3, 0.2, 0.05);
+    shiny.material = shinyMat;
+    shiny.parent = root;
 
-    const horse = new THREE.Mesh(new THREE.BoxGeometry(0.35, 0.22, 0.12), std(0x8a5a2a, 0.8));
+    // Brinquedo de cavalo de madeira e bola
+    const horse = BABYLON.MeshBuilder.CreateBox('toyHorse', { width: 0.35, height: 0.22, depth: 0.12 }, scene);
     horse.position.set(-3.4, 0.14, 2.2);
-    g.add(horse);
-    const ball = new THREE.Mesh(new THREE.SphereGeometry(0.12, 10, 8), std(0x8a1c1c, 0.6));
+    horse.material = woodMat;
+    horse.parent = root;
+
+    const ball = BABYLON.MeshBuilder.CreateSphere('toyBall', { diameter: 0.24, segments: 8 }, scene);
     ball.position.set(-3.1, 0.12, 2.5);
-    g.add(ball);
+    const ballMat = new BABYLON.StandardMaterial('ballMat', scene);
+    ballMat.diffuseColor = new BABYLON.Color3(0.7, 0.15, 0.15);
+    ball.material = ballMat;
+    ball.parent = root;
 
-    for (const x of [-2.6, 2.6]) {
-        const frameW = new THREE.Mesh(new THREE.BoxGeometry(1.1, 1.2, 0.08), wood);
-        frameW.position.set(x, 1.8, -3.88);
-        g.add(frameW);
-        const glass = new THREE.Mesh(
-            new THREE.PlaneGeometry(0.9, 1),
-            new THREE.MeshStandardMaterial({ color: 0x0a1228, emissive: 0x081018, emissiveIntensity: 0.2 })
-        );
-        glass.position.set(x, 1.8, -3.82);
-        g.add(glass);
-        const stars = new THREE.Points(
-            new THREE.BufferGeometry().setFromPoints([
-                new THREE.Vector3(-0.2, 0.2, 0),
-                new THREE.Vector3(0.15, 0.35, 0),
-                new THREE.Vector3(0.3, -0.1, 0)
-            ]),
-            new THREE.PointsMaterial({ color: 0xfff4cc, size: 0.04 })
-        );
-        stars.position.set(x, 1.9, -3.8);
-        g.add(stars);
-    }
-
-    const lamp = new THREE.PointLight(0xffb070, 0.55, 9);
-    lamp.position.set(-2.4, 2.4, 1.5);
-    g.add(lamp);
-
-    g.userData.fire = fire;
-    g.userData.shiny = shiny;
-    return g;
+    root.userData = { fire, shiny };
+    return root;
 }
 
 export function addHomeColliders(collision) {

--- a/labs/guerreiro-castelo/js/world/Ocean.js
+++ b/labs/guerreiro-castelo/js/world/Ocean.js
@@ -1,126 +1,70 @@
 /**
- * Oceano reativo ao clima. Tenta o Water oficial do Three.js;
- * se o mirror/RT falhar, usa um shader próprio sem render target.
+ * Oceano reativo ao clima com simulação de ondas para o navio em Babylon.js.
  */
 
-import * as THREE from 'three';
-import { Water } from 'three/addons/objects/Water.js';
 import { waterNormalTexture } from './Textures.js';
 
-const WAVE_VERT = /* glsl */ `
-uniform float uTime;
-uniform float uIntensity;
-varying vec2 vUv;
-varying float vWave;
-void main() {
-  vUv = uv;
-  vec3 p = position;
-  float k = uIntensity;
-  float w =
-    sin(p.x * 0.08 + uTime * 1.4) * 0.35 * k +
-    sin(p.y * 0.05 + uTime * 1.1) * 0.45 * k +
-    sin((p.x + p.y) * 0.03 + uTime * 0.7) * 0.25 * k;
-  p.z += w;
-  vWave = w;
-  gl_Position = projectionMatrix * modelViewMatrix * vec4(p, 1.0);
-}
-`;
-
-const WAVE_FRAG = /* glsl */ `
-uniform vec3 uColor;
-uniform vec3 uDeep;
-uniform float uFoam;
-varying vec2 vUv;
-varying float vWave;
-void main() {
-  float f = smoothstep(0.15, 0.45, vWave) * uFoam;
-  vec3 col = mix(uDeep, uColor, 0.45 + vWave * 0.3);
-  col = mix(col, vec3(0.85, 0.92, 0.95), f * 0.45);
-  gl_FragColor = vec4(col, 1.0);
-}
-`;
-
 export class Ocean {
-    constructor(scene, normals, quality) {
+    constructor(scene, quality) {
+        this.scene = scene;
         this.intensity = 0.25;
-        this._foam = 0;
+        this.foam = 0;
         this.time = 0;
-        this.water = (quality.id === 'ultra' ? this._tryOfficialWater(scene, normals, quality) : null)
-            || this._shaderWater(scene, quality);
-        this.water.position.y = 0;
-        scene.add(this.water);
-        this._sun = new THREE.Vector3(0.4, 0.6, 0.2);
-    }
 
-    _tryOfficialWater(scene, normals, quality) {
-        try {
-            if (quality.id === 'low') return null;
-            const geo = new THREE.PlaneGeometry(2000, 2000);
-            const waterNormals = normals || waterNormalTexture();
-            waterNormals.wrapS = waterNormals.wrapT = THREE.RepeatWrapping;
-            const water = new Water(geo, {
-                textureWidth: Math.min(256, quality.water),
-                textureHeight: Math.min(256, quality.water),
-                waterNormals,
-                sunDirection: new THREE.Vector3(0.4, 0.6, 0.2).normalize(),
-                sunColor: 0xf2e6c4,
-                waterColor: 0x0a3a4a,
-                distortionScale: 2.8,
-                fog: Boolean(scene.fog)
-            });
-            water.rotation.x = -Math.PI / 2;
-            water.userData.kind = 'three-water';
-            return water;
-        } catch (err) {
-            console.warn('[Ocean] Water addon indisponível, shader próprio.', err);
-            return null;
+        const subs = quality.id === 'ultra' ? 64 : quality.id === 'high' ? 48 : 32;
+        this.mesh = BABYLON.MeshBuilder.CreateGround('oceanMesh', {
+            width: 1600,
+            height: 1600,
+            subdivisions: subs,
+            updatable: true
+        }, scene);
+        this.mesh.position.y = 0;
+        this.mesh.receiveShadows = true;
+
+        this.positions = this.mesh.getVerticesData(BABYLON.VertexBuffer.PositionKind);
+        this.baseY = new Float32Array(this.positions.length / 3);
+        this.origX = new Float32Array(this.positions.length / 3);
+        this.origZ = new Float32Array(this.positions.length / 3);
+
+        for (let i = 0; i < this.positions.length / 3; i++) {
+            this.origX[i] = this.positions[i * 3];
+            this.baseY[i] = this.positions[i * 3 + 1];
+            this.origZ[i] = this.positions[i * 3 + 2];
         }
+
+        // Material PBR / Standard estilizado
+        const mat = new BABYLON.StandardMaterial('oceanMat', scene);
+        mat.diffuseColor = new BABYLON.Color3(0.06, 0.28, 0.42);
+        mat.specularColor = new BABYLON.Color3(0.8, 0.9, 1.0);
+        mat.specularPower = 64;
+        mat.alpha = 0.92;
+        mat.bumpTexture = waterNormalTexture(scene, 16, 16);
+
+        this.mesh.material = mat;
+        this.mat = mat;
+        this.visible = true;
     }
 
-    _shaderWater(scene, quality) {
-        const geo = new THREE.PlaneGeometry(2000, 2000, 1, 1);
-        const mat = new THREE.MeshStandardMaterial({
-            color: 0x1a6a82,
-            roughness: 0.28,
-            metalness: 0.12,
-            envMapIntensity: 0
-        });
-        const mesh = new THREE.Mesh(geo, mat);
-        mesh.rotation.x = -Math.PI / 2;
-        mesh.userData.kind = 'simple-water';
-        mesh.receiveShadow = true;
-        mesh.material.uniforms = {
-            time: { value: 0 },
-            distortionScale: { value: 2 },
-            waterColor: { value: mat.color },
-            sunDirection: { value: new THREE.Vector3() },
-            sunColor: { value: new THREE.Color() },
-            uTime: { value: 0 },
-            uIntensity: { value: 0.25 },
-            uFoam: { value: 0 },
-            uColor: { value: mat.color },
-            uDeep: { value: new THREE.Color(0x062030) }
-        };
-        return mesh;
+    set visible(v) {
+        if (this.mesh) this.mesh.setEnabled(v);
     }
 
-    setSun(dir, color) {
-        this._sun.copy(dir);
-        const u = this.water.material.uniforms;
-        if (u?.sunDirection) u.sunDirection.value.copy(dir).normalize();
-        if (color && u?.sunColor) u.sunColor.value.set(color);
+    get visible() {
+        return this.mesh ? this.mesh.isEnabled() : false;
     }
 
     setStorm(amount) {
         this.intensity = 0.25 + amount * 2.4;
-        this._foam = amount;
-        const u = this.water.material.uniforms;
-        if (!u) return;
-        if (u.distortionScale) u.distortionScale.value = 2.2 + amount * 6;
-        if (u.waterColor) u.waterColor.value.set(amount > 0.4 ? 0x071820 : 0x0a3a4a);
-        if (u.uIntensity) u.uIntensity.value = this.intensity;
-        if (u.uFoam) u.uFoam.value = amount;
-        if (u.uColor) u.uColor.value.set(amount > 0.4 ? 0x1a3040 : 0x1a6a7a);
+        this.foam = amount;
+        if (this.mat) {
+            if (amount > 0.4) {
+                this.mat.diffuseColor = new BABYLON.Color3(0.04, 0.12, 0.18);
+                this.mat.specularColor = new BABYLON.Color3(0.5, 0.6, 0.7);
+            } else {
+                this.mat.diffuseColor = new BABYLON.Color3(0.06, 0.28, 0.42);
+                this.mat.specularColor = new BABYLON.Color3(0.8, 0.9, 1.0);
+            }
+        }
     }
 
     sample(x, z, time) {
@@ -137,9 +81,24 @@ export class Ocean {
 
     update(dt, time) {
         this.time = time;
-        const u = this.water.material.uniforms;
-        if (!u) return;
-        if (u.time) u.time.value = time * (0.4 + this.intensity * 0.5);
-        if (u.uTime) u.uTime.value = time;
+        if (!this.visible) return;
+
+        // Atualização da malha para deformação visual fluida próxima à câmera
+        const k = this.intensity;
+        const len = this.positions.length / 3;
+        for (let i = 0; i < len; i++) {
+            const x = this.origX[i];
+            const z = this.origZ[i];
+            this.positions[i * 3 + 1] =
+                Math.sin(x * 0.08 + time * 1.4) * 0.35 * k +
+                Math.sin(z * 0.05 + time * 1.1) * 0.45 * k +
+                Math.sin((x + z) * 0.03 + time * 0.7) * 0.25 * k;
+        }
+        this.mesh.updateVerticesData(BABYLON.VertexBuffer.PositionKind, this.positions);
+
+        if (this.mat.bumpTexture) {
+            this.mat.bumpTexture.uOffset = time * 0.03;
+            this.mat.bumpTexture.vOffset = time * 0.02;
+        }
     }
 }

--- a/labs/guerreiro-castelo/js/world/Ship.js
+++ b/labs/guerreiro-castelo/js/world/Ship.js
@@ -1,131 +1,188 @@
 /**
- * Navio medieval de madeira — convés, mastro, vela, leme, barris, cordas.
+ * Navio medieval de madeira em Babylon.js (Convés, mastros, velas, leme, cordas, barris).
  */
 
-import * as THREE from 'three';
 import { woodTexture, clothTexture, darkWoodTexture } from './Textures.js';
-import { std } from '../characters/builders.js';
 
-export function buildShip() {
-    const ship = new THREE.Group();
-    ship.name = 'ship';
-    const wood = new THREE.MeshStandardMaterial({ map: woodTexture(), roughness: 0.82, color: 0xc4a06a });
-    const dark = new THREE.MeshStandardMaterial({ map: darkWoodTexture(), roughness: 0.85 });
+export function buildShip(scene) {
+    const root = new BABYLON.TransformNode('shipRoot', scene);
 
-    const hull = new THREE.Mesh(new THREE.BoxGeometry(7.2, 2.2, 18), wood);
+    const woodMat = new BABYLON.StandardMaterial('shipWoodMat', scene);
+    woodMat.diffuseTexture = woodTexture(scene, 4, 4);
+    woodMat.diffuseColor = new BABYLON.Color3(0.85, 0.7, 0.5);
+
+    const darkWoodMat = new BABYLON.StandardMaterial('shipDarkWoodMat', scene);
+    darkWoodMat.diffuseTexture = darkWoodTexture(scene, 3, 3);
+
+    // Casco
+    const hull = BABYLON.MeshBuilder.CreateBox('shipHull', { width: 7.2, height: 2.2, depth: 18 }, scene);
     hull.position.y = 0.2;
-    hull.castShadow = true;
-    hull.receiveShadow = true;
-    ship.add(hull);
+    hull.material = woodMat;
+    hull.parent = root;
+    hull.receiveShadows = true;
 
-    const bow = new THREE.Mesh(new THREE.ConeGeometry(2.2, 4.5, 4), wood);
+    // Proa triangular
+    const bow = BABYLON.MeshBuilder.CreateCylinder('shipBow', {
+        diameterTop: 0,
+        diameterBottom: 4.4,
+        height: 4.5,
+        tessellation: 4
+    }, scene);
     bow.rotation.x = -Math.PI / 2;
     bow.position.set(0, 0.4, -10.2);
-    ship.add(bow);
+    bow.material = woodMat;
+    bow.parent = root;
 
-    const deck = new THREE.Mesh(new THREE.BoxGeometry(6.6, 0.18, 16.5), dark);
+    // Convés principal
+    const deck = BABYLON.MeshBuilder.CreateBox('shipDeck', { width: 6.6, height: 0.18, depth: 16.5 }, scene);
     deck.position.y = 1.35;
-    deck.receiveShadow = true;
-    ship.add(deck);
+    deck.material = darkWoodMat;
+    deck.parent = root;
+    deck.receiveShadows = true;
 
-    const railGeo = new THREE.BoxGeometry(0.12, 0.55, 16);
-    const railL = new THREE.Mesh(railGeo, wood);
+    // Guarda-corpo
+    const railL = BABYLON.MeshBuilder.CreateBox('shipRailL', { width: 0.14, height: 0.55, depth: 16 }, scene);
     railL.position.set(-3.2, 1.7, 0);
-    const railR = railL.clone();
-    railR.position.x = 3.2;
-    ship.add(railL, railR);
+    railL.material = woodMat;
+    railL.parent = root;
 
-    const qdeck = new THREE.Mesh(new THREE.BoxGeometry(6.4, 0.16, 4.2), dark);
+    const railR = BABYLON.MeshBuilder.CreateBox('shipRailR', { width: 0.14, height: 0.55, depth: 16 }, scene);
+    railR.position.set(3.2, 1.7, 0);
+    railR.material = woodMat;
+    railR.parent = root;
+
+    // Tompadilho traseiro (Quarter deck)
+    const qdeck = BABYLON.MeshBuilder.CreateBox('shipQDeck', { width: 6.4, height: 0.16, depth: 4.2 }, scene);
     qdeck.position.set(0, 2.15, 6.2);
-    qdeck.receiveShadow = true;
-    ship.add(qdeck);
-    const qwall = new THREE.Mesh(new THREE.BoxGeometry(6.4, 0.9, 0.2), wood);
+    qdeck.material = darkWoodMat;
+    qdeck.parent = root;
+    qdeck.receiveShadows = true;
+
+    const qwall = BABYLON.MeshBuilder.CreateBox('shipQWall', { width: 6.4, height: 0.9, depth: 0.2 }, scene);
     qwall.position.set(0, 1.8, 4.1);
-    ship.add(qwall);
+    qwall.material = woodMat;
+    qwall.parent = root;
 
-    const mast = new THREE.Mesh(new THREE.CylinderGeometry(0.16, 0.2, 11, 8), dark);
+    // Mastro principal
+    const mast = BABYLON.MeshBuilder.CreateCylinder('shipMast', {
+        diameterTop: 0.32,
+        diameterBottom: 0.4,
+        height: 11,
+        tessellation: 8
+    }, scene);
     mast.position.set(0, 6.8, -0.5);
-    mast.castShadow = true;
-    ship.add(mast);
+    mast.material = darkWoodMat;
+    mast.parent = root;
 
-    const yard = new THREE.Mesh(new THREE.CylinderGeometry(0.08, 0.08, 8, 6), dark);
+    // Verga da vela
+    const yard = BABYLON.MeshBuilder.CreateCylinder('shipYard', {
+        diameter: 0.16,
+        height: 8,
+        tessellation: 6
+    }, scene);
     yard.rotation.z = Math.PI / 2;
     yard.position.set(0, 10.2, -0.5);
-    ship.add(yard);
+    yard.material = darkWoodMat;
+    yard.parent = root;
 
-    const sail = new THREE.Mesh(
-        new THREE.PlaneGeometry(7.2, 6.5, 8, 6),
-        new THREE.MeshStandardMaterial({
-            map: clothTexture(),
-            color: 0xe8dcc4,
-            side: THREE.DoubleSide,
-            roughness: 0.9
-        })
-    );
+    // Vela de tecido
+    const sail = BABYLON.MeshBuilder.CreatePlane('shipSail', { width: 7.2, height: 6.5 }, scene);
     sail.position.set(0, 7.4, -0.7);
-    sail.name = 'sail';
-    ship.add(sail);
+    const sailMat = new BABYLON.StandardMaterial('sailMat', scene);
+    sailMat.diffuseTexture = clothTexture(scene, 3, 3);
+    sailMat.diffuseColor = new BABYLON.Color3(0.95, 0.9, 0.82);
+    sailMat.backFaceCulling = false;
+    sail.material = sailMat;
+    sail.parent = root;
 
-    const helm = new THREE.Group();
-    helm.name = 'helm';
-    const wheel = new THREE.Mesh(new THREE.TorusGeometry(0.42, 0.05, 8, 16), std(0x5a3a18, 0.6, 0.1));
+    // Leme
+    const helmRoot = new BABYLON.TransformNode('shipHelm', scene);
+    helmRoot.position.set(0, 2.7, 7.4);
+    helmRoot.parent = root;
+
+    const wheelMat = new BABYLON.StandardMaterial('helmWheelMat', scene);
+    wheelMat.diffuseColor = new BABYLON.Color3(0.4, 0.25, 0.12);
+
+    const wheel = BABYLON.MeshBuilder.CreateTorus('wheelTorus', {
+        diameter: 0.84,
+        thickness: 0.1,
+        tessellation: 16
+    }, scene);
+    wheel.material = wheelMat;
+    wheel.parent = helmRoot;
+
     for (let i = 0; i < 8; i++) {
-        const spoke = new THREE.Mesh(new THREE.BoxGeometry(0.05, 0.8, 0.05), std(0x5a3a18, 0.7));
+        const spoke = BABYLON.MeshBuilder.CreateBox(`spoke_${i}`, { width: 0.05, height: 0.8, depth: 0.05 }, scene);
         spoke.rotation.z = (i / 8) * Math.PI;
-        helm.add(spoke);
+        spoke.material = wheelMat;
+        spoke.parent = helmRoot;
     }
-    helm.add(wheel);
-    helm.position.set(0, 2.7, 7.4);
-    ship.add(helm);
 
-    const post = new THREE.Mesh(new THREE.CylinderGeometry(0.08, 0.08, 1.1, 6), dark);
+    const post = BABYLON.MeshBuilder.CreateCylinder('helmPost', { diameter: 0.16, height: 1.1 }, scene);
     post.position.set(0, 2.2, 7.4);
-    ship.add(post);
+    post.material = darkWoodMat;
+    post.parent = root;
 
+    // Barris no convés
     for (const x of [-2.2, 2.2]) {
         for (const z of [-4, -1, 2]) {
-            const barrel = new THREE.Mesh(new THREE.CylinderGeometry(0.38, 0.38, 0.7, 10), wood);
+            const barrel = BABYLON.MeshBuilder.CreateCylinder(`barrel_${x}_${z}`, {
+                diameter: 0.76,
+                height: 0.7,
+                tessellation: 10
+            }, scene);
             barrel.position.set(x, 1.72, z);
-            barrel.castShadow = true;
-            barrel.name = 'barrel';
-            ship.add(barrel);
+            barrel.material = woodMat;
+            barrel.parent = root;
         }
     }
 
-    const crate = new THREE.Mesh(new THREE.BoxGeometry(0.8, 0.6, 0.8), wood);
+    // Caixa de mantimentos
+    const crate = BABYLON.MeshBuilder.CreateBox('shipCrate', { width: 0.8, height: 0.6, depth: 0.8 }, scene);
     crate.position.set(1.8, 1.72, 5.2);
-    crate.name = 'crate';
-    ship.add(crate);
+    crate.material = woodMat;
+    crate.parent = root;
 
-    const rope = new THREE.Mesh(
-        new THREE.TubeGeometry(new THREE.CatmullRomCurve3([
-            new THREE.Vector3(-2.4, 1.5, 3),
-            new THREE.Vector3(-1.2, 2.4, 4.5),
-            new THREE.Vector3(0.2, 2.2, 6.8),
-            new THREE.Vector3(0.4, 2.6, 7.5)
-        ]), 16, 0.03, 5, false),
-        std(0x8a6a3a, 0.8)
-    );
-    rope.name = 'stormRope';
-    rope.visible = false;
-    ship.add(rope);
+    // Corda de tempestade que Teco precisa desatar
+    const ropePoints = [
+        new BABYLON.Vector3(-2.4, 1.5, 3),
+        new BABYLON.Vector3(-1.2, 2.4, 4.5),
+        new BABYLON.Vector3(0.2, 2.2, 6.8),
+        new BABYLON.Vector3(0.4, 2.6, 7.5)
+    ];
+    const rope = BABYLON.MeshBuilder.CreateTube('stormRope', {
+        path: ropePoints,
+        radius: 0.04,
+        tessellation: 5
+    }, scene);
+    const ropeMat = new BABYLON.StandardMaterial('ropeMat', scene);
+    ropeMat.diffuseColor = new BABYLON.Color3(0.55, 0.42, 0.25);
+    rope.material = ropeMat;
+    rope.parent = root;
+    rope.setEnabled(false);
 
-    const mooring = new THREE.Mesh(new THREE.CylinderGeometry(0.04, 0.04, 2.4, 5), std(0x8a6a3a, 0.8));
+    // Amarra do navio na praia
+    const mooring = BABYLON.MeshBuilder.CreateCylinder('mooring', { diameter: 0.08, height: 2.4 }, scene);
     mooring.rotation.z = 0.7;
     mooring.position.set(2.6, 1.4, 8.2);
-    mooring.name = 'mooring';
-    ship.add(mooring);
+    mooring.material = ropeMat;
+    mooring.parent = root;
 
-    const cabin = new THREE.Mesh(new THREE.BoxGeometry(4.2, 1.6, 3.2), wood);
+    // Cabine na proa
+    const cabin = BABYLON.MeshBuilder.CreateBox('shipCabin', { width: 4.2, height: 1.6, depth: 3.2 }, scene);
     cabin.position.set(0, 2.15, -5.4);
-    ship.add(cabin);
+    cabin.material = woodMat;
+    cabin.parent = root;
 
-    ship.userData.sail = sail;
-    ship.userData.helm = helm;
-    ship.userData.rope = rope;
-    ship.userData.mooring = mooring;
-    ship.userData.mast = mast;
-    return ship;
+    root.userData = {
+        sail,
+        helm: helmRoot,
+        rope,
+        mooring,
+        mast
+    };
+
+    return root;
 }
 
 export function addShipColliders(collision, ox = 0, oy = 0, oz = 0) {

--- a/labs/guerreiro-castelo/js/world/StormController.js
+++ b/labs/guerreiro-castelo/js/world/StormController.js
@@ -1,8 +1,7 @@
 /**
- * Tempestade: chuva, vento, ondas, fog, relâmpago (luz real, não flash de tela).
+ * Controlador de tempestade: partículas de chuva, vento, trovões e relâmpagos em Babylon.js.
  */
 
-import * as THREE from 'three';
 import { clamp, damp } from '../utils/math.js';
 
 export class StormController {
@@ -18,42 +17,69 @@ export class StormController {
         this.target = 0;
         this.time = 0;
 
-        const count = Math.floor(900 * quality.particles);
-        this._rainGeo = new THREE.BufferGeometry();
-        const pos = new Float32Array(count * 3);
-        for (let i = 0; i < count; i++) {
-            pos[i * 3] = (Math.random() - 0.5) * 40;
-            pos[i * 3 + 1] = Math.random() * 18;
-            pos[i * 3 + 2] = (Math.random() - 0.5) * 40;
-        }
-        this._rainGeo.setAttribute('position', new THREE.BufferAttribute(pos, 3));
-        this.rain = new THREE.Points(
-            this._rainGeo,
-            new THREE.PointsMaterial({
-                color: 0xa8c4d8,
-                size: 0.08,
-                transparent: true,
-                opacity: 0,
-                depthWrite: false
-            })
-        );
-        this.rain.visible = false;
-        scene.add(this.rain);
+        this.emitter = new BABYLON.TransformNode('stormEmitter', scene);
 
-        this.flashLight = new THREE.DirectionalLight(0xc8d8ff, 0);
-        this.flashLight.position.set(-4, 18, 6);
-        scene.add(this.flashLight);
-        this._count = count;
-        this.origin = new THREE.Vector3();
+        // Sistema de partículas de chuva
+        const count = Math.floor(1200 * (quality?.particles || 1));
+        const rainSystem = new BABYLON.ParticleSystem('rain', count, scene);
+
+        // Criar textura de gota procedural em canvas
+        const c = document.createElement('canvas');
+        c.width = 16;
+        c.height = 64;
+        const ctx = c.getContext('2d');
+        const grad = ctx.createLinearGradient(0, 0, 0, 64);
+        grad.addColorStop(0, 'rgba(200, 225, 255, 0)');
+        grad.addColorStop(0.5, 'rgba(200, 225, 255, 0.7)');
+        grad.addColorStop(1, 'rgba(240, 250, 255, 0.9)');
+        ctx.fillStyle = grad;
+        ctx.fillRect(0, 0, 16, 64);
+
+        const tex = new BABYLON.DynamicTexture('rainDrop', c, scene, false);
+        rainSystem.particleTexture = tex;
+
+        rainSystem.emitter = this.emitter;
+        rainSystem.minEmitBox = new BABYLON.Vector3(-25, 18, -25);
+        rainSystem.maxEmitBox = new BABYLON.Vector3(25, 22, 25);
+
+        rainSystem.color1 = new BABYLON.Color4(0.8, 0.9, 1.0, 0.6);
+        rainSystem.color2 = new BABYLON.Color4(0.7, 0.85, 0.95, 0.4);
+        rainSystem.colorDead = new BABYLON.Color4(0.5, 0.7, 0.9, 0.0);
+
+        rainSystem.minSize = 0.15;
+        rainSystem.maxSize = 0.35;
+        rainSystem.minScaleY = 2.5;
+        rainSystem.maxScaleY = 5.0;
+
+        rainSystem.minLifeTime = 0.8;
+        rainSystem.maxLifeTime = 1.4;
+
+        rainSystem.emitRate = 0;
+        rainSystem.blendMode = BABYLON.ParticleSystem.BLENDMODE_STANDARD;
+        rainSystem.gravity = new BABYLON.Vector3(0, -32, 0);
+        rainSystem.direction1 = new BABYLON.Vector3(-2, -28, -1);
+        rainSystem.direction2 = new BABYLON.Vector3(-4, -34, -2);
+        rainSystem.start();
+
+        this.rainSystem = rainSystem;
+        this.maxEmitRate = count;
+
+        // Luz de relâmpago
+        this.flashLight = new BABYLON.DirectionalLight('lightningFlash', new BABYLON.Vector3(0.2, -1, 0.1), scene);
+        this.flashLight.diffuse = new BABYLON.Color3(0.85, 0.92, 1.0);
+        this.flashLight.intensity = 0;
     }
 
     setIntensity(v) {
         this.target = clamp(v, 0, 1);
     }
 
-    follow(origin) {
-        this.origin.copy(origin);
-        this.rain.position.copy(origin);
+    follow(pos) {
+        if (pos) {
+            this.emitter.position.x = pos.x;
+            this.emitter.position.y = pos.y;
+            this.emitter.position.z = pos.z;
+        }
     }
 
     update(dt, game) {
@@ -61,47 +87,40 @@ export class StormController {
         this.rainIntensity = damp(this.rainIntensity, this.target, 1.2, dt);
         this.windIntensity = this.rainIntensity;
         this.waveIntensity = this.rainIntensity;
-        this.fogDensity = 0.008 + this.rainIntensity * 0.028;
+        this.fogDensity = 0.008 + this.rainIntensity * 0.025;
         this.lightLevel = 1 - this.rainIntensity * 0.55;
 
-        if (this.rainIntensity > 0.05) {
-            this.rain.visible = true;
-            this.rain.material.opacity = this.rainIntensity * 0.65;
-            const arr = this._rainGeo.attributes.position.array;
-            const vy = (18 + this.rainIntensity * 22) * dt;
-            const wind = this.windIntensity * 8 * dt;
-            for (let i = 0; i < this._count; i++) {
-                arr[i * 3] += wind;
-                arr[i * 3 + 1] -= vy;
-                if (arr[i * 3 + 1] < 0) {
-                    arr[i * 3] = (Math.random() - 0.5) * 40;
-                    arr[i * 3 + 1] = 16 + Math.random() * 6;
-                    arr[i * 3 + 2] = (Math.random() - 0.5) * 40;
-                }
-            }
-            this._rainGeo.attributes.position.needsUpdate = true;
-        } else {
-            this.rain.visible = false;
+        this.rainSystem.emitRate = Math.floor(this.maxEmitRate * this.rainIntensity);
+
+        // Vento inclina a chuva
+        this.rainSystem.direction1.x = -2 - this.windIntensity * 8;
+        this.rainSystem.direction2.x = -4 - this.windIntensity * 12;
+
+        // Relâmpagos aleatórios durante tempestade intensa
+        if (this.rainIntensity > 0.45 && Math.random() < dt * 0.25) {
+            this.lightning = 0.12 + Math.random() * 0.08;
+            this.thunderDelay = 0.3 + Math.random() * 1.2;
         }
 
-        if (this.rainIntensity > 0.45 && Math.random() < dt * 0.22) {
-            this.lightning = 0.12 + Math.random() * 0.08;
-            this.thunderDelay = 0.4 + Math.random() * 1.4;
-        }
         if (this.lightning > 0) {
             this.lightning -= dt;
-            this.flashLight.intensity = this.lightning > 0.04 ? 3.2 : 0.4;
+            this.flashLight.intensity = this.lightning > 0.04 ? 3.5 : 0.6;
         } else {
             this.flashLight.intensity = 0;
         }
+
         if (this.thunderDelay >= 0) {
             this.thunderDelay -= dt;
-            if (this.thunderDelay < 0) game.audio.play('thunder');
+            if (this.thunderDelay < 0) {
+                game.audio.play('thunder');
+                game.cameraRig?.addShake(0.12, 0.4);
+            }
         }
 
-        if (game.scene.fog) {
-            game.scene.fog.density = this.fogDensity;
+        if (this.scene.fogMode !== BABYLON.Scene.FOGMODE_NONE && game.stageId === 'ship') {
+            this.scene.fogDensity = this.fogDensity;
         }
+
         game.ocean?.setStorm(this.waveIntensity);
     }
 }

--- a/labs/guerreiro-castelo/js/world/Textures.js
+++ b/labs/guerreiro-castelo/js/world/Textures.js
@@ -1,32 +1,17 @@
 /**
- * Texturas procedurais em canvas — o lab não depende de PNG externos.
+ * Texturas procedurais geradas via HTML Canvas para Babylon.js.
+ * Sem dependência de PNGs externos.
  */
 
-import * as THREE from 'three';
 import { hash2 } from '../utils/math.js';
 
 const cache = new Map();
 
-function canvas(size, height = size) {
+function createCanvas(width, height = width) {
     const el = document.createElement('canvas');
-    el.width = size;
+    el.width = width;
     el.height = height;
     return el;
-}
-
-function toTexture(el, { repeat = [1, 1], srgb = true, aniso = 4, normal = false } = {}) {
-    const tex = new THREE.CanvasTexture(el);
-    tex.wrapS = tex.wrapT = THREE.RepeatWrapping;
-    tex.repeat.set(repeat[0], repeat[1]);
-    tex.anisotropy = aniso;
-    if (srgb && !normal) tex.colorSpace = THREE.SRGBColorSpace;
-    tex.needsUpdate = true;
-    return tex;
-}
-
-function cached(key, factory) {
-    if (!cache.has(key)) cache.set(key, factory());
-    return cache.get(key);
 }
 
 function grain(ctx, w, h, amount, seed = 0) {
@@ -43,10 +28,28 @@ function grain(ctx, w, h, amount, seed = 0) {
     ctx.putImageData(img, 0, 0);
 }
 
-export function woodTexture() {
-    return cached('wood', () => {
+function createBabylonDynamicTexture(name, canvasEl, scene, uScale = 1, vScale = 1) {
+    const texture = new BABYLON.DynamicTexture(name, canvasEl, scene, true);
+    texture.uScale = uScale;
+    texture.vScale = vScale;
+    texture.wrapU = BABYLON.Texture.WRAP_ADDRESSMODE;
+    texture.wrapV = BABYLON.Texture.WRAP_ADDRESSMODE;
+    texture.update();
+    return texture;
+}
+
+function cached(key, scene, factory) {
+    const cacheKey = `${key}_${scene?.uid || 'default'}`;
+    if (!cache.has(cacheKey)) {
+        cache.set(cacheKey, factory());
+    }
+    return cache.get(cacheKey);
+}
+
+export function woodTexture(scene, uScale = 4, vScale = 4) {
+    return cached('wood', scene, () => {
         const size = 256;
-        const el = canvas(size);
+        const el = createCanvas(size);
         const ctx = el.getContext('2d');
         ctx.fillStyle = '#6b4423';
         ctx.fillRect(0, 0, size, size);
@@ -60,14 +63,14 @@ export function woodTexture() {
             ctx.stroke();
         }
         grain(ctx, size, size, 28, 4);
-        return toTexture(el, { repeat: [4, 4] });
+        return createBabylonDynamicTexture('tex_wood', el, scene, uScale, vScale);
     });
 }
 
-export function darkWoodTexture() {
-    return cached('darkwood', () => {
+export function darkWoodTexture(scene, uScale = 3, vScale = 3) {
+    return cached('darkwood', scene, () => {
         const size = 256;
-        const el = canvas(size);
+        const el = createCanvas(size);
         const ctx = el.getContext('2d');
         ctx.fillStyle = '#3a2414';
         ctx.fillRect(0, 0, size, size);
@@ -81,14 +84,14 @@ export function darkWoodTexture() {
             ctx.stroke();
         }
         grain(ctx, size, size, 22, 6);
-        return toTexture(el, { repeat: [3, 3] });
+        return createBabylonDynamicTexture('tex_darkwood', el, scene, uScale, vScale);
     });
 }
 
-export function stoneTexture() {
-    return cached('stone', () => {
+export function stoneTexture(scene, uScale = 8, vScale = 8) {
+    return cached('stone', scene, () => {
         const size = 256;
-        const el = canvas(size);
+        const el = createCanvas(size);
         const ctx = el.getContext('2d');
         ctx.fillStyle = '#6a665e';
         ctx.fillRect(0, 0, size, size);
@@ -100,14 +103,14 @@ export function stoneTexture() {
             ctx.fillRect(x, y, 18 + hash2(i, 4) * 30, 12 + hash2(i, 5) * 20);
         }
         grain(ctx, size, size, 36, 9);
-        return toTexture(el, { repeat: [8, 8] });
+        return createBabylonDynamicTexture('tex_stone', el, scene, uScale, vScale);
     });
 }
 
-export function castleStoneTexture() {
-    return cached('castlestone', () => {
+export function castleStoneTexture(scene, uScale = 6, vScale = 8) {
+    return cached('castlestone', scene, () => {
         const size = 512;
-        const el = canvas(size);
+        const el = createCanvas(size);
         const ctx = el.getContext('2d');
         ctx.fillStyle = '#7a7468';
         ctx.fillRect(0, 0, size, size);
@@ -125,14 +128,14 @@ export function castleStoneTexture() {
             }
         }
         grain(ctx, size, size, 24, 11);
-        return toTexture(el, { repeat: [6, 8] });
+        return createBabylonDynamicTexture('tex_castlestone', el, scene, uScale, vScale);
     });
 }
 
-export function mossTexture() {
-    return cached('moss', () => {
+export function mossTexture(scene, uScale = 6, vScale = 6) {
+    return cached('moss', scene, () => {
         const size = 256;
-        const el = canvas(size);
+        const el = createCanvas(size);
         const ctx = el.getContext('2d');
         ctx.fillStyle = '#3a5a28';
         ctx.fillRect(0, 0, size, size);
@@ -144,14 +147,14 @@ export function mossTexture() {
             ctx.fill();
         }
         grain(ctx, size, size, 20, 3);
-        return toTexture(el, { repeat: [6, 6] });
+        return createBabylonDynamicTexture('tex_moss', el, scene, uScale, vScale);
     });
 }
 
-export function grassTexture() {
-    return cached('grass', () => {
+export function grassTexture(scene, uScale = 14, vScale = 14) {
+    return cached('grass', scene, () => {
         const size = 256;
-        const el = canvas(size);
+        const el = createCanvas(size);
         const ctx = el.getContext('2d');
         ctx.fillStyle = '#3d6a28';
         ctx.fillRect(0, 0, size, size);
@@ -166,14 +169,14 @@ export function grassTexture() {
             ctx.stroke();
         }
         grain(ctx, size, size, 22, 3);
-        return toTexture(el, { repeat: [14, 14] });
+        return createBabylonDynamicTexture('tex_grass', el, scene, uScale, vScale);
     });
 }
 
-export function sandTexture() {
-    return cached('sand', () => {
+export function sandTexture(scene, uScale = 10, vScale = 10) {
+    return cached('sand', scene, () => {
         const size = 256;
-        const el = canvas(size);
+        const el = createCanvas(size);
         const ctx = el.getContext('2d');
         ctx.fillStyle = '#cbb48a';
         ctx.fillRect(0, 0, size, size);
@@ -185,26 +188,26 @@ export function sandTexture() {
             ctx.bezierCurveTo(80, hash2(i, 2) * size, 180, hash2(i, 3) * size, size, hash2(i, 4) * size);
             ctx.stroke();
         }
-        return toTexture(el, { repeat: [10, 10] });
+        return createBabylonDynamicTexture('tex_sand', el, scene, uScale, vScale);
     });
 }
 
-export function leatherTexture() {
-    return cached('leather', () => {
+export function leatherTexture(scene, uScale = 2, vScale = 2) {
+    return cached('leather', scene, () => {
         const size = 128;
-        const el = canvas(size);
+        const el = createCanvas(size);
         const ctx = el.getContext('2d');
         ctx.fillStyle = '#5a3a22';
         ctx.fillRect(0, 0, size, size);
         grain(ctx, size, size, 36, 7);
-        return toTexture(el, { repeat: [2, 2] });
+        return createBabylonDynamicTexture('tex_leather', el, scene, uScale, vScale);
     });
 }
 
-export function clothTexture() {
-    return cached('cloth', () => {
+export function clothTexture(scene, uScale = 3, vScale = 3) {
+    return cached('cloth', scene, () => {
         const size = 128;
-        const el = canvas(size);
+        const el = createCanvas(size);
         const ctx = el.getContext('2d');
         ctx.fillStyle = '#4a3a2a';
         ctx.fillRect(0, 0, size, size);
@@ -213,38 +216,38 @@ export function clothTexture() {
             ctx.fillRect(0, y, size, 1);
         }
         grain(ctx, size, size, 18, 2);
-        return toTexture(el, { repeat: [3, 3] });
+        return createBabylonDynamicTexture('tex_cloth', el, scene, uScale, vScale);
     });
 }
 
-export function rustTexture() {
-    return cached('rust', () => {
+export function rustTexture(scene, uScale = 2, vScale = 2) {
+    return cached('rust', scene, () => {
         const size = 128;
-        const el = canvas(size);
+        const el = createCanvas(size);
         const ctx = el.getContext('2d');
         ctx.fillStyle = '#6a3a18';
         ctx.fillRect(0, 0, size, size);
         grain(ctx, size, size, 50, 15);
-        return toTexture(el, { repeat: [2, 2] });
+        return createBabylonDynamicTexture('tex_rust', el, scene, uScale, vScale);
     });
 }
 
-export function plasterTexture() {
-    return cached('plaster', () => {
+export function plasterTexture(scene, uScale = 3, vScale = 3) {
+    return cached('plaster', scene, () => {
         const size = 256;
-        const el = canvas(size);
+        const el = createCanvas(size);
         const ctx = el.getContext('2d');
         ctx.fillStyle = '#c4b49a';
         ctx.fillRect(0, 0, size, size);
         grain(ctx, size, size, 28, 5);
-        return toTexture(el, { repeat: [3, 3] });
+        return createBabylonDynamicTexture('tex_plaster', el, scene, uScale, vScale);
     });
 }
 
-export function rugTexture() {
-    return cached('rug', () => {
+export function rugTexture(scene, uScale = 1, vScale = 1) {
+    return cached('rug', scene, () => {
         const size = 256;
-        const el = canvas(size);
+        const el = createCanvas(size);
         const ctx = el.getContext('2d');
         ctx.fillStyle = '#1e3a7a';
         ctx.fillRect(0, 0, size, size);
@@ -259,76 +262,13 @@ export function rugTexture() {
             ctx.stroke();
         }
         grain(ctx, size, size, 16, 1);
-        return toTexture(el, { repeat: [1, 1] });
+        return createBabylonDynamicTexture('tex_rug', el, scene, uScale, vScale);
     });
 }
 
-export function leafTexture() {
-    return cached('leaf', () => {
-        const size = 128;
-        const el = canvas(size);
-        const ctx = el.getContext('2d');
-        ctx.fillStyle = '#2f6a24';
-        ctx.fillRect(0, 0, size, size);
-        for (let i = 0; i < 80; i++) {
-            ctx.fillStyle = hash2(i, 1) > 0.5 ? '#3e8a30' : '#245818';
-            ctx.globalAlpha = 0.6;
-            ctx.beginPath();
-            ctx.ellipse(hash2(i, 2) * size, hash2(i, 3) * size, 8, 14, hash2(i, 4) * 3, 0, Math.PI * 2);
-            ctx.fill();
-        }
-        return toTexture(el, { repeat: [2, 2] });
-    });
-}
-
-export function barkTexture() {
-    return cached('bark', () => {
-        const size = 256;
-        const el = canvas(size);
-        const ctx = el.getContext('2d');
-        ctx.fillStyle = '#4a321c';
-        ctx.fillRect(0, 0, size, size);
-        for (let i = 0; i < 18; i++) {
-            ctx.strokeStyle = '#2e1e10';
-            ctx.lineWidth = 4 + hash2(i, 1) * 6;
-            ctx.globalAlpha = 0.6;
-            ctx.beginPath();
-            ctx.moveTo(i * 14, 0);
-            ctx.bezierCurveTo(i * 14 + 6, 80, i * 14 - 4, 160, i * 14 + 2, size);
-            ctx.stroke();
-        }
-        grain(ctx, size, size, 24, 8);
-        return toTexture(el, { repeat: [2, 4] });
-    });
-}
-
-export function waterNormalTexture() {
-    return cached('watern', () => {
-        const size = 256;
-        const el = canvas(size);
-        const ctx = el.getContext('2d');
-        const img = ctx.createImageData(size, size);
-        for (let y = 0; y < size; y++) {
-            for (let x = 0; x < size; x++) {
-                const n1 = hash2(x * 0.08, y * 0.08, 1);
-                const n2 = hash2(x * 0.2, y * 0.2, 4);
-                const nx = (n1 - 0.5) * 0.6 + 0.5;
-                const ny = (n2 - 0.5) * 0.6 + 0.5;
-                const i = (y * size + x) * 4;
-                img.data[i] = nx * 255;
-                img.data[i + 1] = ny * 255;
-                img.data[i + 2] = 255;
-                img.data[i + 3] = 255;
-            }
-        }
-        ctx.putImageData(img, 0, 0);
-        return toTexture(el, { repeat: [8, 8], srgb: false, normal: true });
-    });
-}
-
-export function flagTexture(color = '#6b1c1c') {
-    return cached(`flag:${color}`, () => {
-        const el = canvas(128, 80);
+export function flagTexture(scene, color = '#6b1c1c') {
+    return cached(`flag_${color}`, scene, () => {
+        const el = createCanvas(128, 80);
         const ctx = el.getContext('2d');
         ctx.fillStyle = color;
         ctx.fillRect(0, 0, 128, 80);
@@ -346,11 +286,37 @@ export function flagTexture(color = '#6b1c1c') {
         ctx.lineTo(58, 36);
         ctx.closePath();
         ctx.fill();
-        return toTexture(el, { repeat: [1, 1] });
+        return createBabylonDynamicTexture(`tex_flag_${color}`, el, scene, 1, 1);
+    });
+}
+
+export function waterNormalTexture(scene, uScale = 8, vScale = 8) {
+    return cached('watern', scene, () => {
+        const size = 256;
+        const el = createCanvas(size);
+        const ctx = el.getContext('2d');
+        const img = ctx.createImageData(size, size);
+        for (let y = 0; y < size; y++) {
+            for (let x = 0; x < size; x++) {
+                const n1 = hash2(x * 0.08, y * 0.08, 1);
+                const n2 = hash2(x * 0.2, y * 0.2, 4);
+                const nx = (n1 - 0.5) * 0.6 + 0.5;
+                const ny = (n2 - 0.5) * 0.6 + 0.5;
+                const i = (y * size + x) * 4;
+                img.data[i] = nx * 255;
+                img.data[i + 1] = ny * 255;
+                img.data[i + 2] = 255;
+                img.data[i + 3] = 255;
+            }
+        }
+        ctx.putImageData(img, 0, 0);
+        return createBabylonDynamicTexture('tex_watern', el, scene, uScale, vScale);
     });
 }
 
 export function clearTextureCache() {
-    for (const tex of cache.values()) tex.dispose();
+    for (const tex of cache.values()) {
+        try { tex.dispose(); } catch { /* ignore */ }
+    }
     cache.clear();
 }

--- a/labs/guerreiro-castelo/js/world/WeatherSystem.js
+++ b/labs/guerreiro-castelo/js/world/WeatherSystem.js
@@ -1,129 +1,127 @@
 /**
- * Céu (Sky addon), sol/lua, fog e PMREM para PBR.
+ * Sistema de iluminação, sol, sombras, clima e nevoeiro em Babylon.js.
  */
 
-import * as THREE from 'three';
-import { Sky } from 'three/addons/objects/Sky.js';
-
 export class WeatherSystem {
-    constructor(scene, renderer) {
+    constructor(scene, engine) {
         this.scene = scene;
-        this.sky = new Sky();
-        this.sky.scale.setScalar(4500);
-        scene.add(this.sky);
-        this.sun = new THREE.Vector3();
-        this.hemi = new THREE.HemisphereLight(0xb8d0e8, 0x3a2a18, 0.55);
-        scene.add(this.hemi);
-        this.ambient = new THREE.AmbientLight(0xfff4e8, 0.55);
-        scene.add(this.ambient);
-        this.dir = new THREE.DirectionalLight(0xfff2d0, 1.6);
-        this.dir.castShadow = true;
-        this.dir.shadow.mapSize.set(2048, 2048);
-        this.dir.shadow.camera.near = 1;
-        this.dir.shadow.camera.far = 180;
-        this.dir.shadow.camera.left = -40;
-        this.dir.shadow.camera.right = 40;
-        this.dir.shadow.camera.top = 40;
-        this.dir.shadow.camera.bottom = -40;
-        this.dir.shadow.bias = -0.0003;
-        scene.add(this.dir);
-        this.pmrem = new THREE.PMREMGenerator(renderer);
+        this.engine = engine;
+
+        // Luz hemisférica (ambiente)
+        this.hemi = new BABYLON.HemisphericLight('hemiLight', new BABYLON.Vector3(0, 1, 0), scene);
+        this.hemi.intensity = 0.6;
+        this.hemi.groundColor = new BABYLON.Color3(0.2, 0.16, 0.12);
+
+        // Luz direcional (sol/lua)
+        this.dir = new BABYLON.DirectionalLight('sunLight', new BABYLON.Vector3(-0.4, -0.8, -0.4), scene);
+        this.dir.position = new BABYLON.Vector3(40, 80, 40);
+        this.dir.intensity = 1.6;
+
+        // Gerador de sombras
+        this.shadowGenerator = new BABYLON.ShadowGenerator(1024, this.dir);
+        this.shadowGenerator.usePoissonSampling = true;
+        this.shadowGenerator.bias = 0.002;
+        this.shadowGenerator.darkness = 0.45;
+
         this.preset = 'day';
+        this.exposure = 1.0;
         this.apply('day');
     }
 
     apply(preset) {
         this.preset = preset;
-        const u = this.sky.material.uniforms;
-        let elevation = 18;
-        let azimuth = 160;
-        let turbidity = 4;
-        let rayleigh = 1.2;
-        let exposure = 1;
-        let hemi = 0.55;
-        let dirI = 1.6;
-        let fogCol = 0x9ec4d4;
-        let fogDen = 0.006;
+        const scene = this.scene;
+        scene.fogMode = BABYLON.Scene.FOGMODE_EXP2;
 
         if (preset === 'night') {
-            elevation = -4;
-            azimuth = 200;
-            turbidity = 2;
-            rayleigh = 0.4;
-            exposure = 0.45;
-            hemi = 0.18;
-            dirI = 0.15;
-            fogCol = 0x0a1020;
-            fogDen = 0.02;
-            this.dir.color.set(0x8899cc);
-            this.hemi.color.set(0x334466);
-            this.hemi.groundColor.set(0x1a1210);
+            this.hemi.diffuse = new BABYLON.Color3(0.15, 0.2, 0.35);
+            this.hemi.groundColor = new BABYLON.Color3(0.08, 0.08, 0.12);
+            this.hemi.intensity = 0.35;
+
+            this.dir.direction = new BABYLON.Vector3(-0.3, -0.6, 0.5).normalize();
+            this.dir.diffuse = new BABYLON.Color3(0.35, 0.45, 0.7);
+            this.dir.intensity = 0.4;
+
+            scene.clearColor = new BABYLON.Color4(0.04, 0.06, 0.12, 1);
+            scene.fogColor = new BABYLON.Color3(0.04, 0.06, 0.12);
+            scene.fogDensity = 0.015;
+            this.exposure = 0.6;
         } else if (preset === 'storm') {
-            elevation = 8;
-            azimuth = 140;
-            turbidity = 12;
-            rayleigh = 0.6;
-            exposure = 0.55;
-            hemi = 0.22;
-            dirI = 0.35;
-            fogCol = 0x4a5560;
-            fogDen = 0.018;
-            this.dir.color.set(0xc0c8d0);
-            this.hemi.color.set(0x6a7380);
-            this.hemi.groundColor.set(0x2a2420);
+            this.hemi.diffuse = new BABYLON.Color3(0.3, 0.35, 0.4);
+            this.hemi.groundColor = new BABYLON.Color3(0.15, 0.16, 0.18);
+            this.hemi.intensity = 0.4;
+
+            this.dir.direction = new BABYLON.Vector3(0.2, -0.8, -0.3).normalize();
+            this.dir.diffuse = new BABYLON.Color3(0.5, 0.55, 0.6);
+            this.dir.intensity = 0.6;
+
+            scene.clearColor = new BABYLON.Color4(0.18, 0.22, 0.26, 1);
+            scene.fogColor = new BABYLON.Color3(0.18, 0.22, 0.26);
+            scene.fogDensity = 0.022;
+            this.exposure = 0.7;
         } else if (preset === 'dawn') {
-            elevation = 6;
-            azimuth = 110;
-            turbidity = 6;
-            rayleigh = 2.2;
-            exposure = 0.9;
-            hemi = 0.5;
-            dirI = 1.3;
-            fogCol = 0xf0c8a0;
-            fogDen = 0.008;
-            this.dir.color.set(0xffd0a0);
-            this.hemi.color.set(0xffe0c0);
-            this.hemi.groundColor.set(0x4a3020);
+            this.hemi.diffuse = new BABYLON.Color3(0.9, 0.65, 0.5);
+            this.hemi.groundColor = new BABYLON.Color3(0.3, 0.2, 0.15);
+            this.hemi.intensity = 0.65;
+
+            this.dir.direction = new BABYLON.Vector3(-0.8, -0.3, -0.2).normalize();
+            this.dir.diffuse = new BABYLON.Color3(1.0, 0.75, 0.5);
+            this.dir.intensity = 1.8;
+
+            scene.clearColor = new BABYLON.Color4(0.7, 0.5, 0.4, 1);
+            scene.fogColor = new BABYLON.Color3(0.7, 0.5, 0.4);
+            scene.fogDensity = 0.008;
+            this.exposure = 1.0;
         } else if (preset === 'interior') {
-            elevation = 12;
-            turbidity = 8;
-            rayleigh = 0.3;
-            exposure = 0.35;
-            hemi = 0.08;
-            dirI = 0.05;
-            fogCol = 0x0c0a08;
-            fogDen = 0.045;
-            this.dir.color.set(0xffcc88);
+            this.hemi.diffuse = new BABYLON.Color3(0.25, 0.22, 0.2);
+            this.hemi.groundColor = new BABYLON.Color3(0.1, 0.08, 0.06);
+            this.hemi.intensity = 0.25;
+
+            this.dir.direction = new BABYLON.Vector3(0, -1, 0);
+            this.dir.diffuse = new BABYLON.Color3(0.8, 0.6, 0.4);
+            this.dir.intensity = 0.2;
+
+            scene.clearColor = new BABYLON.Color4(0.04, 0.03, 0.03, 1);
+            scene.fogColor = new BABYLON.Color3(0.04, 0.03, 0.03);
+            scene.fogDensity = 0.035;
+            this.exposure = 0.5;
         } else {
-            this.dir.color.set(0xfff2d0);
-            this.hemi.color.set(0xb8d0e8);
-            this.hemi.groundColor.set(0x3a2a18);
+            // Day default
+            this.hemi.diffuse = new BABYLON.Color3(0.75, 0.85, 0.95);
+            this.hemi.groundColor = new BABYLON.Color3(0.35, 0.28, 0.2);
+            this.hemi.intensity = 0.75;
+
+            this.dir.direction = new BABYLON.Vector3(-0.4, -0.85, -0.35).normalize();
+            this.dir.diffuse = new BABYLON.Color3(1.0, 0.96, 0.88);
+            this.dir.intensity = 1.7;
+
+            scene.clearColor = new BABYLON.Color4(0.55, 0.72, 0.85, 1);
+            scene.fogColor = new BABYLON.Color3(0.55, 0.72, 0.85);
+            scene.fogDensity = 0.005;
+            this.exposure = 1.0;
         }
 
-        u.turbidity.value = turbidity;
-        u.rayleigh.value = rayleigh;
-        u.mieCoefficient.value = 0.005;
-        u.mieDirectionalG.value = 0.8;
-        const phi = THREE.MathUtils.degToRad(90 - elevation);
-        const theta = THREE.MathUtils.degToRad(azimuth);
-        this.sun.setFromSphericalCoords(1, phi, theta);
-        u.sunPosition.value.copy(this.sun);
-        this.dir.position.copy(this.sun).multiplyScalar(40);
-        this.dir.intensity = dirI;
-        this.hemi.intensity = hemi;
-        if (this.ambient) {
-            this.ambient.intensity = preset === 'interior' ? 0.12 : preset === 'night' ? 0.18 : 0.55;
-        }
-        this.scene.fog = new THREE.FogExp2(fogCol, fogDen);
-        this.scene.background = new THREE.Color(fogCol);
-        this.exposure = exposure;
-        this.scene.environment = null;
-        return exposure;
+        return this.exposure;
     }
 
-    setShadowSize(size) {
-        this.dir.shadow.mapSize.set(size, size);
-        this.dir.shadow.map?.dispose();
-        this.dir.shadow.map = null;
+    setShadowQuality(quality) {
+        let size = 1024;
+        if (quality === 'low') {
+            this.shadowGenerator.getShadowMap().renderList = [];
+            return;
+        } else if (quality === 'medium') {
+            size = 1024;
+            this.shadowGenerator.usePoissonSampling = true;
+        } else if (quality === 'high' || quality === 'ultra') {
+            size = 2048;
+            this.shadowGenerator.useContactHardeningShadow = true;
+            this.shadowGenerator.contactHardeningLightSizeUVRatio = 0.05;
+        }
+        this.shadowGenerator.mapSize = size;
+    }
+
+    addShadowCaster(mesh, includeChildren = true) {
+        if (!this.shadowGenerator) return;
+        this.shadowGenerator.addShadowCaster(mesh, includeChildren);
     }
 }

--- a/labs/index.html
+++ b/labs/index.html
@@ -1075,7 +1075,7 @@
           <h2>O Guerreiro e o Castelo</h2>
           <p>Aventura 3D cinematográfica: Dico e Teco atravessam o mar, entram no castelo e resgatam Camila</p>
           <div class="project-tags">
-            <span class="tag">three.js</span>
+            <span class="tag">Babylon.js</span>
             <span class="tag">3D</span>
             <span class="tag">Aventura</span>
           </div>


### PR DESCRIPTION
## 🎯 Objetivo

Reconstruir e migrar o lab 3D **"O Guerreiro e o Castelo"** para a engine Babylon.js v7 com aprimoramentos completos de iluminação dinâmica, texturas procedurais, animações, controles de toque/desktop e fidelidade de jogabilidade.

## ✨ O que mudou

- **Engine Babylon.js v7**: Substituição completa de Three.js pela CDN do Babylon.js v7 (`babylon.js`, `babylonjs.loaders`, `babylonjs.materials`).
- **Iluminação & Sombras**: Implementação de `HemisphericLight` para ambientação, `DirectionalLight` com `ShadowGenerator` para projeção de sombras dinâmicas e `PointLight` orgânico em tochas e lareira.
- **Texturas Procedurais**: Geração em `DynamicTexture` de padrões de madeira, pedra de castelo, musgo, areia, grama, ferro e mapas de relevo marinho.
- **Física & Clima**: Oceano com deformação de malha e amostragem física de oscilação do navio (`pitch`, `roll`, `yaw`), e controlador de tempestade com chuva de partículas e relâmpagos.
- **Modelagem & Animações**: Hierarquia de nós `TransformNode` com `CharacterAnimator` cobrindo todos os personagens e seus comportamentos (Dico, Teco, Camila, Guardas, Tigre, Ravi e tripulação).
- **Controles & UI**: Joystick analógico virtual de toque com zona de câmera livre e botões ergonômicos (alvos ≥ 44×44px, safe-area insets), além de suporte completo a teclado/mouse com *Pointer Lock*.
- **Narrativa & Áudio**: Preservação fluida de todos os 12 capítulos da história e sintetização procedural de áudio por Web Audio API puro.
- **Catálogo & SEO**: Tag de tecnologia atualizada para Babylon.js na galeria e schemas/metatags consistentes.

## 🧪 Como testar

1. Na raiz do repo: `python3 -m http.server 8000`
2. Abrir [http://localhost:8000/labs/guerreiro-castelo/](http://localhost:8000/labs/guerreiro-castelo/)
3. Testar a introdução na sala da lareira, a transição para o navio, a tempestade com o leme e o resgate no castelo
4. Responsivo: Testar no DevTools em **375×667** (iPhone SE), **390×844** (iPhone 14) e **landscape curto** (~667×375) — verificar joystick virtual, botões e sem overflow horizontal

## ✅ Checklist

- [x] Links conferidos: pasta do lab ↔ card da galeria ↔ README ↔ sitemap (e corrigidos se quebravam)
- [x] README atualizado (linha na tabela + URL + contagem no badge/texto) — conferido
- [x] SEO consistente: title, description, canonical, author, robots, OG, Twitter, JSON-LD
- [x] Testado via HTTP na raiz, não via `file://`
- [x] Responsivo: 375px / 390px / landscape — overflow, HUD, toque, safe-area (`viewport-fit=cover`)
- [x] Nada fora do escopo foi quebrado