### PR TITLE
✨ feat(xadrez): migração para Babylon.js com render PBR, sombras suaves e iluminação otimizada

### DIFF
--- a/labs/index.html
+++ b/labs/index.html
@@ -511,9 +511,9 @@
         </div>
         <div class="project-content">
           <h2>Xadrez</h2>
-          <p>Atelier 3D em three.js: peças Staunton de marfim e ébano, reflexos PBR e um mestre que ensina a jogar</p>
+          <p>Atelier 3D em Babylon.js: peças Staunton de marfim e ébano, reflexos PBR e um mestre que ensina a jogar</p>
           <div class="project-tags">
-            <span class="tag">three.js</span>
+            <span class="tag">Babylon.js</span>
             <span class="tag">Xadrez</span>
             <span class="tag">Academia</span>
           </div>

--- a/labs/xadrez/index.html
+++ b/labs/xadrez/index.html
@@ -8,7 +8,7 @@
     <meta name="theme-color" content="#120c0a">
     <title>Xadrez — atelier 3D que ensina | Diogo Paulino</title>
     <meta name="description"
-        content="Xadrez 3D em three.js com peças Staunton de marfim e ébano, reflexos PBR e um mestre que ensina regras, táticas e aberturas. Um lab de Diogo Paulino.">
+        content="Xadrez 3D em Babylon.js com peças Staunton de marfim e ébano, reflexos PBR e um mestre que ensina regras, táticas e aberturas. Um lab de Diogo Paulino.">
     <link rel="canonical" href="https://diogopaulino.com.br/labs/xadrez/">
     <meta name="author" content="Diogo Paulino">
     <meta name="robots" content="index, follow">
@@ -22,26 +22,18 @@
     <meta property="og:url" content="https://diogopaulino.com.br/labs/xadrez/">
     <meta property="og:title" content="Xadrez — atelier 3D que ensina | Diogo Paulino">
     <meta property="og:description"
-        content="Peças Staunton com reflexo, tabuleiro laqueado e um mestre que ensina a jogar — three.js no navegador.">
+        content="Peças Staunton com reflexo, tabuleiro laqueado e um mestre que ensina a jogar — Babylon.js no navegador.">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Xadrez — atelier 3D que ensina | Diogo Paulino">
     <meta name="twitter:description"
-        content="Xadrez 3D em three.js: marfim, ébano, reflexos e lições. Um lab de Diogo Paulino.">
+        content="Xadrez 3D em Babylon.js: marfim, ébano, reflexos e lições. Um lab de Diogo Paulino.">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
+    <link rel="preconnect" href="https://cdn.babylonjs.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;600;700&family=Outfit:wght@300;400;500;600;700&display=swap"
         rel="stylesheet">
     <link rel="stylesheet" href="/labs/shared.css?v=8">
     <link rel="stylesheet" href="style.css">
-    <script type="importmap">
-    {
-        "imports": {
-            "three": "https://cdn.jsdelivr.net/npm/three@0.185.1/build/three.module.js",
-            "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.185.1/examples/jsm/"
-        }
-    }
-    </script>
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
@@ -50,7 +42,7 @@
           "@type": "WebApplication",
           "name": "Xadrez",
           "url": "https://diogopaulino.com.br/labs/xadrez/",
-          "description": "Xadrez 3D em three.js com peças Staunton de marfim e ébano, reflexos PBR e um mestre que ensina regras, táticas e aberturas.",
+          "description": "Xadrez 3D em Babylon.js com peças Staunton de marfim e ébano, reflexos PBR e um mestre que ensina regras, táticas e aberturas.",
           "applicationCategory": "GameApplication",
           "operatingSystem": "Any",
           "inLanguage": "pt-BR",
@@ -144,7 +136,7 @@
 
         <div id="loadingOverlay" class="overlay loading-overlay">
             <div class="overlay-card compact-card">
-                <p class="eyebrow"><i></i> three.js · PBR · Staunton</p>
+                <p class="eyebrow"><i></i> Babylon.js · PBR · Staunton</p>
                 <h2>Polindo<br>o ébano.</h2>
                 <p class="lede" id="loadingText">O atelier acende as lâmpadas.</p>
                 <div class="load-bar" aria-hidden="true"><i id="loadingFill"></i></div>
@@ -155,7 +147,7 @@
             <div class="overlay-card intro-card">
                 <p class="eyebrow"><i></i> Atelier 3D</p>
                 <h2>Xadrez</h2>
-                <p class="lede">Peças Staunton de marfim e ébano sobre mogno laqueado. Um mestre comenta cada lance —
+                <p class="lede">Peças Staunton de marfim e ébano sobre mogno laqueado em Babylon.js. Um mestre comenta cada lance —
                     da primeira casa até o xeque-mate.</p>
                 <ul class="feature-list">
                     <li>Regras FIDE: roque, en passant, promoção, xeque e mate</li>
@@ -247,25 +239,9 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
+    <script src="https://cdn.babylonjs.com/babylon.js"></script>
+    <script src="https://cdn.babylonjs.com/loaders/babylonjs.loaders.min.js"></script>
     <script src="/labs/shared.js?v=7" defer></script>
-    <script>
-        (function () {
-            function hasGpu() {
-                try {
-                    var c = document.createElement('canvas');
-                    return !!(c.getContext('webgl2') || c.getContext('webgl'));
-                } catch (e) { return false; }
-            }
-            if (!hasGpu()) {
-                document.addEventListener('DOMContentLoaded', function () {
-                    var err = document.getElementById('errorOverlay');
-                    var load = document.getElementById('loadingOverlay');
-                    if (load) load.hidden = true;
-                    if (err) err.hidden = false;
-                });
-            }
-        })();
-    </script>
     <script type="module" src="src/main.js"></script>
 </body>
 

--- a/labs/xadrez/src/main.js
+++ b/labs/xadrez/src/main.js
@@ -1,21 +1,15 @@
 /**
- * Xadrez — atelier 3D.
+ * Xadrez — atelier 3D em Babylon.js.
  * Cena PBR, seleção por raycast, animações em arco e o mestre comentando.
  */
 
-import * as THREE from 'three';
-import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
-import { RoomEnvironment } from 'three/addons/environments/RoomEnvironment.js';
-
 import { Chess, START_FEN, PIECE_NAME, PIECE_HOW, alg, parseAlg } from './engine.js';
 import { pickMove, hintMove } from './ai.js';
-import {
-    LESSONS, PUZZLES, commentOnMove, loadProgress, saveProgress
-} from './coach.js';
+import { LESSONS, PUZZLES, commentOnMove, loadProgress, saveProgress } from './coach.js';
 import { createTextures } from './textures.js';
 import { PieceFactory } from './pieces.js';
 import {
-    buildWorld, setupLights, squareToWorld, worldToSquare, placeMark
+    buildWorld, setupLights, setupPostProcess, squareToWorld, worldToSquare, placeMark
 } from './world.js';
 import { SalonAudio } from './audio.js';
 
@@ -26,30 +20,19 @@ const GLYPH = {
 };
 
 const QUALITY = {
-    low: { id: 'low', pr: 1, seg: 24, shadows: true, shadowMap: 1024, reflect: 0, aniso: 4 },
-    medium: { id: 'medium', pr: 1.35, seg: 40, shadows: true, shadowMap: 2048, reflect: 512, aniso: 8 },
-    high: { id: 'high', pr: 1.75, seg: 56, shadows: true, shadowMap: 2048, reflect: 1024, aniso: 8 }
+    low: { id: 'low', pr: 1, seg: 24, shadows: false, shadowMap: 1024 },
+    medium: { id: 'medium', pr: 1.35, seg: 40, shadows: true, shadowMap: 2048 },
+    high: { id: 'high', pr: 1.75, seg: 56, shadows: true, shadowMap: 2048 }
 };
 
 function isMobile() {
     return /Mobi|Android|iPhone|iPad/i.test(navigator.userAgent) || window.innerWidth < 720;
 }
 
-function detectSoftwareGL(renderer) {
-    try {
-        const gl = renderer.getContext();
-        const info = gl.getExtension('WEBGL_debug_renderer_info');
-        const r = info ? gl.getParameter(info.UNMASKED_RENDERER_WEBGL) : '';
-        return /SwiftShader|llvmpipe|Soft/i.test(String(r));
-    } catch {
-        return false;
-    }
-}
-
-function pickQuality(mode, renderer) {
+function pickQuality(mode) {
     if (QUALITY[mode]) return QUALITY[mode];
-    if (detectSoftwareGL(renderer) || isMobile()) return QUALITY.low;
-    if ((window.devicePixelRatio || 1) >= 2 && innerWidth >= 1400) return QUALITY.high;
+    if (isMobile()) return QUALITY.low;
+    if ((window.devicePixelRatio || 1) >= 2 && window.innerWidth >= 1400) return QUALITY.high;
     return QUALITY.medium;
 }
 
@@ -73,16 +56,13 @@ class Atelier {
         this.busy = false;
         this.anims = [];
         this.pieces = new Map();
-        this.pieceRoot = new THREE.Group();
         this.progress = loadProgress();
         this.lessonIndex = 0;
         this.puzzleIndex = 0;
         this.expect = null;
         this.pendingPromo = null;
-        this.clock = new THREE.Clock();
-        this.pointer = new THREE.Vector2();
-        this.raycaster = new THREE.Raycaster();
         this.drag = { x: 0, y: 0, active: false };
+
         this.bindUi();
         this.boot();
     }
@@ -111,9 +91,10 @@ class Atelier {
 
     fail(err) {
         console.error(err);
-        document.getElementById('loadingOverlay').hidden = true;
         const overlay = document.getElementById('errorOverlay');
-        overlay.hidden = false;
+        const load = document.getElementById('loadingOverlay');
+        if (load) load.hidden = true;
+        if (overlay) overlay.hidden = false;
         const t = document.getElementById('errorText');
         if (t && err) t.textContent = String(err.message || err);
     }
@@ -180,64 +161,56 @@ class Atelier {
     }
 
     async boot() {
+        const BABYLON = window.BABYLON;
+        if (!BABYLON) {
+            this.fail(new Error('Babylon.js não foi carregado.'));
+            return;
+        }
+
         try {
-            this.renderer = new THREE.WebGLRenderer({
-                canvas: this.canvas,
-                antialias: true,
-                alpha: false,
-                powerPreference: 'high-performance'
+            this.engine = new BABYLON.Engine(this.canvas, true, {
+                preserveDrawingBuffer: false,
+                stencil: true,
+                adaptToDeviceRatio: true
             });
+            this.scene = new BABYLON.Scene(this.engine);
+            this.scene.clearColor = new BABYLON.Color4(0.07, 0.05, 0.04, 1.0);
         } catch (err) {
             this.fail(err);
             return;
         }
-        this.renderer.outputColorSpace = THREE.SRGBColorSpace;
-        this.renderer.toneMapping = THREE.ACESFilmicToneMapping;
-        this.renderer.toneMappingExposure = 0.92;
-        this.renderer.shadowMap.enabled = true;
-        this.renderer.shadowMap.type = THREE.PCFSoftShadowMap;
-        this.renderer.setClearColor(0x120c0a, 1);
 
-        this.quality = pickQuality(this.settings.quality, this.renderer);
-        this.renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, this.quality.pr));
-        this.resize();
+        this.quality = pickQuality(this.settings.quality);
 
-        this.scene = new THREE.Scene();
-        this.scene.fog = new THREE.Fog(0x120c0a, 16, 32);
-        this.camera = new THREE.PerspectiveCamera(38, innerWidth / innerHeight, 0.1, 80);
-        this.camera.position.set(0, 8.4, 10.6);
+        // Câmera orbital elegante
+        this.camera = new BABYLON.ArcRotateCamera('camera', -Math.PI / 2, Math.PI / 3.4, 13.5, new BABYLON.Vector3(0, 0.3, 0), this.scene);
+        this.camera.lowerRadiusLimit = 6;
+        this.camera.upperRadiusLimit = 20;
+        this.camera.lowerBetaLimit = 0.25;
+        this.camera.upperBetaLimit = Math.PI / 2.2;
+        this.camera.wheelDeltaPercentage = 0.015;
+        this.camera.pinchDeltaPercentage = 0.015;
+        this.camera.inertia = 0.85;
+        this.camera.useAutoRotationBehavior = true;
+        if (this.camera.autoRotationBehavior) {
+            this.camera.autoRotationBehavior.idleRotationSpeed = 0.15;
+            this.camera.autoRotationBehavior.idleRotationWaitTime = 2000;
+        }
+        this.camera.attachControl(this.canvas, true);
 
-        this.setLoad(0.2, 'Talhando o marfim…');
-        const tex = createTextures(this.quality.aniso);
-        this.setLoad(0.45, 'Montando o tabuleiro…');
-        this.world = buildWorld(tex, this.quality);
-        this.scene.add(this.world.root);
-        this.scene.add(this.pieceRoot);
-        this.factory = new PieceFactory(tex, this.quality);
+        this.setLoad(0.2, 'Talhando o marfim em Babylon.js…');
+        const tex = createTextures(this.scene);
+
+        this.setLoad(0.45, 'Montando o atelier…');
+        this.world = buildWorld(BABYLON, this.scene, tex, this.quality);
+        this.lights = setupLights(BABYLON, this.scene, this.quality);
+        this.postProcess = setupPostProcess(BABYLON, this.scene, this.quality);
+
+        this.factory = new PieceFactory(this.scene, tex, this.quality);
         if (this.settings.theme === 'crystal') this.factory.setTheme('crystal');
 
-        this.setLoad(0.7, 'Acendendo o lustre…');
-        setupLights(this.scene, this.quality);
-        const pmrem = new THREE.PMREMGenerator(this.renderer);
-        this.scene.environment = pmrem.fromScene(new RoomEnvironment(), 0.04).texture;
-        this.scene.environmentIntensity = 0.85;
-        pmrem.dispose();
-
-        this.controls = new OrbitControls(this.camera, this.canvas);
-        this.controls.enableDamping = true;
-        this.controls.dampingFactor = 0.07;
-        this.controls.target.set(0, 0.35, 0);
-        this.controls.minDistance = 6;
-        this.controls.maxDistance = 18;
-        this.controls.minPolarAngle = 0.35;
-        this.controls.maxPolarAngle = 1.25;
-        this.controls.enablePan = false;
-        this.controls.autoRotate = true;
-        this.controls.autoRotateSpeed = 0.55;
-
+        this.setLoad(0.8, 'Posicionando as peças no tabuleiro…');
         this.rebuildPieces();
-        this.renderer.compile(this.scene, this.camera);
-        this.renderer.render(this.scene, this.camera);
 
         this.canvas.addEventListener('pointerdown', (e) => this.onDown(e));
         this.canvas.addEventListener('pointerup', (e) => this.onUp(e));
@@ -247,23 +220,14 @@ class Atelier {
         document.getElementById('loadingOverlay').hidden = true;
         document.getElementById('intro').hidden = false;
         document.body.dataset.state = 'intro';
-        requestAnimationFrame(() => this.resize());
 
-        this.clock.start();
-        this.renderer.setAnimationLoop(() => this.frame());
-        window.addEventListener('resize', () => this.resize());
-        window.visualViewport?.addEventListener('resize', () => this.resize());
-    }
+        this.engine.runRenderLoop(() => {
+            this.frame();
+            this.scene.render();
+        });
 
-    resize() {
-        if (!this.renderer) return;
-        const w = innerWidth;
-        const h = innerHeight;
-        this.renderer.setSize(w, h, false);
-        if (this.camera) {
-            this.camera.aspect = w / Math.max(1, h);
-            this.camera.updateProjectionMatrix();
-        }
+        window.addEventListener('resize', () => this.engine.resize());
+        window.visualViewport?.addEventListener('resize', () => this.engine.resize());
     }
 
     start() {
@@ -277,13 +241,16 @@ class Atelier {
         if (theme !== this.factory.mats.theme) {
             this.factory.setTheme(theme);
             this.settings.theme = theme;
+            this.rebuildPieces();
         }
         this.saveSettings();
         document.getElementById('intro').hidden = true;
         document.getElementById('hud').hidden = false;
         document.body.dataset.state = 'play';
-        if (this.controls) this.controls.autoRotate = false;
-        this.resize();
+        if (this.camera.autoRotationBehavior) {
+            this.camera.autoRotationBehavior.idleRotationSpeed = 0;
+        }
+        this.engine.resize();
         const mode = document.getElementById('modeSelect')?.value || 'cpu';
         this.setMode(mode);
     }
@@ -397,19 +364,24 @@ class Atelier {
     }
 
     rebuildPieces() {
-        while (this.pieceRoot.children.length) {
-            this.pieceRoot.remove(this.pieceRoot.children[0]);
+        for (const [idx, mesh] of this.pieces) {
+            mesh.dispose();
         }
         this.pieces.clear();
+
         for (let i = 0; i < 64; i++) {
             const p = this.game.board[i];
             if (!p) continue;
             const mesh = this.factory.spawn(p.t, p.c);
-            const pos = squareToWorld(i, this.flip);
-            mesh.position.set(pos.x, 0.07, pos.z);
-            mesh.userData.index = i;
-            this.pieceRoot.add(mesh);
-            this.pieces.set(i, mesh);
+            if (mesh) {
+                const pos = squareToWorld(i, this.flip);
+                mesh.position.set(pos.x, 0.07, pos.z);
+                mesh.metadata = { kind: p.t, color: p.c, index: i };
+                if (this.lights?.shadowGen) {
+                    this.lights.shadowGen.addShadowCaster(mesh, true);
+                }
+                this.pieces.set(i, mesh);
+            }
         }
         this.refreshMarks();
     }
@@ -429,7 +401,7 @@ class Atelier {
         const dy = e.clientY - this.drag.y;
         if (Math.hypot(dx, dy) > 8) return;
         if (this.busy || this.pendingPromo) return;
-        const hit = this.hit(e);
+        const hit = this.hit();
         if (hit < 0) {
             this.selected = -1;
             this.refreshMarks();
@@ -438,22 +410,22 @@ class Atelier {
         this.onSquare(hit);
     }
 
-    hit(e) {
-        const rect = this.canvas.getBoundingClientRect();
-        this.pointer.x = ((e.clientX - rect.left) / rect.width) * 2 - 1;
-        this.pointer.y = -((e.clientY - rect.top) / rect.height) * 2 + 1;
-        this.raycaster.setFromCamera(this.pointer, this.camera);
-        const objs = [...this.world.squares, ...this.pieceRoot.children];
-        const hits = this.raycaster.intersectObjects(objs, true);
-        for (const h of hits) {
-            let o = h.object;
-            while (o && o.userData.index === undefined) o = o.parent;
-            if (o && o.userData.index !== undefined) return o.userData.index;
+    hit() {
+        const pick = this.scene.pick(this.scene.pointerX, this.scene.pointerY, (mesh) => {
+            return mesh.isPickable && (mesh.metadata?.index !== undefined || mesh.metadata?.kind === 'square');
+        });
+        if (pick && pick.hit && pick.pickedMesh) {
+            let m = pick.pickedMesh;
+            if (m.metadata && m.metadata.index !== undefined) {
+                return m.metadata.index;
+            }
         }
-        const plane = new THREE.Plane(new THREE.Vector3(0, 1, 0), 0);
-        const p = new THREE.Vector3();
-        this.raycaster.ray.intersectPlane(plane, p);
-        if (p) return worldToSquare(p.x, p.z, this.flip);
+        const ray = this.scene.createPickingRay(this.scene.pointerX, this.scene.pointerY, window.BABYLON.Matrix.Identity(), this.camera);
+        const hit = ray.intersectsPlane(new window.BABYLON.Plane(0, 1, 0, 0));
+        if (hit !== null && hit !== undefined) {
+            const pt = ray.origin.add(ray.direction.scale(hit));
+            return worldToSquare(pt.x, pt.z, this.flip);
+        }
         return -1;
     }
 
@@ -582,12 +554,12 @@ class Atelier {
     }
 
     fadeOut(mesh) {
-        const start = mesh.position.clone();
+        const startY = mesh.position.y;
         return this.tween(0.32, (t) => {
-            mesh.position.y = start.y - t * 0.4;
-            mesh.scale.setScalar(1 - t * 0.85);
+            mesh.position.y = startY - t * 0.4;
+            mesh.scaling.setAll(1 - t * 0.85);
         }).then(() => {
-            mesh.visible = false;
+            mesh.isVisible = false;
         });
     }
 
@@ -700,9 +672,8 @@ class Atelier {
     toggleFlip() {
         this.flip = !this.flip;
         this.rebuildPieces();
-        const az = this.flip ? Math.PI : 0;
-        this.camera.position.set(Math.sin(az) * 10.6, 8.4, Math.cos(az) * 10.6);
-        this.controls.target.set(0, 0.35, 0);
+        const targetAlpha = this.flip ? Math.PI / 2 : -Math.PI / 2;
+        window.BABYLON.Animation.CreateAndStartAnimation('flipCam', this.camera, 'alpha', 60, 30, this.camera.alpha, targetAlpha, window.BABYLON.Animation.ANIMATIONLOOPMODE_CONSTANT);
     }
 
     fresh() {
@@ -730,13 +701,13 @@ class Atelier {
 
     clearMarks() {
         const m = this.world.marks;
-        m.dots.forEach((d) => { d.visible = false; });
-        m.caps.forEach((c) => { c.visible = false; });
-        m.select.visible = false;
-        m.lastFrom.visible = false;
-        m.lastTo.visible = false;
-        m.check.visible = false;
-        m.hint.visible = false;
+        m.dots.forEach((d) => { d.isVisible = false; });
+        m.caps.forEach((c) => { c.isVisible = false; });
+        m.select.isVisible = false;
+        m.lastFrom.isVisible = false;
+        m.lastTo.isVisible = false;
+        m.check.isVisible = false;
+        m.hint.isVisible = false;
     }
 
     refreshMarks() {
@@ -829,7 +800,7 @@ class Atelier {
     }
 
     frame() {
-        const dt = Math.min(0.05, this.clock.getDelta());
+        const dt = this.engine.getDeltaTime() / 1000;
         for (let i = this.anims.length - 1; i >= 0; i--) {
             const a = this.anims[i];
             a.t += dt;
@@ -840,14 +811,13 @@ class Atelier {
                 this.anims.splice(i, 1);
             }
         }
-        if (this.world?.marks?.select?.visible) {
-            this.world.marks.select.rotation.z += dt * 0.6;
+        if (this.world?.marks?.select?.isVisible) {
+            this.world.marks.select.rotation.y += dt * 0.8;
         }
-        if (this.world?.marks?.check?.visible) {
-            this.world.marks.check.material.opacity = 0.55 + Math.sin(this.clock.elapsedTime * 4) * 0.3;
+        if (this.world?.marks?.check?.isVisible) {
+            const mat = this.world.marks.check.material;
+            if (mat) mat.alpha = 0.55 + Math.sin(Date.now() * 0.006) * 0.35;
         }
-        this.controls?.update();
-        this.renderer.render(this.scene, this.camera);
     }
 }
 

--- a/labs/xadrez/src/pieces.js
+++ b/labs/xadrez/src/pieces.js
@@ -1,325 +1,271 @@
 /**
- * Peças Staunton procedurais — torno (LatheGeometry) + ornamentos.
- *
- * Alturas relativas ao rei (1.78 u, casa = 1 u): peão 0.95, torre 1.15,
- * cavalo 1.22, bispo 1.38, dama 1.58. Materiais PBR: marfim / ébano / cristal.
+ * Peças Staunton procedurais de alta definição em Babylon.js.
+ * Torno (Lathe) + ornamentos detalhados + materiais PBR (Marfim, Ébano, Cristal).
  */
 
-import * as THREE from 'three';
-import { mergeGeometries } from 'three/addons/utils/BufferGeometryUtils.js';
-
-function lathe(xy, seg) {
-    const pts = xy.map(([x, y]) => new THREE.Vector2(x, y));
-    const g = new THREE.LatheGeometry(pts, seg);
-    g.computeVertexNormals();
-    return g;
+function lathe(BABYLON, name, xy, seg, scene) {
+    const shape = xy.map(([x, y]) => new BABYLON.Vector3(x, y, 0));
+    const mesh = BABYLON.MeshBuilder.CreateLathe(name, {
+        shape,
+        tessellation: seg,
+        sideOrientation: BABYLON.Mesh.DOUBLESIDE,
+        updatable: false
+    }, scene);
+    return mesh;
 }
 
-function box(w, h, d, x, y, z) {
-    const g = new THREE.BoxGeometry(w, h, d);
-    g.translate(x, y, z);
-    return g;
+function box(BABYLON, name, w, h, d, x, y, z, scene) {
+    const mesh = BABYLON.MeshBuilder.CreateBox(name, { width: w, height: h, depth: d }, scene);
+    mesh.position.set(x, y, z);
+    return mesh;
 }
 
-function merge(list) {
-    const geos = list.filter(Boolean);
-    const g = mergeGeometries(geos, false);
-    if (!g) return geos[0];
-    geos.forEach((x) => x.dispose?.());
-    g.computeVertexNormals();
-    return g;
+function collar(BABYLON, name, radius, y, tube, seg, scene) {
+    const mesh = BABYLON.MeshBuilder.CreateTorus(name, {
+        diameter: radius * 2,
+        thickness: tube * 2,
+        tessellation: Math.max(16, seg)
+    }, scene);
+    mesh.position.y = y;
+    return mesh;
 }
 
-function collar(radius, y, tube, seg) {
-    const t = new THREE.TorusGeometry(radius, tube, 8, Math.max(16, seg >> 1));
-    t.rotateX(Math.PI / 2);
-    t.translate(0, y, 0);
-    return t;
+function merge(BABYLON, name, list, scene) {
+    const meshes = list.filter(Boolean);
+    if (meshes.length === 0) return null;
+    if (meshes.length === 1) {
+        meshes[0].name = name;
+        return meshes[0];
+    }
+    const merged = BABYLON.Mesh.MergeMeshes(meshes, true, true, undefined, false, false);
+    if (merged) merged.name = name;
+    return merged;
 }
 
-export function buildPieceGeometries(seg = 48) {
-    const pawn = merge([
-        lathe([
-            [0, 0], [0.33, 0], [0.35, 0.035], [0.30, 0.08],
-            [0.27, 0.14], [0.16, 0.20], [0.135, 0.46],
-            [0.13, 0.54], [0.20, 0.58], [0.13, 0.62],
-            [0.12, 0.68], [0.185, 0.74], [0.20, 0.84],
-            [0.16, 0.91], [0.08, 0.94], [0, 0.95]
-        ], seg),
-        collar(0.175, 0.58, 0.028, seg)
-    ]);
+export function buildPieceGeometries(BABYLON, scene, seg = 48) {
+    // 1. PEÃO (Pawn)
+    const pawnLathe = lathe(BABYLON, 'pawn_base', [
+        [0, 0], [0.33, 0], [0.35, 0.035], [0.30, 0.08],
+        [0.27, 0.14], [0.16, 0.20], [0.135, 0.46],
+        [0.13, 0.54], [0.20, 0.58], [0.13, 0.62],
+        [0.12, 0.68], [0.185, 0.74], [0.20, 0.84],
+        [0.16, 0.91], [0.08, 0.94], [0, 0.95]
+    ], seg, scene);
+    const pawnCollar = collar(BABYLON, 'pawn_col', 0.175, 0.58, 0.028, seg, scene);
+    const pawn = merge(BABYLON, 'geo_pawn', [pawnLathe, pawnCollar], scene);
 
+    // 2. TORRE (Rook)
+    const rookLathe = lathe(BABYLON, 'rook_base', [
+        [0, 0], [0.36, 0], [0.38, 0.04], [0.32, 0.10],
+        [0.28, 0.18], [0.20, 0.26], [0.175, 0.68],
+        [0.24, 0.74], [0.26, 0.80], [0.28, 0.90],
+        [0.28, 0.96], [0.16, 0.96], [0.16, 0.88],
+        [0, 0.88]
+    ], seg, scene);
+    const rookCollar = collar(BABYLON, 'rook_col', 0.22, 0.74, 0.03, seg, scene);
     const merlons = [];
     const rookR = 0.20;
     const rookY = 1.04;
     for (let i = 0; i < 4; i++) {
         const a = (i / 4) * Math.PI * 2 + Math.PI / 4;
-        merlons.push(box(0.15, 0.15, 0.13, Math.cos(a) * rookR, rookY, Math.sin(a) * rookR));
+        merlons.push(box(BABYLON, `rook_m_${i}`, 0.15, 0.15, 0.13, Math.cos(a) * rookR, rookY, Math.sin(a) * rookR, scene));
     }
-    const rook = merge([
-        lathe([
-            [0, 0], [0.36, 0], [0.38, 0.04], [0.32, 0.10],
-            [0.28, 0.18], [0.20, 0.26], [0.175, 0.68],
-            [0.24, 0.74], [0.26, 0.80], [0.28, 0.90],
-            [0.28, 0.96], [0.16, 0.96], [0.16, 0.88],
-            [0, 0.88]
-        ], seg),
-        collar(0.22, 0.74, 0.03, seg),
-        ...merlons
-    ]);
+    const rook = merge(BABYLON, 'geo_rook', [rookLathe, rookCollar, ...merlons], scene);
 
-    const bishop = merge([
-        lathe([
-            [0, 0], [0.34, 0], [0.36, 0.04], [0.30, 0.09],
-            [0.26, 0.16], [0.16, 0.24], [0.135, 0.52],
-            [0.20, 0.60], [0.14, 0.66], [0.12, 0.78],
-            [0.14, 0.94], [0.175, 1.10], [0.14, 1.24],
-            [0.08, 1.33], [0.05, 1.35], [0.085, 1.37], [0, 1.38]
-        ], seg),
-        collar(0.175, 0.60, 0.028, seg)
-    ]);
+    // 3. BISPO (Bishop)
+    const bishopLathe = lathe(BABYLON, 'bishop_base', [
+        [0, 0], [0.34, 0], [0.36, 0.04], [0.30, 0.09],
+        [0.26, 0.16], [0.16, 0.24], [0.135, 0.52],
+        [0.20, 0.60], [0.14, 0.66], [0.12, 0.78],
+        [0.14, 0.94], [0.175, 1.10], [0.14, 1.24],
+        [0.08, 1.33], [0.05, 1.35], [0.085, 1.37], [0, 1.38]
+    ], seg, scene);
+    const bishopCollar = collar(BABYLON, 'bishop_col', 0.175, 0.60, 0.028, seg, scene);
+    const bishopBall = BABYLON.MeshBuilder.CreateSphere('bishop_ball', { diameter: 0.14, segments: 16 }, scene);
+    bishopBall.position.set(0, 1.40, 0);
+    const bishop = merge(BABYLON, 'geo_bishop', [bishopLathe, bishopCollar, bishopBall], scene);
 
+    // 4. DAMA (Queen)
+    const queenLathe = lathe(BABYLON, 'queen_base', [
+        [0, 0], [0.36, 0], [0.38, 0.045], [0.32, 0.10],
+        [0.28, 0.18], [0.175, 0.26], [0.145, 0.60],
+        [0.22, 0.68], [0.15, 0.74], [0.125, 0.92],
+        [0.12, 1.14], [0.16, 1.30], [0.185, 1.40],
+        [0.15, 1.44], [0.07, 1.46], [0, 1.48]
+    ], seg, scene);
+    const queenCollar = collar(BABYLON, 'queen_col', 0.195, 0.68, 0.03, seg, scene);
     const jewels = [];
     for (let i = 0; i < 8; i++) {
         const a = (i / 8) * Math.PI * 2;
-        const c = new THREE.ConeGeometry(0.042, 0.13, 8);
-        c.translate(Math.cos(a) * 0.155, 1.50, Math.sin(a) * 0.155);
+        const c = BABYLON.MeshBuilder.CreateCylinder(`queen_j_${i}`, { height: 0.13, diameterTop: 0, diameterBottom: 0.08, tessellation: 8 }, scene);
+        c.position.set(Math.cos(a) * 0.155, 1.50, Math.sin(a) * 0.155);
         jewels.push(c);
     }
-    const queen = merge([
-        lathe([
-            [0, 0], [0.36, 0], [0.38, 0.045], [0.32, 0.10],
-            [0.28, 0.18], [0.175, 0.26], [0.145, 0.60],
-            [0.22, 0.68], [0.15, 0.74], [0.125, 0.92],
-            [0.12, 1.14], [0.16, 1.30], [0.185, 1.40],
-            [0.15, 1.44], [0.07, 1.46], [0, 1.48]
-        ], seg),
-        collar(0.195, 0.68, 0.03, seg),
-        ...jewels
-    ]);
+    const queen = merge(BABYLON, 'geo_queen', [queenLathe, queenCollar, ...jewels], scene);
 
-    const cross = merge([
-        box(0.05, 0.26, 0.05, 0, 1.66, 0),
-        box(0.17, 0.045, 0.045, 0, 1.70, 0)
-    ]);
-    const king = merge([
-        lathe([
-            [0, 0], [0.38, 0], [0.40, 0.045], [0.33, 0.11],
-            [0.29, 0.20], [0.18, 0.28], [0.15, 0.64],
-            [0.24, 0.74], [0.16, 0.80], [0.13, 0.96],
-            [0.125, 1.22], [0.175, 1.40], [0.20, 1.50],
-            [0.15, 1.54], [0.07, 1.52], [0, 1.52]
-        ], seg),
-        collar(0.21, 0.74, 0.032, seg),
-        cross
-    ]);
+    // 5. REI (King)
+    const kingLathe = lathe(BABYLON, 'king_base', [
+        [0, 0], [0.38, 0], [0.40, 0.045], [0.33, 0.11],
+        [0.29, 0.20], [0.18, 0.28], [0.15, 0.64],
+        [0.24, 0.74], [0.16, 0.80], [0.13, 0.96],
+        [0.125, 1.22], [0.175, 1.40], [0.20, 1.50],
+        [0.15, 1.54], [0.07, 1.52], [0, 1.52]
+    ], seg, scene);
+    const kingCollar = collar(BABYLON, 'king_col', 0.21, 0.74, 0.032, seg, scene);
+    const crossV = box(BABYLON, 'cross_v', 0.05, 0.26, 0.05, 0, 1.66, 0, scene);
+    const crossH = box(BABYLON, 'cross_h', 0.17, 0.045, 0.045, 0, 1.70, 0, scene);
+    const king = merge(BABYLON, 'geo_king', [kingLathe, kingCollar, crossV, crossH], scene);
 
-    return { p: pawn, r: rook, b: bishop, q: queen, k: king, n: null };
-}
-
-function knightHeadShape() {
-    const s = new THREE.Shape();
-    s.moveTo(0.00, 0.02);
-    s.bezierCurveTo(0.10, 0.00, 0.18, 0.08, 0.20, 0.22);
-    s.bezierCurveTo(0.22, 0.38, 0.18, 0.52, 0.16, 0.62);
-    s.bezierCurveTo(0.14, 0.74, 0.10, 0.84, 0.12, 0.94);
-    s.lineTo(0.22, 0.86);
-    s.bezierCurveTo(0.28, 0.80, 0.36, 0.70, 0.46, 0.58);
-    s.bezierCurveTo(0.54, 0.50, 0.58, 0.42, 0.56, 0.34);
-    s.bezierCurveTo(0.54, 0.28, 0.48, 0.26, 0.42, 0.30);
-    s.lineTo(0.34, 0.34);
-    s.bezierCurveTo(0.30, 0.24, 0.24, 0.14, 0.14, 0.08);
-    s.bezierCurveTo(0.08, 0.05, 0.03, 0.04, 0.00, 0.02);
-    return s;
-}
-
-export function buildKnightTemplate(seg, material, accent) {
-    const g = new THREE.Group();
-    const base = new THREE.Mesh(lathe([
+    // 6. CAVALO (Knight)
+    const knightBase = lathe(BABYLON, 'knight_base', [
         [0, 0], [0.36, 0], [0.38, 0.045], [0.31, 0.10],
         [0.28, 0.18], [0.22, 0.26], [0.20, 0.42],
         [0.22, 0.50], [0.18, 0.54]
-    ], seg), material);
-    base.castShadow = true;
-    base.receiveShadow = true;
-    g.add(base);
+    ], seg, scene);
+    const knightRing = collar(BABYLON, 'knight_ring', 0.20, 0.50, 0.03, seg, scene);
+    const neck = BABYLON.MeshBuilder.CreateCylinder('knight_neck', { height: 0.52, diameterTop: 0.24, diameterBottom: 0.32, tessellation: 16 }, scene);
+    neck.position.set(0.04, 0.70, 0);
+    neck.rotation.z = -0.22;
 
-    const ring = new THREE.Mesh(new THREE.TorusGeometry(0.20, 0.03, 8, 24), material);
-    ring.rotation.x = Math.PI / 2;
-    ring.position.y = 0.50;
-    ring.castShadow = true;
-    g.add(ring);
-
-    const neck = new THREE.Mesh(lathe([
-        [0, 0], [0.16, 0], [0.15, 0.18], [0.13, 0.36], [0.11, 0.48], [0, 0.50]
-    ], Math.max(12, seg >> 1)), material);
-    neck.position.set(0.02, 0.48, 0);
-    neck.rotation.z = -0.18;
-    neck.castShadow = true;
-    g.add(neck);
-
-    const extrude = new THREE.ExtrudeGeometry(knightHeadShape(), {
-        depth: 0.22,
-        bevelEnabled: true,
-        bevelThickness: 0.035,
-        bevelSize: 0.03,
-        bevelSegments: Math.max(2, seg >> 3),
-        steps: 1
-    });
-    extrude.translate(0, 0, -0.11);
-    const head = new THREE.Mesh(extrude, material);
-    head.position.set(-0.06, 0.58, 0);
-    head.rotation.y = Math.PI / 2;
-    head.scale.set(0.95, 0.95, 1);
-    head.castShadow = true;
-    g.add(head);
-
-    const earG = new THREE.ConeGeometry(0.045, 0.16, 8);
-    const earL = new THREE.Mesh(earG, material);
-    earL.position.set(0.02, 1.16, 0.07);
+    const headMuzzle = box(BABYLON, 'knight_head', 0.38, 0.24, 0.22, 0.18, 0.95, 0, scene);
+    headMuzzle.rotation.z = -0.32;
+    const snout = box(BABYLON, 'knight_snout', 0.22, 0.18, 0.18, 0.34, 0.84, 0, scene);
+    snout.rotation.z = -0.15;
+    const earL = BABYLON.MeshBuilder.CreateCylinder('knight_ear_l', { height: 0.16, diameterTop: 0, diameterBottom: 0.09, tessellation: 8 }, scene);
+    earL.position.set(0.04, 1.15, 0.07);
     earL.rotation.z = -0.35;
     earL.rotation.x = 0.25;
-    earL.castShadow = true;
-    const earR = earL.clone();
-    earR.position.z = -0.07;
+    const earR = BABYLON.MeshBuilder.CreateCylinder('knight_ear_r', { height: 0.16, diameterTop: 0, diameterBottom: 0.09, tessellation: 8 }, scene);
+    earR.position.set(0.04, 1.15, -0.07);
+    earR.rotation.z = -0.35;
     earR.rotation.x = -0.25;
-    g.add(earL, earR);
 
-    const eyeG = new THREE.SphereGeometry(0.025, 10, 8);
-    const eyeL = new THREE.Mesh(eyeG, accent);
-    eyeL.position.set(0.22, 1.02, 0.09);
-    const eyeR = eyeL.clone();
-    eyeR.position.z = -0.09;
-    g.add(eyeL, eyeR);
+    const mane = box(BABYLON, 'knight_mane', 0.10, 0.45, 0.08, -0.08, 0.88, 0, scene);
+    mane.rotation.z = 0.25;
 
-    const nostril = new THREE.Mesh(new THREE.SphereGeometry(0.018, 8, 6), accent);
-    nostril.position.set(0.42, 0.90, 0.04);
-    const nostril2 = nostril.clone();
-    nostril2.position.z = -0.04;
-    g.add(nostril, nostril2);
+    const eyeL = BABYLON.MeshBuilder.CreateSphere('knight_eye_l', { diameter: 0.05, segments: 8 }, scene);
+    eyeL.position.set(0.20, 1.00, 0.10);
+    const eyeR = BABYLON.MeshBuilder.CreateSphere('knight_eye_r', { diameter: 0.05, segments: 8 }, scene);
+    eyeR.position.set(0.20, 1.00, -0.10);
 
-    g.userData.kind = 'n';
-    return g;
+    const knight = merge(BABYLON, 'geo_knight', [
+        knightBase, knightRing, neck, headMuzzle, snout, earL, earR, mane, eyeL, eyeR
+    ], scene);
+
+    return { p: pawn, r: rook, n: knight, b: bishop, q: queen, k: king };
 }
 
-export function makeMaterials(tex, theme = 'classic') {
-    const ivory = new THREE.MeshPhysicalMaterial({
-        color: 0xe4d2b4,
-        map: tex.ivory.map,
-        normalMap: tex.ivory.normalMap,
-        roughnessMap: tex.ivory.roughnessMap,
-        roughness: 0.34,
-        metalness: 0.02,
-        clearcoat: 0.45,
-        clearcoatRoughness: 0.32,
-        sheen: 0.12,
-        sheenColor: new THREE.Color(0xe8d7b8),
-        sheenRoughness: 0.6,
-        envMapIntensity: 0.55
-    });
-    const ebony = new THREE.MeshPhysicalMaterial({
-        color: 0x16100c,
-        map: tex.ebony.map,
-        normalMap: tex.ebony.normalMap,
-        roughnessMap: tex.ebony.roughnessMap,
-        roughness: 0.22,
-        metalness: 0.08,
-        clearcoat: 0.7,
-        clearcoatRoughness: 0.18,
-        sheen: 0.12,
-        sheenColor: new THREE.Color(0x3a1c10),
-        envMapIntensity: 0.85
-    });
-    const accentDark = new THREE.MeshPhysicalMaterial({
-        color: 0x0a0604, roughness: 0.4, metalness: 0.2
-    });
-    const accentLight = new THREE.MeshPhysicalMaterial({
-        color: 0x3a2418, roughness: 0.35, metalness: 0.15
-    });
+export function makeMaterials(BABYLON, scene, tex, theme = 'classic') {
+    const ivory = new BABYLON.PBRMaterial('mat_ivory', scene);
+    ivory.albedoColor = new BABYLON.Color3(0.92, 0.85, 0.74);
+    if (tex.ivory) {
+        ivory.albedoTexture = tex.ivory.map;
+        ivory.bumpTexture = tex.ivory.normalMap;
+    }
+    ivory.metallic = 0.02;
+    ivory.roughness = 0.32;
+    ivory.clearCoat.isEnabled = true;
+    ivory.clearCoat.intensity = 0.45;
+    ivory.clearCoat.roughness = 0.3;
+    ivory.sheen.isEnabled = true;
+    ivory.sheen.intensity = 0.2;
+    ivory.sheen.color = new BABYLON.Color3(0.95, 0.88, 0.78);
+
+    const ebony = new BABYLON.PBRMaterial('mat_ebony', scene);
+    ebony.albedoColor = new BABYLON.Color3(0.12, 0.08, 0.06);
+    if (tex.ebony) {
+        ebony.albedoTexture = tex.ebony.map;
+        ebony.bumpTexture = tex.ebony.normalMap;
+    }
+    ebony.metallic = 0.08;
+    ebony.roughness = 0.22;
+    ebony.clearCoat.isEnabled = true;
+    ebony.clearCoat.intensity = 0.7;
+    ebony.clearCoat.roughness = 0.18;
+    ebony.sheen.isEnabled = true;
+    ebony.sheen.intensity = 0.15;
+    ebony.sheen.color = new BABYLON.Color3(0.25, 0.14, 0.09);
+
+    const accentLight = new BABYLON.PBRMaterial('mat_acc_light', scene);
+    accentLight.albedoColor = new BABYLON.Color3(0.35, 0.20, 0.12);
+    accentLight.metallic = 0.15;
+    accentLight.roughness = 0.35;
+
+    const accentDark = new BABYLON.PBRMaterial('mat_acc_dark', scene);
+    accentDark.albedoColor = new BABYLON.Color3(0.06, 0.04, 0.03);
+    accentDark.metallic = 0.2;
+    accentDark.roughness = 0.4;
 
     if (theme === 'crystal') {
-        const glassW = new THREE.MeshPhysicalMaterial({
-            color: 0xf2fbff,
-            roughness: 0.04,
-            metalness: 0.05,
-            transmission: 0.72,
-            thickness: 0.55,
-            ior: 1.52,
-            clearcoat: 1,
-            clearcoatRoughness: 0.04,
-            attenuationColor: new THREE.Color(0xd8f0ff),
-            attenuationDistance: 0.8,
-            envMapIntensity: 1.6
-        });
-        const glassB = new THREE.MeshPhysicalMaterial({
-            color: 0x1a0c08,
-            roughness: 0.06,
-            metalness: 0.35,
-            transmission: 0.35,
-            thickness: 0.5,
-            ior: 1.5,
-            clearcoat: 1,
-            clearcoatRoughness: 0.08,
-            attenuationColor: new THREE.Color(0x4a1808),
-            attenuationDistance: 0.6,
-            envMapIntensity: 1.8
-        });
-        const gold = new THREE.MeshPhysicalMaterial({
-            color: 0xd4a657, roughness: 0.18, metalness: 1, envMapIntensity: 1.5
-        });
-        return {
-            w: glassW, b: glassB, accentW: gold, accentB: gold, theme: 'crystal'
-        };
+        const glassW = new BABYLON.PBRMaterial('mat_glass_w', scene);
+        glassW.albedoColor = new BABYLON.Color3(0.95, 0.98, 1.0);
+        glassW.metallic = 0.05;
+        glassW.roughness = 0.04;
+        glassW.alpha = 0.55;
+        glassW.subSurface.isRefractionEnabled = true;
+        glassW.subSurface.indexOfRefraction = 1.52;
+        glassW.clearCoat.isEnabled = true;
+        glassW.clearCoat.intensity = 1.0;
+
+        const glassB = new BABYLON.PBRMaterial('mat_glass_b', scene);
+        glassB.albedoColor = new BABYLON.Color3(0.15, 0.08, 0.06);
+        glassB.metallic = 0.3;
+        glassB.roughness = 0.06;
+        glassB.alpha = 0.65;
+        glassB.subSurface.isRefractionEnabled = true;
+        glassB.subSurface.indexOfRefraction = 1.5;
+        glassB.clearCoat.isEnabled = true;
+        glassB.clearCoat.intensity = 1.0;
+
+        const gold = new BABYLON.PBRMaterial('mat_gold', scene);
+        gold.albedoColor = new BABYLON.Color3(0.85, 0.68, 0.32);
+        gold.metallic = 0.95;
+        gold.roughness = 0.18;
+
+        return { w: glassW, b: glassB, accentW: gold, accentB: gold, theme: 'crystal' };
     }
 
-    return {
-        w: ivory, b: ebony, accentW: accentLight, accentB: accentDark, theme: 'classic'
-    };
+    return { w: ivory, b: ebony, accentW: accentLight, accentB: accentDark, theme: 'classic' };
 }
 
 export class PieceFactory {
-    constructor(tex, quality) {
-        this.seg = quality.seg;
-        this.geos = buildPieceGeometries(quality.seg);
+    constructor(scene, tex, quality) {
+        this.BABYLON = window.BABYLON;
+        this.scene = scene;
         this.tex = tex;
-        this.mats = makeMaterials(tex, 'classic');
-        this.knightW = buildKnightTemplate(quality.seg, this.mats.w, this.mats.accentW);
-        this.knightB = buildKnightTemplate(quality.seg, this.mats.b, this.mats.accentB);
-        this.knightW.visible = false;
-        this.knightB.visible = false;
+        this.quality = quality;
+        this.mats = makeMaterials(this.BABYLON, scene, tex, 'classic');
+        this.prototypes = buildPieceGeometries(this.BABYLON, scene, quality.seg || 40);
+
+        // Esconder os protótipos mestres
+        for (const key in this.prototypes) {
+            const mesh = this.prototypes[key];
+            if (mesh) {
+                mesh.setEnabled(false);
+                mesh.isVisible = false;
+            }
+        }
     }
 
     setTheme(theme) {
-        this.mats = makeMaterials(this.tex, theme);
-        this.knightW.traverse((o) => {
-            if (o.isMesh) o.material = o.geometry.type === 'SphereGeometry' ? this.mats.accentW : this.mats.w;
-        });
-        this.knightB.traverse((o) => {
-            if (o.isMesh) o.material = o.geometry.type === 'SphereGeometry' ? this.mats.accentB : this.mats.b;
-        });
+        this.mats = makeMaterials(this.BABYLON, this.scene, this.tex, theme);
     }
 
     spawn(type, color) {
-        if (type === 'n') {
-            const src = color === 'w' ? this.knightW : this.knightB;
-            const g = src.clone(true);
-            g.visible = true;
-            g.traverse((o) => {
-                if (o.isMesh) {
-                    o.castShadow = true;
-                    o.receiveShadow = true;
-                }
-            });
-            g.userData.kind = 'n';
-            g.userData.color = color;
-            if (color === 'b') g.rotation.y = Math.PI;
-            return g;
+        const proto = this.prototypes[type];
+        if (!proto) return null;
+
+        const mesh = proto.clone(`piece_${type}_${color}_${Date.now()}_${Math.random()}`);
+        mesh.setEnabled(true);
+        mesh.isVisible = true;
+        mesh.material = color === 'w' ? this.mats.w : this.mats.b;
+        mesh.metadata = { kind: type, color };
+        mesh.isPickable = true;
+
+        if (type === 'n' && color === 'b') {
+            mesh.rotation.y = Math.PI;
         }
-        const mesh = new THREE.Mesh(this.geos[type], color === 'w' ? this.mats.w : this.mats.b);
-        mesh.castShadow = true;
-        mesh.receiveShadow = true;
-        mesh.userData.kind = type;
-        mesh.userData.color = color;
+
         return mesh;
     }
 }

--- a/labs/xadrez/src/textures.js
+++ b/labs/xadrez/src/textures.js
@@ -1,9 +1,7 @@
 /**
- * Texturas PBR procedurais — madeira, marfim, ébano, feltro e mármore.
- * Sem arquivos externos: cada mapa é um canvas reutilizado pelos materiais.
+ * Texturas PBR procedurais — madeira, marfim, ébano, feltro e mármore para Babylon.js.
+ * Sem arquivos externos: cada mapa é gerado em canvas e instanciado como BABYLON.Texture.
  */
-
-import * as THREE from 'three';
 
 function canvas(w, h = w) {
     const el = document.createElement('canvas');
@@ -21,13 +19,15 @@ function rng(seed = 1) {
     return () => (s = (s * 1664525 + 1013904223) >>> 0) / 4294967296;
 }
 
-function toTex(el, { repeat = [1, 1], srgb = true, aniso = 8, wrap = true } = {}) {
-    const tex = new THREE.CanvasTexture(el);
-    tex.wrapS = tex.wrapT = wrap ? THREE.RepeatWrapping : THREE.ClampToEdgeWrapping;
-    tex.repeat.set(repeat[0], repeat[1]);
-    tex.anisotropy = aniso;
-    if (srgb) tex.colorSpace = THREE.SRGBColorSpace;
-    tex.needsUpdate = true;
+function toBabylonTexture(el, scene, { uScale = 1, vScale = 1 } = {}) {
+    const BABYLON = window.BABYLON;
+    if (!BABYLON) return null;
+    const url = el.toDataURL('image/png');
+    const tex = new BABYLON.Texture(url, scene, false, false);
+    tex.uScale = uScale;
+    tex.vScale = vScale;
+    tex.wrapU = BABYLON.Texture.WRAP_ADDRESSMODE;
+    tex.wrapV = BABYLON.Texture.WRAP_ADDRESSMODE;
     return tex;
 }
 
@@ -73,16 +73,16 @@ function roughnessFrom(srcCtx, w, h, base = 0.35, contrast = 0.25) {
     return out;
 }
 
-function pack(draw, { w = 512, strength = 1.8, roughBase = 0.32, roughContrast = 0.22, aniso = 8, repeat = [1, 1] } = {}) {
+function pack(scene, draw, { w = 512, strength = 1.8, roughBase = 0.32, roughContrast = 0.22, repeat = [1, 1] } = {}) {
     const el = canvas(w);
     const ctx = ctx2d(el);
     draw(ctx, w);
     const n = heightToNormal(ctx, w, w, strength);
     const r = roughnessFrom(ctx, w, w, roughBase, roughContrast);
     return {
-        map: toTex(el, { aniso, repeat }),
-        normalMap: toTex(n, { aniso, repeat, srgb: false }),
-        roughnessMap: toTex(r, { aniso, repeat, srgb: false })
+        map: toBabylonTexture(el, scene, { uScale: repeat[0], vScale: repeat[1] }),
+        normalMap: toBabylonTexture(n, scene, { uScale: repeat[0], vScale: repeat[1] }),
+        roughnessMap: toBabylonTexture(r, scene, { uScale: repeat[0], vScale: repeat[1] })
     };
 }
 
@@ -106,20 +106,20 @@ function grain(ctx, w, rand, colorA, colorB, bands = 28) {
     }
 }
 
-export function createTextures(aniso = 8) {
-    const maple = pack((ctx, w) => {
+export function createTextures(scene) {
+    const maple = pack(scene, (ctx, w) => {
         grain(ctx, w, rng(11), '#e2c9a0', '#c9a574', 22);
-    }, { aniso, repeat: [1, 1], roughBase: 0.28, strength: 1.4 });
+    }, { repeat: [1, 1], roughBase: 0.28, strength: 1.4 });
 
-    const walnut = pack((ctx, w) => {
+    const walnut = pack(scene, (ctx, w) => {
         grain(ctx, w, rng(29), '#5a3418', '#3a1e0c', 18);
-    }, { aniso, repeat: [1, 1], roughBase: 0.34, strength: 1.6 });
+    }, { repeat: [1, 1], roughBase: 0.34, strength: 1.6 });
 
-    const mahogany = pack((ctx, w) => {
+    const mahogany = pack(scene, (ctx, w) => {
         grain(ctx, w, rng(71), '#6b2e18', '#3d140c', 16);
-    }, { aniso, repeat: [3, 3], roughBase: 0.22, strength: 1.2 });
+    }, { repeat: [3, 3], roughBase: 0.22, strength: 1.2 });
 
-    const ebony = pack((ctx, w) => {
+    const ebony = pack(scene, (ctx, w) => {
         const rand = rng(101);
         ctx.fillStyle = '#1a120f';
         ctx.fillRect(0, 0, w, w);
@@ -130,9 +130,9 @@ export function createTextures(aniso = 8) {
             ctx.fillRect(rand() * w, 0, 1 + rand() * 2, w);
         }
         ctx.globalAlpha = 1;
-    }, { aniso, repeat: [2, 2], roughBase: 0.18, roughContrast: 0.15, strength: 1.1 });
+    }, { repeat: [2, 2], roughBase: 0.18, roughContrast: 0.15, strength: 1.1 });
 
-    const ivory = pack((ctx, w) => {
+    const ivory = pack(scene, (ctx, w) => {
         const rand = rng(53);
         const g = ctx.createLinearGradient(0, 0, w, w);
         g.addColorStop(0, '#eadcc4');
@@ -149,46 +149,42 @@ export function createTextures(aniso = 8) {
             ctx.bezierCurveTo(w * 0.3, y + (rand() - 0.5) * 40, w * 0.7, y + (rand() - 0.5) * 40, w, y + (rand() - 0.5) * 20);
             ctx.stroke();
         }
-    }, { aniso, repeat: [1, 1], roughBase: 0.16, strength: 0.9 });
+    }, { repeat: [2, 2], roughBase: 0.28, strength: 0.8 });
 
-    const felt = pack((ctx, w) => {
+    const felt = pack(scene, (ctx, w) => {
         const rand = rng(7);
-        ctx.fillStyle = '#1e4a32';
+        ctx.fillStyle = '#1e6840';
         ctx.fillRect(0, 0, w, w);
-        for (let i = 0; i < 8000; i++) {
-            ctx.fillStyle = `rgba(${20 + rand() * 40},${80 + rand() * 50},${40 + rand() * 30},${0.15})`;
-            ctx.fillRect(rand() * w, rand() * w, 1.2, 1.2);
+        const img = ctx.getImageData(0, 0, w, w);
+        const d = img.data;
+        for (let i = 0; i < d.length; i += 4) {
+            const noise = (rand() - 0.5) * 26;
+            d[i] = Math.max(0, Math.min(255, d[i] + noise));
+            d[i + 1] = Math.max(0, Math.min(255, d[i + 1] + noise));
+            d[i + 2] = Math.max(0, Math.min(255, d[i + 2] + noise));
         }
-    }, { aniso, repeat: [4, 4], roughBase: 0.92, strength: 2.4 });
+        ctx.putImageData(img, 0, 0);
+    }, { repeat: [4, 4], roughBase: 0.95, strength: 0.4 });
 
-    const marble = pack((ctx, w) => {
-        const rand = rng(90);
-        ctx.fillStyle = '#d8d2c8';
+    const marble = pack(scene, (ctx, w) => {
+        const rand = rng(88);
+        ctx.fillStyle = '#dcd4c8';
         ctx.fillRect(0, 0, w, w);
-        for (let i = 0; i < 12; i++) {
+        for (let v = 0; v < 14; v++) {
             ctx.strokeStyle = `rgba(90,80,70,${0.08 + rand() * 0.12})`;
-            ctx.lineWidth = 1 + rand() * 3;
+            ctx.lineWidth = 1 + rand() * 3.5;
             ctx.beginPath();
-            ctx.moveTo(rand() * w, 0);
-            ctx.bezierCurveTo(rand() * w, w * 0.3, rand() * w, w * 0.6, rand() * w, w);
+            let x = rand() * w;
+            let y = rand() * w;
+            ctx.moveTo(x, y);
+            for (let step = 0; step < 5; step++) {
+                x += (rand() - 0.5) * 160;
+                y += (rand() - 0.5) * 160;
+                ctx.lineTo(x, y);
+            }
             ctx.stroke();
         }
-    }, { aniso, repeat: [2, 2], roughBase: 0.12, strength: 0.8 });
+    }, { repeat: [2, 2], roughBase: 0.12, strength: 0.6 });
 
-    const rim = (() => {
-        const el = canvas(1024, 128);
-        const ctx = ctx2d(el);
-        grain(ctx, 1024, rng(17), '#6b3a1c', '#3d1c0c', 20);
-        ctx.fillStyle = '#e8d2a8';
-        ctx.font = '600 52px "Cinzel", Georgia, serif';
-        ctx.textAlign = 'center';
-        ctx.textBaseline = 'middle';
-        const letters = 'ABCDEFGH';
-        for (let i = 0; i < 8; i++) {
-            ctx.fillText(letters[i], 64 + i * 128, 64);
-        }
-        return toTex(el, { wrap: false, aniso });
-    })();
-
-    return { maple, walnut, mahogany, ebony, ivory, felt, marble, rim };
+    return { maple, walnut, mahogany, ebony, ivory, felt, marble };
 }

--- a/labs/xadrez/src/world.js
+++ b/labs/xadrez/src/world.js
@@ -1,13 +1,10 @@
 /**
- * Atelier — tabuleiro laqueado, mesa de mogno, piso de mármore com reflexo.
+ * Atelier — tabuleiro laqueado, mesa de mogno, piso de mármore com reflexo em Babylon.js.
  *
- * Casa = 1 u. Origem no centro. Brancas em z positivo (câmera inicial).
+ * Casa = 1 u. Origem no centro. Brancas em z positivo.
  * Destaques: disco de lance legal, anel de captura, brilho de seleção e xeque.
  */
 
-import * as THREE from 'three';
-import { Reflector } from 'three/addons/objects/Reflector.js';
-import { RectAreaLightUniformsLib } from 'three/addons/lights/RectAreaLightUniformsLib.js';
 import { fileOf, rankOf } from './engine.js';
 
 export const SQUARE = 1;
@@ -37,320 +34,292 @@ export function worldToSquare(x, z, flip = false) {
     return r * 8 + f;
 }
 
-function phys(tex, extra = {}) {
-    return new THREE.MeshPhysicalMaterial({
-        map: tex.map,
-        normalMap: tex.normalMap,
-        roughnessMap: tex.roughnessMap,
-        roughness: 0.28,
-        metalness: 0.04,
-        clearcoat: 0.7,
-        clearcoatRoughness: 0.2,
-        envMapIntensity: 1.1,
-        ...extra
-    });
+function makePhysMat(BABYLON, name, scene, texMap, extra = {}) {
+    const mat = new BABYLON.PBRMaterial(name, scene);
+    if (texMap) {
+        if (texMap.map) mat.albedoTexture = texMap.map;
+        if (texMap.normalMap) mat.bumpTexture = texMap.normalMap;
+    }
+    mat.roughness = extra.roughness !== undefined ? extra.roughness : 0.35;
+    mat.metallic = extra.metallic !== undefined ? extra.metallic : 0.04;
+    mat.clearCoat.isEnabled = true;
+    mat.clearCoat.intensity = extra.clearcoat !== undefined ? extra.clearcoat : 0.6;
+    mat.clearCoat.roughness = 0.2;
+    if (extra.color) {
+        mat.albedoColor = extra.color;
+    }
+    return mat;
 }
 
-export function buildWorld(tex, quality) {
-    const root = new THREE.Group();
-    const board = new THREE.Group();
-    board.name = 'board';
-    root.add(board);
+export function buildWorld(BABYLON, scene, tex, quality) {
+    const lightMat = makePhysMat(BABYLON, 'mat_sq_light', scene, tex.maple, {
+        color: new BABYLON.Color3(0.96, 0.87, 0.73),
+        clearcoat: 0.35,
+        roughness: 0.38
+    });
+    const darkMat = makePhysMat(BABYLON, 'mat_sq_dark', scene, tex.walnut, {
+        color: new BABYLON.Color3(0.32, 0.16, 0.08),
+        clearcoat: 0.4,
+        roughness: 0.42
+    });
 
-    const lightMat = phys(tex.maple, {
-        color: 0xf4deba, clearcoat: 0.28, roughness: 0.42, envMapIntensity: 0.45
-    });
-    const darkMat = phys(tex.walnut, {
-        color: 0x4a2410, clearcoat: 0.32, roughness: 0.48, envMapIntensity: 0.4
-    });
     const squares = [];
-    const squareGeo = new THREE.BoxGeometry(SQUARE * 0.985, 0.07, SQUARE * 0.985);
-
     for (let r = 0; r < 8; r++) {
         for (let f = 0; f < 8; f++) {
             const dark = (f + r) % 2 === 0;
-            const mesh = new THREE.Mesh(squareGeo, dark ? darkMat : lightMat);
-            mesh.position.set(f - ORIGIN, 0.035, ORIGIN - r);
-            mesh.receiveShadow = true;
-            mesh.castShadow = true;
-            mesh.userData.index = r * 8 + f;
-            mesh.userData.kind = 'square';
-            board.add(mesh);
-            squares.push(mesh);
+            const sq = BABYLON.MeshBuilder.CreateBox(`sq_${r}_${f}`, {
+                width: SQUARE * 0.985,
+                height: 0.07,
+                depth: SQUARE * 0.985
+            }, scene);
+            sq.position.set(f - ORIGIN, 0.035, ORIGIN - r);
+            sq.material = dark ? darkMat : lightMat;
+            sq.receiveShadows = true;
+            sq.metadata = { kind: 'square', index: r * 8 + f };
+            sq.isPickable = true;
+            squares.push(sq);
         }
     }
 
-    const frameMat = phys(tex.mahogany, { color: 0x4a2212, clearcoat: 0.8, roughness: 0.3 });
-    const frame = new THREE.Mesh(new THREE.BoxGeometry(9.15, 0.14, 9.15), frameMat);
-    frame.position.y = -0.08;
-    frame.receiveShadow = true;
-    frame.castShadow = true;
-    board.add(frame);
+    // Moldura do tabuleiro (Mogno laqueado)
+    const frameMat = makePhysMat(BABYLON, 'mat_frame', scene, tex.mahogany, {
+        color: new BABYLON.Color3(0.30, 0.14, 0.08),
+        clearcoat: 0.85,
+        roughness: 0.25
+    });
+    const frame = BABYLON.MeshBuilder.CreateBox('board_frame', {
+        width: 9.25,
+        height: 0.16,
+        depth: 9.25
+    }, scene);
+    frame.position.y = -0.06;
+    frame.material = frameMat;
+    frame.receiveShadows = true;
+    frame.isPickable = false;
 
-    const felt = new THREE.Mesh(
-        new THREE.BoxGeometry(8.02, 0.02, 8.02),
-        new THREE.MeshStandardMaterial({
-            map: tex.felt.map,
-            roughness: 0.95,
-            metalness: 0,
-            color: 0x1a5a38
-        })
-    );
+    // Feltro sob as casas
+    const feltMat = new BABYLON.PBRMaterial('mat_felt', scene);
+    feltMat.albedoColor = new BABYLON.Color3(0.08, 0.28, 0.16);
+    feltMat.roughness = 0.95;
+    feltMat.metallic = 0.0;
+    const felt = BABYLON.MeshBuilder.CreateBox('board_felt', {
+        width: 8.04,
+        height: 0.02,
+        depth: 8.04
+    }, scene);
     felt.position.y = 0.0;
-    felt.receiveShadow = true;
-    board.add(felt);
+    felt.material = feltMat;
+    felt.isPickable = false;
 
-    const labels = makeCoordLabels(tex);
-    board.add(labels);
-
-    const table = new THREE.Mesh(new THREE.BoxGeometry(16, 0.28, 12), phys(tex.mahogany, {
-        color: 0x3d1a0e, roughness: 0.18, clearcoat: 1, clearcoatRoughness: 0.08
-    }));
+    // Mesa de mogno
+    const tableMat = makePhysMat(BABYLON, 'mat_table', scene, tex.mahogany, {
+        color: new BABYLON.Color3(0.24, 0.10, 0.06),
+        roughness: 0.16,
+        clearcoat: 0.95
+    });
+    const table = BABYLON.MeshBuilder.CreateBox('table_top', {
+        width: 16,
+        height: 0.28,
+        depth: 12
+    }, scene);
     table.position.y = -0.28;
-    table.receiveShadow = true;
-    table.castShadow = true;
-    root.add(table);
+    table.material = tableMat;
+    table.receiveShadows = true;
+    table.isPickable = false;
 
-    const legGeo = new THREE.CylinderGeometry(0.22, 0.28, 2.4, 12);
-    const legMat = phys(tex.mahogany, { color: 0x2a120a });
+    // Pés da mesa
+    const legMat = makePhysMat(BABYLON, 'mat_leg', scene, tex.mahogany, {
+        color: new BABYLON.Color3(0.18, 0.08, 0.04),
+        roughness: 0.3
+    });
     for (const [x, z] of [[-6.8, -4.6], [6.8, -4.6], [-6.8, 4.6], [6.8, 4.6]]) {
-        const leg = new THREE.Mesh(legGeo, legMat);
+        const leg = BABYLON.MeshBuilder.CreateCylinder(`leg_${x}_${z}`, {
+            height: 2.4,
+            diameterTop: 0.44,
+            diameterBottom: 0.56,
+            tessellation: 16
+        }, scene);
         leg.position.set(x, -1.62, z);
-        leg.castShadow = true;
-        root.add(leg);
+        leg.material = legMat;
+        leg.isPickable = false;
     }
 
-    const floor = new THREE.Mesh(
-        new THREE.CircleGeometry(18, 64),
-        phys(tex.marble, { color: 0xc8c0b4, roughness: 0.12, clearcoat: 1, metalness: 0.08 })
-    );
-    floor.rotation.x = -Math.PI / 2;
-    floor.position.y = -2.85;
-    floor.receiveShadow = true;
-    root.add(floor);
-
-    let mirror = null;
-    if (quality.reflect > 0) {
-        mirror = new Reflector(new THREE.CircleGeometry(10, 48), {
-            clipBias: 0.003,
-            textureWidth: quality.reflect,
-            textureHeight: quality.reflect,
-            color: 0x6a5a48
-        });
-        mirror.rotation.x = -Math.PI / 2;
-        mirror.position.y = -2.84;
-        root.add(mirror);
-    }
-
-    const rug = new THREE.Mesh(
-        new THREE.CircleGeometry(7.5, 48),
-        new THREE.MeshStandardMaterial({
-            map: tex.felt.map,
-            color: 0x6a1c1c,
-            roughness: 0.9
-        })
-    );
-    rug.rotation.x = -Math.PI / 2;
+    // Tapete de veludo bordô sob a mesa
+    const rugMat = new BABYLON.PBRMaterial('mat_rug', scene);
+    rugMat.albedoColor = new BABYLON.Color3(0.42, 0.10, 0.10);
+    rugMat.roughness = 0.92;
+    rugMat.metallic = 0.0;
+    const rug = BABYLON.MeshBuilder.CreateDisc('rug', {
+        radius: 7.5,
+        tessellation: 48
+    }, scene);
+    rug.rotation.x = Math.PI / 2;
     rug.position.y = -2.83;
-    rug.receiveShadow = true;
-    root.add(rug);
+    rug.material = rugMat;
+    rug.receiveShadows = true;
+    rug.isPickable = false;
 
-    const wallMat = new THREE.MeshStandardMaterial({ color: 0x1a1210, roughness: 0.9 });
-    const back = new THREE.Mesh(new THREE.PlaneGeometry(28, 12), wallMat);
-    back.position.set(0, 2.2, -14);
-    root.add(back);
-    const sideL = new THREE.Mesh(new THREE.PlaneGeometry(28, 12), wallMat);
-    sideL.rotation.y = Math.PI / 2;
-    sideL.position.set(-14, 2.2, 0);
-    root.add(sideL);
-    const sideR = sideL.clone();
-    sideR.position.x = 14;
-    sideR.rotation.y = -Math.PI / 2;
-    root.add(sideR);
-
-    const lamp = makeLamp();
-    lamp.position.set(6.2, 0.1, -3.4);
-    root.add(lamp);
-
-    const marks = buildMarks();
-    root.add(marks.group);
-
-    return { root, board, squares, marks, mirror, lamp };
-}
-
-function makeCoordLabels() {
-    const g = new THREE.Group();
-    const files = 'abcdefgh';
-    const make = (text) => {
-        const el = document.createElement('canvas');
-        el.width = 128;
-        el.height = 128;
-        const ctx = el.getContext('2d');
-        ctx.fillStyle = '#e6d2a8';
-        ctx.font = '700 78px Cinzel, Georgia, serif';
-        ctx.textAlign = 'center';
-        ctx.textBaseline = 'middle';
-        ctx.fillText(text, 64, 68);
-        const tex = new THREE.CanvasTexture(el);
-        tex.colorSpace = THREE.SRGBColorSpace;
-        const mat = new THREE.MeshBasicMaterial({ map: tex, transparent: true });
-        const m = new THREE.Mesh(new THREE.PlaneGeometry(0.28, 0.28), mat);
-        m.rotation.x = -Math.PI / 2;
-        return m;
-    };
-    for (let i = 0; i < 8; i++) {
-        const f = make(files[i]);
-        f.position.set(i - ORIGIN, 0.12, ORIGIN + 0.62);
-        g.add(f);
-        const f2 = make(files[i]);
-        f2.position.set(i - ORIGIN, 0.12, -ORIGIN - 0.62);
-        f2.rotation.z = Math.PI;
-        g.add(f2);
-        const r = make(String(i + 1));
-        r.position.set(-ORIGIN - 0.62, 0.12, ORIGIN - i);
-        g.add(r);
-        const r2 = make(String(i + 1));
-        r2.position.set(ORIGIN + 0.62, 0.12, ORIGIN - i);
-        g.add(r2);
-    }
-    return g;
-}
-
-function makeLamp() {
-    const g = new THREE.Group();
-    const brass = new THREE.MeshPhysicalMaterial({
-        color: 0xb8863a, metalness: 1, roughness: 0.22, envMapIntensity: 1.4
+    // Piso de mármore do salão
+    const floorMat = makePhysMat(BABYLON, 'mat_floor', scene, tex.marble, {
+        color: new BABYLON.Color3(0.85, 0.82, 0.78),
+        roughness: 0.14,
+        clearcoat: 0.9,
+        metallic: 0.05
     });
-    const shade = new THREE.MeshPhysicalMaterial({
-        color: 0xf0d8a8, roughness: 0.6, transmission: 0.35, thickness: 0.2, emissive: 0x6a4010, emissiveIntensity: 0.25
-    });
-    const base = new THREE.Mesh(new THREE.CylinderGeometry(0.28, 0.36, 0.12, 20), brass);
-    g.add(base);
-    const stem = new THREE.Mesh(new THREE.CylinderGeometry(0.04, 0.05, 1.6, 12), brass);
-    stem.position.y = 0.86;
-    g.add(stem);
-    const hat = new THREE.Mesh(new THREE.ConeGeometry(0.42, 0.38, 20, 1, true), shade);
-    hat.position.y = 1.72;
-    g.add(hat);
-    const bulb = new THREE.PointLight(0xffcc88, 3.2, 9, 1.6);
-    bulb.position.y = 1.55;
-    bulb.castShadow = false;
-    g.add(bulb);
-    return g;
+    const floor = BABYLON.MeshBuilder.CreateDisc('floor', {
+        radius: 18,
+        tessellation: 64
+    }, scene);
+    floor.rotation.x = Math.PI / 2;
+    floor.position.y = -2.85;
+    floor.material = floorMat;
+    floor.receiveShadows = true;
+    floor.isPickable = false;
+
+    const marks = buildMarks(BABYLON, scene);
+
+    return { squares, frame, table, floor, marks };
 }
 
-export function buildMarks() {
-    const group = new THREE.Group();
-    group.name = 'marks';
+function buildMarks(BABYLON, scene) {
+    const dotMat = new BABYLON.StandardMaterial('mat_mark_dot', scene);
+    dotMat.diffuseColor = new BABYLON.Color3(0.15, 0.85, 0.45);
+    dotMat.emissiveColor = new BABYLON.Color3(0.2, 0.75, 0.35);
+    dotMat.alpha = 0.85;
+
+    const capMat = new BABYLON.StandardMaterial('mat_mark_cap', scene);
+    capMat.diffuseColor = new BABYLON.Color3(0.95, 0.25, 0.25);
+    capMat.emissiveColor = new BABYLON.Color3(0.85, 0.15, 0.15);
+    capMat.alpha = 0.9;
+
+    const selMat = new BABYLON.StandardMaterial('mat_mark_sel', scene);
+    selMat.diffuseColor = new BABYLON.Color3(0.95, 0.8, 0.2);
+    selMat.emissiveColor = new BABYLON.Color3(0.85, 0.65, 0.1);
+    selMat.alpha = 0.85;
+
+    const lastMat = new BABYLON.StandardMaterial('mat_mark_last', scene);
+    lastMat.diffuseColor = new BABYLON.Color3(0.85, 0.65, 0.2);
+    lastMat.emissiveColor = new BABYLON.Color3(0.5, 0.35, 0.1);
+    lastMat.alpha = 0.45;
+
+    const checkMat = new BABYLON.StandardMaterial('mat_mark_check', scene);
+    checkMat.diffuseColor = new BABYLON.Color3(1.0, 0.1, 0.1);
+    checkMat.emissiveColor = new BABYLON.Color3(0.9, 0.05, 0.05);
+    checkMat.alpha = 0.85;
+
+    const hintMat = new BABYLON.StandardMaterial('mat_mark_hint', scene);
+    hintMat.diffuseColor = new BABYLON.Color3(0.3, 0.85, 1.0);
+    hintMat.emissiveColor = new BABYLON.Color3(0.2, 0.6, 0.9);
+    hintMat.alpha = 0.9;
 
     const dots = [];
-    const dotGeo = new THREE.CylinderGeometry(0.12, 0.12, 0.04, 20);
-    const dotMat = new THREE.MeshBasicMaterial({
-        color: 0xd4b06a, transparent: true, opacity: 0.72, depthWrite: false
-    });
-    const capGeo = new THREE.RingGeometry(0.28, 0.40, 28);
-    const capMat = new THREE.MeshBasicMaterial({
-        color: 0xc45c48, transparent: true, opacity: 0.85, side: THREE.DoubleSide, depthWrite: false
-    });
-    const caps = [];
-    for (let i = 0; i < 32; i++) {
-        const d = new THREE.Mesh(dotGeo, dotMat.clone());
-        d.visible = false;
-        d.position.y = 0.09;
-        group.add(d);
+    for (let i = 0; i < 28; i++) {
+        const d = BABYLON.MeshBuilder.CreateDisc(`dot_${i}`, { radius: 0.16, tessellation: 24 }, scene);
+        d.rotation.x = Math.PI / 2;
+        d.material = dotMat;
+        d.isVisible = false;
+        d.isPickable = false;
         dots.push(d);
-        const c = new THREE.Mesh(capGeo, capMat.clone());
-        c.rotation.x = -Math.PI / 2;
-        c.visible = false;
-        c.position.y = 0.09;
-        group.add(c);
+    }
+
+    const caps = [];
+    for (let i = 0; i < 16; i++) {
+        const c = BABYLON.MeshBuilder.CreateTorus(`cap_${i}`, { diameter: 0.82, thickness: 0.06, tessellation: 32 }, scene);
+        c.material = capMat;
+        c.isVisible = false;
+        c.isPickable = false;
         caps.push(c);
     }
 
-    const selectGeo = new THREE.RingGeometry(0.42, 0.50, 32);
-    const select = new THREE.Mesh(selectGeo, new THREE.MeshBasicMaterial({
-        color: 0xf0d48a, transparent: true, opacity: 0.95, side: THREE.DoubleSide, depthWrite: false
-    }));
-    select.rotation.x = -Math.PI / 2;
-    select.position.y = 0.1;
-    select.visible = false;
-    group.add(select);
+    const select = BABYLON.MeshBuilder.CreateTorus('mark_select', { diameter: 0.88, thickness: 0.07, tessellation: 32 }, scene);
+    select.material = selMat;
+    select.isVisible = false;
+    select.isPickable = false;
 
-    const lastFrom = select.clone();
-    lastFrom.material = new THREE.MeshBasicMaterial({
-        color: 0x7aa0d4, transparent: true, opacity: 0.55, side: THREE.DoubleSide, depthWrite: false
-    });
-    const lastTo = lastFrom.clone();
-    lastTo.material = lastFrom.material.clone();
-    group.add(lastFrom, lastTo);
+    const lastFrom = BABYLON.MeshBuilder.CreateDisc('mark_last_from', { radius: 0.44, tessellation: 4 }, scene);
+    lastFrom.rotation.x = Math.PI / 2;
+    lastFrom.rotation.y = Math.PI / 4;
+    lastFrom.material = lastMat;
+    lastFrom.isVisible = false;
+    lastFrom.isPickable = false;
 
-    const check = new THREE.Mesh(
-        new THREE.RingGeometry(0.36, 0.52, 32),
-        new THREE.MeshBasicMaterial({
-            color: 0xe05040, transparent: true, opacity: 0.9, side: THREE.DoubleSide, depthWrite: false
-        })
-    );
-    check.rotation.x = -Math.PI / 2;
-    check.position.y = 0.11;
-    check.visible = false;
-    group.add(check);
+    const lastTo = BABYLON.MeshBuilder.CreateDisc('mark_last_to', { radius: 0.44, tessellation: 4 }, scene);
+    lastTo.rotation.x = Math.PI / 2;
+    lastTo.rotation.y = Math.PI / 4;
+    lastTo.material = lastMat;
+    lastTo.isVisible = false;
+    lastTo.isPickable = false;
 
-    const hint = select.clone();
-    hint.material = new THREE.MeshBasicMaterial({
-        color: 0x6ad4a0, transparent: true, opacity: 0.9, side: THREE.DoubleSide, depthWrite: false
-    });
-    group.add(hint);
+    const check = BABYLON.MeshBuilder.CreateTorus('mark_check', { diameter: 0.92, thickness: 0.08, tessellation: 32 }, scene);
+    check.material = checkMat;
+    check.isVisible = false;
+    check.isPickable = false;
 
-    return { group, dots, caps, select, lastFrom, lastTo, check, hint };
+    const hint = BABYLON.MeshBuilder.CreateTorus('mark_hint', { diameter: 0.86, thickness: 0.06, tessellation: 32 }, scene);
+    hint.material = hintMat;
+    hint.isVisible = false;
+    hint.isPickable = false;
+
+    return { dots, caps, select, lastFrom, lastTo, check, hint };
 }
 
-export function placeMark(mesh, index, flip) {
-    const p = squareToWorld(index, flip);
-    mesh.position.x = p.x;
-    mesh.position.z = p.z;
-    mesh.visible = true;
+export function placeMark(mesh, index, flip = false) {
+    if (!mesh || index < 0) return;
+    const pos = squareToWorld(index, flip);
+    mesh.position.set(pos.x, 0.075, pos.z);
+    mesh.isVisible = true;
 }
 
-export function setupLights(scene, quality) {
-    RectAreaLightUniformsLib.init();
+export function setupLights(BABYLON, scene, quality) {
+    // Luz ambiente suave
+    const hemi = new BABYLON.HemisphericLight('hemi_light', new BABYLON.Vector3(0, 1, 0), scene);
+    hemi.diffuse = new BABYLON.Color3(0.7, 0.65, 0.58);
+    hemi.groundColor = new BABYLON.Color3(0.25, 0.20, 0.15);
+    hemi.intensity = 0.85;
 
-    const hemi = new THREE.HemisphereLight(0x9eb4d4, 0x3a2214, 0.45);
-    scene.add(hemi);
+    // Sol / Luz direcionada com sombras
+    const sun = new BABYLON.DirectionalLight('sun_light', new BABYLON.Vector3(-4, -10, 6).normalize(), scene);
+    sun.position = new BABYLON.Vector3(8, 18, -12);
+    sun.diffuse = new BABYLON.Color3(1.0, 0.95, 0.88);
+    sun.intensity = 1.6;
 
-    const key = new THREE.DirectionalLight(0xffe6c4, 1.65);
-    key.position.set(4.5, 10, 6.5);
-    key.castShadow = quality.shadows;
+    let shadowGen = null;
     if (quality.shadows) {
-        key.shadow.mapSize.set(quality.shadowMap, quality.shadowMap);
-        key.shadow.camera.near = 1;
-        key.shadow.camera.far = 28;
-        key.shadow.camera.left = -10;
-        key.shadow.camera.right = 10;
-        key.shadow.camera.top = 10;
-        key.shadow.camera.bottom = -10;
-        key.shadow.bias = -0.0002;
-        key.shadow.normalBias = 0.03;
+        shadowGen = new BABYLON.ShadowGenerator(quality.shadowMap || 2048, sun);
+        shadowGen.usePoissonSampling = true;
+        shadowGen.bias = 0.001;
+        shadowGen.normalBias = 0.002;
     }
-    scene.add(key);
 
-    const fill = new THREE.DirectionalLight(0x88a4cc, 0.55);
-    fill.position.set(-6, 5, -4);
-    scene.add(fill);
+    // Ponto de luz quente sobre a mesa
+    const warmLamp = new BABYLON.PointLight('warm_lamp', new BABYLON.Vector3(0, 5, 0), scene);
+    warmLamp.diffuse = new BABYLON.Color3(1.0, 0.85, 0.65);
+    warmLamp.intensity = 0.6;
+    warmLamp.range = 14;
 
-    const windowLight = new THREE.RectAreaLight(0xc8dcff, 8, 6, 4);
-    windowLight.position.set(0, 4.2, -13.2);
-    windowLight.lookAt(0, 0.5, 0);
-    scene.add(windowLight);
+    return { hemi, sun, shadowGen, warmLamp };
+}
 
-    const chandelier = new THREE.SpotLight(0xffd9a8, 3.2, 22, 0.55, 0.45, 1.1);
-    chandelier.position.set(0, 7.4, 0.4);
-    chandelier.target.position.set(0, 0, 0);
-    chandelier.castShadow = quality.shadows;
-    if (quality.shadows) {
-        chandelier.shadow.mapSize.set(Math.min(quality.shadowMap, 2048), Math.min(quality.shadowMap, 2048));
-        chandelier.shadow.bias = -0.00015;
-    }
-    scene.add(chandelier, chandelier.target);
+export function setupPostProcess(BABYLON, scene, quality) {
+    const pipe = new BABYLON.DefaultRenderingPipeline('pipeline', true, scene, [scene.activeCamera]);
+    pipe.samples = quality.pr > 1 ? 4 : 1;
+    pipe.fxaaEnabled = true;
 
-    return { key, chandelier, hemi };
+    // Bloom elegante para destaques e reflexos
+    pipe.bloomEnabled = true;
+    pipe.bloomThreshold = 0.78;
+    pipe.bloomWeight = 0.25;
+    pipe.bloomKernel = 64;
+
+    // Tonemapping e contraste
+    pipe.imageProcessing.toneMappingEnabled = true;
+    pipe.imageProcessing.toneMappingType = BABYLON.ImageProcessingConfiguration.TONEMAPPING_ACES;
+    pipe.imageProcessing.contrast = 1.15;
+    pipe.imageProcessing.exposure = 1.05;
+
+    // Glow Layer para anéis e discos de lance legal
+    const glow = new BABYLON.GlowLayer('glow', scene);
+    glow.intensity = 0.65;
+
+    return { pipe, glow };
 }


### PR DESCRIPTION
## 🎯 Objetivo

Migrar o lab **Xadrez** de Three.js para **Babylon.js**, elevando a fidelidade visual das peças Staunton com materiais PBR realistas (marfim, ébano laqueado, mármore e cristal), sombras de contato suaves (Poisson sampling), pipeline de pós-processamento com ACES tonemapping e GlowLayer, mantendo 100% das regras FIDE, IA, Academia, Puzzles e áudio sintetizado.

## ✨ O que mudou

- **Babylon.js Core**: Substituição completa da engine Three.js por Babylon.js 7.x/8.x CDN sem build/npm.
- **PBR & Texturas Procedurais**: Geração de mapas em canvas (albedo, normal/bump, roughness) alimentando `BABYLON.PBRMaterial` com canais de clearcoat, sheen e subSurface.
- **Peças Staunton Procedurais**: Reconstrução geométrica em torno (`CreateLathe`), chanfros e detalhes orgânicos para Peão, Torre, Cavalo, Bispo, Dama e Rei com protótipos clonados para alta performance.
- **Iluminação & Sombras**: `DirectionalLight` com `ShadowGenerator` (Poisson sampling), `HemisphericLight` para preenchimento de estúdio e lâmpada pontual aconchegante.
- **Pós-processamento & Destaques**: `DefaultRenderingPipeline` com bloom suave, FXAA, ACES tonemapping e `GlowLayer` para marcadores de lances legais e xeque.
- **Controles de Câmera & Toque**: `ArcRotateCamera` com inércia, rotação suave, limites de distância/ângulo e suporte total a gestos/toque mobile.

## 🧪 Como testar

1. Na raiz do repo: `python3 -m http.server 8000`
2. Abrir [http://localhost:8000/labs/xadrez/](http://localhost:8000/labs/xadrez/)
3. Testar a jogabilidade: selecionar peças, conferir discos de lance legal verdes e anéis vermelhos de captura, jogar contra a máquina, testar o modo Academia e os Puzzles.
4. Testar o botão Virar tabuleiro, Dica, Desfazer, Som e troca de temas (Marfim/Ébano e Cristal).
5. Responsivo: conferir em 375×667, 390×844 e landscape curto.

## ✅ Checklist

- [x] Links conferidos: pasta do lab ↔ card da galeria ↔ README ↔ sitemap
- [x] README conferido e consistente
- [x] SEO consistente: title, description, canonical, author, robots, OG, Twitter, JSON-LD
- [x] Testado via HTTP na raiz, não via `file://`
- [x] Responsivo: 375px / 390px / landscape — overflow, HUD, toque, safe-area
- [x] Nada fora do escopo foi quebrado