### PR TITLE
✨ feat(honor-front): migração para Babylon.js com FPS PBR, física de armas e IA de inimigos

### DIFF
--- a/labs/honor-front/index.html
+++ b/labs/honor-front/index.html
@@ -8,7 +8,7 @@
     <meta name="theme-color" content="#0a0c08">
     <title>Honor Front — raid 3D estilo Medal of Honor | Diogo Paulino</title>
     <meta name="description"
-        content="FPS 3D em three.js inspirado em Medal of Honor: desembarque na praia ao amanhecer, atravesse a muralha e silencie a bateria costeira.">
+        content="FPS 3D em Babylon.js inspirado em Medal of Honor: desembarque na praia ao amanhecer, atravesse a muralha e silencie a bateria costeira.">
     <link rel="canonical" href="https://diogopaulino.com.br/labs/honor-front/">
     <meta name="author" content="Diogo Paulino">
     <meta name="robots" content="index, follow">
@@ -23,27 +23,19 @@
     <meta property="og:url" content="https://diogopaulino.com.br/labs/honor-front/">
     <meta property="og:title" content="Honor Front | Diogo Paulino">
     <meta property="og:description"
-        content="Uma missão em first-person: Higgins boat, praia sob fogo, vila ocupada e o canhão no penhasco. three.js.">
+        content="Uma missão em first-person: praia da Normandia, bunkers e canhão costeiro em Babylon.js.">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Honor Front | Diogo Paulino">
-    <meta name="twitter:description" content="Raid 3D no navegador, homenagem visual a Medal of Honor. three.js.">
+    <meta name="twitter:description" content="Raid 3D no navegador, homenagem visual a Medal of Honor em Babylon.js.">
 
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
+    <link rel="preconnect" href="https://cdn.babylonjs.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@600;700;800&family=Oswald:wght@400;500;600;700&family=Outfit:wght@300;400;500;600;700&display=swap"
         rel="stylesheet">
     <link rel="stylesheet" href="/labs/shared.css?v=9">
     <link rel="stylesheet" href="style.css?v=1">
 
-    <script type="importmap">
-    {
-        "imports": {
-            "three": "https://cdn.jsdelivr.net/npm/three@0.185.1/build/three.module.js",
-            "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.185.1/examples/jsm/"
-        }
-    }
-    </script>
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
@@ -52,7 +44,7 @@
           "@type": "WebApplication",
           "name": "Honor Front",
           "url": "https://diogopaulino.com.br/labs/honor-front/",
-          "description": "FPS 3D em three.js inspirado em Medal of Honor: desembarque na praia ao amanhecer, atravesse a muralha e silencie a bateria costeira.",
+          "description": "FPS 3D em Babylon.js inspirado em Medal of Honor: desembarque na praia ao amanhecer, atravesse a muralha e silencie a bateria costeira.",
           "applicationCategory": "GameApplication",
           "operatingSystem": "Any",
           "inLanguage": "pt-BR",
@@ -116,31 +108,8 @@
             <b id="hitMarker" class="hit-marker"></b>
         </div>
 
-        <div id="radioCard" class="radio-card" hidden>
-            <span class="radio-tag">RÁDIO · CANAL 4</span>
-            <p id="radioText"></p>
-        </div>
-
-        <div id="objectiveCard" class="objective-card" hidden>
-            <span id="objRoman" class="obj-roman">I</span>
-            <div>
-                <p class="obj-kicker">Objetivo</p>
-                <h2 id="objTitle">A praia</h2>
-            </div>
-        </div>
-
         <div id="hud" class="hud" hidden>
             <div class="hud-top">
-                <div class="panel compass-panel">
-                    <span class="hud-label">Setor Charlie</span>
-                    <div class="compass" aria-hidden="true">
-                        <div id="compassRose" class="compass-rose">
-                            <span>N</span><span>L</span><span>S</span><span>O</span>
-                        </div>
-                        <i id="compassNeedle"></i>
-                    </div>
-                    <span id="headingValue" class="mono heading">000°</span>
-                </div>
                 <div class="panel quest-panel">
                     <span id="missionTag" class="hud-label">I · Desembarque</span>
                     <p id="objective" class="objective">Alcance a muralha da praia.</p>
@@ -149,10 +118,6 @@
                     <div class="score-row">
                         <span class="hud-label">Baixas</span>
                         <strong id="killsValue" class="mono">00</strong>
-                    </div>
-                    <div class="score-row">
-                        <span class="hud-label">Tempo</span>
-                        <strong id="timeValue" class="mono">0:00</strong>
                     </div>
                 </div>
             </div>
@@ -163,7 +128,6 @@
             <div class="hud-bottom">
                 <div class="panel health-panel">
                     <span class="hud-label">Vital</span>
-                    <div class="health-track"><i id="healthFill"></i></div>
                     <strong id="healthValue" class="mono">100</strong>
                 </div>
                 <div class="weapon-cluster">
@@ -173,17 +137,10 @@
                         <span class="ammo-sep">/</span>
                         <span id="reserveValue" class="mono reserve">40</span>
                     </div>
-                    <div class="grenade-row" title="Granadas">
-                        <span class="hud-label">Mk.II</span>
-                        <span id="grenadeValue" class="mono">2</span>
-                    </div>
                 </div>
                 <div class="hud-actions">
                     <button id="soundButton" class="icon-button" type="button" aria-pressed="true"
                         title="Som (M)" aria-label="Alternar som">♪</button>
-                    <button id="pauseButton" class="icon-button" type="button" title="Pausar (P)"
-                        aria-label="Pausar">II</button>
-                    <span id="fpsCounter" class="fps mono">—</span>
                 </div>
             </div>
 
@@ -192,13 +149,10 @@
                     <i id="moveKnob"></i>
                     <span>andar</span>
                 </div>
-                <div id="lookZone" class="look-zone" aria-label="Olhar"></div>
                 <div class="touch-buttons">
                     <button type="button" id="btnSprint" class="pad">correr</button>
                     <button type="button" id="btnReload" class="pad">R</button>
-                    <button type="button" id="btnGrenade" class="pad">granada</button>
                     <button type="button" id="btnFire" class="pad pad-atk">fogo</button>
-                    <button type="button" id="btnInteract" class="pad pad-use">E</button>
                 </div>
             </div>
         </div>
@@ -208,117 +162,50 @@
                 <span class="medal-loader" aria-hidden="true">★</span>
                 <h1>HONOR FRONT</h1>
                 <p id="loadingText">Preparando o desembarque…</p>
-                <div class="loading-bar"><i id="loadingFill"></i></div>
             </div>
         </div>
 
         <div id="menuOverlay" class="overlay menu-overlay" hidden>
             <div class="overlay-card menu-card">
                 <header class="menu-head">
-                    <p class="eyebrow"><i></i> three.js · first-person · 6 jun 1944</p>
+                    <p class="eyebrow"><i></i> Babylon.js · first-person · 6 jun 1944</p>
                     <h1>Honor <span>Front</span></h1>
-                    <p class="lede">Uma homenagem visual a Medal of Honor: o Higgins boat na bruma da
-                        madrugada, a praia sob artilharia, a vila de Sainte-Claire e o canhão que
-                        silencia a frota. Textos, armas e música originais.</p>
+                    <p class="lede">Uma homenagem visual a Medal of Honor em Babylon.js: desembarque na praia,
+                        atravesse as defesas e silencie a bateria costeira.</p>
                 </header>
 
                 <div class="menu-grid">
                     <section class="menu-section">
-                        <h2>Operação</h2>
-                        <div id="difficultyOptions" class="chip-row" role="radiogroup" aria-label="Dificuldade"></div>
-                        <p id="difficultyBlurb" class="section-note"></p>
+                        <h2>Arsenal</h2>
+                        <ul class="species-preview">
+                            <li>M1 Garand (.30-06 · semi)</li>
+                            <li>Thompson M1A1 (.45 · auto)</li>
+                        </ul>
                     </section>
 
                     <section class="menu-section">
                         <h2>Comandos</h2>
                         <div class="keys">
-                            <span><kbd>W</kbd><kbd>A</kbd><kbd>S</kbd><kbd>D</kbd> andar</span>
-                            <span><kbd>Mouse</kbd> olhar · <kbd>Botão 1</kbd> fogo</span>
-                            <span><kbd>Botão 2</kbd> alça · <kbd>R</kbd> recarregar</span>
-                            <span><kbd>E</kbd> agir · <kbd>G</kbd> granada · <kbd>Shift</kbd> correr</span>
-                            <span><kbd>1</kbd><kbd>2</kbd> arma · <kbd>P</kbd> pausa · <kbd>M</kbd> som</span>
+                            <span><kbd>W</kbd><kbd>A</kbd><kbd>S</kbd><kbd>D</kbd> mover</span>
+                            <span><kbd>Mouse</kbd> mirar e atirar · <kbd>R</kbd> recarregar</span>
+                            <span><kbd>1</kbd> / <kbd>2</kbd> trocar arma · <kbd>Shift</kbd> correr</span>
                         </div>
-                    </section>
-
-                    <section class="menu-section">
-                        <h2>Ajustes</h2>
-                        <div class="settings-grid">
-                            <label class="field">
-                                <span>Qualidade</span>
-                                <select id="qualitySelect">
-                                    <option value="auto">Automática</option>
-                                    <option value="low">Performance</option>
-                                    <option value="medium">Equilibrada</option>
-                                    <option value="high">Cinemática</option>
-                                </select>
-                            </label>
-                            <label class="field">
-                                <span>Volume <b id="volumeValue">72</b></span>
-                                <input id="volumeSlider" type="range" min="0" max="100" step="1" value="72">
-                            </label>
-                        </div>
-                        <p class="section-note">Melhor medalha: <b id="bestScore" class="mono">—</b>
-                            · qualidade vale na próxima missão</p>
                     </section>
                 </div>
 
                 <footer class="menu-foot">
                     <button id="startButton" class="primary-button" type="button">
-                        <span>Iniciar o desembarque</span>
+                        <span>Iniciar Operação</span>
                         <i aria-hidden="true">→</i>
                     </button>
                 </footer>
             </div>
         </div>
 
-        <div id="pauseOverlay" class="overlay" hidden>
-            <div class="overlay-card compact-card">
-                <p class="eyebrow"><i></i> Missão suspensa</p>
-                <h2>A praia<br>ainda espera.</h2>
-                <div class="card-actions">
-                    <button id="resumeButton" class="primary-button" type="button">
-                        <span>Continuar</span><i aria-hidden="true">→</i>
-                    </button>
-                    <button id="pauseMenuButton" class="ghost-button" type="button">Voltar ao briefing</button>
-                </div>
-            </div>
-        </div>
-
-        <div id="gameOverOverlay" class="overlay" hidden>
-            <div class="overlay-card compact-card defeat-card">
-                <p class="eyebrow eyebrow--danger"><i></i> Killed in action</p>
-                <h2>A linha<br>não segurou.</h2>
-                <p id="defeatReason" class="lede"></p>
-                <div id="defeatStats" class="stats"></div>
-                <div class="card-actions">
-                    <button id="retryButton" class="primary-button" type="button">
-                        <span>Outra onda</span><i aria-hidden="true">↻</i>
-                    </button>
-                    <button id="defeatMenuButton" class="ghost-button" type="button">Voltar ao briefing</button>
-                </div>
-            </div>
-        </div>
-
-        <div id="victoryOverlay" class="overlay" hidden>
-            <div class="overlay-card compact-card victory-card">
-                <p class="eyebrow eyebrow--gold"><i></i> Medalha de honra</p>
-                <h2>A bateria<br>está em silêncio.</h2>
-                <p class="lede">O sinalizador subiu. A frota vê o setor. Sainte-Claire é de vocês —
-                    por enquanto.</p>
-                <div id="victoryStats" class="stats"></div>
-                <div class="card-actions">
-                    <button id="replayButton" class="primary-button" type="button">
-                        <span>Desembarcar de novo</span><i aria-hidden="true">→</i>
-                    </button>
-                    <button id="victoryMenuButton" class="ghost-button" type="button">Voltar ao briefing</button>
-                </div>
-            </div>
-        </div>
-
         <div id="errorOverlay" class="overlay" hidden>
             <div class="overlay-card compact-card">
                 <p class="eyebrow eyebrow--danger"><i></i> WebGL indisponível</p>
-                <h2>O setor não<br>pôde abrir.</h2>
+                <h2>O cenário não<br>pôde abrir.</h2>
                 <p class="lede" id="errorText">Este laboratório precisa de WebGL. Tente um navegador
                     atualizado ou reative a aceleração de hardware.</p>
             </div>
@@ -327,26 +214,10 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=8" defer></script>
-    <script>
-        (function () {
-            function hasGpu() {
-                try {
-                    var c = document.createElement('canvas');
-                    return !!(c.getContext('webgl2') || c.getContext('webgl'));
-                } catch (e) { return false; }
-            }
-            if (!hasGpu()) {
-                document.addEventListener('DOMContentLoaded', function () {
-                    var err = document.getElementById('errorOverlay');
-                    var load = document.getElementById('loadingOverlay');
-                    if (load) load.hidden = true;
-                    if (err) err.hidden = false;
-                });
-            }
-        })();
-    </script>
-    <script type="module" src="src/main.js?v=1"></script>
+    <script src="https://cdn.babylonjs.com/babylon.js"></script>
+    <script src="https://cdn.babylonjs.com/loaders/babylonjs.loaders.min.js"></script>
+    <script src="/labs/shared.js?v=9" defer></script>
+    <script type="module" src="src/main.js"></script>
 </body>
 
 </html>

--- a/labs/honor-front/src/effects.js
+++ b/labs/honor-front/src/effects.js
@@ -1,177 +1,56 @@
 /**
- * Faíscas, explosões, traçantes e o clarão da boca do cano.
- * Buffer pré-alocado para não acordar o GC no meio do desembarque.
+ * Efeitos de combate para Honor Front em Babylon.js:
+ * Muzzle flash, faíscas de impacto, poeira de projéteis e explosões.
  */
 
-import * as THREE from 'three';
-import { sparkTexture } from './textures.js';
-
-export class Effects {
-    constructor(scene, quality) {
+export class CombatEffects {
+    constructor(BABYLON, scene) {
+        this.BABYLON = BABYLON;
         this.scene = scene;
-        this.max = quality.particles;
-        this.cursor = 0;
-        this.pos = new Float32Array(this.max * 3);
-        this.col = new Float32Array(this.max * 3);
-        this.size = new Float32Array(this.max);
-        this.alpha = new Float32Array(this.max);
-        this.vel = new Float32Array(this.max * 3);
-        this.life = new Float32Array(this.max);
-        this.maxLife = new Float32Array(this.max);
 
-        const geo = new THREE.BufferGeometry();
-        geo.setAttribute('position', new THREE.BufferAttribute(this.pos, 3));
-        geo.setAttribute('aColor', new THREE.BufferAttribute(this.col, 3));
-        geo.setAttribute('aSize', new THREE.BufferAttribute(this.size, 1));
-        geo.setAttribute('aAlpha', new THREE.BufferAttribute(this.alpha, 1));
-        geo.boundingSphere = new THREE.Sphere(new THREE.Vector3(), 1e6);
-
-        this.geo = geo;
-        this.points = new THREE.Points(geo, new THREE.ShaderMaterial({
-            transparent: true,
-            depthWrite: false,
-            fog: false,
-            blending: THREE.AdditiveBlending,
-            uniforms: {
-                uMap: { value: sparkTexture() },
-                uScale: { value: 540 }
-            },
-            vertexShader: /* glsl */ `
-                attribute vec3 aColor;
-                attribute float aSize;
-                attribute float aAlpha;
-                varying vec3 vColor;
-                varying float vAlpha;
-                uniform float uScale;
-                void main() {
-                    vColor = aColor;
-                    vAlpha = aAlpha;
-                    vec4 mv = modelViewMatrix * vec4(position, 1.0);
-                    gl_PointSize = aSize * uScale / max(0.001, -mv.z);
-                    gl_Position = projectionMatrix * mv;
-                }
-            `,
-            fragmentShader: /* glsl */ `
-                uniform sampler2D uMap;
-                varying vec3 vColor;
-                varying float vAlpha;
-                void main() {
-                    if (vAlpha < 0.01) discard;
-                    vec4 tex = texture2D(uMap, gl_PointCoord);
-                    gl_FragColor = vec4(vColor * tex.rgb, tex.a * vAlpha);
-                    #include <tonemapping_fragment>
-                    #include <colorspace_fragment>
-                }
-            `
-        }));
-        scene.add(this.points);
-
-        this.tracers = [];
-        this.muzzle = new THREE.PointLight(0xffc070, 0, 8);
-        scene.add(this.muzzle);
-        this.muzzleLife = 0;
-
-        this.artillery = new THREE.PointLight(0xffaa66, 0, 40);
-        scene.add(this.artillery);
-        this.artilleryT = 2;
+        // Flash do cano
+        this.flashLight = new BABYLON.PointLight('muzzle_light', new BABYLON.Vector3(0, 0, 0), scene);
+        this.flashLight.diffuse = new BABYLON.Color3(1.0, 0.8, 0.4);
+        this.flashLight.intensity = 0;
+        this.flashLight.range = 14;
     }
 
-    spawn(x, y, z, { count = 12, color = [1, 0.55, 0.2], speed = 6, size = 0.7, life = 0.5, lift = 0.8 } = {}) {
-        for (let i = 0; i < count; i++) {
-            const id = this.cursor++ % this.max;
-            const i3 = id * 3;
-            this.pos[i3] = x;
-            this.pos[i3 + 1] = y;
-            this.pos[i3 + 2] = z;
-            this.vel[i3] = (Math.random() - 0.5) * speed;
-            this.vel[i3 + 1] = Math.random() * speed * lift;
-            this.vel[i3 + 2] = (Math.random() - 0.5) * speed;
-            this.col[i3] = color[0];
-            this.col[i3 + 1] = color[1];
-            this.col[i3 + 2] = color[2];
-            this.size[id] = size * (0.5 + Math.random());
-            this.life[id] = life * (0.6 + Math.random() * 0.6);
-            this.maxLife[id] = this.life[id];
-            this.alpha[id] = 1;
-        }
-        this.geo.attributes.position.needsUpdate = true;
-        this.geo.attributes.aColor.needsUpdate = true;
-        this.geo.attributes.aSize.needsUpdate = true;
-        this.geo.attributes.aAlpha.needsUpdate = true;
+    muzzleFlash(pos) {
+        this.flashLight.position.copyFrom(pos);
+        this.flashLight.intensity = 3.5;
+        setTimeout(() => {
+            this.flashLight.intensity = 0;
+        }, 45);
     }
 
-    explosion(x, y, z, scale = 1) {
-        this.spawn(x, y, z, { count: 28 * scale, color: [1, 0.45, 0.12], speed: 10 * scale, size: 1.4, life: 0.7, lift: 1.1 });
-        this.spawn(x, y + 0.4, z, { count: 16 * scale, color: [0.35, 0.32, 0.28], speed: 4, size: 2.2, life: 1.4, lift: 0.6 });
-        this.artillery.position.set(x, y + 2, z);
-        this.artillery.intensity = 18 * scale;
-        this.artilleryT = 0.25;
-    }
+    impactSparks(pos) {
+        const BABYLON = this.BABYLON;
+        const emitter = BABYLON.MeshBuilder.CreateSphere('spark_emit', { diameter: 0.05 }, this.scene);
+        emitter.position.copyFrom(pos);
+        emitter.isVisible = false;
 
-    sparks(x, y, z) {
-        this.spawn(x, y, z, { count: 8, color: [1, 0.85, 0.4], speed: 5, size: 0.4, life: 0.28, lift: 0.4 });
-    }
+        const ps = new BABYLON.ParticleSystem('sparks', 24, this.scene);
+        ps.emitter = emitter;
+        ps.targetStopDuration = 0.2;
+        ps.disposeOnStop = true;
 
-    blood(x, y, z) {
-        this.spawn(x, y, z, { count: 10, color: [0.55, 0.05, 0.04], speed: 3.2, size: 0.45, life: 0.4, lift: 0.3 });
-    }
+        ps.color1 = new BABYLON.Color4(1.0, 0.85, 0.4, 1.0);
+        ps.color2 = new BABYLON.Color4(1.0, 0.4, 0.1, 1.0);
+        ps.colorDead = new BABYLON.Color4(0.5, 0.1, 0, 0.0);
 
-    muzzleFlash(x, y, z) {
-        this.muzzle.position.set(x, y, z);
-        this.muzzle.intensity = 6;
-        this.muzzleLife = 0.05;
-        this.spawn(x, y, z, { count: 6, color: [1, 0.8, 0.35], speed: 2, size: 0.35, life: 0.08, lift: 0.2 });
-    }
+        ps.minSize = 0.05;
+        ps.maxSize = 0.15;
+        ps.minLifeTime = 0.15;
+        ps.maxLifeTime = 0.35;
+        ps.emitRate = 120;
+        ps.blendMode = BABYLON.ParticleSystem.BLENDMODE_ADD;
+        ps.gravity = new BABYLON.Vector3(0, -9.8, 0);
 
-    tracer(from, to) {
-        const geo = new THREE.BufferGeometry().setFromPoints([from.clone(), to.clone()]);
-        const line = new THREE.Line(geo, new THREE.LineBasicMaterial({
-            color: 0xffd080,
-            transparent: true,
-            opacity: 0.85
-        }));
-        this.scene.add(line);
-        this.tracers.push({ line, life: 0.08 });
-    }
+        ps.createSphereEmitter(0.2);
+        ps.minEmitPower = 3;
+        ps.maxEmitPower = 7;
 
-    flare(x, y, z) {
-        this.spawn(x, y, z, { count: 40, color: [1, 0.25, 0.12], speed: 3, size: 1.6, life: 2.4, lift: 2.4 });
-    }
-
-    update(dt) {
-        for (let i = 0; i < this.max; i++) {
-            if (this.life[i] <= 0) {
-                this.alpha[i] = 0;
-                continue;
-            }
-            this.life[i] -= dt;
-            const i3 = i * 3;
-            this.vel[i3 + 1] -= 6 * dt;
-            this.pos[i3] += this.vel[i3] * dt;
-            this.pos[i3 + 1] += this.vel[i3 + 1] * dt;
-            this.pos[i3 + 2] += this.vel[i3 + 2] * dt;
-            this.alpha[i] = Math.max(0, this.life[i] / this.maxLife[i]);
-        }
-        this.geo.attributes.position.needsUpdate = true;
-        this.geo.attributes.aAlpha.needsUpdate = true;
-
-        this.muzzleLife -= dt;
-        if (this.muzzleLife <= 0) this.muzzle.intensity = 0;
-
-        this.artilleryT -= dt;
-        if (this.artilleryT <= 0) this.artillery.intensity = 0;
-        else this.artillery.intensity *= 0.86;
-
-        for (let i = this.tracers.length - 1; i >= 0; i--) {
-            const t = this.tracers[i];
-            t.life -= dt;
-            t.line.material.opacity = Math.max(0, t.life / 0.08);
-            if (t.life <= 0) {
-                this.scene.remove(t.line);
-                t.line.geometry.dispose();
-                t.line.material.dispose();
-                this.tracers.splice(i, 1);
-            }
-        }
+        ps.start();
+        setTimeout(() => emitter.dispose(), 400);
     }
 }

--- a/labs/honor-front/src/enemies.js
+++ b/labs/honor-front/src/enemies.js
@@ -1,9 +1,7 @@
 /**
- * Patrulhas do Eixo: cobertura simples, linha de visão e rajadas.
+ * Patrulhas e defensores do Eixo para Honor Front em Babylon.js.
  */
 
-import * as THREE from 'three';
-import { heightAt, randRange } from './utils.js';
 import { buildSoldier } from './models.js';
 
 const SPAWNS = [
@@ -24,32 +22,34 @@ const SPAWNS = [
 ];
 
 export class Enemies {
-    constructor(scene) {
-        this.list = [];
+    constructor(BABYLON, scene, heightAt) {
+        this.BABYLON = BABYLON;
         this.scene = scene;
+        this.list = [];
+
         for (const s of SPAWNS) {
-            const mesh = buildSoldier({ team: 'axis' });
-            mesh.position.set(s.x, heightAt(s.x, s.z), s.z);
-            mesh.rotation.y = s.yaw;
-            scene.add(mesh);
+            const root = buildSoldier(BABYLON, scene);
+            const y = heightAt(s.x, s.z);
+            root.position.set(s.x, y, s.z);
+            root.rotation.y = s.yaw;
+
             this.list.push({
-                mesh,
+                root,
                 x: s.x,
                 z: s.z,
-                y: heightAt(s.x, s.z),
+                y,
                 yaw: s.yaw,
                 health: s.mg ? 90 : 70,
                 alive: true,
-                cooldown: randRange(0.4, 1.6),
+                cooldown: 0.8 + Math.random() * 0.8,
                 alert: 0,
                 mg: !!s.mg,
-                phase: randRange(0, 10),
-                radius: 0.55
+                radius: 0.65
             });
         }
     }
 
-    reset() {
+    reset(heightAt) {
         for (let i = 0; i < this.list.length; i++) {
             const e = this.list[i];
             const s = SPAWNS[i];
@@ -59,12 +59,11 @@ export class Enemies {
             e.yaw = s.yaw;
             e.health = s.mg ? 90 : 70;
             e.alive = true;
-            e.cooldown = randRange(0.3, 1.4);
+            e.cooldown = 0.8 + Math.random() * 0.8;
             e.alert = 0;
-            e.mesh.visible = true;
-            e.mesh.position.set(e.x, e.y, e.z);
-            e.mesh.rotation.y = e.yaw;
-            e.mesh.rotation.x = 0;
+            e.root.setEnabled(true);
+            e.root.position.set(e.x, e.y, e.z);
+            e.root.rotation.set(0, e.yaw, 0);
         }
     }
 
@@ -82,7 +81,7 @@ export class Enemies {
             const py = origin.y + dir.y * t;
             const pz = origin.z + dir.z * t;
             const dist = Math.hypot(px - e.x, py - (e.y + 1.15), pz - e.z);
-            if (dist < 0.72) {
+            if (dist < 0.85) {
                 best = e;
                 bestT = t;
             }
@@ -96,78 +95,37 @@ export class Enemies {
         enemy.alert = 1;
         if (enemy.health <= 0) {
             enemy.alive = false;
-            enemy.mesh.rotation.x = 1.35;
-            enemy.mesh.position.y = enemy.y + 0.15;
-            return true;
+            enemy.root.rotation.x = 1.35;
+            enemy.root.position.y = enemy.y + 0.15;
+            return true; // eliminado
         }
         return false;
     }
 
-    explodeAt(x, y, z, radius, amount) {
-        const killed = [];
+    update(dt, player, onShoot) {
+        if (!player.alive) return;
+
         for (const e of this.list) {
             if (!e.alive) continue;
-            const d = Math.hypot(e.x - x, e.z - z, (e.y + 1) - y);
-            if (d < radius) {
-                if (this.damage(e, amount * (1 - d / radius))) killed.push(e);
-            }
-        }
-        return killed;
-    }
-
-    update(dt, player, world, difficulty, onShoot) {
-        for (const e of this.list) {
-            const parts = e.mesh.userData.parts;
-            if (!e.alive) {
-                if (parts) {
-                    parts.arms[0].rotation.x = -0.4;
-                    parts.arms[1].rotation.x = 0.2;
-                }
-                continue;
-            }
 
             const dx = player.x - e.x;
             const dz = player.z - e.z;
             const dist = Math.hypot(dx, dz);
-            const range = e.mg ? 95 : 52;
-            const canSee = dist < range && hasLos(e, player, world);
 
-            if (canSee) e.alert = Math.min(1, e.alert + dt * 1.4);
-            else e.alert = Math.max(0, e.alert - dt * 0.25);
+            if (dist < 45) {
+                // Alinhar mira na direção do jogador
+                const targetYaw = Math.atan2(dx, dz);
+                e.yaw = targetYaw;
+                e.root.rotation.y = e.yaw;
 
-            if (e.alert > 0.25 && dist > 0.01) {
-                const want = Math.atan2(dx, dz);
-                e.yaw += Math.atan2(Math.sin(want - e.yaw), Math.cos(want - e.yaw)) * dt * 3.2;
-                e.mesh.rotation.y = e.yaw;
-            }
-
-            e.phase += dt * (e.alert > 0.4 ? 0.4 : 1.2);
-            if (parts) {
-                const idle = Math.sin(e.phase) * 0.08;
-                parts.arms[1].rotation.x = -0.35 - e.alert * 0.4;
-                parts.arms[0].rotation.x = idle;
-                parts.legs[0].rotation.x = 0;
-                parts.head.rotation.x = -0.08;
-            }
-
-            e.cooldown -= dt;
-            if (canSee && e.alert > 0.55 && e.cooldown <= 0 && player.alive) {
-                const acc = difficulty.enemyAcc * (e.mg ? 0.85 : 1);
-                const lead = Math.random() < acc;
-                e.cooldown = e.mg ? 0.12 + Math.random() * 0.08 : 0.55 + Math.random() * 0.55;
-                onShoot(e, lead, dist);
+                e.cooldown -= dt;
+                if (e.cooldown <= 0) {
+                    e.cooldown = e.mg ? 0.35 : 1.4;
+                    if (onShoot) {
+                        onShoot(e, dist);
+                    }
+                }
             }
         }
     }
-}
-
-function hasLos(e, player, world) {
-    const steps = 6;
-    for (let i = 1; i < steps; i++) {
-        const t = i / steps;
-        const x = e.x + (player.x - e.x) * t;
-        const z = e.z + (player.z - e.z) * t;
-        if (world.blocked(x, z, 0.15)) return false;
-    }
-    return true;
 }

--- a/labs/honor-front/src/main.js
+++ b/labs/honor-front/src/main.js
@@ -1,647 +1,351 @@
 /**
- * Honor Front — laço principal, desembarque cinematográfico e a missão.
+ * Honor Front — FPS 3D em Babylon.js inspirado em Medal of Honor.
+ * Desembarque na praia, travessia da muralha e bateria costeira.
  */
 
-import * as THREE from 'three';
-import {
-    QUALITY, DIFFICULTY, OBJECTIVES, WORLD, PLAYER,
-    loadSettings, saveSettings
-} from './config.js';
-import { clamp, detectMobile, detectSoftwareGL, rendererIsSoftware, formatTime } from './utils.js';
-import { Input } from './input.js';
-import { GameAudio } from './audio.js';
-import { Hud, statsBlock } from './hud.js';
 import { Player } from './player.js';
 import { Loadout } from './weapons.js';
 import { Enemies } from './enemies.js';
-import { Effects } from './effects.js';
-import { createSkyUniforms, createSky, createOcean, createLights } from './sky.js';
-import { buildWorld } from './world.js';
+import { CombatEffects } from './effects.js';
+import { CombatAudio } from './audio.js';
+import { heightAt, buildCombatWorld } from './world.js';
+import { setupAtmosphere } from './sky.js';
+import { clamp } from './utils.js';
 
-const AIM = new THREE.Vector3();
-const ORIGIN = new THREE.Vector3();
-const HIT = new THREE.Vector3();
-const DIR = new THREE.Vector3();
-
-class Game {
+class HonorFront {
     constructor() {
-        this.hud = new Hud();
         this.canvas = document.getElementById('scene');
-        this.settings = loadSettings();
-        this.state = 'loading';
-        this.time = 0;
-        this.elapsed = 0;
+        this.state = 'boot';
+
+        this.player = new Player();
+        this.audio = new CombatAudio();
+        this.keys = {};
+        this.input = {
+            move: { x: 0, z: 0, sprint: false },
+            look: { x: 0, y: 0 },
+            adsHeld: false,
+            consumeLook: () => {
+                const l = { ...this.input.look };
+                this.input.look.x = 0;
+                this.input.look.y = 0;
+                return l;
+            }
+        };
+
+        this.locked = false;
+        this.fireHeld = false;
         this.kills = 0;
-        this.objIndex = 0;
-        this.fade = 1;
-        this.fadeDir = -1;
-        this.fpsAccum = 0;
-        this.fpsFrames = 0;
-        this.hudAccum = 0;
-        this.shellT = 1.2;
-        this.landingT = 0;
-        this.pendingCharge = null;
-        this.flareT = 0;
+
+        this.bindUi();
+        this.boot();
     }
 
-    resolveQuality() {
-        const choice = this.settings.quality;
-        if (choice !== 'auto' && QUALITY[choice]) return QUALITY[choice];
-        if (detectMobile() || detectSoftwareGL()) return QUALITY.low;
-        const big = Math.min(window.innerWidth, window.innerHeight) >= 900;
-        return big ? QUALITY.high : QUALITY.medium;
+    bindUi() {
+        document.getElementById('startButton')?.addEventListener('click', () => this.start());
+        document.getElementById('soundButton')?.addEventListener('click', () => this.toggleMute());
+        document.getElementById('btnFire')?.addEventListener('pointerdown', () => this.fireHeld = true);
+        document.getElementById('btnFire')?.addEventListener('pointerup', () => this.fireHeld = false);
+        document.getElementById('btnReload')?.addEventListener('click', () => this.tryReload());
+        document.getElementById('btnSprint')?.addEventListener('pointerdown', () => this.input.move.sprint = true);
+        document.getElementById('btnSprint')?.addEventListener('pointerup', () => this.input.move.sprint = false);
+
+        // Pointer Lock no canvas
+        this.canvas.addEventListener('click', () => {
+            if (this.state === 'play' && document.pointerLockElement !== this.canvas) {
+                this.canvas.requestPointerLock();
+            }
+        });
+
+        document.addEventListener('pointerlockchange', () => {
+            this.locked = document.pointerLockElement === this.canvas;
+        });
+
+        window.addEventListener('mousemove', (e) => {
+            if (this.locked) {
+                this.input.look.x += e.movementX;
+                this.input.look.y += e.movementY;
+            }
+        });
+
+        window.addEventListener('mousedown', (e) => {
+            if (this.locked) {
+                if (e.button === 0) this.fireHeld = true;
+                if (e.button === 2) this.input.adsHeld = true;
+            }
+        });
+
+        window.addEventListener('mouseup', (e) => {
+            if (e.button === 0) {
+                this.fireHeld = false;
+                this.loadout?.releaseTrigger();
+            }
+            if (e.button === 2) this.input.adsHeld = false;
+        });
+
+        window.addEventListener('contextmenu', (e) => {
+            if (this.locked) e.preventDefault();
+        });
+
+        window.addEventListener('keydown', (e) => {
+            this.keys[e.code] = true;
+            if (e.code === 'KeyR') this.tryReload();
+            if (e.code === 'Digit1') this.loadout?.switchTo(1);
+            if (e.code === 'Digit2') this.loadout?.switchTo(2);
+            if (e.code === 'KeyM') this.toggleMute();
+        });
+
+        window.addEventListener('keyup', (e) => {
+            this.keys[e.code] = false;
+        });
+
+        // Touch joystick rédea/movimento
+        const stick = document.getElementById('moveStick');
+        const knob = document.getElementById('moveKnob');
+        if (stick && knob) {
+            let active = false;
+            let startX = 0, startY = 0;
+
+            const onMove = (clientX, clientY) => {
+                if (!active) return;
+                const dx = clientX - startX;
+                const dy = clientY - startY;
+                const max = 44;
+                const dist = Math.hypot(dx, dy);
+                const k = dist > 0 ? Math.min(dist, max) / dist : 0;
+                knob.style.transform = `translate(${dx * k}px, ${dy * k}px)`;
+                this.input.move.x = clamp((dx * k) / max, -1, 1);
+                this.input.move.z = -clamp((dy * k) / max, -1, 1);
+            };
+
+            stick.addEventListener('pointerdown', (e) => {
+                active = true;
+                startX = e.clientX;
+                startY = e.clientY;
+                stick.setPointerCapture(e.pointerId);
+            });
+
+            stick.addEventListener('pointermove', (e) => onMove(e.clientX, e.clientY));
+
+            const onEnd = () => {
+                active = false;
+                knob.style.transform = 'translate(0px, 0px)';
+                this.input.move.x = 0;
+                this.input.move.z = 0;
+            };
+
+            stick.addEventListener('pointerup', onEnd);
+            stick.addEventListener('pointercancel', onEnd);
+        }
     }
 
-    difficulty() {
-        return DIFFICULTY[this.settings.difficulty] || DIFFICULTY.ranger;
+    tryReload() {
+        if (this.loadout?.tryReload()) {
+            this.audio.reload(this.loadout.current);
+        }
     }
 
-    async init() {
-        this.hud.setLoading(0.1, 'Abrindo o canal de rádio…');
-        this.quality = this.resolveQuality();
-        this.mobile = detectMobile();
+    async boot() {
+        const BABYLON = window.BABYLON;
+        if (!BABYLON) return;
 
         try {
-            this.renderer = new THREE.WebGLRenderer({
-                canvas: this.canvas,
-                antialias: this.quality.antialias,
-                powerPreference: 'high-performance',
-                alpha: false
+            this.engine = new BABYLON.Engine(this.canvas, true, {
+                preserveDrawingBuffer: false,
+                stencil: true,
+                adaptToDeviceRatio: true
             });
+            this.scene = new BABYLON.Scene(this.engine);
+            this.scene.clearColor = new BABYLON.Color4(0.45, 0.52, 0.6, 1.0);
         } catch (err) {
-            this.hud.showError('Não foi possível criar o contexto WebGL.');
+            console.error(err);
             return;
         }
 
-        this.renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, this.quality.pixelRatio));
-        this.renderer.setSize(window.innerWidth, window.innerHeight);
-        this.renderer.outputColorSpace = THREE.SRGBColorSpace;
-        this.renderer.toneMapping = THREE.ACESFilmicToneMapping;
-        this.renderer.toneMappingExposure = 1.05;
-        this.renderer.shadowMap.enabled = this.quality.shadows;
-        this.renderer.shadowMap.type = THREE.PCFSoftShadowMap;
-        this.renderer.setClearColor(0xc48a58);
+        // Iluminação & Atmosfera
+        this.lights = setupAtmosphere(BABYLON, this.scene);
 
-        if (rendererIsSoftware(this.renderer) && this.quality.id !== 'low') {
-            this.quality = QUALITY.low;
-            this.renderer.setPixelRatio(1);
-            this.renderer.shadowMap.enabled = false;
-        }
+        // Cenário da Praia e Bunkers
+        this.world = buildCombatWorld(BABYLON, this.scene);
 
-        this.scene = new THREE.Scene();
-        this.scene.fog = new THREE.FogExp2(0xc49268, this.quality.fog);
+        // Câmera do Jogador
+        this.camera = new BABYLON.FreeCamera('fpsCam', new BABYLON.Vector3(0, 1.6, -70), this.scene);
+        this.camera.minZ = 0.05;
+        this.camera.maxZ = 800;
 
-        this.camera = new THREE.PerspectiveCamera(
-            PLAYER.hipFov,
-            window.innerWidth / window.innerHeight,
-            0.08,
-            this.quality.far
-        );
+        // Armas
+        this.loadout = new Loadout(BABYLON, this.camera, this.scene);
 
-        this.hud.setLoading(0.28, 'Pintando a alvorada sobre o Canal…');
-        this.skyUniforms = createSkyUniforms();
-        this.sky = createSky(this.skyUniforms);
-        this.scene.add(this.sky);
-        this.ocean = createOcean(this.skyUniforms, this.quality);
-        this.scene.add(this.ocean);
-        this.lights = createLights(this.scene, this.quality);
+        // Efeitos
+        this.effects = new CombatEffects(BABYLON, this.scene);
 
-        this.hud.setLoading(0.52, 'Erguendo Sainte-Claire…');
-        this.world = buildWorld(this.scene, this.quality);
+        // Inimigos
+        this.enemies = new Enemies(BABYLON, this.scene, heightAt);
 
-        this.hud.setLoading(0.72, 'Distribuindo o armamento…');
-        this.input = new Input(this.canvas);
-        this.audio = new GameAudio();
-        this.player = new Player();
-        this.loadout = new Loadout(this.camera);
-        this.enemies = new Enemies(this.scene);
-        this.effects = new Effects(this.scene, this.quality);
+        // Pipeline PBR
+        const pipe = new BABYLON.DefaultRenderingPipeline('pipeline', true, this.scene, [this.camera]);
+        pipe.fxaaEnabled = true;
+        pipe.bloomEnabled = true;
+        pipe.bloomThreshold = 0.82;
+        pipe.bloomWeight = 0.22;
+        pipe.imageProcessing.toneMappingEnabled = true;
+        pipe.imageProcessing.toneMappingType = BABYLON.ImageProcessingConfiguration.TONEMAPPING_ACES;
+        pipe.imageProcessing.contrast = 1.18;
 
-        this.clock = new THREE.Clock();
-        this._bindUi();
-        this.input.bindTouch(this.hud);
-        window.addEventListener('resize', () => this._resize());
+        document.getElementById('loadingOverlay').hidden = true;
+        document.getElementById('menuOverlay').hidden = false;
+        document.body.dataset.state = 'intro';
 
-        this.hud.setLoading(1, 'Rampa pronta.');
-        this.hud.hideLoading();
-        this._showMenu();
-        this.clock.start();
-        this.renderer.setAnimationLoop(() => this._frame());
+        this.engine.runRenderLoop(() => {
+            this.frame();
+            this.scene.render();
+        });
+
+        window.addEventListener('resize', () => this.engine.resize());
     }
 
-    _bindUi() {
-        const h = this.hud;
-        h.el.qualitySelect.value = this.settings.quality;
-        h.el.volumeSlider.value = this.settings.volume;
-        h.setVolumeLabel(this.settings.volume);
-        h.setMuted(this.settings.muted);
-        h.setBest(this.settings.best);
-        this._refreshDifficulty();
+    start() {
+        this.state = 'play';
+        document.getElementById('menuOverlay').hidden = true;
+        document.getElementById('hud').hidden = false;
+        document.getElementById('crosshair').hidden = false;
+        document.getElementById('touchControls').hidden = !('ontouchstart' in window);
+        document.body.dataset.state = 'play';
 
-        h.el.startButton.addEventListener('click', () => this.start());
-        h.el.resumeButton.addEventListener('click', () => this.resume());
-        h.el.pauseMenuButton.addEventListener('click', () => this.toMenu());
-        h.el.retryButton.addEventListener('click', () => this.start());
-        h.el.defeatMenuButton.addEventListener('click', () => this.toMenu());
-        h.el.replayButton.addEventListener('click', () => this.start());
-        h.el.victoryMenuButton.addEventListener('click', () => this.toMenu());
-        h.el.pauseButton.addEventListener('click', () => this.togglePause());
-        h.el.soundButton.addEventListener('click', () => this.toggleMute());
-
-        h.el.qualitySelect.addEventListener('change', () => {
-            this.settings.quality = h.el.qualitySelect.value;
-            saveSettings(this.settings);
-        });
-        h.el.volumeSlider.addEventListener('input', () => {
-            this.settings.volume = Number(h.el.volumeSlider.value);
-            h.setVolumeLabel(this.settings.volume);
-            this.audio.setVolume(this.settings.volume / 100);
-            saveSettings(this.settings);
-        });
-
-        this.input.on('pause', () => this.togglePause());
-        this.input.on('mute', () => this.toggleMute());
-        this.input.on('confirm', () => {
-            if (this.state === 'menu') this.start();
-        });
-
-        this.canvas.addEventListener('click', () => {
-            if (this.state === 'playing' || this.state === 'landing') this.input.requestLock();
-        });
-    }
-
-    _showMenu() {
-        this.state = 'menu';
-        this.hud.setState('menu');
-        this.hud.showHud(false);
-        this.hud.showMenu(true);
-        this.hud.showPause(false);
-        this.hud.hideDefeat();
-        this.hud.hideVictory();
-        this._refreshDifficulty();
-        this.input.exitLock();
-        this.input.enabled = false;
-        this.fade = 0.35;
-        this._refreshDifficulty();
-    }
-
-    _refreshDifficulty() {
-        this.hud.fillDifficulty(this.settings.difficulty, (id) => {
-            this.settings.difficulty = id;
-            saveSettings(this.settings);
-            this._refreshDifficulty();
-        });
-    }
-
-    async start() {
-        await this.audio.unlock();
-        this.audio.setVolume(this.settings.volume / 100);
-        this.audio.setMuted(this.settings.muted);
-
-        const diff = this.difficulty();
-        this.player.maxHealth = diff.health;
-        this.player.spawn(0, WORLD.boatStartZ + 0.4, Math.PI, this.world.heightAt);
-        this.player.onBoat = true;
-        this.loadout.reset(diff.magBonus);
-        this.enemies.reset();
+        this.player.spawn(0, -60, Math.PI, heightAt);
+        this.loadout.reset();
+        this.enemies.reset(heightAt);
         this.kills = 0;
-        this.elapsed = 0;
-        this.objIndex = 0;
-        this.landingT = 0;
-        this.pendingCharge = null;
-        this.flareT = 0;
-        this.world.boat.position.set(0, 0.08, WORLD.boatStartZ);
-        for (const it of this.world.interactables) it.done = false;
-        for (const p of this.world.pickups) {
-            p.used = false;
-            p.mesh.visible = true;
-        }
 
-        this.hud.hideDefeat();
-        this.hud.hideVictory();
-        this.hud.showMenu(false);
-        this.hud.showHud(true);
-        this.hud.setTouchVisible(this.mobile);
-        this.hud.setHealth(this.player.health, this.player.maxHealth);
-        this.hud.setKills(0);
-        this.hud.setTime(0);
-        this.hud.setObjective(OBJECTIVES[0]);
-        this.hud.showObjectiveCard(OBJECTIVES[0]);
-        this.audio.radioBeep();
-        this.hud.radio('06 JUN 1944 — SETOR CHARLIE. Ranger, a bateria silencia a praia. A rampa cai em instantes.');
-        this.hud.say('Aguarde a rampa', 4);
-
-        this.state = 'landing';
-        this.hud.setState('landing');
-        this.input.enabled = true;
-        this.input.requestLock();
-        this.fade = 1;
-        this.fadeDir = -1;
-    }
-
-    togglePause() {
-        if (this.state === 'playing' || this.state === 'landing') {
-            this.state = 'pause';
-            this.hud.setState('pause');
-            this.hud.showPause(true);
-            this.input.exitLock();
-            this.input.enabled = false;
-        } else if (this.state === 'pause') {
-            this.resume();
-        }
-    }
-
-    resume() {
-        if (this.state !== 'pause') return;
-        this.state = this.player.onBoat ? 'landing' : 'playing';
-        this.hud.setState(this.state);
-        this.hud.showPause(false);
-        this.input.enabled = true;
-        this.input.requestLock();
-    }
-
-    toMenu() {
-        this.hud.showPause(false);
-        this.hud.hideDefeat();
-        this.hud.hideVictory();
-        this._showMenu();
+        this.audio.init();
+        this.canvas.requestPointerLock?.();
     }
 
     toggleMute() {
-        this.settings.muted = !this.settings.muted;
-        this.audio.setMuted(this.settings.muted);
-        this.hud.setMuted(this.settings.muted);
-        saveSettings(this.settings);
-    }
-
-    _setObjective(i) {
-        this.objIndex = i;
-        const obj = OBJECTIVES[i];
-        this.hud.setObjective(obj);
-        this.hud.showObjectiveCard(obj);
-        this.audio.radioBeep();
-        this.hud.radio(obj.radio);
-    }
-
-    _completeObjective() {
-        const next = this.objIndex + 1;
-        if (next >= OBJECTIVES.length) {
-            this._victory();
-            return;
-        }
-        this._setObjective(next);
-        if (OBJECTIVES[this.objIndex - 1]?.id === 'mg') {
-            this.loadout.unlockThompson();
-            this.hud.say('Thompson recuperado', 3);
+        const muted = this.audio.toggleMute();
+        const btn = document.getElementById('soundButton');
+        if (btn) {
+            btn.setAttribute('aria-pressed', String(!muted));
         }
     }
 
-    _victory() {
-        this.state = 'victory';
-        this.hud.setState('victory');
-        this.input.exitLock();
-        this.input.enabled = false;
-        const score = this.kills * 120 + Math.max(0, 900 - Math.floor(this.elapsed)) + Math.round(this.player.health);
-        if (score > this.settings.best) {
-            this.settings.best = score;
-            saveSettings(this.settings);
-            this.hud.setBest(score);
-        }
-        this.hud.showHud(false);
-        this.hud.showVictory(statsBlock([
-            ['Baixas', String(this.kills)],
-            ['Tempo', formatTime(this.elapsed)],
-            ['Medalha', String(score)]
-        ]));
-    }
+    frame() {
+        const dt = Math.min(0.05, this.engine.getDeltaTime() / 1000);
 
-    _defeat(reason) {
-        this.state = 'defeat';
-        this.hud.setState('defeat');
-        this.input.exitLock();
-        this.input.enabled = false;
-        this.hud.showHud(false);
-        this.hud.showDefeat(reason, statsBlock([
-            ['Baixas', String(this.kills)],
-            ['Tempo', formatTime(this.elapsed)],
-            ['Objetivo', OBJECTIVES[this.objIndex].title]
-        ]));
-    }
+        if (this.state === 'play') {
+            // Teclado
+            if (this.keys['KeyW'] || this.keys['ArrowUp']) this.input.move.z = 1;
+            else if (this.keys['KeyS'] || this.keys['ArrowDown']) this.input.move.z = -1;
+            else if (!('ontouchstart' in window)) this.input.move.z = 0;
 
-    _resize() {
-        const w = window.innerWidth;
-        const h = window.innerHeight;
-        this.camera.aspect = w / h;
-        this.camera.updateProjectionMatrix();
-        this.renderer.setSize(w, h);
-    }
+            if (this.keys['KeyA'] || this.keys['ArrowLeft']) this.input.move.x = -1;
+            else if (this.keys['KeyD'] || this.keys['ArrowRight']) this.input.move.x = 1;
+            else if (!('ontouchstart' in window)) this.input.move.x = 0;
 
-    _frame() {
-        const dt = Math.min(0.05, this.clock.getDelta());
-        this.time += dt;
-        this.skyUniforms.uTime.value = this.time;
-        this.world.update(this.time);
-        this.effects.update(dt);
+            this.input.move.sprint = !!(this.keys['ShiftLeft'] || this.keys['ShiftRight']);
 
-        this.fade = clamp(this.fade + this.fadeDir * dt * 1.2, 0, 1);
-        this.hud.setFade(this.fade);
+            // Jogador
+            const pRes = this.player.update(dt, this.input, heightAt);
+            if (pRes.footstep) this.audio.footstep(this.player.wet ? 'water' : 'sand');
 
-        if (this.state === 'menu' || this.state === 'pause' || this.state === 'victory' || this.state === 'defeat') {
-            this._orbitPreview(dt);
-            this.renderer.render(this.scene, this.camera);
-            return;
-        }
+            // Atualização da câmera
+            this.camera.position.set(this.player.x, this.player.y + this.player.bob, this.player.z);
+            this.camera.rotation.set(this.player.pitch, this.player.yaw, 0);
 
-        if (this.state === 'landing') this._updateLanding(dt);
-        if (this.state === 'playing' || this.state === 'landing') this._updatePlay(dt);
+            // Disparo de armas
+            if (this.fireHeld) {
+                const res = this.loadout.tryFire(true);
+                if (res.shot) {
+                    this.audio.shoot(this.loadout.current);
+                    const tipPos = this.camera.position.add(this.camera.getDirection(new window.BABYLON.Vector3(0.18, -0.12, 0.75)));
+                    this.effects.muzzleFlash(tipPos);
 
-        this.renderer.render(this.scene, this.camera);
-    }
-
-    _orbitPreview() {
-        const t = this.time * 0.08;
-        this.camera.position.set(Math.sin(t) * 18, 9, 40 + Math.cos(t) * 22);
-        this.camera.lookAt(0, 3, 90);
-        this.loadout.garandView.visible = false;
-        this.loadout.thompsonView.visible = false;
-    }
-
-    _updateLanding(dt) {
-        this.landingT += dt;
-        const u = clamp(this.landingT / WORLD.boatDuration, 0, 1);
-        const ease = 1 - (1 - u) * (1 - u);
-        this.world.boat.position.z = THREE.MathUtils.lerp(WORLD.boatStartZ, WORLD.boatEndZ, ease);
-        this.world.boat.position.y = 0.1 + Math.sin(this.time * 1.4) * 0.08;
-        this.player.x = this.world.boat.position.x;
-        this.player.z = this.world.boat.position.z + 0.6;
-        this.player.y = this.world.boat.position.y + 0.55;
-
-        this.shellT -= dt;
-        if (this.shellT <= 0) {
-            this.shellT = 0.7 + Math.random() * 1.4;
-            const x = (Math.random() - 0.5) * 36;
-            const z = 12 + Math.random() * 70;
-            this.effects.explosion(x, this.world.heightAt(x, z) + 0.4, z, 0.85);
-            this.audio.explosion();
-        }
-
-        if (u >= 1) {
-            this.player.onBoat = false;
-            this.player.z = WORLD.boatEndZ + 3.2;
-            this.player.y = this.world.heightAt(this.player.x, this.player.z);
-            this.state = 'playing';
-            this.hud.setState('playing');
-            this.hud.say('Move! Move! Move!', 2.4);
-            this.hud.radio(OBJECTIVES[0].radio);
-            this.loadout._syncView();
-        }
-    }
-
-    _updatePlay(dt) {
-        this.elapsed += dt;
-        const locked = this.input.locked || this.mobile;
-        this.input.enabled = this.state === 'playing' || this.state === 'landing';
-
-        if (this.state === 'landing') {
-            const look = this.input.consumeLook();
-            this.player.yaw -= look.x * 0.0022;
-            this.player.pitch = clamp(this.player.pitch - look.y * 0.002, -1.1, 1.1);
-        }
-
-        const movingInfo = this.state === 'playing'
-            ? this.player.update(dt, this.input, this.world, locked)
-            : { footstep: false, moving: false };
-
-        if (movingInfo.footstep) this.audio.footstep(this.player.wet);
-
-        this.player.applyToCamera(this.camera);
-        const fov = THREE.MathUtils.lerp(PLAYER.hipFov, PLAYER.adsFov, this.player.ads);
-        if (Math.abs(this.camera.fov - fov) > 0.05) {
-            this.camera.fov = fov;
-            this.camera.updateProjectionMatrix();
-        }
-
-        const slot = this.input.consumeWeapon();
-        if (slot) this.loadout.switchTo(slot);
-
-        if (this.input.consumeReload()) {
-            if (this.loadout.tryReload()) this.audio.reload();
-        }
-
-        if (this.state === 'playing') {
-            const fire = this.loadout.tryFire(this.input.fireHeld);
-            if (fire.empty && this.input.fireHeld) {
-                if (this.loadout.tryReload()) this.audio.reload();
-            }
-            if (fire.shot) this._firePlayer();
-            if (fire.ping) this.audio.ping();
-
-            if (this.input.consumeGrenade()) {
-                this.camera.getWorldDirection(DIR);
-                ORIGIN.copy(this.camera.position).addScaledVector(DIR, 0.6);
-                ORIGIN.y -= 0.1;
-                const g = this.loadout.throwGrenade(ORIGIN, DIR);
-                if (g) this.scene.add(g.mesh);
-            }
-        }
-
-        this.loadout.update(dt, movingInfo.moving, this.player.ads, this.world.heightAt);
-
-        for (const g of this.loadout.popExploded()) {
-            const p = g.mesh.position;
-            this.effects.explosion(p.x, p.y, p.z, 1.15);
-            this.audio.explosion();
-            this.scene.remove(g.mesh);
-            const killed = this.enemies.explodeAt(p.x, p.y, p.z, 6.5, 90);
-            this.kills += killed.length;
-            if (Math.hypot(this.player.x - p.x, this.player.z - p.z) < 5.5) {
-                if (this.player.hurt(28)) this.hud.flashHit();
-            }
-        }
-
-        this.enemies.update(dt, this.player, this.world, this.difficulty(), (enemy, lead) => {
-            ORIGIN.set(enemy.x, enemy.y + 1.35, enemy.z);
-            if (lead) {
-                HIT.set(this.player.x, this.player.y + PLAYER.eye, this.player.z);
-            } else {
-                HIT.set(
-                    this.player.x + (Math.random() - 0.5) * 3.2,
-                    this.player.y + PLAYER.eye + (Math.random() - 0.5) * 1.4,
-                    this.player.z + (Math.random() - 0.5) * 3.2
-                );
-            }
-            this.effects.tracer(ORIGIN, HIT);
-            this.effects.muzzleFlash(ORIGIN.x, ORIGIN.y, ORIGIN.z);
-            if (enemy.mg && Math.random() < 0.4) this.audio.shot('thompson');
-            else if (Math.random() < 0.35) this.audio.shot('garand');
-            if (lead && this.player.alive) {
-                const dmg = this.difficulty().enemyDamage * (enemy.mg ? 1.15 : 1);
-                if (this.player.hurt(dmg)) {
-                    this.hud.flashHit();
-                    this.audio.hit();
-                    this.hud.setHealth(this.player.health, this.player.maxHealth);
+                    // Raycast de tiro
+                    const camRay = this.camera.getForwardRay(180);
+                    const hit = this.enemies.hitTest(this.camera.position, camRay.direction);
+                    if (hit) {
+                        const died = this.enemies.damage(hit.enemy, this.loadout.spec.damage || 45);
+                        this.effects.impactSparks(new window.BABYLON.Vector3(hit.enemy.x, hit.enemy.y + 1.2, hit.enemy.z));
+                        this.audio.hit();
+                        this.flashHitmarker();
+                        if (died) {
+                            this.kills++;
+                            this.checkObjectives();
+                        }
+                    }
+                }
+                if (res.ping) {
+                    this.audio.ping();
+                }
+                if (res.empty) {
+                    this.audio.empty();
                 }
             }
-        });
 
-        this._interact(dt);
-        this._pickups();
-        this._checkObjective();
-        this._ambientShells(dt);
+            this.loadout.update(dt);
 
-        if (!this.player.alive) this._defeat('O fogo da muralha encontrou você na areia.');
+            // Inimigos AI
+            this.enemies.update(dt, this.player, (e, dist) => {
+                this.audio.enemyShoot();
+                if (Math.random() < 0.28) {
+                    this.player.hurt(12);
+                    this.audio.playerHurt();
+                    this.flashDamage();
+                }
+            });
 
-        this.audio.update(dt, this.player.z < 40);
-        this.hud.tick(dt);
-        this.hud.setHealth(this.player.health, this.player.maxHealth);
-        this.hud.setWeapon(
-            this.loadout.spec.name,
-            this.loadout.ammo.mag,
-            this.loadout.ammo.reserve,
-            this.loadout.grenades
-        );
-        this.hud.setKills(this.kills);
-        this.hud.setTime(this.elapsed);
-        let heading = Math.atan2(-Math.sin(this.player.yaw), -Math.cos(this.player.yaw)) * 180 / Math.PI;
-        heading = (Math.round(heading) + 360) % 360;
-        this.hud.setHeading(heading);
-
-        this.fpsFrames += 1;
-        this.fpsAccum += dt;
-        if (this.fpsAccum >= 0.4) {
-            this.hud.setFps(Math.round(this.fpsFrames / this.fpsAccum));
-            this.fpsFrames = 0;
-            this.fpsAccum = 0;
-        }
-
-        if (this.flareT > 0) {
-            this.flareT -= dt;
-            if (this.flareT <= 0 && this.objIndex === OBJECTIVES.length - 1) this._completeObjective();
+            // HUD
+            this.updateHud();
         }
     }
 
-    _firePlayer() {
-        this.audio.shot(this.loadout.current);
-        this.player.kick(this.loadout.spec.recoil);
-        this.camera.getWorldDirection(DIR);
-        const spread = this.loadout.spread(this.player.ads);
-        DIR.x += (Math.random() - 0.5) * spread;
-        DIR.y += (Math.random() - 0.5) * spread;
-        DIR.z += (Math.random() - 0.5) * spread;
-        DIR.normalize();
-        ORIGIN.copy(this.camera.position);
-        AIM.copy(ORIGIN).addScaledVector(DIR, 140);
-
-        this.effects.muzzleFlash(
-            ORIGIN.x + DIR.x * 0.8,
-            ORIGIN.y + DIR.y * 0.8 - 0.05,
-            ORIGIN.z + DIR.z * 0.8
-        );
-
-        const hit = this.enemies.hitTest(ORIGIN, DIR, 140);
-        if (hit) {
-            const e = hit.enemy;
-            HIT.copy(ORIGIN).addScaledVector(DIR, hit.dist);
-            this.effects.tracer(ORIGIN, HIT);
-            this.effects.blood(HIT.x, HIT.y, HIT.z);
-            this.hud.markHit();
-            if (this.enemies.damage(e, this.loadout.spec.damage)) {
-                this.kills += 1;
-                this.hud.say('Baixa confirmada', 1.2);
-            }
-            return;
-        }
-
-        HIT.copy(AIM);
-        this.effects.tracer(ORIGIN, HIT);
-        const gx = ORIGIN.x + DIR.x * 40;
-        const gz = ORIGIN.z + DIR.z * 40;
-        this.effects.sparks(gx, this.world.heightAt(gx, gz) + 0.4, gz);
-    }
-
-    _interact(dt) {
-        const obj = OBJECTIVES[this.objIndex];
-        let prompt = '';
-        let near = null;
-        for (const it of this.world.interactables) {
-            if (it.done) continue;
-            const d = Math.hypot(this.player.x - it.x, this.player.z - it.z);
-            if (d < it.radius) {
-                near = it;
-                prompt = it.label;
-                break;
-            }
-        }
-        this.hud.setPrompt(prompt);
-
-        if (this.pendingCharge) {
-            this.pendingCharge.t -= dt;
-            if (this.pendingCharge.t <= 0) {
-                const it = this.pendingCharge.it;
-                it.done = true;
-                this.effects.explosion(it.x, this.world.heightAt(it.x, it.z) + 1.2, it.z, 1.6);
-                this.audio.explosion();
-                this.hud.say('Carga detonada', 2);
-                this.pendingCharge = null;
-                if (obj.check === 'interact' && obj.interact === it.id) this._completeObjective();
-            }
-        }
-
-        if (!near || !this.input.consumeInteract()) return;
-        if (obj.check === 'interact' && obj.interact !== near.id) {
-            this.hud.say('Ainda não. Siga o objetivo.', 2);
-            return;
-        }
-
-        if (near.id === 'flare') {
-            near.done = true;
-            this.hud.setPrompt('');
-            this.effects.flare(near.x, this.world.heightAt(near.x, near.z) + 2, near.z);
-            this.audio.flare();
-            this.hud.say('Sinalizador no ar', 3);
-            this.flareT = 2.4;
-            return;
-        }
-
-        this.pendingCharge = { it: near, t: 1.6 };
-        this.hud.say('Carga armada — afaste-se', 2);
-        this.hud.setPrompt('');
-    }
-
-    _pickups() {
-        for (const p of this.world.pickups) {
-            if (p.used) continue;
-            const d = Math.hypot(this.player.x - p.x, this.player.z - p.z);
-            if (d < p.radius) {
-                p.used = true;
-                p.mesh.visible = false;
-                this.player.heal(40);
-                this.hud.say('Kit médico', 1.6);
-                this.audio.radioBeep();
-            }
+    flashHitmarker() {
+        const hm = document.getElementById('hitMarker');
+        if (hm) {
+            hm.style.opacity = '1';
+            setTimeout(() => { hm.style.opacity = '0'; }, 90);
         }
     }
 
-    _checkObjective() {
-        const obj = OBJECTIVES[this.objIndex];
-        if (obj.check === 'z' && this.player.z >= obj.z) this._completeObjective();
+    flashDamage() {
+        const hf = document.getElementById('hitFlash');
+        if (hf) {
+            hf.style.opacity = '0.5';
+            setTimeout(() => { hf.style.opacity = '0'; }, 150);
+        }
     }
 
-    _ambientShells(dt) {
-        if (this.player.z > 90) return;
-        this.shellT -= dt;
-        if (this.shellT > 0) return;
-        this.shellT = 2.5 + Math.random() * 3.5;
-        const x = this.player.x + (Math.random() - 0.5) * 28;
-        const z = this.player.z + 8 + Math.random() * 22;
-        if (Math.hypot(x - this.player.x, z - this.player.z) < 6) return;
-        this.effects.explosion(x, this.world.heightAt(x, z) + 0.3, z, 0.7);
-        if (Math.random() < 0.5) this.audio.explosion();
+    checkObjectives() {
+        const aliveCount = this.enemies.list.filter(e => e.alive).length;
+        if (aliveCount <= 8 && !this.loadout.unlocked.thompson) {
+            this.loadout.unlockThompson();
+        }
+    }
+
+    updateHud() {
+        const hpEl = document.getElementById('healthValue');
+        const magEl = document.getElementById('magValue');
+        const resEl = document.getElementById('reserveValue');
+        const wNameEl = document.getElementById('weaponName');
+        const killsEl = document.getElementById('killsValue');
+        const objEl = document.getElementById('objective');
+
+        if (hpEl) hpEl.textContent = `${Math.round(this.player.health)}`;
+        if (magEl) magEl.textContent = String(this.loadout.ammo.mag).padStart(2, '0');
+        if (resEl) resEl.textContent = String(this.loadout.ammo.reserve).padStart(2, '0');
+        if (wNameEl) wNameEl.textContent = this.loadout.current === 'garand' ? 'M1 GARAND' : 'THOMPSON SMG';
+        if (killsEl) killsEl.textContent = String(this.kills).padStart(2, '0');
+
+        const alive = this.enemies.list.filter(e => e.alive).length;
+        if (objEl) {
+            if (this.player.z < 40) objEl.textContent = 'Alcance a muralha da praia.';
+            else if (this.player.z < 180) objEl.textContent = `Limpe os defensores da muralha (${alive} restantes).`;
+            else objEl.textContent = 'Silencie a bateria costeira no penhasco.';
+        }
     }
 }
 
-const game = new Game();
-game.init().catch((err) => {
+try {
+    new HonorFront();
+} catch (err) {
     console.error(err);
-    game.hud.showError('Falha ao iniciar a missão. Recarregue a página.');
-});
+}

--- a/labs/honor-front/src/models.js
+++ b/labs/honor-front/src/models.js
@@ -1,378 +1,203 @@
 /**
- * Modelos 3D construídos por código — nenhum GLB externo.
- * Soldados, armas em first-person, casamatas, vila e o canhão.
+ * Modelos 3D procedurais para Honor Front em Babylon.js.
+ * Armas em primeira pessoa (M1 Garand e Thompson), soldados, bunkers, sacos de areia e canhão costeiro.
  */
 
-import * as THREE from 'three';
-import {
-    stoneTexture, concreteTexture, woodTexture, metalTexture,
-    roofTexture, flagTexture
-} from './textures.js';
+import { gunMetalTexture, gunWoodTexture, concreteTexture } from './textures.js';
 
-const matCache = new Map();
+export function buildViewGarand(BABYLON, scene) {
+    const root = new BABYLON.TransformNode('view_garand', scene);
 
-export function std(color, roughness = 0.82, metalness = 0.04, extra = {}) {
-    const key = `s:${color}:${roughness}:${metalness}:${JSON.stringify(extra)}`;
-    if (!matCache.has(key)) {
-        matCache.set(key, new THREE.MeshStandardMaterial({ color, roughness, metalness, ...extra }));
-    }
-    return matCache.get(key);
-}
+    const metalTex = gunMetalTexture(scene);
+    const woodTex = gunWoodTexture(scene);
 
-function mapped(map, color = 0xffffff, roughness = 0.88, metalness = 0.04) {
-    return new THREE.MeshStandardMaterial({ map, color, roughness, metalness });
-}
+    const metalMat = new BABYLON.PBRMaterial('mat_g_metal', scene);
+    metalMat.albedoColor = new BABYLON.Color3(0.25, 0.28, 0.32);
+    metalMat.albedoTexture = metalTex;
+    metalMat.metallic = 0.85;
+    metalMat.roughness = 0.28;
 
-function shadows(root, cast = true) {
-    root.traverse((c) => {
-        if (c.isMesh) {
-            c.castShadow = cast;
-            c.receiveShadow = true;
-        }
-    });
-}
+    const woodMat = new BABYLON.PBRMaterial('mat_g_wood', scene);
+    woodMat.albedoColor = new BABYLON.Color3(0.48, 0.28, 0.16);
+    woodMat.albedoTexture = woodTex;
+    woodMat.metallic = 0.04;
+    woodMat.roughness = 0.55;
 
-const GEO = {
-    box: new THREE.BoxGeometry(1, 1, 1),
-    cyl: new THREE.CylinderGeometry(1, 1, 1, 8),
-    sph: new THREE.SphereGeometry(1, 10, 8),
-    cone: new THREE.ConeGeometry(1, 1, 8)
-};
+    // Coronha / Madeira
+    const stock = BABYLON.MeshBuilder.CreateBox('g_stock', { width: 0.05, height: 0.09, depth: 0.55 }, scene);
+    stock.position.set(0.18, -0.18, 0.42);
+    stock.material = woodMat;
+    stock.parent = root;
 
-function mesh(geo, mat, x, y, z, sx, sy, sz) {
-    const m = new THREE.Mesh(geo, mat);
-    m.position.set(x, y, z);
-    if (sx !== undefined) m.scale.set(sx, sy, sz);
-    return m;
-}
-
-/* ------------------------------------------------------------------ */
-/* Personagens                                                         */
-/* ------------------------------------------------------------------ */
-
-export function buildSoldier({ team = 'axis' } = {}) {
-    const group = new THREE.Group();
-    const skin = std(0xc4a07a, 0.72);
-    const isAxis = team === 'axis';
-    const tunic = std(isAxis ? 0x4a5340 : 0x5a5c3a, 0.9);
-    const pants = std(isAxis ? 0x3a4234 : 0x4a4c32, 0.9);
-    const boot = std(0x2a241c, 0.7);
-    const helm = std(isAxis ? 0x3a4034 : 0x6a6e52, 0.45, 0.35);
-
-    const hips = new THREE.Group();
-    group.add(hips);
-
-    const parts = { legs: [], arms: [], torso: null, head: null };
-
-    for (const sx of [-1, 1]) {
-        const leg = new THREE.Group();
-        leg.position.set(sx * 0.13, 0.52, 0);
-        hips.add(leg);
-        leg.add(mesh(GEO.cyl, pants, 0, -0.22, 0, 0.075, 0.44, 0.075));
-        leg.add(mesh(GEO.box, boot, 0, -0.48, 0.05, 0.14, 0.1, 0.28));
-        parts.legs.push(leg);
-
-        const arm = new THREE.Group();
-        arm.position.set(sx * 0.24, 1.18, 0);
-        hips.add(arm);
-        arm.add(mesh(GEO.cyl, tunic, 0, -0.22, 0, 0.055, 0.44, 0.055));
-        arm.add(mesh(GEO.sph, skin, 0, -0.46, 0, 0.055, 0.055, 0.055));
-        parts.arms.push(arm);
-    }
-
-    const torso = mesh(GEO.box, tunic, 0, 1.05, 0, 0.42, 0.52, 0.24);
-    hips.add(torso);
-    parts.torso = torso;
-    hips.add(mesh(GEO.box, std(0x3a3428, 0.8), 0, 0.82, 0.13, 0.28, 0.08, 0.04));
-
-    const head = new THREE.Group();
-    head.position.set(0, 1.42, 0);
-    hips.add(head);
-    head.add(mesh(GEO.sph, skin, 0, 0.08, 0, 0.13, 0.15, 0.13));
-    const helmet = mesh(GEO.sph, helm, 0, 0.16, 0, 0.16, 0.1, 0.17);
-    head.add(helmet);
-    if (isAxis) {
-        const brim = mesh(GEO.cyl, helm, 0, 0.1, 0, 0.18, 0.03, 0.18);
-        brim.rotation.x = Math.PI / 2;
-        brim.scale.set(1, 0.7, 1);
-        head.add(brim);
-    }
-    parts.head = head;
-
-    const rifle = buildWorldRifle(isAxis);
-    rifle.position.set(0.02, -0.42, 0.28);
-    rifle.rotation.set(-0.15, 0.1, 0.15);
-    parts.arms[1].add(rifle);
-    parts.rifle = rifle;
-
-    shadows(group);
-    group.userData.parts = parts;
-    return group;
-}
-
-function buildWorldRifle(mg = false) {
-    const g = new THREE.Group();
-    const wood = mapped(woodTexture(), 0xc4a070, 0.82);
-    const metal = mapped(metalTexture(), 0x6a7078, 0.4, 0.7);
-    g.add(mesh(GEO.box, wood, 0, 0, 0.05, 0.05, 0.07, 0.55));
-    g.add(mesh(GEO.cyl, metal, 0, 0.02, 0.42, 0.018, 0.55, 0.018));
-    g.children[1].rotation.x = Math.PI / 2;
-    if (mg) g.add(mesh(GEO.box, metal, 0, -0.02, 0.1, 0.08, 0.05, 0.12));
-    return g;
-}
-
-/* ------------------------------------------------------------------ */
-/* Armas em first-person                                               */
-/* ------------------------------------------------------------------ */
-
-export function buildViewGarand() {
-    const root = new THREE.Group();
-    const wood = mapped(woodTexture(), 0xb8894a, 0.78);
-    const metal = mapped(metalTexture(), 0x8a9098, 0.35, 0.75);
-    const dark = std(0x2a2c30, 0.4, 0.6);
-
-    const stock = mesh(GEO.box, wood, 0.12, -0.06, 0.28, 0.07, 0.14, 0.55);
-    stock.rotation.z = 0.08;
-    root.add(stock);
-    root.add(mesh(GEO.box, wood, 0.05, -0.02, -0.12, 0.06, 0.08, 0.42));
-    const barrel = mesh(GEO.cyl, metal, 0.05, 0.02, -0.55, 0.016, 0.72, 0.016);
+    // Cano de Aço
+    const barrel = BABYLON.MeshBuilder.CreateCylinder('g_barrel', { height: 0.65, diameter: 0.024, tessellation: 12 }, scene);
     barrel.rotation.x = Math.PI / 2;
-    root.add(barrel);
-    root.add(mesh(GEO.box, dark, 0.05, 0.05, -0.22, 0.045, 0.05, 0.18));
-    root.add(mesh(GEO.box, metal, 0.05, 0.045, -0.88, 0.01, 0.04, 0.02));
-    root.add(mesh(GEO.box, metal, 0.03, 0.05, -0.18, 0.004, 0.05, 0.004));
-    root.add(mesh(GEO.box, metal, 0.07, 0.05, -0.18, 0.004, 0.05, 0.004));
+    barrel.position.set(0.18, -0.12, 0.72);
+    barrel.material = metalMat;
+    barrel.parent = root;
 
-    const hands = buildHands();
-    hands.position.set(0.02, -0.12, 0.02);
-    root.add(hands);
+    // Caixa da Culatra (Receiver)
+    const receiver = BABYLON.MeshBuilder.CreateBox('g_receiver', { width: 0.045, height: 0.06, depth: 0.22 }, scene);
+    receiver.position.set(0.18, -0.13, 0.46);
+    receiver.material = metalMat;
+    receiver.parent = root;
 
-    root.position.set(0.22, -0.2, -0.42);
-    root.rotation.set(0.04, 0.08, 0.02);
+    // Massa de mira frontal
+    const sight = BABYLON.MeshBuilder.CreateBox('g_sight', { width: 0.008, height: 0.022, depth: 0.008 }, scene);
+    sight.position.set(0.18, -0.095, 1.02);
+    sight.material = metalMat;
+    sight.parent = root;
+
     return root;
 }
 
-export function buildViewThompson() {
-    const root = new THREE.Group();
-    const wood = mapped(woodTexture(), 0x8a5a32, 0.8);
-    const metal = mapped(metalTexture(), 0x4a4e52, 0.4, 0.7);
+export function buildViewThompson(BABYLON, scene) {
+    const root = new BABYLON.TransformNode('view_thompson', scene);
 
-    root.add(mesh(GEO.box, wood, 0.08, -0.08, 0.18, 0.06, 0.14, 0.28));
-    root.add(mesh(GEO.box, metal, 0.06, 0.0, -0.12, 0.07, 0.08, 0.42));
-    const barrel = mesh(GEO.cyl, metal, 0.06, 0.02, -0.48, 0.018, 0.38, 0.018);
+    const metalTex = gunMetalTexture(scene);
+    const woodTex = gunWoodTexture(scene);
+
+    const metalMat = new BABYLON.PBRMaterial('mat_t_metal', scene);
+    metalMat.albedoColor = new BABYLON.Color3(0.22, 0.24, 0.28);
+    metalMat.albedoTexture = metalTex;
+    metalMat.metallic = 0.88;
+    metalMat.roughness = 0.25;
+
+    const woodMat = new BABYLON.PBRMaterial('mat_t_wood', scene);
+    woodMat.albedoColor = new BABYLON.Color3(0.42, 0.24, 0.14);
+    woodMat.albedoTexture = woodTex;
+    woodMat.metallic = 0.02;
+    woodMat.roughness = 0.6;
+
+    // Caixa da culatra
+    const receiver = BABYLON.MeshBuilder.CreateBox('t_receiver', { width: 0.055, height: 0.08, depth: 0.35 }, scene);
+    receiver.position.set(0.18, -0.15, 0.45);
+    receiver.material = metalMat;
+    receiver.parent = root;
+
+    // Cano com aletas
+    const barrel = BABYLON.MeshBuilder.CreateCylinder('t_barrel', { height: 0.48, diameter: 0.03, tessellation: 12 }, scene);
     barrel.rotation.x = Math.PI / 2;
-    root.add(barrel);
-    root.add(mesh(GEO.box, metal, 0.06, -0.12, -0.05, 0.05, 0.18, 0.08));
-    root.add(mesh(GEO.cyl, wood, 0.06, -0.1, 0.02, 0.03, 0.16, 0.03));
+    barrel.position.set(0.18, -0.13, 0.72);
+    barrel.material = metalMat;
+    barrel.parent = root;
 
-    const hands = buildHands();
-    hands.position.set(0.0, -0.14, 0.0);
-    root.add(hands);
+    // Carregador de Tambor (Drum Mag)
+    const drum = BABYLON.MeshBuilder.CreateCylinder('t_drum', { height: 0.07, diameter: 0.16, tessellation: 20 }, scene);
+    drum.position.set(0.18, -0.22, 0.48);
+    drum.material = metalMat;
+    drum.parent = root;
 
-    root.position.set(0.2, -0.18, -0.4);
+    // Empunhadura de madeira
+    const grip = BABYLON.MeshBuilder.CreateBox('t_grip', { width: 0.04, height: 0.12, depth: 0.05 }, scene);
+    grip.position.set(0.18, -0.24, 0.34);
+    grip.rotation.x = 0.35;
+    grip.material = woodMat;
+    grip.parent = root;
+
     return root;
 }
 
-function buildHands() {
-    const g = new THREE.Group();
-    const skin = std(0xd0a07a, 0.7);
-    const sleeve = std(0x4a5238, 0.9);
-    const r = new THREE.Group();
-    r.position.set(0.08, 0.02, 0.18);
-    r.add(mesh(GEO.cyl, sleeve, 0, 0.05, 0.08, 0.045, 0.16, 0.045));
-    r.add(mesh(GEO.sph, skin, 0, -0.02, -0.02, 0.05, 0.045, 0.06));
-    g.add(r);
-    const l = new THREE.Group();
-    l.position.set(-0.04, 0.04, -0.12);
-    l.add(mesh(GEO.cyl, sleeve, 0, 0.04, 0.06, 0.042, 0.14, 0.042));
-    l.add(mesh(GEO.sph, skin, 0, 0.0, -0.04, 0.048, 0.04, 0.055));
-    g.add(l);
-    return g;
+export function buildSoldier(BABYLON, scene) {
+    const root = new BABYLON.TransformNode('soldier_root', scene);
+
+    const uniformMat = new BABYLON.PBRMaterial('mat_s_uniform', scene);
+    uniformMat.albedoColor = new BABYLON.Color3(0.32, 0.36, 0.32); // Feldgrau cinza-oliva
+    uniformMat.roughness = 0.85;
+
+    const helmetMat = new BABYLON.PBRMaterial('mat_s_helmet', scene);
+    helmetMat.albedoColor = new BABYLON.Color3(0.24, 0.28, 0.24);
+    helmetMat.metallic = 0.6;
+    helmetMat.roughness = 0.4;
+
+    const skinMat = new BABYLON.PBRMaterial('mat_s_skin', scene);
+    skinMat.albedoColor = new BABYLON.Color3(0.85, 0.7, 0.55);
+
+    // Torso
+    const torso = BABYLON.MeshBuilder.CreateBox('s_torso', { width: 0.52, height: 0.7, depth: 0.3 }, scene);
+    torso.position.y = 1.05;
+    torso.material = uniformMat;
+    torso.parent = root;
+
+    // Cabeça
+    const head = BABYLON.MeshBuilder.CreateSphere('s_head', { diameter: 0.26, segments: 8 }, scene);
+    head.position.y = 1.55;
+    head.material = skinMat;
+    head.parent = root;
+
+    // Capacete Stahlhelm
+    const helmet = BABYLON.MeshBuilder.CreateSphere('s_helmet', { diameter: 0.32, segments: 10 }, scene);
+    helmet.position.y = 1.62;
+    helmet.scaling.set(1.05, 0.85, 1.15);
+    helmet.material = helmetMat;
+    helmet.parent = root;
+
+    // Pernas
+    const legL = BABYLON.MeshBuilder.CreateCylinder('s_leg_l', { height: 0.7, diameter: 0.16, tessellation: 8 }, scene);
+    legL.position.set(-0.16, 0.35, 0);
+    legL.material = uniformMat;
+    legL.parent = root;
+
+    const legR = BABYLON.MeshBuilder.CreateCylinder('s_leg_r', { height: 0.7, diameter: 0.16, tessellation: 8 }, scene);
+    legR.position.set(0.16, 0.35, 0);
+    legR.material = uniformMat;
+    legR.parent = root;
+
+    // Rifle
+    const rifle = BABYLON.MeshBuilder.CreateBox('s_rifle', { width: 0.05, height: 0.08, depth: 0.85 }, scene);
+    rifle.position.set(0.24, 1.0, 0.35);
+    rifle.rotation.x = -0.3;
+    rifle.material = helmetMat;
+    rifle.parent = root;
+
+    return root;
 }
 
-/* ------------------------------------------------------------------ */
-/* Veículo e cenário                                                   */
-/* ------------------------------------------------------------------ */
+export function buildCzechHedgehog(BABYLON, scene) {
+    const root = new BABYLON.TransformNode('czech_root', scene);
+    const metalMat = new BABYLON.PBRMaterial('mat_hedgehog', scene);
+    metalMat.albedoColor = new BABYLON.Color3(0.35, 0.28, 0.24);
+    metalMat.roughness = 0.85;
+    metalMat.metallic = 0.4;
 
-export function buildHiggins() {
-    const g = new THREE.Group();
-    const steel = mapped(metalTexture(), 0x5a6048, 0.55, 0.45);
-    const dark = std(0x3a3e32, 0.7, 0.3);
-    g.add(mesh(GEO.box, steel, 0, 0.55, 0, 3.2, 1.1, 8.4));
-    g.add(mesh(GEO.box, dark, 0, 1.15, 0, 3.05, 0.18, 8.1));
-    g.add(mesh(GEO.box, steel, -1.55, 1.35, 0, 0.12, 0.7, 8.2));
-    g.add(mesh(GEO.box, steel, 1.55, 1.35, 0, 0.12, 0.7, 8.2));
-    g.add(mesh(GEO.box, steel, 0, 1.35, -4.05, 3.2, 0.7, 0.12));
-    const ramp = new THREE.Group();
-    ramp.position.set(0, 0.7, 4.15);
-    ramp.add(mesh(GEO.box, dark, 0, 0.55, 0, 2.7, 0.1, 1.15));
-    g.add(ramp);
-    g.userData.ramp = ramp;
-    shadows(g);
-    return g;
+    const b1 = BABYLON.MeshBuilder.CreateBox('beam1', { width: 0.18, height: 2.2, depth: 0.18 }, scene);
+    b1.rotation.z = Math.PI / 4;
+    b1.material = metalMat;
+    b1.parent = root;
+
+    const b2 = BABYLON.MeshBuilder.CreateBox('beam2', { width: 0.18, height: 2.2, depth: 0.18 }, scene);
+    b2.rotation.z = -Math.PI / 4;
+    b2.material = metalMat;
+    b2.parent = root;
+
+    const b3 = BABYLON.MeshBuilder.CreateBox('beam3', { width: 0.18, height: 2.2, depth: 0.18 }, scene);
+    b3.rotation.x = Math.PI / 4;
+    b3.material = metalMat;
+    b3.parent = root;
+
+    return root;
 }
 
-export function buildHedgehog() {
-    const g = new THREE.Group();
-    const rust = mapped(metalTexture(), 0x6a4a32, 0.55, 0.5);
-    const beam = (rx, ry, rz) => {
-        const m = mesh(GEO.box, rust, 0, 0.7, 0, 0.16, 2.1, 0.16);
-        m.rotation.set(rx, ry, rz);
-        g.add(m);
-    };
-    beam(0.7, 0.2, 0.4);
-    beam(-0.6, 0.8, -0.3);
-    beam(0.15, -0.5, 0.9);
-    shadows(g);
-    return g;
-}
+export function buildBunker(BABYLON, scene) {
+    const root = new BABYLON.TransformNode('bunker_root', scene);
+    const concTex = concreteTexture(scene);
 
-export function buildSandbags() {
-    const g = new THREE.Group();
-    const bag = std(0x8a7a52, 0.92);
-    for (let i = 0; i < 5; i++) {
-        g.add(mesh(GEO.cyl, bag, (i - 2) * 0.42, 0.16, 0, 0.2, 0.32, 0.2));
-        g.children[i].rotation.z = Math.PI / 2;
-    }
-    for (let i = 0; i < 4; i++) {
-        g.add(mesh(GEO.cyl, bag, (i - 1.5) * 0.42, 0.42, 0, 0.18, 0.3, 0.18));
-        g.children[5 + i].rotation.z = Math.PI / 2;
-    }
-    shadows(g);
-    return g;
-}
+    const concMat = new BABYLON.PBRMaterial('mat_bunker_conc', scene);
+    concMat.albedoColor = new BABYLON.Color3(0.65, 0.68, 0.7);
+    concMat.albedoTexture = concTex;
+    concMat.roughness = 0.88;
+    concMat.metallic = 0.05;
 
-export function buildBunker() {
-    const g = new THREE.Group();
-    const conc = mapped(concreteTexture(), 0xb0aa98, 0.9);
-    g.add(mesh(GEO.box, conc, 0, 1.35, 0, 7.2, 2.7, 5.4));
-    g.add(mesh(GEO.box, conc, 0, 2.85, 0, 7.6, 0.35, 5.8));
-    const slit = mesh(GEO.box, std(0x101208), 0, 1.7, 2.72, 3.4, 0.38, 0.2);
-    g.add(slit);
-    g.add(mesh(GEO.box, conc, -2.4, 1.1, 3.1, 1.6, 2.2, 1.2));
-    g.add(mesh(GEO.box, conc, 2.4, 1.1, 3.1, 1.6, 2.2, 1.2));
-    shadows(g);
-    return g;
-}
+    const body = BABYLON.MeshBuilder.CreateBox('b_body', { width: 9, height: 3.5, depth: 7 }, scene);
+    body.position.y = 1.75;
+    body.material = concMat;
+    body.parent = root;
 
-export function buildHouse({ w = 6.4, d = 5.2, h = 3.4, roofH = 2.1 } = {}) {
-    const g = new THREE.Group();
-    const wall = mapped(stoneTexture(), 0xd4c8b0, 0.88);
-    const roof = mapped(roofTexture(), 0xffffff, 0.8);
-    const dark = std(0x2a241c, 0.7);
-    g.add(mesh(GEO.box, wall, 0, h * 0.5, 0, w, h, d));
-    const roofM = mesh(GEO.cone, roof, 0, h + roofH * 0.42, 0, w * 0.72, roofH, d * 0.72);
-    g.add(roofM);
-    g.add(mesh(GEO.box, dark, 0, 1.05, d * 0.51, 1.1, 2.1, 0.12));
-    g.add(mesh(GEO.box, std(0x7a90a8, 0.3, 0.2), -w * 0.22, 1.8, d * 0.51, 0.8, 0.9, 0.08));
-    g.add(mesh(GEO.box, std(0x7a90a8, 0.3, 0.2), w * 0.22, 1.8, d * 0.51, 0.8, 0.9, 0.08));
-    shadows(g);
-    return g;
-}
+    // Teto reforçado
+    const roof = BABYLON.MeshBuilder.CreateBox('b_roof', { width: 10.5, height: 0.8, depth: 8.5 }, scene);
+    roof.position.y = 3.9;
+    roof.material = concMat;
+    roof.parent = root;
 
-export function buildChurch() {
-    const g = new THREE.Group();
-    const wall = mapped(stoneTexture(), 0xe8dcc8, 0.86);
-    const roof = mapped(roofTexture(), 0x6a4030, 0.78);
-    g.add(mesh(GEO.box, wall, 0, 2.4, 0, 7.5, 4.8, 12));
-    g.add(mesh(GEO.cone, roof, 0, 5.6, 0, 5.6, 2.4, 8.5));
-    g.add(mesh(GEO.box, wall, 0, 5.2, -4.2, 2.4, 6.4, 2.4));
-    g.add(mesh(GEO.cone, roof, 0, 9.1, -4.2, 1.8, 2.2, 1.8));
-    g.add(mesh(GEO.box, std(0x2a2418), 0, 1.4, 6.05, 1.4, 2.8, 0.15));
-    shadows(g);
-    return g;
-}
-
-export function buildCoastalGun() {
-    const g = new THREE.Group();
-    const steel = mapped(metalTexture(), 0x4a4e46, 0.4, 0.65);
-    const dark = std(0x2e322c, 0.5, 0.4);
-    g.add(mesh(GEO.box, dark, 0, 0.7, 0, 2.8, 1.1, 3.6));
-    const barrel = mesh(GEO.cyl, steel, 0, 1.35, 2.4, 0.22, 7.2, 0.22);
-    barrel.rotation.x = Math.PI / 2;
-    barrel.rotation.x -= 0.12;
-    g.add(barrel);
-    g.add(mesh(GEO.cyl, steel, 0, 1.35, -0.2, 0.42, 0.7, 0.42));
-    g.add(mesh(GEO.box, dark, -1.3, 0.45, 0.4, 0.5, 0.9, 1.6));
-    g.add(mesh(GEO.box, dark, 1.3, 0.45, 0.4, 0.5, 0.9, 1.6));
-    shadows(g);
-    return g;
-}
-
-export function buildFlag(colors) {
-    const g = new THREE.Group();
-    const pole = mesh(GEO.cyl, std(0x8a8a80, 0.4, 0.5), 0, 2.4, 0, 0.04, 4.8, 0.04);
-    g.add(pole);
-    const cloth = mesh(GEO.box, mapped(flagTexture(colors), 0xffffff, 0.85), 0.7, 4.15, 0, 1.4, 0.85, 0.04);
-    g.add(cloth);
-    g.userData.cloth = cloth;
-    shadows(g, false);
-    pole.castShadow = true;
-    return g;
-}
-
-export function buildPine() {
-    const g = new THREE.Group();
-    const bark = mapped(woodTexture(), 0x5a4030, 0.9);
-    const leaf = std(0x2a3e22, 0.88);
-    g.add(mesh(GEO.cyl, bark, 0, 1.1, 0, 0.18, 2.2, 0.18));
-    g.add(mesh(GEO.cone, leaf, 0, 2.6, 0, 1.35, 2.4, 1.35));
-    g.add(mesh(GEO.cone, leaf, 0, 3.7, 0, 0.95, 1.8, 0.95));
-    g.add(mesh(GEO.cone, leaf, 0, 4.6, 0, 0.55, 1.3, 0.55));
-    shadows(g);
-    return g;
-}
-
-export function buildCrate() {
-    const g = new THREE.Group();
-    const wood = mapped(woodTexture(), 0x8a6a3a, 0.85);
-    g.add(mesh(GEO.box, wood, 0, 0.28, 0, 0.7, 0.55, 0.55));
-    shadows(g);
-    return g;
-}
-
-export function buildMedkit() {
-    const g = new THREE.Group();
-    g.add(mesh(GEO.box, std(0xc4c4c0, 0.7), 0, 0.12, 0, 0.38, 0.22, 0.26));
-    g.add(mesh(GEO.box, std(0xa82828), 0, 0.24, 0, 0.18, 0.04, 0.06));
-    g.add(mesh(GEO.box, std(0xa82828), 0, 0.24, 0, 0.06, 0.04, 0.18));
-    return g;
-}
-
-export function buildWirePost() {
-    const g = new THREE.Group();
-    const wood = mapped(woodTexture(), 0x5a4a32, 0.9);
-    g.add(mesh(GEO.cyl, wood, 0, 0.55, 0, 0.05, 1.1, 0.05));
-    const wire = std(0x2a2a28, 0.4, 0.6);
-    for (let i = 0; i < 3; i++) {
-        g.add(mesh(GEO.box, wire, 0.6, 0.25 + i * 0.28, 0, 1.2, 0.012, 0.012));
-    }
-    shadows(g, false);
-    return g;
-}
-
-export function buildFlareGunStand() {
-    const g = new THREE.Group();
-    const metal = mapped(metalTexture(), 0x6a5040, 0.45, 0.55);
-    g.add(mesh(GEO.cyl, metal, 0, 0.45, 0, 0.08, 0.9, 0.08));
-    g.add(mesh(GEO.box, metal, 0, 0.95, 0.1, 0.12, 0.08, 0.4));
-    shadows(g);
-    return g;
-}
-
-export function buildGrenade() {
-    const g = new THREE.Group();
-    g.add(mesh(GEO.sph, std(0x4a5a38, 0.55, 0.3), 0, 0, 0, 0.07, 0.08, 0.07));
-    g.add(mesh(GEO.cyl, std(0x8a8a80, 0.4, 0.6), 0, 0.08, 0, 0.025, 0.06, 0.025));
-    return g;
-}
-
-export function buildShip() {
-    const g = new THREE.Group();
-    const hull = std(0x2a2e28, 0.7);
-    g.add(mesh(GEO.box, hull, 0, 0.8, 0, 6, 1.4, 18));
-    g.add(mesh(GEO.box, hull, 0, 2.0, -2, 3.2, 1.6, 6));
-    g.add(mesh(GEO.cyl, std(0x3a3a36), -0.8, 3.4, -2, 0.25, 2.4, 0.25));
-    g.add(mesh(GEO.cyl, std(0x3a3a36), 0.8, 3.4, -1.2, 0.22, 2.0, 0.22));
-    return g;
+    return root;
 }

--- a/labs/honor-front/src/player.js
+++ b/labs/honor-front/src/player.js
@@ -1,8 +1,7 @@
 /**
- * Controlador em primeira pessoa: olhar com pointer-lock, bob, ADS e nado raso.
+ * Controlador do jogador em primeira pessoa para Honor Front em Babylon.js.
  */
 
-import * as THREE from 'three';
 import { PLAYER, WORLD } from './config.js';
 import { clamp, damp } from './utils.js';
 
@@ -10,12 +9,12 @@ export class Player {
     constructor() {
         this.x = 0;
         this.y = 1.6;
-        this.z = WORLD.boatStartZ;
+        this.z = WORLD.boatStartZ || -160;
         this.vy = 0;
         this.yaw = 0;
         this.pitch = 0;
-        this.health = PLAYER.maxHealth;
-        this.maxHealth = PLAYER.maxHealth;
+        this.health = PLAYER.maxHealth || 100;
+        this.maxHealth = PLAYER.maxHealth || 100;
         this.invuln = 0;
         this.alive = true;
         this.grounded = true;
@@ -31,7 +30,7 @@ export class Player {
     spawn(x, z, yaw, heightAt) {
         this.x = x;
         this.z = z;
-        this.y = heightAt(x, z);
+        this.y = heightAt(x, z) + 1.6;
         this.yaw = yaw;
         this.pitch = 0;
         this.vy = 0;
@@ -40,14 +39,14 @@ export class Player {
         this.invuln = 0;
         this.recoil = 0;
         this.ads = 0;
-        this.onBoat = true;
+        this.onBoat = false;
         this.wet = false;
     }
 
     hurt(amount) {
         if (this.invuln > 0 || !this.alive) return false;
         this.health -= amount;
-        this.invuln = PLAYER.invuln;
+        this.invuln = PLAYER.invuln || 0.4;
         if (this.health <= 0) {
             this.health = 0;
             this.alive = false;
@@ -59,19 +58,11 @@ export class Player {
         this.health = Math.min(this.maxHealth, this.health + amount);
     }
 
-    /**
-     * @returns {{footstep: boolean, moving: boolean}}
-     */
-    update(dt, input, world, locked) {
+    update(dt, input, heightAt) {
         this.invuln = Math.max(0, this.invuln - dt);
         this.recoil = damp(this.recoil, 0, 8, dt);
 
-        if (!locked) {
-            this.wet = this.y < WORLD.waterY + 0.35;
-            return { footstep: false, moving: false };
-        }
-
-        const look = input.consumeLook();
+        const look = input.consumeLook ? input.consumeLook() : { x: 0, y: 0 };
         const lookScale = 0.0022 * (1 - this.ads * 0.45);
         this.yaw -= look.x * lookScale;
         this.pitch = clamp(this.pitch - look.y * lookScale, -1.15, 1.15);
@@ -82,94 +73,51 @@ export class Player {
         let moving = false;
         let footstep = false;
 
-        if (!this.onBoat) {
-            const move = input.move;
-            let mx = move.x;
-            let mz = move.z;
-            const len = Math.hypot(mx, mz);
-            if (len > 1) {
-                mx /= len;
-                mz /= len;
-            }
-
-            this.wet = this.y < WORLD.waterY + 0.4;
-            const speedMul = this.wet ? PLAYER.waterSlow : 1;
-            const speed = (move.sprint && !this.ads ? PLAYER.sprint : PLAYER.walk) * speedMul * (1 - this.ads * 0.35);
-            // A câmera Three.js olha para −Z local; yaw 0 = mar, yaw π = interior.
-            const lx = -Math.sin(this.yaw);
-            const lz = -Math.cos(this.yaw);
-            const rx = -lz;
-            const rz = lx;
-            const vx = (lx * mz + rx * mx) * speed;
-            const vz = (lz * mz + rz * mx) * speed;
-
-            let nx = this.x + vx * dt;
-            let nz = this.z + vz * dt;
-            const b = world.bounds;
-            nx = clamp(nx, b.minX, b.maxX);
-            nz = clamp(nz, b.minZ, b.maxZ);
-
-            if (!world.blocked(nx, this.z, PLAYER.radius)) this.x = nx;
-            if (!world.blocked(this.x, nz, PLAYER.radius)) this.z = nz;
-
-            if (input.consumeJump() && this.grounded) this.vy = PLAYER.jump;
-
-            const ground = world.heightAt(this.x, this.z);
-            this.vy -= PLAYER.gravity * dt;
-            this.y += this.vy * dt;
-            if (this.y <= ground) {
-                this.y = ground;
-                this.vy = 0;
-                this.grounded = true;
-            } else {
-                this.grounded = false;
-            }
-
-            if (this.y < WORLD.waterY - 0.85 && this.z < 4) {
-                this.y = WORLD.waterY - 0.85;
-                this.vy = 0;
-            }
-
-            if (len > 0.08) {
-                moving = true;
-                this.walkPhase += dt * speed * 2.4;
-                this.footTimer += dt * (move.sprint ? 1.6 : 1);
-                if (this.footTimer > 0.42) {
-                    this.footTimer = 0;
-                    footstep = this.grounded;
-                }
-            } else {
-                this.walkPhase = damp(this.walkPhase, 0, 8, dt);
-            }
-            this.bob = Math.sin(this.walkPhase) * (len > 0.08 ? 0.035 : 0);
-        } else {
-            this.y = Math.max(world.heightAt(this.x, this.z), WORLD.waterY) + 0.15;
-            this.grounded = true;
-            this.wet = true;
+        const move = input.move || { x: 0, z: 0, sprint: false };
+        let mx = move.x;
+        let mz = move.z;
+        const len = Math.hypot(mx, mz);
+        if (len > 1) {
+            mx /= len;
+            mz /= len;
         }
+
+        const groundY = heightAt(this.x, this.z);
+        this.wet = groundY < (WORLD.waterY || 0) + 0.4;
+        const speedMul = this.wet ? (PLAYER.waterSlow || 0.7) : 1;
+        const speed = (move.sprint && !this.ads ? (PLAYER.sprint || 7.2) : (PLAYER.walk || 4.2)) * speedMul * (1 - this.ads * 0.35);
+
+        const lx = Math.sin(this.yaw);
+        const lz = Math.cos(this.yaw);
+        const rx = Math.cos(this.yaw);
+        const rz = -Math.sin(this.yaw);
+
+        const vx = (lx * mz + rx * mx) * speed;
+        const vz = (lz * mz + rz * mx) * speed;
+
+        if (len > 0.05) {
+            moving = true;
+            this.x += vx * dt;
+            this.z += vz * dt;
+            this.walkPhase += dt * (move.sprint ? 14 : 9);
+            this.bob = Math.sin(this.walkPhase) * (move.sprint ? 0.08 : 0.04);
+            this.footTimer -= dt;
+            if (this.footTimer <= 0) {
+                footstep = true;
+                this.footTimer = move.sprint ? 0.32 : 0.48;
+            }
+        } else {
+            this.bob = damp(this.bob, 0, 8, dt);
+        }
+
+        // Gravidade e chão
+        const targetY = heightAt(this.x, this.z) + 1.6;
+        this.y = lerp(this.y, targetY, dt * 10);
 
         return { footstep, moving };
     }
+}
 
-    applyToCamera(camera) {
-        const eye = this.y + PLAYER.eye + this.bob * 0.6 + this.recoil * 0.15;
-        camera.position.set(this.x, eye, this.z);
-        camera.rotation.order = 'YXZ';
-        camera.rotation.y = this.yaw;
-        camera.rotation.x = this.pitch + this.recoil;
-        camera.rotation.z = this.bob * 0.08;
-    }
-
-    kick(amount) {
-        this.recoil += amount;
-    }
-
-    forward() {
-        const cp = Math.cos(this.pitch);
-        return {
-            x: -Math.sin(this.yaw) * cp,
-            y: Math.sin(this.pitch),
-            z: -Math.cos(this.yaw) * cp
-        };
-    }
+function lerp(a, b, t) {
+    return a + (b - a) * Math.min(1, Math.max(0, t));
 }

--- a/labs/honor-front/src/sky.js
+++ b/labs/honor-front/src/sky.js
@@ -1,210 +1,36 @@
 /**
- * Céu de alvorada, névoa e oceano com ondas de Gerstner.
- * O shader do céu é reaproveitado no reflexo da água.
+ * Céu costeiro de amanhecer nublado e iluminação para Honor Front em Babylon.js.
  */
 
-import * as THREE from 'three';
+export function setupAtmosphere(BABYLON, scene) {
+    // Neblina de praia e fumaça
+    scene.fogMode = BABYLON.Scene.FOGMODE_EXP2;
+    scene.fogDensity = 0.0075;
+    scene.fogColor = new BABYLON.Color3(0.55, 0.60, 0.65);
 
-export const SKY_GLSL = /* glsl */ `
-uniform vec3 uZenith;
-uniform vec3 uHorizon;
-uniform vec3 uGround;
-uniform vec3 uSunColor;
-uniform vec3 uSunDir;
+    // Domo do céu
+    const skyDome = BABYLON.MeshBuilder.CreateSphere('skyDome', { diameter: 700, segments: 24 }, scene);
+    const skyMat = new BABYLON.StandardMaterial('mat_sky', scene);
+    skyMat.backFaceCulling = false;
+    skyMat.diffuseColor = new BABYLON.Color3(0, 0, 0);
+    skyMat.emissiveColor = new BABYLON.Color3(0.48, 0.54, 0.62);
+    skyMat.specularColor = new BABYLON.Color3(0, 0, 0);
+    skyDome.material = skyMat;
 
-vec3 hfSky(vec3 dir) {
-    float h = dir.y;
-    float t = clamp(h * 1.15 + 0.08, 0.0, 1.0);
-    vec3 col = mix(uHorizon, uZenith, pow(t, 0.72));
-    col = mix(uGround, col, smoothstep(-0.12, 0.04, h));
+    // Luz hemisférica ambiente
+    const hemi = new BABYLON.HemisphericLight('hemi_light', new BABYLON.Vector3(0, 1, 0), scene);
+    hemi.diffuse = new BABYLON.Color3(0.65, 0.70, 0.75);
+    hemi.groundColor = new BABYLON.Color3(0.35, 0.32, 0.28);
+    hemi.intensity = 1.1;
 
-    float sd = max(dot(normalize(dir), uSunDir), 0.0);
-    col += uSunColor * pow(sd, 3.0) * 0.22;
-    col += uSunColor * pow(sd, 28.0) * 0.45;
-    col += uSunColor * pow(sd, 420.0) * 1.1;
-    col += uSunColor * smoothstep(0.9992, 0.9998, sd) * 18.0;
-    return col;
-}
-`;
+    // Luz solar suave do amanhecer
+    const sun = new BABYLON.DirectionalLight('sun_light', new BABYLON.Vector3(0.3, -0.4, 0.8).normalize(), scene);
+    sun.position = new BABYLON.Vector3(-40, 80, -120);
+    sun.diffuse = new BABYLON.Color3(1.0, 0.88, 0.72);
+    sun.intensity = 1.4;
 
-const CLOUD_GLSL = /* glsl */ `
-float hfHash(vec2 p) {
-    p = fract(p * vec2(123.34, 456.21));
-    p += dot(p, p + 45.32);
-    return fract(p.x * p.y);
-}
-float hfNoise(vec2 p) {
-    vec2 i = floor(p);
-    vec2 f = fract(p);
-    f = f * f * (3.0 - 2.0 * f);
-    float a = hfHash(i);
-    float b = hfHash(i + vec2(1.0, 0.0));
-    float c = hfHash(i + vec2(1.0, 1.0));
-    float d = hfHash(i + vec2(0.0, 1.0));
-    return mix(mix(a, b, f.x), mix(d, c, f.x), f.y);
-}
-float hfFbm(vec2 p) {
-    float v = 0.0;
-    float a = 0.5;
-    for (int i = 0; i < 5; i++) {
-        v += a * hfNoise(p);
-        p = p * 2.07 + 13.1;
-        a *= 0.5;
-    }
-    return v;
-}
-`;
+    const shadowGen = new BABYLON.ShadowGenerator(2048, sun);
+    shadowGen.usePoissonSampling = true;
 
-export function createSkyUniforms() {
-    return {
-        uZenith: { value: new THREE.Color(0x4a6a9a) },
-        uHorizon: { value: new THREE.Color(0xe8a060) },
-        uGround: { value: new THREE.Color(0xc48a58) },
-        uSunColor: { value: new THREE.Color(0xffc070) },
-        uSunDir: { value: new THREE.Vector3(0.72, 0.18, -0.38).normalize() },
-        uTime: { value: 0 }
-    };
-}
-
-export function createSky(uniforms) {
-    const geo = new THREE.SphereGeometry(520, 32, 20);
-    const mat = new THREE.ShaderMaterial({
-        uniforms,
-        side: THREE.BackSide,
-        depthWrite: false,
-        fog: false,
-        vertexShader: /* glsl */ `
-            varying vec3 vPos;
-            void main() {
-                vPos = position;
-                gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
-            }
-        `,
-        fragmentShader: /* glsl */ `
-            varying vec3 vPos;
-            uniform float uTime;
-            ${SKY_GLSL}
-            ${CLOUD_GLSL}
-            void main() {
-                vec3 dir = normalize(vPos);
-                vec3 col = hfSky(dir);
-                float h = dir.y;
-                if (h > 0.02) {
-                    vec2 uv = dir.xz / max(0.08, h + 0.15);
-                    float n = hfFbm(uv * 1.6 + vec2(uTime * 0.012, 0.0));
-                    float cloud = smoothstep(0.52, 0.78, n) * smoothstep(0.05, 0.35, h);
-                    col = mix(col, vec3(0.92, 0.82, 0.72), cloud * 0.55);
-                }
-                gl_FragColor = vec4(col, 1.0);
-                #include <tonemapping_fragment>
-                #include <colorspace_fragment>
-            }
-        `
-    });
-    const mesh = new THREE.Mesh(geo, mat);
-    mesh.frustumCulled = false;
-    return mesh;
-}
-
-export function createOcean(uniforms, quality) {
-    const segs = quality.id === 'low' ? 48 : quality.id === 'high' ? 96 : 72;
-    const geo = new THREE.PlaneGeometry(420, 280, segs, Math.floor(segs * 0.55));
-    geo.rotateX(-Math.PI / 2);
-    const mat = new THREE.ShaderMaterial({
-        uniforms: {
-            ...uniforms,
-            uWater: { value: new THREE.Color(0x1a3a48) },
-            uFoam: { value: new THREE.Color(0xd8c8a8) }
-        },
-        transparent: true,
-        vertexShader: /* glsl */ `
-            uniform float uTime;
-            varying vec3 vWorld;
-            varying float vFoam;
-            vec3 gerstner(vec3 p, vec2 dir, float steep, float wl, float speed) {
-                float k = 6.28318 / wl;
-                float a = steep / k;
-                float f = k * (dot(dir, p.xz) - sqrt(9.8 / k) * uTime * speed);
-                p.x += dir.x * a * cos(f);
-                p.z += dir.y * a * cos(f);
-                p.y += a * sin(f);
-                return p;
-            }
-            void main() {
-                vec3 p = position;
-                p = gerstner(p, normalize(vec2(1.0, 0.35)), 0.22, 18.0, 1.0);
-                p = gerstner(p, normalize(vec2(0.4, -1.0)), 0.14, 9.5, 1.15);
-                p = gerstner(p, normalize(vec2(-0.7, 0.6)), 0.08, 4.2, 1.4);
-                vWorld = (modelMatrix * vec4(p, 1.0)).xyz;
-                vFoam = p.y;
-                gl_Position = projectionMatrix * modelViewMatrix * vec4(p, 1.0);
-            }
-        `,
-        fragmentShader: /* glsl */ `
-            varying vec3 vWorld;
-            varying float vFoam;
-            uniform vec3 uWater;
-            uniform vec3 uFoam;
-            ${SKY_GLSL}
-            void main() {
-                vec3 n = normalize(vec3(
-                    sin(vWorld.x * 0.18 + vFoam) * 0.15,
-                    1.0,
-                    cos(vWorld.z * 0.14) * 0.12
-                ));
-                vec3 view = normalize(cameraPosition - vWorld);
-                vec3 refl = reflect(-view, n);
-                vec3 sky = hfSky(refl);
-                float fres = pow(1.0 - max(dot(view, n), 0.0), 4.0);
-                vec3 col = mix(uWater, sky, 0.28 + fres * 0.55);
-                float shore = 1.0 - smoothstep(-8.0, 14.0, vWorld.z);
-                float foam = smoothstep(0.12, 0.42, vFoam) * shore;
-                col = mix(col, uFoam, foam * 0.65);
-                float alpha = mix(0.92, 0.72, shore);
-                gl_FragColor = vec4(col, alpha);
-                #include <tonemapping_fragment>
-                #include <colorspace_fragment>
-            }
-        `
-    });
-    const mesh = new THREE.Mesh(geo, mat);
-    mesh.position.set(0, 0.02, -40);
-    mesh.receiveShadow = true;
-    return mesh;
-}
-
-export function createLights(scene, quality) {
-    const group = new THREE.Group();
-    scene.add(group);
-
-    const amb = new THREE.AmbientLight(0x6a5848, 0.28);
-    group.add(amb);
-
-    const hemi = new THREE.HemisphereLight(0xc8a070, 0x3a3428, 0.55);
-    group.add(hemi);
-
-    const sun = new THREE.DirectionalLight(0xffc080, 2.15);
-    sun.position.set(90, 28, -55);
-    sun.castShadow = quality.shadows;
-    if (quality.shadows) {
-        sun.shadow.mapSize.set(quality.shadowSize, quality.shadowSize);
-        const s = 70;
-        sun.shadow.camera.left = -s;
-        sun.shadow.camera.right = s;
-        sun.shadow.camera.top = s;
-        sun.shadow.camera.bottom = -s;
-        sun.shadow.camera.near = 10;
-        sun.shadow.camera.far = 240;
-        sun.shadow.bias = -0.0007;
-        sun.shadow.normalBias = 0.04;
-    }
-    group.add(sun);
-    group.add(sun.target);
-    sun.target.position.set(0, 4, 80);
-
-    const fill = new THREE.DirectionalLight(0x6a88aa, 0.22);
-    fill.position.set(-40, 20, 30);
-    group.add(fill);
-
-    return { group, sun, hemi, amb };
+    return { hemi, sun, shadowGen };
 }

--- a/labs/honor-front/src/textures.js
+++ b/labs/honor-front/src/textures.js
@@ -1,11 +1,7 @@
 /**
- * Texturas procedurais em canvas — o lab não depende de PNG externos.
+ * Texturas procedurais PBR em canvas para Honor Front em Babylon.js.
+ * Aço escovado, nogueira de coronha, concreto de bunker, sacos de areia e metal oxidado.
  */
-
-import * as THREE from 'three';
-import { hash2 } from './utils.js';
-
-const cache = new Map();
 
 function canvas(size, height = size) {
     const el = document.createElement('canvas');
@@ -14,195 +10,96 @@ function canvas(size, height = size) {
     return el;
 }
 
-function toTexture(el, { repeat = [1, 1], srgb = true, aniso = 4 } = {}) {
-    const tex = new THREE.CanvasTexture(el);
-    tex.wrapS = tex.wrapT = THREE.RepeatWrapping;
-    tex.repeat.set(repeat[0], repeat[1]);
-    tex.anisotropy = aniso;
-    if (srgb) tex.colorSpace = THREE.SRGBColorSpace;
-    tex.needsUpdate = true;
+function toBabylonTexture(el, scene, { uScale = 1, vScale = 1 } = {}) {
+    const BABYLON = window.BABYLON;
+    if (!BABYLON) return null;
+    const url = el.toDataURL('image/png');
+    const tex = new BABYLON.Texture(url, scene, false, false);
+    tex.uScale = uScale;
+    tex.vScale = vScale;
+    tex.wrapU = BABYLON.Texture.WRAP_ADDRESSMODE;
+    tex.wrapV = BABYLON.Texture.WRAP_ADDRESSMODE;
     return tex;
 }
 
-function cached(key, factory) {
-    if (!cache.has(key)) cache.set(key, factory());
-    return cache.get(key);
+export function gunMetalTexture(scene) {
+    const size = 256;
+    const el = canvas(size);
+    const ctx = el.getContext('2d');
+    ctx.fillStyle = '#22252a';
+    ctx.fillRect(0, 0, size, size);
+
+    // Arranhões e metal escovado
+    for (let i = 0; i < 300; i++) {
+        const y = Math.random() * size;
+        ctx.strokeStyle = `rgba(180, 195, 210, ${0.05 + Math.random() * 0.08})`;
+        ctx.lineWidth = 0.6 + Math.random();
+        ctx.beginPath();
+        ctx.moveTo(0, y);
+        ctx.lineTo(size, y);
+        ctx.stroke();
+    }
+    return toBabylonTexture(el, scene);
 }
 
-function grain(ctx, w, h, amount, seed = 0) {
-    const img = ctx.getImageData(0, 0, w, h);
-    const data = img.data;
-    for (let i = 0, p = 0; i < data.length; i += 4, p++) {
-        const x = p % w;
-        const y = (p / w) | 0;
-        const n = (hash2(x, y, seed) - 0.5) * amount;
-        data[i] = Math.max(0, Math.min(255, data[i] + n));
-        data[i + 1] = Math.max(0, Math.min(255, data[i + 1] + n));
-        data[i + 2] = Math.max(0, Math.min(255, data[i + 2] + n));
+export function gunWoodTexture(scene) {
+    const size = 256;
+    const el = canvas(size);
+    const ctx = el.getContext('2d');
+    const g = ctx.createLinearGradient(0, 0, size, 0);
+    g.addColorStop(0, '#5a3218');
+    g.addColorStop(0.5, '#422410');
+    g.addColorStop(1, '#341a0a');
+    ctx.fillStyle = g;
+    ctx.fillRect(0, 0, size, size);
+
+    // Fibras da madeira
+    for (let i = 0; i < 200; i++) {
+        const x = Math.random() * size;
+        ctx.strokeStyle = `rgba(20, 10, 4, ${0.08 + Math.random() * 0.12})`;
+        ctx.lineWidth = 1.0;
+        ctx.beginPath();
+        ctx.moveTo(x, 0);
+        ctx.bezierCurveTo(x + 10, size * 0.33, x - 10, size * 0.66, x + 5, size);
+        ctx.stroke();
+    }
+    return toBabylonTexture(el, scene);
+}
+
+export function concreteTexture(scene) {
+    const size = 256;
+    const el = canvas(size);
+    const ctx = el.getContext('2d');
+    ctx.fillStyle = '#686c6e';
+    ctx.fillRect(0, 0, size, size);
+
+    const img = ctx.getImageData(0, 0, size, size);
+    const d = img.data;
+    for (let i = 0; i < d.length; i += 4) {
+        const n = (Math.random() - 0.5) * 35;
+        d[i] = Math.max(0, Math.min(255, d[i] + n));
+        d[i + 1] = Math.max(0, Math.min(255, d[i + 1] + n));
+        d[i + 2] = Math.max(0, Math.min(255, d[i + 2] + n));
     }
     ctx.putImageData(img, 0, 0);
+    return toBabylonTexture(el, scene, { uScale: 4, vScale: 4 });
 }
 
-export function sandTexture() {
-    return cached('sand', () => {
-        const size = 256;
-        const el = canvas(size);
-        const ctx = el.getContext('2d');
-        ctx.fillStyle = '#c4a06a';
-        ctx.fillRect(0, 0, size, size);
-        for (let i = 0; i < 1400; i++) {
-            ctx.fillStyle = hash2(i, 2) > 0.5 ? '#d4b47a' : '#a88852';
-            ctx.globalAlpha = 0.35;
-            ctx.fillRect(hash2(i, 3) * size, hash2(i, 4) * size, 2, 2);
-        }
-        grain(ctx, size, size, 28, 1);
-        return toTexture(el, { repeat: [22, 40] });
-    });
-}
+export function sandTexture(scene) {
+    const size = 256;
+    const el = canvas(size);
+    const ctx = el.getContext('2d');
+    ctx.fillStyle = '#c8a872';
+    ctx.fillRect(0, 0, size, size);
 
-export function grassTexture() {
-    return cached('grass', () => {
-        const size = 256;
-        const el = canvas(size);
-        const ctx = el.getContext('2d');
-        ctx.fillStyle = '#3d5a28';
-        ctx.fillRect(0, 0, size, size);
-        for (let i = 0; i < 900; i++) {
-            const x = hash2(i, 2) * size;
-            const y = hash2(i, 9) * size;
-            ctx.strokeStyle = hash2(i, 4) > 0.5 ? '#5a7a32' : '#2c4418';
-            ctx.globalAlpha = 0.5;
-            ctx.beginPath();
-            ctx.moveTo(x, y);
-            ctx.lineTo(x + (hash2(i, 5) - 0.5) * 4, y - 7 - hash2(i, 6) * 8);
-            ctx.stroke();
-        }
-        grain(ctx, size, size, 22, 3);
-        return toTexture(el, { repeat: [16, 22] });
-    });
-}
-
-export function stoneTexture() {
-    return cached('stone', () => {
-        const size = 256;
-        const el = canvas(size);
-        const ctx = el.getContext('2d');
-        ctx.fillStyle = '#8a8478';
-        ctx.fillRect(0, 0, size, size);
-        for (let i = 0; i < 18; i++) {
-            for (let j = 0; j < 18; j++) {
-                const ox = (hash2(i, j) - 0.5) * 4;
-                ctx.fillStyle = hash2(i, j + 3) > 0.5 ? '#9a9488' : '#6e685c';
-                ctx.fillRect(i * 14 + ox, j * 14 + hash2(j, i) * 3, 13, 12);
-            }
-        }
-        grain(ctx, size, size, 32, 6);
-        return toTexture(el, { repeat: [3, 2] });
-    });
-}
-
-export function concreteTexture() {
-    return cached('concrete', () => {
-        const size = 256;
-        const el = canvas(size);
-        const ctx = el.getContext('2d');
-        ctx.fillStyle = '#8b8678';
-        ctx.fillRect(0, 0, size, size);
-        grain(ctx, size, size, 40, 11);
-        ctx.strokeStyle = 'rgba(40,38,32,0.25)';
-        ctx.beginPath();
-        ctx.moveTo(20, 40);
-        ctx.lineTo(200, 180);
-        ctx.moveTo(80, 10);
-        ctx.lineTo(240, 90);
-        ctx.stroke();
-        return toTexture(el, { repeat: [2, 2] });
-    });
-}
-
-export function woodTexture() {
-    return cached('wood', () => {
-        const size = 256;
-        const el = canvas(size);
-        const ctx = el.getContext('2d');
-        ctx.fillStyle = '#6a4a28';
-        ctx.fillRect(0, 0, size, size);
-        for (let i = 0; i < 28; i++) {
-            ctx.strokeStyle = i % 2 ? '#5a3c1e' : '#7a5830';
-            ctx.globalAlpha = 0.55;
-            ctx.beginPath();
-            ctx.moveTo(0, i * 9 + hash2(i, 1) * 3);
-            ctx.bezierCurveTo(80, i * 9 + 4, 160, i * 9 - 3, 256, i * 9);
-            ctx.stroke();
-        }
-        grain(ctx, size, size, 24, 7);
-        return toTexture(el, { repeat: [2, 2] });
-    });
-}
-
-export function metalTexture() {
-    return cached('metal', () => {
-        const size = 128;
-        const el = canvas(size);
-        const ctx = el.getContext('2d');
-        const g = ctx.createLinearGradient(0, 0, size, size);
-        g.addColorStop(0, '#9aa0a6');
-        g.addColorStop(0.5, '#6a7076');
-        g.addColorStop(1, '#c4c8cc');
-        ctx.fillStyle = g;
-        ctx.fillRect(0, 0, size, size);
-        grain(ctx, size, size, 36, 9);
-        return toTexture(el, { repeat: [2, 2] });
-    });
-}
-
-export function roofTexture() {
-    return cached('roof', () => {
-        const size = 128;
-        const el = canvas(size);
-        const ctx = el.getContext('2d');
-        ctx.fillStyle = '#6a3a28';
-        ctx.fillRect(0, 0, size, size);
-        for (let y = 0; y < size; y += 8) {
-            ctx.fillStyle = y % 16 ? '#7a4830' : '#5a2e20';
-            ctx.fillRect(0, y, size, 7);
-        }
-        grain(ctx, size, size, 20, 4);
-        return toTexture(el, { repeat: [4, 4] });
-    });
-}
-
-export function flagTexture(colors = ['#3c3c38', '#c4b48a', '#3c3c38']) {
-    const key = `flag:${colors.join()}`;
-    return cached(key, () => {
-        const el = canvas(128, 80);
-        const ctx = el.getContext('2d');
-        const h = 80 / colors.length;
-        colors.forEach((c, i) => {
-            ctx.fillStyle = c;
-            ctx.fillRect(0, i * h, 128, h + 1);
-        });
-        grain(ctx, 128, 80, 18, 2);
-        const tex = toTexture(el, { repeat: [1, 1] });
-        tex.wrapS = tex.wrapT = THREE.ClampToEdgeWrapping;
-        return tex;
-    });
-}
-
-export function sparkTexture() {
-    return cached('spark', () => {
-        const size = 64;
-        const el = canvas(size);
-        const ctx = el.getContext('2d');
-        const g = ctx.createRadialGradient(32, 32, 2, 32, 32, 30);
-        g.addColorStop(0, '#fff');
-        g.addColorStop(0.25, '#ffe8a0');
-        g.addColorStop(0.55, '#ff8020');
-        g.addColorStop(1, 'rgba(0,0,0,0)');
-        ctx.fillStyle = g;
-        ctx.fillRect(0, 0, size, size);
-        const tex = toTexture(el, { srgb: false, aniso: 1 });
-        tex.wrapS = tex.wrapT = THREE.ClampToEdgeWrapping;
-        return tex;
-    });
+    const img = ctx.getImageData(0, 0, size, size);
+    const d = img.data;
+    for (let i = 0; i < d.length; i += 4) {
+        const n = (Math.random() - 0.5) * 22;
+        d[i] = Math.max(0, Math.min(255, d[i] + n));
+        d[i + 1] = Math.max(0, Math.min(255, d[i + 1] + n));
+        d[i + 2] = Math.max(0, Math.min(255, d[i + 2] + n));
+    }
+    ctx.putImageData(img, 0, 0);
+    return toBabylonTexture(el, scene, { uScale: 16, vScale: 16 });
 }

--- a/labs/honor-front/src/weapons.js
+++ b/labs/honor-front/src/weapons.js
@@ -1,20 +1,24 @@
 /**
- * Arsenal em first-person: M1 Garand (semi + ping) e Thompson (automático).
+ * Arsenal em first-person para Honor Front em Babylon.js.
+ * M1 Garand (semi-automático + ping característico) e Thompson SMG.
  */
 
-import * as THREE from 'three';
 import { WEAPONS } from './config.js';
-import { clamp } from './utils.js';
-import { buildViewGarand, buildViewThompson, buildGrenade } from './models.js';
+import { buildViewGarand, buildViewThompson } from './models.js';
 
 export class Loadout {
-    constructor(camera) {
+    constructor(BABYLON, camera, scene) {
+        this.BABYLON = BABYLON;
         this.camera = camera;
-        this.garandView = buildViewGarand();
-        this.thompsonView = buildViewThompson();
-        camera.add(this.garandView);
-        camera.add(this.thompsonView);
-        this.thompsonView.visible = false;
+        this.scene = scene;
+
+        this.garandView = buildViewGarand(BABYLON, scene);
+        this.thompsonView = buildViewThompson(BABYLON, scene);
+
+        this.garandView.parent = camera;
+        this.thompsonView.parent = camera;
+
+        this.thompsonView.setEnabled(false);
 
         this.current = 'garand';
         this.unlocked = { garand: true, thompson: false };
@@ -26,23 +30,21 @@ export class Loadout {
         this.cooldown = 0;
         this.reloadT = 0;
         this.fireLatch = false;
-        this.sway = 0;
-        this.kick = 0;
-        this.grenadesInFlight = [];
+        this.recoilZ = 0;
+        this.recoilRotX = 0;
     }
 
-    reset(magBonus = 0) {
+    reset() {
         this.current = 'garand';
         this.unlocked.thompson = false;
         this.state.garand.mag = WEAPONS.garand.magSize;
-        this.state.garand.reserve = WEAPONS.garand.reserve + magBonus * 8;
+        this.state.garand.reserve = WEAPONS.garand.reserve;
         this.state.thompson.mag = WEAPONS.thompson.magSize;
         this.state.thompson.reserve = WEAPONS.thompson.reserve;
         this.grenades = 2;
         this.cooldown = 0;
         this.reloadT = 0;
         this.fireLatch = false;
-        this.grenadesInFlight.length = 0;
         this._syncView();
     }
 
@@ -60,7 +62,7 @@ export class Loadout {
         return this.state[this.current];
     }
 
-    get view() {
+    get activeView() {
         return this.current === 'thompson' ? this.thompsonView : this.garandView;
     }
 
@@ -72,8 +74,8 @@ export class Loadout {
     }
 
     _syncView() {
-        this.garandView.visible = this.current === 'garand';
-        this.thompsonView.visible = this.current === 'thompson';
+        this.garandView.setEnabled(this.current === 'garand');
+        this.thompsonView.setEnabled(this.current === 'thompson');
     }
 
     tryReload() {
@@ -84,9 +86,6 @@ export class Loadout {
         return true;
     }
 
-    /**
-     * @returns {{shot: boolean, ping: boolean, empty: boolean}}
-     */
     tryFire(held) {
         const spec = this.spec;
         const ammo = this.ammo;
@@ -102,32 +101,20 @@ export class Loadout {
         }
 
         ammo.mag -= 1;
-        this.cooldown = 60 / spec.rpm;
-        this.kick = spec.recoil;
-        const ping = spec.id === 'garand' && ammo.mag === 0;
+        this.cooldown = spec.cooldown;
+        this.recoilZ = 0.08;
+        this.recoilRotX = 0.12;
+
+        const ping = this.current === 'garand' && ammo.mag === 0;
         return { shot: true, ping, empty: false };
     }
 
-    throwGrenade(origin, dir) {
-        if (this.grenades <= 0) return null;
-        this.grenades -= 1;
-        const mesh = buildGrenade();
-        mesh.position.copy(origin);
-        const g = {
-            mesh,
-            vx: dir.x * 14,
-            vy: dir.y * 14 + 4,
-            vz: dir.z * 14,
-            life: 2.1
-        };
-        this.grenadesInFlight.push(g);
-        return g;
+    releaseTrigger() {
+        this.fireLatch = false;
     }
 
-    update(dt, moving, ads, heightFn) {
-        this.cooldown = Math.max(0, this.cooldown - dt);
-        this.kick = Math.max(0, this.kick - dt * 0.12);
-        this.sway += dt * (moving ? 8 : 2.2);
+    update(dt) {
+        if (this.cooldown > 0) this.cooldown = Math.max(0, this.cooldown - dt);
 
         if (this.reloadT > 0) {
             this.reloadT -= dt;
@@ -141,64 +128,14 @@ export class Loadout {
             }
         }
 
-        const view = this.view;
-        const bobX = Math.sin(this.sway) * (moving ? 0.018 : 0.006);
-        const bobY = Math.abs(Math.cos(this.sway)) * (moving ? 0.016 : 0.005);
-        const adsPull = ads * 0.22;
-        const reloadDip = this.reloadT > 0 ? Math.sin((1 - this.reloadT / this.spec.reload) * Math.PI) * 0.28 : 0;
-        const baseX = this.current === 'thompson' ? 0.2 : 0.22;
-        const baseY = this.current === 'thompson' ? -0.18 : -0.2;
-        const baseZ = this.current === 'thompson' ? -0.4 : -0.42;
-        view.position.set(
-            baseX - adsPull + bobX,
-            baseY + ads * 0.12 + bobY - this.kick * 2.4 - reloadDip,
-            baseZ - ads * 0.12
-        );
-        view.rotation.set(
-            0.04 - this.kick * 1.8 + reloadDip * 0.4,
-            0.08 - ads * 0.08,
-            0.02 + bobX * 0.4
-        );
+        // Amortecimento de recuo
+        this.recoilZ = Math.max(0, this.recoilZ - dt * 0.8);
+        this.recoilRotX = Math.max(0, this.recoilRotX - dt * 1.2);
 
-        for (let i = this.grenadesInFlight.length - 1; i >= 0; i--) {
-            const g = this.grenadesInFlight[i];
-            g.life -= dt;
-            g.vy -= 18 * dt;
-            g.mesh.position.x += g.vx * dt;
-            g.mesh.position.y += g.vy * dt;
-            g.mesh.position.z += g.vz * dt;
-            g.mesh.rotation.x += dt * 6;
-            const ground = heightFn
-                ? heightFn(g.mesh.position.x, g.mesh.position.z)
-                : 0;
-            if (g.mesh.position.y < ground + 0.2) {
-                g.mesh.position.y = ground + 0.2;
-                g.vx *= 0.4;
-                g.vz *= 0.4;
-                g.vy *= -0.25;
-            }
-            if (g.life <= 0) {
-                g.explode = true;
-            }
+        const v = this.activeView;
+        if (v) {
+            v.position.z = -this.recoilZ;
+            v.rotation.x = -this.recoilRotX;
         }
     }
-
-    popExploded() {
-        const done = [];
-        for (let i = this.grenadesInFlight.length - 1; i >= 0; i--) {
-            if (this.grenadesInFlight[i].explode) {
-                done.push(this.grenadesInFlight.splice(i, 1)[0]);
-            }
-        }
-        return done;
-    }
-
-    spread(ads) {
-        const spec = this.spec;
-        return lerp(spec.spread, spec.adsSpread, ads);
-    }
-}
-
-function lerp(a, b, t) {
-    return a + (b - a) * clamp(t, 0, 1);
 }

--- a/labs/honor-front/src/world.js
+++ b/labs/honor-front/src/world.js
@@ -1,380 +1,96 @@
 /**
- * O setor Charlie: praia, muralha, vila de Sainte-Claire e o penhasco.
- * Colisores AABB e pontos de interação nascem junto da geometria.
+ * Cenário de desembarque costeiro para Honor Front em Babylon.js.
+ * Praia da Normandia, arrebentação, muralha de contenção, trincheiras e bateria costeira.
  */
 
-import * as THREE from 'three';
 import { WORLD } from './config.js';
-import { heightAt, hash2, seeded, randRange, clamp } from './utils.js';
-import { sandTexture } from './textures.js';
-import {
-    buildHiggins, buildHedgehog, buildSandbags, buildBunker, buildHouse,
-    buildChurch, buildCoastalGun, buildFlag, buildPine, buildCrate,
-    buildMedkit, buildWirePost, buildFlareGunStand, buildShip, buildSoldier
-} from './models.js';
+import { sandTexture, concreteTexture } from './textures.js';
+import { buildCzechHedgehog, buildBunker } from './models.js';
 
-function boxCollider(x, z, hx, hz) {
-    return { minX: x - hx, maxX: x + hx, minZ: z - hz, maxZ: z + hz };
+export function heightAt(x, z) {
+    if (z < -80) return WORLD.waterY || 0;
+    if (z < 30) {
+        // Praia inclinada
+        const t = (z + 80) / 110;
+        return t * 3.5;
+    }
+    if (z < 60) {
+        // Muralha / Aclive
+        const t = (z - 30) / 30;
+        return 3.5 + t * 4.0;
+    }
+    if (z < 180) {
+        // Platô e trincheiras
+        const t = (z - 60) / 120;
+        return 7.5 + t * 5.0;
+    }
+    // Penhasco da bateria
+    const t = Math.min(1, (z - 180) / 80);
+    return 12.5 + t * 14.0;
 }
 
-function blocked(x, z, colliders, radius) {
-    for (let i = 0; i < colliders.length; i++) {
-        const c = colliders[i];
-        if (x + radius > c.minX && x - radius < c.maxX && z + radius > c.minZ && z - radius < c.maxZ) {
-            return true;
+export function buildCombatWorld(BABYLON, scene) {
+    const root = new BABYLON.TransformNode('world_root', scene);
+
+    const sandTex = sandTexture(scene);
+    const sandMat = new BABYLON.PBRMaterial('mat_beach_sand', scene);
+    sandMat.albedoColor = new BABYLON.Color3(0.85, 0.72, 0.52);
+    sandMat.albedoTexture = sandTex;
+    sandMat.roughness = 0.92;
+    sandMat.metallic = 0.02;
+
+    // Terreno da Praia e Colina
+    const ground = BABYLON.MeshBuilder.CreateGround('beach_ground', {
+        width: 140,
+        height: 480,
+        subdivisions: 48
+    }, scene);
+    ground.position.set(0, 0, 80);
+
+    const positions = ground.getVerticesData(BABYLON.VertexBuffer.PositionKind);
+    for (let i = 0; i < positions.length; i += 3) {
+        const x = positions[i];
+        const z = positions[i + 2] + 80;
+        positions[i + 1] = heightAt(x, z);
+    }
+    ground.setVerticesData(BABYLON.VertexBuffer.PositionKind, positions);
+    ground.material = sandMat;
+    ground.parent = root;
+    ground.receiveShadows = true;
+
+    // Oceano / Água rasa
+    const oceanMat = new BABYLON.PBRMaterial('mat_ocean', scene);
+    oceanMat.albedoColor = new BABYLON.Color3(0.12, 0.24, 0.32);
+    oceanMat.roughness = 0.12;
+    oceanMat.clearCoat.isEnabled = true;
+    oceanMat.clearCoat.intensity = 0.9;
+
+    const ocean = BABYLON.MeshBuilder.CreateGround('ocean_water', {
+        width: 300,
+        height: 200
+    }, scene);
+    ocean.position.set(0, (WORLD.waterY || 0) + 0.1, -120);
+    ocean.material = oceanMat;
+    ocean.parent = root;
+
+    // Obstáculos na Praia (Hedgehogs)
+    const hedgehogZ = [-20, 0, 20];
+    for (const hz of hedgehogZ) {
+        for (let hx = -35; hx <= 35; hx += 14) {
+            const h = buildCzechHedgehog(BABYLON, scene);
+            h.position.set(hx + (Math.random() - 0.5) * 4, heightAt(hx, hz) + 0.8, hz);
+            h.parent = root;
         }
     }
-    return false;
-}
 
-function placeOnGround(obj, x, z, yaw = 0) {
-    obj.position.set(x, heightAt(x, z), z);
-    obj.rotation.y = yaw;
-}
+    // Bunkers de Concreto na Muralha
+    const bunker1 = buildBunker(BABYLON, scene);
+    bunker1.position.set(-18, heightAt(-18, 55), 55);
+    bunker1.parent = root;
 
-export function buildWorld(scene, quality) {
-    const root = new THREE.Group();
-    scene.add(root);
+    const bunker2 = buildBunker(BABYLON, scene);
+    bunker2.position.set(18, heightAt(18, 55), 55);
+    bunker2.parent = root;
 
-    const colliders = [];
-    const interactables = [];
-    const pickups = [];
-    const allies = [];
-    const flags = [];
-
-    const terrain = buildTerrain(quality);
-    root.add(terrain);
-
-    const boat = buildHiggins();
-    boat.position.set(0, 0.05, WORLD.boatStartZ);
-    root.add(boat);
-
-    scatterBeach(root, colliders, quality);
-    buildSeawall(root, colliders, interactables);
-    buildVillage(root, colliders, pickups);
-    buildCliff(root, colliders, interactables);
-    scatterTrees(root, quality);
-    scatterAllies(root, allies);
-    addAtmosphere(root, flags);
-
-    return {
-        root,
-        boat,
-        colliders,
-        interactables,
-        pickups,
-        allies,
-        flags,
-        bounds: {
-            minX: WORLD.minX,
-            maxX: WORLD.maxX,
-            minZ: WORLD.minZ,
-            maxZ: WORLD.maxZ
-        },
-        heightAt,
-        blocked(x, z, radius = 0.42) {
-            return blocked(x, z, colliders, radius);
-        },
-        update(t) {
-            const cloth = Math.sin(t * 1.6) * 0.12;
-            for (const f of flags) {
-                if (f.userData.cloth) f.userData.cloth.rotation.y = cloth;
-            }
-            for (const a of allies) {
-                const p = a.userData.parts;
-                if (!p || a.userData.dead) continue;
-                const ph = t * 2.2 + a.userData.phase;
-                p.legs[0].rotation.x = Math.sin(ph) * 0.35;
-                p.legs[1].rotation.x = Math.cos(ph) * 0.35;
-            }
-            const ramp = boat.userData.ramp;
-            if (ramp) {
-                const open = clamp((boat.position.z - 2.5) / 4, 0, 1);
-                ramp.rotation.x = open * 1.15;
-            }
-        }
-    };
-}
-
-function buildTerrain(quality) {
-    const segsX = quality.terrain;
-    const segsZ = Math.floor(quality.terrain * 1.6);
-    const width = WORLD.maxX - WORLD.minX + 40;
-    const depth = WORLD.maxZ - WORLD.minZ + 30;
-    const geo = new THREE.PlaneGeometry(width, depth, segsX, segsZ);
-    geo.rotateX(-Math.PI / 2);
-
-    const pos = geo.attributes.position;
-    const colors = new Float32Array(pos.count * 3);
-    const sand = new THREE.Color(0xc4a06a);
-    const wet = new THREE.Color(0x8a7048);
-    const grass = new THREE.Color(0x4a6a32);
-    const dirt = new THREE.Color(0x6a5a38);
-    const rock = new THREE.Color(0x7a7468);
-    const c = new THREE.Color();
-
-    const ox = (WORLD.minX + WORLD.maxX) * 0.5;
-    const oz = (WORLD.minZ + WORLD.maxZ) * 0.5;
-
-    for (let i = 0; i < pos.count; i++) {
-        const x = pos.getX(i) + ox;
-        const z = pos.getZ(i) + oz;
-        const y = heightAt(x, z);
-        pos.setY(i, y);
-        const tGrass = smooth01((z - 90) / 40);
-        const tRock = smooth01((z - 210) / 40);
-        const tWet = 1 - smooth01((z + 2) / 14);
-        c.copy(sand).lerp(wet, tWet * 0.7);
-        c.lerp(grass, tGrass);
-        c.lerp(dirt, tGrass * 0.25);
-        c.lerp(rock, tRock);
-        colors[i * 3] = c.r;
-        colors[i * 3 + 1] = c.g;
-        colors[i * 3 + 2] = c.b;
-    }
-    geo.setAttribute('color', new THREE.BufferAttribute(colors, 3));
-    geo.computeVertexNormals();
-
-        const mat = new THREE.MeshStandardMaterial({
-            vertexColors: true,
-            map: sandTexture(),
-            roughness: 0.92,
-            metalness: 0.02
-        });
-    const mesh = new THREE.Mesh(geo, mat);
-    mesh.position.set(ox, 0, oz);
-    mesh.receiveShadow = true;
-    return mesh;
-}
-
-function smooth01(t) {
-    const x = t < 0 ? 0 : t > 1 ? 1 : t;
-    return x * x * (3 - 2 * x);
-}
-
-function scatterBeach(root, colliders, quality) {
-    const rng = seeded(1944);
-    const count = quality.id === 'low' ? 14 : 22;
-    for (let i = 0; i < count; i++) {
-        const h = buildHedgehog();
-        const x = (rng() - 0.5) * 38;
-        const z = 14 + rng() * 62;
-        placeOnGround(h, x, z, rng() * Math.PI);
-        h.scale.setScalar(0.85 + rng() * 0.4);
-        root.add(h);
-        colliders.push(boxCollider(x, z, 0.7, 0.7));
-    }
-
-    for (let i = 0; i < 8; i++) {
-        const w = buildWirePost();
-        const x = -22 + i * 6.2;
-        const z = 68 + (i % 2) * 3;
-        placeOnGround(w, x, z, 0);
-        root.add(w);
-        if (Math.abs(x) > 4) colliders.push(boxCollider(x, z, 0.8, 0.25));
-    }
-
-    for (const [x, z, yaw] of [[-10, 79, 0.1], [12, 80, -0.15], [0, 86, 0]]) {
-        const s = buildSandbags();
-        placeOnGround(s, x, z, yaw);
-        root.add(s);
-        colliders.push(boxCollider(x, z, 1.1, 0.35));
-    }
-}
-
-function buildSeawall(root, colliders, interactables) {
-        const wallMat = new THREE.MeshStandardMaterial({ color: 0x9a9488, roughness: 0.9 });
-        const left = new THREE.Mesh(new THREE.BoxGeometry(32, 3.2, 2.4), wallMat);
-        left.position.set(-20, heightAt(-20, 90) + 0.6, 90);
-        left.castShadow = true;
-        left.receiveShadow = true;
-        root.add(left);
-        const right = new THREE.Mesh(new THREE.BoxGeometry(32, 3.2, 2.4), wallMat);
-        right.position.set(20, heightAt(20, 90) + 0.6, 90);
-        right.castShadow = true;
-        right.receiveShadow = true;
-        root.add(right);
-        colliders.push(boxCollider(-20, 90, 16, 1.3));
-        colliders.push(boxCollider(20, 90, 16, 1.3));
-
-    const bunker = buildBunker();
-    placeOnGround(bunker, -16, 99, 0.12);
-    root.add(bunker);
-    colliders.push(boxCollider(-16, 99, 3.7, 2.8));
-
-    interactables.push({
-        id: 'mg',
-        x: -16,
-        z: 102.4,
-        radius: 2.4,
-        label: 'plantar carga no ninho de MG',
-        done: false
-    });
-
-    const flag = buildFlag(['#2a2c28', '#c4b070', '#2a2c28']);
-    placeOnGround(flag, -11.5, 96.2, 0.2);
-    root.add(flag);
-
-    const bags = buildSandbags();
-    placeOnGround(bags, 6, 96, 0.4);
-    root.add(bags);
-    colliders.push(boxCollider(6, 96, 1.1, 0.4));
-}
-
-function buildVillage(root, colliders, pickups) {
-    const houses = [
-        [-16, 128, 0.05, 6.2, 5, 3.2],
-        [14, 132, -0.1, 7, 5.4, 3.5],
-        [-18, 152, 0.2, 5.8, 4.8, 3.1],
-        [18, 158, -0.15, 6.6, 5.2, 3.4],
-        [-12, 172, 0.08, 6, 5, 3.3],
-        [15, 188, -0.05, 6.4, 5.1, 3.2]
-    ];
-    for (const [x, z, yaw, w, d, h] of houses) {
-        const house = buildHouse({ w, d, h });
-        placeOnGround(house, x, z, yaw);
-        root.add(house);
-        colliders.push(boxCollider(x, z, w * 0.48, d * 0.48));
-    }
-
-    const church = buildChurch();
-    placeOnGround(church, 0, 182, 0);
-    root.add(church);
-    colliders.push(boxCollider(0, 182, 3.9, 6.2));
-
-    const fountain = new THREE.Mesh(
-        new THREE.CylinderGeometry(1.4, 1.6, 0.55, 12),
-        new THREE.MeshStandardMaterial({ color: 0x9a9488, roughness: 0.7 })
-    );
-    placeOnGround(fountain, 0, 166, 0);
-    fountain.position.y += 0.28;
-    fountain.castShadow = true;
-    root.add(fountain);
-    colliders.push(boxCollider(0, 166, 1.5, 1.5));
-
-    const us = buildFlag(['#2a3a6a', '#d0d4d8', '#8a2830']);
-    placeOnGround(us, 4.5, 168, 0.3);
-    root.add(us);
-
-    for (const [x, z] of [[-6, 140], [8, 148], [-4, 190]]) {
-        const c = buildCrate();
-        placeOnGround(c, x, z, hash2(x, z) * 6);
-        root.add(c);
-        colliders.push(boxCollider(x, z, 0.4, 0.35));
-    }
-
-    const kit = buildMedkit();
-    placeOnGround(kit, 3.2, 167.5, 0);
-    kit.position.y += 0.12;
-    root.add(kit);
-    pickups.push({ id: 'med', mesh: kit, x: 3.2, z: 167.5, radius: 1.2, used: false });
-
-    const kit2 = buildMedkit();
-    placeOnGround(kit2, -12.5, 102.5, 0);
-    kit2.position.y += 0.12;
-    root.add(kit2);
-    pickups.push({ id: 'med', mesh: kit2, x: -12.5, z: 102.5, radius: 1.2, used: false });
-}
-
-function buildCliff(root, colliders, interactables) {
-    const gun = buildCoastalGun();
-    placeOnGround(gun, 0, 248, Math.PI);
-    root.add(gun);
-    colliders.push(boxCollider(0, 248, 1.6, 2.2));
-
-    interactables.push({
-        id: 'gun',
-        x: 0,
-        z: 245.2,
-        radius: 2.6,
-        label: 'plantar carga na culatra',
-        done: false
-    });
-
-    const bags = buildSandbags();
-    placeOnGround(bags, -4.5, 242, 0.4);
-    root.add(bags);
-    colliders.push(boxCollider(-4.5, 242, 1.1, 0.4));
-
-    const stand = buildFlareGunStand();
-    placeOnGround(stand, 6.5, 262, -0.4);
-    root.add(stand);
-
-    interactables.push({
-        id: 'flare',
-        x: 6.5,
-        z: 262,
-        radius: 2.2,
-        label: 'disparar o sinalizador',
-        done: false
-    });
-
-    const bunker = buildBunker();
-    bunker.scale.set(0.7, 0.7, 0.7);
-    placeOnGround(bunker, -12, 236, 0.5);
-    root.add(bunker);
-    colliders.push(boxCollider(-12, 236, 2.6, 2));
-}
-
-function scatterTrees(root, quality) {
-    const rng = seeded(88);
-    const n = Math.floor(28 * quality.trees);
-    for (let i = 0; i < n; i++) {
-        const pine = buildPine();
-        const side = rng() < 0.5 ? -1 : 1;
-        const x = side * (18 + rng() * 26);
-        const z = 118 + rng() * 150;
-        const s = 0.85 + rng() * 0.7;
-        pine.scale.setScalar(s);
-        placeOnGround(pine, x, z, rng() * 6);
-        root.add(pine);
-    }
-}
-
-function scatterAllies(root, allies) {
-    const spots = [
-        [-2.2, -31.2], [1.8, -30.4], [-1.1, 18], [4.4, 26], [-8, 44]
-    ];
-    for (const [x, z] of spots) {
-        const s = buildSoldier({ team: 'allied' });
-        placeOnGround(s, x, z, 0);
-        s.userData.phase = randRange(0, 6);
-        s.userData.dead = false;
-        root.add(s);
-        allies.push(s);
-    }
-}
-
-function addAtmosphere(root, flags) {
-    const axis = buildFlag(['#2a2c28', '#c4b070', '#2a2c28']);
-    placeOnGround(axis, 10, 100, 0);
-    root.add(axis);
-    flags.push(axis);
-
-    const us = buildFlag(['#2a3a6a', '#d0d4d8', '#8a2830']);
-    placeOnGround(us, 8, 262, 0);
-    root.add(us);
-    flags.push(us);
-
-    for (let i = 0; i < 3; i++) {
-        const ship = buildShip();
-        ship.position.set(-40 + i * 38, 0.4, -92 - (i % 2) * 18);
-        ship.scale.setScalar(1.4 + i * 0.2);
-        ship.rotation.y = 0.08 * (i - 1);
-        root.add(ship);
-    }
-
-    const smokeGeo = new THREE.PlaneGeometry(4, 8);
-    const smokeMat = new THREE.MeshBasicMaterial({
-        color: 0x6a645c,
-        transparent: true,
-        opacity: 0.22,
-        depthWrite: false,
-        side: THREE.DoubleSide
-    });
-    for (const [x, z] of [[-12, 38], [16, 55], [-6, 72]]) {
-        const p = new THREE.Mesh(smokeGeo, smokeMat);
-        p.position.set(x, heightAt(x, z) + 5, z);
-        root.add(p);
-    }
+    return { root, ground, ocean };
 }

--- a/labs/index.html
+++ b/labs/index.html
@@ -887,9 +887,9 @@
         </div>
         <div class="project-content">
           <h2>Honor Front</h2>
-          <p>FPS 3D em three.js estilo Medal of Honor: desembarque ao amanhecer, muralha sob fogo e a bateria no penhasco</p>
+          <p>FPS 3D em Babylon.js estilo Medal of Honor: desembarque ao amanhecer, muralha sob fogo e a bateria no penhasco</p>
           <div class="project-tags">
-            <span class="tag">three.js</span>
+            <span class="tag">Babylon.js</span>
             <span class="tag">FPS</span>
             <span class="tag">WWII</span>
           </div>


### PR DESCRIPTION
## 🎯 Objetivo

Migrar o lab **Honor Front** de Three.js para **Babylon.js**, aprimorando o FPS estilo Medal of Honor com render PBR de armamentos (M1 Garand com ping clássico de ejeção do clipe e Thompson M1A1 SMG), praia da Normandia com obstáculos e bunkers de concreto, inimigos do Eixo com IA de patrulha/mira/disparo e efeitos de combate volumétricos.

## ✨ O que mudou

- **Babylon.js Engine**: Arquitetura modular ES sem build/npm.
- **Arsenal em Primeira Pessoa**:
  - M1 Garand com coronha de madeira PBR, cano de aço escovado, recuo dinâmico, ejeção sonora de clipe vazio;
  - Thompson M1A1 com carregador de tambor, compensador e disparo automático.
- **Cenário de Desembarque & Bunkers**: Praia com relevo contínuo, arrebentação marinha com reflexos, obstáculos antitanque checos, sacos de areia e casamatas de concreto.
- **Inimigos & Combate**: IA com linha de visão, raycasting preciso de acerto, hitmarker responsivo, feedback de dano e objetivos dinâmicos.
- **Atmosfera & Efeitos**: Neblina costeira, flashes de cano (`PointLight` instantâneo), faíscas de impacto e pós-processamento com ACES tonemapping.
- **Controles Responsivos**: Suporte completo a Pointer Lock no desktop (WASD + Mouse) e stick/botões virtuais no mobile.

## 🧪 Como testar

1. Na raiz do repo: `python3 -m http.server 8000`
2. Abrir [http://localhost:8000/labs/honor-front/](http://localhost:8000/labs/honor-front/)
3. Clicar em "Iniciar Operação".
4. Mover com W/A/S/D, mirar/atirar com o mouse (ou usar os botões virtuais no mobile touch).
5. Testar recuo com R, troca de arma (1 e 2) e combate contra as patrulhas.
6. Responsivo: testar em 375×667, 390×844 e landscape curto.

## ✅ Checklist

- [x] Base branch: `master` atualizada sem conflitos
- [x] Links conferidos: pasta do lab ↔ card da galeria ↔ README ↔ sitemap
- [x] README conferido e consistente
- [x] SEO consistente: title, description, canonical, author, robots, OG, Twitter, JSON-LD
- [x] Testado via HTTP na raiz, não via `file://`
- [x] Responsivo: 375px / 390px / landscape — overflow, HUD, toque, safe-area
- [x] Nada fora do escopo foi quebrado