### PR TITLE
🎨 UI: Melhorar gráficos e física do Tatu Bola

### DIFF
--- a/labs/tatu-bola/index.html
+++ b/labs/tatu-bola/index.html
@@ -6,9 +6,9 @@
     <meta name="viewport"
         content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover">
     <meta name="theme-color" content="#1a0c18">
-    <title>Tatu Bola — platformer 3D PS1 | Diogo Paulino</title>
+    <title>Tatu Bola — platformer 3D | Diogo Paulino</title>
     <meta name="description"
-        content="Jogo 3D em three.js no espírito PlayStation 1: controle o tatu-bola, pule, role e colete sete cristais na ilha low-poly.">
+        content="Jogo 3D em three.js: controle o tatu-bola, pule, role e colete sete cristais na ilha low-poly.">
     <link rel="canonical" href="https://diogopaulino.com.br/labs/tatu-bola/">
     <meta name="author" content="Diogo Paulino">
     <meta name="robots" content="index, follow">
@@ -23,10 +23,10 @@
     <meta property="og:url" content="https://diogopaulino.com.br/labs/tatu-bola/">
     <meta property="og:title" content="Tatu Bola | Diogo Paulino">
     <meta property="og:description"
-        content="Platformer 3D low-poly: role, pule e colete cristais numa ilha de 1997. three.js no navegador.">
+        content="Platformer 3D low-poly: role, pule e colete cristais numa ilha paradisíaca. three.js no navegador.">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Tatu Bola | Diogo Paulino">
-    <meta name="twitter:description" content="Tatu que vira bola, cristais e ilha PS1 em three.js. PRESS START.">
+    <meta name="twitter:description" content="Tatu que vira bola, cristais e ilha 3D em three.js. PRESS START.">
 
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -52,7 +52,7 @@
           "@type": "WebApplication",
           "name": "Tatu Bola",
           "url": "https://diogopaulino.com.br/labs/tatu-bola/",
-          "description": "Jogo 3D em three.js no espírito PlayStation 1: controle o tatu-bola, pule, role e colete sete cristais na ilha low-poly.",
+          "description": "Jogo 3D em three.js: controle o tatu-bola, pule, role e colete sete cristais na ilha low-poly.",
           "applicationCategory": "GameApplication",
           "operatingSystem": "Any",
           "inLanguage": "pt-BR",
@@ -169,10 +169,10 @@
         <div id="menuOverlay" class="overlay menu-overlay" hidden>
             <div class="overlay-card menu-card">
                 <header class="menu-head">
-                    <p class="eyebrow"><i></i> three.js · low-poly PS1 · 1997</p>
+                    <p class="eyebrow"><i></i> three.js · low-poly · 3D platformer</p>
                     <h1>Tatu <span>Bola</span></h1>
                     <p class="lede">Um tatu-bola numa ilha de polígonos. Pule, role, quebre caixas e
-                        devolva sete cristais ao ídolo do templo — no espírito dos mascotes de 32 bits.</p>
+                        devolva sete cristais ao ídolo do templo.</p>
                 </header>
 
                 <div class="menu-grid">
@@ -200,9 +200,9 @@
                                 <span>Qualidade</span>
                                 <select id="qualitySelect">
                                     <option value="auto">Automática</option>
-                                    <option value="low">PS1 (pixelado)</option>
-                                    <option value="medium">Equilibrada</option>
-                                    <option value="high">Nítida</option>
+                                    <option value="low">Baixa</option>
+                                    <option value="medium">Média</option>
+                                    <option value="high">Alta</option>
                                 </select>
                             </label>
                             <label class="field">

--- a/labs/tatu-bola/src/config.js
+++ b/labs/tatu-bola/src/config.js
@@ -20,20 +20,20 @@ export const ISLAND = {
 export const PLAYER = {
     radius: 0.52,
     height: 0.95,
-    accel: 42,
-    airAccel: 18,
-    maxSpeed: 9.2,
-    rollSpeed: 14.5,
-    friction: 7.2,
-    airFriction: 1.4,
-    jump: 11.4,
-    doubleJump: 9.4,
-    gravity: 38,
-    coyote: 0.12,
+    accel: 60,
+    airAccel: 25,
+    maxSpeed: 10.5,
+    rollSpeed: 16.0,
+    friction: 10.0,
+    airFriction: 2.0,
+    jump: 12.0,
+    doubleJump: 10.0,
+    gravity: 42,
+    coyote: 0.15,
     rollTime: 0.72,
     rollCooldown: 0.28,
     invuln: 1.65,
-    swimSpeed: 3.4,
+    swimSpeed: 4.0,
     drownTime: 2.6
 };
 
@@ -50,10 +50,10 @@ export const QUEST = {
 };
 
 export const QUALITY = {
-    auto: { pixel: 0.72, shadows: true, snap: 88, particles: 1 },
-    low: { pixel: 0.42, shadows: false, snap: 52, particles: 0.4 },
-    medium: { pixel: 0.62, shadows: true, snap: 72, particles: 0.75 },
-    high: { pixel: 1, shadows: true, snap: 110, particles: 1.15 }
+    auto: { pixel: 1.0, shadows: true, particles: 1.0 },
+    low: { pixel: 1.0, shadows: false, particles: 0.5 },
+    medium: { pixel: 1.0, shadows: true, particles: 0.8 },
+    high: { pixel: 1.0, shadows: true, particles: 1.2 }
 };
 
 /** Cristais — (x, z). Y é amostrado do terreno + offset. */

--- a/labs/tatu-bola/src/main.js
+++ b/labs/tatu-bola/src/main.js
@@ -85,7 +85,7 @@ class Game {
         this.renderer.shadowMap.enabled = true;
         this.renderer.shadowMap.type = THREE.PCFSoftShadowMap;
         this.renderer.setClearColor(0xff9a72, 1);
-        this.renderer.toneMapping = THREE.NoToneMapping;
+        this.renderer.toneMapping = THREE.ACESFilmicToneMapping;
 
         this.scene = new THREE.Scene();
         this.camera = new THREE.PerspectiveCamera(55, 1, 0.12, 140);
@@ -163,11 +163,11 @@ class Game {
 
     applyQuality() {
         const q = this.qualityPreset();
-        this.renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, q.pixel));
+        this.renderer.setPixelRatio(window.devicePixelRatio || 1);
         this.renderer.shadowMap.enabled = q.shadows;
         this.world.setShadows(q.shadows);
         setSnap(q.snap);
-        this.canvas.style.imageRendering = q.pixel < 0.9 ? 'pixelated' : 'auto';
+        this.canvas.style.imageRendering = 'auto';
     }
 
     resize() {
@@ -359,9 +359,9 @@ class Game {
         );
         const ground = this.world.heightAt(this._wanted.x, this._wanted.z);
         this._wanted.y = Math.max(this._wanted.y, ground + 1.6);
-        this.camera.position.x = damp(this.camera.position.x, this._wanted.x, 4.8, dt);
-        this.camera.position.y = damp(this.camera.position.y, this._wanted.y, 4.8, dt);
-        this.camera.position.z = damp(this.camera.position.z, this._wanted.z, 4.8, dt);
+        this.camera.position.x = damp(this.camera.position.x, this._wanted.x, 8.0, dt);
+        this.camera.position.y = damp(this.camera.position.y, this._wanted.y, 8.0, dt);
+        this.camera.position.z = damp(this.camera.position.z, this._wanted.z, 8.0, dt);
         this._look.set(
             this.player.position.x,
             this.player.position.y + cam.look + 0.85,

--- a/labs/tatu-bola/src/models.js
+++ b/labs/tatu-bola/src/models.js
@@ -13,70 +13,19 @@ function geo(key, factory) {
 
 export const retroMaterials = [];
 
-/** Aspecto (largura/altura) do canvas — mantém a célula do snap quadrada em pixels. */
-let snapAspect = 1;
-
-/** Grade do snap em NDC: uSnap.x células na horizontal, uSnap.y na vertical. */
-function snapCell(mat, out) {
-    const s = mat.userData.snap;
-    return out.set(s, s / snapAspect);
-}
-
-function refreshSnap(mat) {
-    const uniform = mat.userData.shader?.uniforms.uSnap;
-    if (uniform) snapCell(mat, uniform.value);
-}
-
-export function retroMat(color, { snap = 80, ...props } = {}) {
+export function retroMat(color, { snap, ...props } = {}) {
     const mat = new THREE.MeshLambertMaterial({
         color,
         flatShading: true,
         ...props
     });
     mat.userData.retro = true;
-    mat.userData.snap = snap;
-    mat.onBeforeCompile = (shader) => {
-        shader.uniforms.uSnap = { value: snapCell(mat, new THREE.Vector2()) };
-        mat.userData.shader = shader;
-        shader.vertexShader = `uniform vec2 uSnap;\n${shader.vertexShader}`.replace(
-            '#include <project_vertex>',
-            /* glsl */ `
-            vec4 mvPosition = vec4( transformed, 1.0 );
-            #ifdef USE_BATCHING
-                mvPosition = batchingMatrix * mvPosition;
-            #endif
-            #ifdef USE_INSTANCING
-                mvPosition = instanceMatrix * mvPosition;
-            #endif
-            mvPosition = modelViewMatrix * mvPosition;
-            gl_Position = projectionMatrix * mvPosition;
-            // Snap de vértice PS1 — só vale à frente do olho. Atrás da câmera
-            // w é negativo: dividir por ele inverte o sinal do NDC e atira o
-            // triângulo para o outro lado da tela (polígonos gigantes piscando).
-            if ( gl_Position.w > 0.0001 ) {
-                vec2 ndc = gl_Position.xy / gl_Position.w;
-                gl_Position.xy = floor( ndc * uSnap + 0.5 ) / uSnap * gl_Position.w;
-            }
-            `
-        );
-    };
-    mat.customProgramCacheKey = () => 'tatubola-ps1';
     retroMaterials.push(mat);
     return mat;
 }
 
-export function setSnap(value) {
-    for (const mat of retroMaterials) {
-        mat.userData.snap = value;
-        refreshSnap(mat);
-    }
-}
-
-/** Chamar no resize: `aspect` = largura/altura do canvas. */
-export function setSnapAspect(aspect) {
-    snapAspect = aspect > 0 ? aspect : 1;
-    for (const mat of retroMaterials) refreshSnap(mat);
-}
+export function setSnap(value) {}
+export function setSnapAspect(aspect) {}
 
 function mesh(geometry, color, extras) {
     const m = new THREE.Mesh(geometry, retroMat(color, extras));

--- a/labs/tatu-bola/src/player.js
+++ b/labs/tatu-bola/src/player.js
@@ -197,7 +197,7 @@ export class Player {
 
         this._animate(dt, spd, inWater);
         let turn = wrapPi(this.yaw - this.mesh.rotation.y);
-        this.mesh.rotation.y += turn * (1 - Math.exp(-10 * dt));
+        this.mesh.rotation.y += turn * (1 - Math.exp(-25 * dt));
 
         if (this.blob) {
             this.blob.position.y = 0.04 - this.position.y * 0.002;


### PR DESCRIPTION
## 🎯 Objetivo

Melhorar a estética visual do Tatu Bola (removendo o efeito "tosco" de PS1) e refinar a jogabilidade para torná-la mais responsiva.

## ✨ O que mudou

- **Gráficos:** Removido o shader de *vertex snapping* que causava tremor na tela (estilo PS1).
- **Gráficos:** Resolução agora obedece o `devicePixelRatio` nativo e não escala para baixo, deixando o jogo nítido e liso em vez de pixelado.
- **Gráficos:** Adotado `ACESFilmicToneMapping` para melhor balanço de cores e luz.
- **Jogabilidade:** Câmera agora acompanha o personagem bem mais rápido.
- **Jogabilidade:** Física do tatu ajustada (aceleração, fricção, rotação, pulo) para os controles responderem instantaneamente sem escorregar.
- **Textos e UI:** Títulos e SEO limpos da limitação "PS1", focando em "Low-poly 3D platformer", e opções de Qualidade simplificadas (Baixa, Média, Alta).

## 🧪 Como testar

1. Na raiz do repo: `python3 -m http.server 8000`
2. Abrir http://localhost:8000/labs/tatu-bola/
3. Entrar no jogo e testar o movimento rápido e preciso (aceleração, rotação e pulo do tatu).
4. Rotacionar a câmera e observar o follow ágil e fluido.
5. Observar as arestas e geometria 3D perfeitamente fixas no grid de mundo, sem o tremor excessivo nos vértices.

## ✅ Checklist

- [x] Links conferidos: pasta do lab ↔ card da galeria ↔ README ↔ sitemap (e corrigidos se quebravam)
- [x] README atualizado (linha na tabela + URL + contagem no badge/texto) — obrigatório em lab novo, renomeado ou removido
- [x] SEO consistente: title, description, canonical, author, robots, OG, Twitter, JSON-LD (e contagem nos metas da galeria)
- [x] Testado via HTTP na raiz, não via `file://`
- [x] Responsivo: 375px / 390px / landscape — overflow, HUD, toque, safe-area (`viewport-fit=cover`)
- [x] Nada fora do escopo foi quebrado
