### PR TITLE
🧪 lab: Orbis com Sistema Solar hiper-realista

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Cada pasta em `/labs/<slug>/` é o mesmo slug do card da galeria, da linha abaix
 | 🎖️ **[Honor Front](https://diogopaulino.com.br/labs/honor-front/)** | FPS 3D estilo Medal of Honor — desembarque ao amanhecer, muralha sob fogo e a bateria no penhasco |
 | 🦁 **[Safari Dourado](https://diogopaulino.com.br/labs/safari-dourado/)** | Savana 3D ao entardecer — dirija o jeep, enquadre elefantes e leões e complete o caderno de campo |
 | 🌅 **[Aurelia Festival](https://diogopaulino.com.br/labs/aurelia/)** | Festival de velocidade estilo Forza — supercarros, Costa Aurélia ao pôr do sol e photo mode |
-| 🪐 **[Orbis](https://diogopaulino.com.br/labs/orbis/)** | Observatório de exoplanetas — gere sistemas, aproxime a órbita e forje oceanos, magma e anéis |
+| 🪐 **[Orbis](https://diogopaulino.com.br/labs/orbis/)** | Sistema Solar 3D hiper-realista — explore de Mercúrio a Netuno com shaders customizados |
 | ✨ **[Aetherion](https://diogopaulino.com.br/labs/aetherion/)** | Observatório estelar em shaders, com mundos vivos e um buraco negro |
 | 🏍️ **[Neon Rider](https://diogopaulino.com.br/labs/neon-rider/)** | Avenida infinita anos 80 — moto, néon, rádio synthwave e fitas VHS |
 | 🍞 **[Torradeira 64](https://diogopaulino.com.br/labs/toaster-64/)** | Kart 3D cômico — disquetes de ouro, Clippy, Pac-Man e o cachorro do Duck Hunt |

--- a/labs/index.html
+++ b/labs/index.html
@@ -988,7 +988,7 @@
         </div>
         <div class="project-content">
           <h2>Orbis</h2>
-          <p>Observatório 3D de exoplanetas: gere sistemas estelares, aproxime a órbita e forje oceanos, magma e anéis</p>
+          <p>Explore nosso Sistema Solar em 3D hiper-realista: de Mercúrio a Netuno, aproxime órbitas e observe shaders customizados</p>
           <div class="project-tags">
             <span class="tag">three.js</span>
             <span class="tag">Shaders</span>

--- a/labs/orbis/index.html
+++ b/labs/orbis/index.html
@@ -6,9 +6,9 @@
     <meta name="viewport"
         content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover">
     <meta name="theme-color" content="#02040a">
-    <title>Orbis — observatório de exoplanetas | Diogo Paulino</title>
+    <title>Orbis — Sistema Solar em 3D | Diogo Paulino</title>
     <meta name="description"
-        content="Gere sistemas estelares em 3D: exoplanetas procedurais com atmosferas, anéis, auroras e um atelier para forjar mundos no navegador.">
+        content="Explore nosso Sistema Solar em 3D hiper-realista: Sol, Mercúrio, Vênus, Terra, Marte, Júpiter, Saturno, Urano e Netuno com shaders customizados.">
     <link rel="canonical" href="https://diogopaulino.com.br/labs/orbis/">
     <meta name="author" content="Diogo Paulino">
     <meta name="robots" content="index, follow">
@@ -21,13 +21,13 @@
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="Diogo Paulino · Labs">
     <meta property="og:url" content="https://diogopaulino.com.br/labs/orbis/">
-    <meta property="og:title" content="Orbis — observatório de exoplanetas | Diogo Paulino">
+    <meta property="og:title" content="Orbis — Sistema Solar em 3D | Diogo Paulino">
     <meta property="og:description"
-        content="Sistemas estelares procedurais em three.js: clique um planeta, aproxime a órbita e forje oceanos, magma e anéis em tempo real.">
+        content="Explore nosso Sistema Solar em 3D hiper-realista com shaders customizados em three.js.">
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Orbis — observatório de exoplanetas | Diogo Paulino">
+    <meta name="twitter:title" content="Orbis — Sistema Solar em 3D | Diogo Paulino">
     <meta name="twitter:description"
-        content="Sistemas estelares procedurais em three.js com shaders de superfície, atmosfera e bloom.">
+        content="Explore nosso Sistema Solar em 3D hiper-realista com shaders customizados.">
 
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -53,7 +53,7 @@
           "@type": "WebApplication",
           "name": "Orbis",
           "url": "https://diogopaulino.com.br/labs/orbis/",
-          "description": "Gere sistemas estelares em 3D: exoplanetas procedurais com atmosferas, anéis, auroras e um atelier para forjar mundos no navegador.",
+          "description": "Explore nosso Sistema Solar em 3D hiper-realista: Sol, Mercúrio, Vênus, Terra, Marte, Júpiter, Saturno, Urano e Netuno.",
           "applicationCategory": "WebApplication",
           "operatingSystem": "Any",
           "inLanguage": "pt-BR",
@@ -163,17 +163,15 @@
             <div id="sliders" class="sliders"></div>
         </div>
 
-        <footer class="dock">
+        <footer class="dock" style="display: none;">
             <div id="presetRail" class="preset-rail" role="list"></div>
             <form id="seedForm" class="seed-form" autocomplete="off">
-                <label class="sr-only" for="seedInput">Seed ou nome</label>
-                <input id="seedInput" type="text" placeholder="Seed ou nome…" maxlength="32">
-                <button type="submit" class="btn ghost">Abrir</button>
+                <input id="seedInput" type="text" placeholder="Seed ou nome…">
             </form>
-            <button id="newSystem" class="btn primary" type="button">Novo sistema</button>
+            <button id="newSystem" type="button">Novo sistema</button>
         </footer>
 
-        <p class="hint">Arraste para orbitar · clique um mundo · <kbd>R</kbd> novo sistema · <kbd>H</kbd> esconde UI</p>
+        <p class="hint">Arraste para orbitar · clique um mundo · <kbd>H</kbd> esconde UI</p>
         <p class="fps-badge" aria-hidden="true"><span id="fps">60</span> fps</p>
     </main>
 

--- a/labs/orbis/src/catalog.js
+++ b/labs/orbis/src/catalog.js
@@ -1,563 +1,6 @@
 /**
- * Catálogo procedural de sistemas estelares e exoplanetas.
- *
- * Zonas orbitais (em função da órbita habitável da estrela):
- *  - interior  → lava, deserto, carbono
- *  - habitável → terra, oceano, noturna, tóxica
- *  - exterior  → gelo, gigante gasoso, gigante de gelo
+ * Catálogo do Sistema Solar hiper-realista.
  */
-import { mulberry32, pick, pickWeighted, randRange, randInt } from './rng.js';
-
-export const STAR_TYPES = [
-    {
-        id: 'M',
-        w: 26,
-        name: 'Anã vermelha',
-        color: [1.0, 0.42, 0.26],
-        corona: [1.0, 0.28, 0.12],
-        radius: 0.72,
-        intensity: 55,
-        habitable: 4.4,
-        innerOrbit: 1.85,
-        orbitStep: 1.15,
-        limb: 0.52,
-        nebulaA: [0.12, 0.02, 0.03],
-        nebulaB: [0.04, 0.01, 0.08]
-    },
-    {
-        id: 'K',
-        w: 22,
-        name: 'Anã laranja',
-        color: [1.0, 0.68, 0.38],
-        corona: [1.0, 0.5, 0.18],
-        radius: 0.9,
-        intensity: 72,
-        habitable: 5.4,
-        innerOrbit: 2.05,
-        orbitStep: 1.28,
-        limb: 0.46,
-        nebulaA: [0.1, 0.03, 0.02],
-        nebulaB: [0.03, 0.04, 0.1]
-    },
-    {
-        id: 'G',
-        w: 22,
-        name: 'Anã amarela',
-        color: [1.0, 0.9, 0.68],
-        corona: [1.0, 0.72, 0.28],
-        radius: 1.08,
-        intensity: 95,
-        habitable: 6.3,
-        innerOrbit: 2.25,
-        orbitStep: 1.42,
-        limb: 0.42,
-        nebulaA: [0.03, 0.05, 0.14],
-        nebulaB: [0.08, 0.03, 0.06]
-    },
-    {
-        id: 'F',
-        w: 14,
-        name: 'Estrela branca',
-        color: [0.92, 0.95, 1.0],
-        corona: [0.7, 0.82, 1.0],
-        radius: 1.22,
-        intensity: 120,
-        habitable: 7.4,
-        innerOrbit: 2.55,
-        orbitStep: 1.55,
-        limb: 0.38,
-        nebulaA: [0.02, 0.06, 0.14],
-        nebulaB: [0.06, 0.02, 0.1]
-    },
-    {
-        id: 'A',
-        w: 10,
-        name: 'Estrela branco-azul',
-        color: [0.75, 0.84, 1.0],
-        corona: [0.45, 0.62, 1.0],
-        radius: 1.38,
-        intensity: 150,
-        habitable: 8.6,
-        innerOrbit: 2.9,
-        orbitStep: 1.7,
-        limb: 0.34,
-        nebulaA: [0.02, 0.04, 0.16],
-        nebulaB: [0.08, 0.02, 0.12]
-    },
-    {
-        id: 'B',
-        w: 6,
-        name: 'Gigante azul',
-        color: [0.5, 0.68, 1.0],
-        corona: [0.3, 0.48, 1.0],
-        radius: 1.7,
-        intensity: 210,
-        habitable: 10.4,
-        innerOrbit: 3.4,
-        orbitStep: 1.9,
-        limb: 0.28,
-        nebulaA: [0.02, 0.05, 0.18],
-        nebulaB: [0.1, 0.01, 0.08]
-    }
-];
-
-const PREFIX = [
-    'Lyra', 'Kepler', 'Helios', 'Nyx', 'Vega', 'Orion', 'Astra', 'Thalassa',
-    'Pyre', 'Glacies', 'Aether', 'Solara', 'Rigel', 'Altair', 'Mira', 'Erebus',
-    'Auriga', 'Draco', 'Callisto', 'Io', 'Vesper', 'Nova', 'Lumen', 'Umbra',
-    'Arcadia', 'Celeste', 'Hyperion', 'Selene', 'Phoebus', 'Andromeda'
-];
-
-const SUFFIX = [
-    'Prime', 'Minor', 'Reach', 'Hollow', 'Dawn', 'Vale', 'Expanse',
-    'Cluster', 'Deep', 'Gate', 'Halo', 'Verge'
-];
-
-const PLANET_NAMES = [
-    'Aethel', 'Boreal', 'Cinder', 'Dune', 'Elys', 'Fenn', 'Gossamer', 'Hade',
-    'Icarus', 'Juno', 'Kite', 'Lumen', 'Maris', 'Nox', 'Orrin', 'Pyxis',
-    'Quill', 'Rime', 'Sable', 'Thal', 'Umbra', 'Vesper', 'Wisp', 'Xanthe',
-    'Yara', 'Zephyr', 'Iris', 'Kael', 'Nereid', 'Phaeton'
-];
-
-const KINDS = {
-    lava: {
-        label: 'Vulcânico',
-        water: [0.02, 0.12],
-        ice: [0, 0.05],
-        temp: [0.72, 1],
-        clouds: [0.05, 0.28],
-        atmos: [0.35, 0.7],
-        mountain: [0.55, 1],
-        warp: [0.35, 0.7],
-        cities: [0, 0.05],
-        emissive: [0.55, 1],
-        kind: 0,
-        rings: 0,
-        moons: [0, 1],
-        oceanDeep: [0.18, 0.04, 0.02],
-        oceanShallow: [0.45, 0.12, 0.04],
-        landA: [0.18, 0.06, 0.04],
-        landB: [0.32, 0.1, 0.05],
-        desert: [0.55, 0.18, 0.06],
-        snow: [0.35, 0.12, 0.08],
-        lava: [1.0, 0.38, 0.08],
-        atmosColor: [1.0, 0.4, 0.16],
-        atmosColor2: [1.0, 0.15, 0.04]
-    },
-    desert: {
-        label: 'Árido',
-        water: [0.08, 0.28],
-        ice: [0.02, 0.18],
-        temp: [0.45, 0.85],
-        clouds: [0.04, 0.32],
-        atmos: [0.25, 0.55],
-        mountain: [0.3, 0.7],
-        warp: [0.25, 0.55],
-        cities: [0, 0.2],
-        emissive: [0, 0.05],
-        kind: 0,
-        rings: 0,
-        moons: [0, 1],
-        oceanDeep: [0.12, 0.18, 0.22],
-        oceanShallow: [0.35, 0.42, 0.32],
-        landA: [0.62, 0.38, 0.18],
-        landB: [0.45, 0.22, 0.1],
-        desert: [0.78, 0.52, 0.28],
-        snow: [0.85, 0.82, 0.75],
-        lava: [0.4, 0.1, 0.02],
-        atmosColor: [0.85, 0.55, 0.28],
-        atmosColor2: [0.95, 0.72, 0.4]
-    },
-    terra: {
-        label: 'Terrestre',
-        water: [0.38, 0.62],
-        ice: [0.12, 0.32],
-        temp: [0.38, 0.62],
-        clouds: [0.28, 0.7],
-        atmos: [0.55, 0.95],
-        mountain: [0.25, 0.6],
-        warp: [0.4, 0.75],
-        cities: [0.15, 0.7],
-        emissive: [0, 0.02],
-        kind: 0,
-        rings: 0,
-        moons: [0, 2],
-        oceanDeep: [0.02, 0.12, 0.32],
-        oceanShallow: [0.08, 0.42, 0.52],
-        landA: [0.14, 0.38, 0.16],
-        landB: [0.28, 0.32, 0.12],
-        desert: [0.62, 0.5, 0.22],
-        snow: [0.9, 0.93, 0.95],
-        lava: [0.6, 0.2, 0.05],
-        atmosColor: [0.35, 0.55, 1.0],
-        atmosColor2: [0.55, 0.82, 1.0]
-    },
-    ocean: {
-        label: 'Oceânico',
-        water: [0.72, 0.92],
-        ice: [0.08, 0.28],
-        temp: [0.32, 0.58],
-        clouds: [0.4, 0.85],
-        atmos: [0.65, 1],
-        mountain: [0.1, 0.35],
-        warp: [0.3, 0.6],
-        cities: [0, 0.15],
-        emissive: [0, 0],
-        kind: 0,
-        rings: 0,
-        moons: [0, 1],
-        oceanDeep: [0.01, 0.08, 0.28],
-        oceanShallow: [0.05, 0.45, 0.55],
-        landA: [0.2, 0.42, 0.22],
-        landB: [0.45, 0.4, 0.2],
-        desert: [0.7, 0.62, 0.35],
-        snow: [0.92, 0.95, 0.98],
-        lava: [0.5, 0.15, 0.04],
-        atmosColor: [0.25, 0.6, 0.95],
-        atmosColor2: [0.55, 0.9, 1.0]
-    },
-    night: {
-        label: 'Ecumenópole',
-        water: [0.22, 0.42],
-        ice: [0.04, 0.16],
-        temp: [0.4, 0.65],
-        clouds: [0.18, 0.5],
-        atmos: [0.5, 0.85],
-        mountain: [0.15, 0.4],
-        warp: [0.35, 0.65],
-        cities: [0.75, 1],
-        emissive: [0.08, 0.22],
-        kind: 0,
-        rings: 0,
-        moons: [0, 1],
-        oceanDeep: [0.02, 0.05, 0.14],
-        oceanShallow: [0.08, 0.16, 0.28],
-        landA: [0.08, 0.08, 0.12],
-        landB: [0.14, 0.12, 0.16],
-        desert: [0.2, 0.16, 0.12],
-        snow: [0.4, 0.42, 0.5],
-        lava: [0.3, 0.5, 1.0],
-        atmosColor: [0.45, 0.35, 0.9],
-        atmosColor2: [0.9, 0.5, 0.3]
-    },
-    toxic: {
-        label: 'Tóxico',
-        water: [0.25, 0.55],
-        ice: [0, 0.12],
-        temp: [0.5, 0.85],
-        clouds: [0.45, 0.9],
-        atmos: [0.7, 1],
-        mountain: [0.3, 0.7],
-        warp: [0.4, 0.8],
-        cities: [0, 0.1],
-        emissive: [0.05, 0.25],
-        kind: 0,
-        rings: 0,
-        moons: [0, 1],
-        oceanDeep: [0.08, 0.22, 0.1],
-        oceanShallow: [0.28, 0.55, 0.18],
-        landA: [0.22, 0.4, 0.12],
-        landB: [0.4, 0.22, 0.35],
-        desert: [0.5, 0.45, 0.12],
-        snow: [0.55, 0.7, 0.45],
-        lava: [0.6, 1.0, 0.2],
-        atmosColor: [0.45, 0.95, 0.25],
-        atmosColor2: [0.7, 0.3, 0.9]
-    },
-    ice: {
-        label: 'Glacial',
-        water: [0.15, 0.4],
-        ice: [0.55, 0.95],
-        temp: [0, 0.28],
-        clouds: [0.2, 0.6],
-        atmos: [0.3, 0.7],
-        mountain: [0.35, 0.75],
-        warp: [0.25, 0.55],
-        cities: [0, 0.12],
-        emissive: [0, 0.04],
-        kind: 0,
-        rings: 0.15,
-        moons: [0, 2],
-        oceanDeep: [0.05, 0.14, 0.28],
-        oceanShallow: [0.25, 0.45, 0.55],
-        landA: [0.55, 0.68, 0.78],
-        landB: [0.35, 0.42, 0.5],
-        desert: [0.45, 0.4, 0.38],
-        snow: [0.92, 0.96, 1.0],
-        lava: [0.2, 0.35, 0.7],
-        atmosColor: [0.55, 0.75, 1.0],
-        atmosColor2: [0.75, 0.9, 1.0]
-    },
-    carbon: {
-        label: 'Carbonáceo',
-        water: [0.05, 0.22],
-        ice: [0, 0.1],
-        temp: [0.25, 0.55],
-        clouds: [0.08, 0.35],
-        atmos: [0.2, 0.5],
-        mountain: [0.45, 0.9],
-        warp: [0.3, 0.65],
-        cities: [0, 0.08],
-        emissive: [0.02, 0.12],
-        kind: 0,
-        rings: 0,
-        moons: [0, 1],
-        oceanDeep: [0.04, 0.05, 0.08],
-        oceanShallow: [0.1, 0.1, 0.12],
-        landA: [0.08, 0.07, 0.08],
-        landB: [0.18, 0.14, 0.12],
-        desert: [0.28, 0.2, 0.14],
-        snow: [0.4, 0.38, 0.36],
-        lava: [0.7, 0.25, 0.1],
-        atmosColor: [0.35, 0.28, 0.25],
-        atmosColor2: [0.55, 0.4, 0.3]
-    },
-    gas: {
-        label: 'Gigante gasoso',
-        water: [0.4, 0.6],
-        ice: [0.1, 0.3],
-        temp: [0.2, 0.55],
-        clouds: [0, 0.15],
-        atmos: [0.85, 1],
-        mountain: [0.35, 0.85],
-        warp: [0.2, 0.5],
-        cities: [0, 0],
-        emissive: [0, 0.08],
-        kind: 1,
-        rings: 0.85,
-        moons: [1, 2],
-        oceanDeep: [0.55, 0.32, 0.18],
-        oceanShallow: [0.85, 0.62, 0.35],
-        landA: [0.72, 0.48, 0.28],
-        landB: [0.4, 0.28, 0.55],
-        desert: [0.9, 0.75, 0.45],
-        snow: [0.85, 0.8, 0.7],
-        lava: [0.9, 0.4, 0.15],
-        atmosColor: [0.85, 0.65, 0.4],
-        atmosColor2: [0.55, 0.4, 0.85]
-    },
-    icegiant: {
-        label: 'Gigante de gelo',
-        water: [0.4, 0.6],
-        ice: [0.4, 0.8],
-        temp: [0, 0.3],
-        clouds: [0, 0.12],
-        atmos: [0.8, 1],
-        mountain: [0.25, 0.65],
-        warp: [0.15, 0.4],
-        cities: [0, 0],
-        emissive: [0, 0.04],
-        kind: 1,
-        rings: 0.45,
-        moons: [1, 2],
-        oceanDeep: [0.15, 0.35, 0.55],
-        oceanShallow: [0.35, 0.7, 0.75],
-        landA: [0.25, 0.45, 0.7],
-        landB: [0.4, 0.55, 0.5],
-        desert: [0.55, 0.7, 0.8],
-        snow: [0.8, 0.9, 1.0],
-        lava: [0.3, 0.5, 0.9],
-        atmosColor: [0.4, 0.7, 0.95],
-        atmosColor2: [0.55, 0.85, 0.9]
-    }
-};
-
-const INNER_KINDS = [
-    { id: 'lava', w: 34 },
-    { id: 'desert', w: 28 },
-    { id: 'carbon', w: 22 },
-    { id: 'toxic', w: 10 },
-    { id: 'night', w: 6 }
-];
-
-const HAB_KINDS = [
-    { id: 'terra', w: 32 },
-    { id: 'ocean', w: 22 },
-    { id: 'night', w: 12 },
-    { id: 'desert', w: 12 },
-    { id: 'toxic', w: 10 },
-    { id: 'ice', w: 7 },
-    { id: 'carbon', w: 5 }
-];
-
-const OUTER_KINDS = [
-    { id: 'gas', w: 28 },
-    { id: 'icegiant', w: 24 },
-    { id: 'ice', w: 26 },
-    { id: 'carbon', w: 10 },
-    { id: 'ocean', w: 6 },
-    { id: 'toxic', w: 6 }
-];
-
-const LORE = {
-    lava: [
-        'Rios de basalto abrem a crosta como veias em brasa.',
-        'A noite nunca chega: o magma pinta o horizonte de âmbar.',
-        'Cadeias de vulcões espirram vidro obsidiana na órbita baixa.'
-    ],
-    desert: [
-        'Dunas de óxido atravessam um único mar interior.',
-        'Tempestades de areia esculpem cânions em silêncio de séculos.',
-        'O equador ferve; os polos guardam geada de dióxido.'
-    ],
-    terra: [
-        'Continentes verdes sob um céu que ainda lembra o nosso.',
-        'Cidades acendem na face noturna como um segundo céu.',
-        'Correntes oceânicas carregam nuvens em espirais lentas.'
-    ],
-    ocean: [
-        'Um único arquipélago resiste a um oceano do tamanho do mundo.',
-        'Tempestades de vapor desenham tufões visíveis do espaço.',
-        'A luz da estrela atravessa água rasa e devolve turquesa.'
-    ],
-    night: [
-        'A crosta inteira é cidade: um circuito que nunca apaga.',
-        'Arranha-céus orbitais projetam auroras artificiais nos polos.',
-        'O lado noturno pulsa em âmbar, ciano e violeta.'
-    ],
-    toxic: [
-        'A atmosfera mastiga metal e pinta o céu de verde-veneno.',
-        'Lagos ácidos espelham uma lua pálida e doente.',
-        'Nuvens de enxofre descem como cortinas sobre vales mortos.'
-    ],
-    ice: [
-        'Gelo de metano racha em placas do tamanho de continentes.',
-        'Uma aurora permanente lambe os polos em silêncio.',
-        'O sol distante só consegue dourar as cristas das geleiras.'
-    ],
-    carbon: [
-        'Uma joia opaca de grafite e diamante bruto.',
-        'Cânions negros absorvem quase toda a luz da estrela.',
-        'A superfície brilha como carvão molhado sob o vento.'
-    ],
-    gas: [
-        'Faixas de amônia giram em torno de uma tempestade eterna.',
-        'Um sistema de anéis varre a órbita como um disco de cinzas douradas.',
-        'A Grande Mancha deste mundo engole luas menores.'
-    ],
-    icegiant: [
-        'Metano profundo tinge o gigante de azul-elétrico.',
-        'Anéis tênues de gelo orbitam como um halo quebrado.',
-        'Ventos a milhares de km/h riscavam as faixas do equador.'
-    ]
-};
-
-function sampleRange(rng, pair) {
-    if (typeof pair === 'number') return pair;
-    return randRange(rng, pair[0], pair[1]);
-}
-
-function jitterColor(rng, rgb, amt = 0.08) {
-    return rgb.map((c) => Math.min(1, Math.max(0, c + (rng() - 0.5) * amt)));
-}
-
-function kindForZone(rng, zone) {
-    const table = zone < 0.72 ? INNER_KINDS : zone < 1.28 ? HAB_KINDS : OUTER_KINDS;
-    return pickWeighted(rng, table).id;
-}
-
-function planetRadius(rng, kindId) {
-    if (kindId === 'gas') return randRange(rng, 0.42, 0.58);
-    if (kindId === 'icegiant') return randRange(rng, 0.34, 0.46);
-    if (kindId === 'ocean' || kindId === 'terra') return randRange(rng, 0.2, 0.3);
-    if (kindId === 'ice') return randRange(rng, 0.18, 0.28);
-    return randRange(rng, 0.16, 0.26);
-}
-
-function makePlanet(rng, kindId, index) {
-    const spec = KINDS[kindId];
-    const ringsChance = spec.rings;
-    const rings = rng() < ringsChance ? randRange(rng, 0.35, 1) : (rng() < 0.06 ? randRange(rng, 0.2, 0.5) : 0);
-
-    return {
-        kindId,
-        kind: spec.kind,
-        label: spec.label,
-        name: pick(rng, PLANET_NAMES),
-        designation: String.fromCharCode(98 + index),
-        lore: pick(rng, LORE[kindId]),
-        water: sampleRange(rng, spec.water),
-        ice: sampleRange(rng, spec.ice),
-        temp: sampleRange(rng, spec.temp),
-        clouds: sampleRange(rng, spec.clouds),
-        atmos: sampleRange(rng, spec.atmos),
-        mountain: sampleRange(rng, spec.mountain),
-        warp: sampleRange(rng, spec.warp),
-        cities: sampleRange(rng, spec.cities),
-        emissive: sampleRange(rng, spec.emissive),
-        rings,
-        moons: randInt(rng, spec.moons[0], spec.moons[1]),
-        oceanDeep: jitterColor(rng, spec.oceanDeep, 0.06),
-        oceanShallow: jitterColor(rng, spec.oceanShallow, 0.06),
-        landA: jitterColor(rng, spec.landA, 0.08),
-        landB: jitterColor(rng, spec.landB, 0.08),
-        desert: jitterColor(rng, spec.desert, 0.08),
-        snow: jitterColor(rng, spec.snow, 0.04),
-        lava: jitterColor(rng, spec.lava, 0.1),
-        atmosColor: jitterColor(rng, spec.atmosColor, 0.08),
-        atmosColor2: jitterColor(rng, spec.atmosColor2, 0.08),
-        ringColor: jitterColor(rng, spec.kind === 1 ? spec.desert : spec.snow, 0.1),
-        seed: rng() * 1000,
-        cloudSeed: rng() * 1000,
-        aurora: kindId === 'ice' || kindId === 'terra' ? randRange(rng, 0.25, 0.85) : rng() * 0.25
-    };
-}
-
-function systemName(rng, star) {
-    const prefix = pick(rng, PREFIX);
-    const mode = rng();
-    if (mode < 0.4) return `${prefix}-${randInt(rng, 12, 980)}`;
-    if (mode < 0.7) return `${prefix} ${pick(rng, SUFFIX)}`;
-    return `${prefix} ${star.id}-${randInt(rng, 2, 88)}`;
-}
-
-export function generateSystem(seed) {
-    const rng = mulberry32(seed >>> 0);
-    const star = { ...pickWeighted(rng, STAR_TYPES) };
-    star.seed = rng() * 800;
-    star.spin = randRange(rng, 0.04, 0.14);
-    star.spot = randRange(rng, 0.08, 0.35);
-
-    const count = randInt(rng, 4, 6);
-    const planets = [];
-    let orbit = star.innerOrbit + rng() * 0.35;
-
-    for (let i = 0; i < count; i++) {
-        orbit += star.orbitStep * randRange(rng, 0.78, 1.18);
-        const zone = orbit / star.habitable;
-        const kindId = kindForZone(rng, zone);
-        const planet = makePlanet(rng, kindId, i);
-        planet.orbit = orbit;
-        planet.radius = planetRadius(rng, kindId);
-        planet.inclination = (rng() - 0.5) * 0.18;
-        planet.orbitSpeed = (0.22 + rng() * 0.08) / Math.sqrt(orbit);
-        planet.spin = (0.25 + rng() * 1.4) * (rng() < 0.12 ? -1 : 1);
-        planet.tilt = (rng() - 0.5) * 0.55;
-        planet.phase = rng() * Math.PI * 2;
-        planets.push(planet);
-    }
-
-    return {
-        seed: seed >>> 0,
-        name: systemName(rng, star),
-        star,
-        planets,
-        belt: {
-            inner: planets[Math.min(2, planets.length - 1)].orbit + 0.35,
-            outer: planets[Math.min(3, planets.length - 1)].orbit - 0.25,
-            count: 1
-        }
-    };
-}
-
-export const SHOWCASE = [
-    { seed: 1, title: 'Via habitável' },
-    { seed: 8, title: 'Gigante em anéis' },
-    { seed: 29, title: 'Anã vermelha' },
-    { seed: 2, title: 'Catedral de gelo' },
-    { seed: 14, title: 'Forja vulcânica' }
-];
 
 export const SLIDERS = [
     { key: 'water', label: 'Oceanos', min: 0, max: 1, step: 0.01 },
@@ -571,3 +14,155 @@ export const SLIDERS = [
     { key: 'rings', label: 'Anéis', min: 0, max: 1, step: 0.01 },
     { key: 'aurora', label: 'Aurora', min: 0, max: 1, step: 0.01 }
 ];
+
+export const SHOWCASE = [
+    { seed: 1, title: 'Sistema Solar' }
+];
+
+export function generateSystem(seed) {
+    const star = {
+        id: 'G',
+        w: 22,
+        name: 'Sol',
+        color: [1.0, 0.92, 0.72],
+        corona: [1.0, 0.75, 0.35],
+        radius: 1.15,
+        intensity: 105,
+        habitable: 6.3,
+        innerOrbit: 2.25,
+        orbitStep: 1.42,
+        limb: 0.42,
+        nebulaA: [0.02, 0.04, 0.12],
+        nebulaB: [0.06, 0.02, 0.05],
+        seed: 12345,
+        spin: 0.04,
+        spot: 0.15
+    };
+
+    const planets = [
+        {
+            kindId: 'carbon',
+            kind: 0,
+            label: 'Rochoso Árido',
+            name: 'Mercúrio',
+            designation: 'I',
+            lore: 'O planeta mais próximo do Sol, marcado por crateras e sem atmosfera visível.',
+            water: 0, ice: 0, temp: 0.85, clouds: 0, atmos: 0.02, mountain: 0.8, warp: 0.6, cities: 0, emissive: 0.0,
+            rings: 0, moons: 0,
+            oceanDeep: [0.15, 0.15, 0.15], oceanShallow: [0.25, 0.25, 0.25], landA: [0.35, 0.35, 0.35], landB: [0.45, 0.45, 0.45],
+            desert: [0.55, 0.55, 0.55], snow: [0.65, 0.65, 0.65], lava: [1.0, 0.3, 0.1], atmosColor: [0.1, 0.1, 0.1], atmosColor2: [0.2, 0.2, 0.2],
+            ringColor: [0, 0, 0], seed: 101, cloudSeed: 101, aurora: 0,
+            orbit: 3.2, radius: 0.14, inclination: 0.12, orbitSpeed: 0.45, spin: 0.02, tilt: 0.01, phase: 0
+        },
+        {
+            kindId: 'toxic',
+            kind: 0,
+            label: 'Estufa Tóxica',
+            name: 'Vênus',
+            designation: 'II',
+            lore: 'Um inferno nublado com pressão esmagadora e chuvas de ácido sulfúrico.',
+            water: 0, ice: 0, temp: 0.95, clouds: 0.9, atmos: 1.0, mountain: 0.5, warp: 0.4, cities: 0, emissive: 0.1,
+            rings: 0, moons: 0,
+            oceanDeep: [0.6, 0.4, 0.2], oceanShallow: [0.7, 0.5, 0.3], landA: [0.75, 0.55, 0.35], landB: [0.8, 0.6, 0.4],
+            desert: [0.9, 0.7, 0.45], snow: [1.0, 0.85, 0.55], lava: [1.0, 0.5, 0.1], atmosColor: [0.9, 0.75, 0.4], atmosColor2: [1.0, 0.85, 0.55],
+            ringColor: [0, 0, 0], seed: 102, cloudSeed: 102, aurora: 0,
+            orbit: 4.8, radius: 0.24, inclination: 0.06, orbitSpeed: 0.32, spin: -0.01, tilt: 3.09, phase: 1.2
+        },
+        {
+            kindId: 'terra',
+            kind: 0,
+            label: 'Terrestre',
+            name: 'Terra',
+            designation: 'III',
+            lore: 'Oásis azul pálido, o único mundo conhecido a abrigar vida.',
+            water: 0.71, ice: 0.12, temp: 0.48, clouds: 0.45, atmos: 0.65, mountain: 0.45, warp: 0.55, cities: 0.5, emissive: 0,
+            rings: 0, moons: 1,
+            oceanDeep: [0.02, 0.12, 0.35], oceanShallow: [0.05, 0.3, 0.5], landA: [0.15, 0.35, 0.15], landB: [0.25, 0.4, 0.12],
+            desert: [0.7, 0.6, 0.35], snow: [0.95, 0.95, 1.0], lava: [0.8, 0.3, 0.1], atmosColor: [0.35, 0.55, 1.0], atmosColor2: [0.55, 0.82, 1.0],
+            ringColor: [0, 0, 0], seed: 103, cloudSeed: 103, aurora: 0.65,
+            orbit: 6.4, radius: 0.25, inclination: 0, orbitSpeed: 0.27, spin: 0.4, tilt: 0.41, phase: 2.5
+        },
+        {
+            kindId: 'desert',
+            kind: 0,
+            label: 'Deserto Frio',
+            name: 'Marte',
+            designation: 'IV',
+            lore: 'O planeta vermelho, outrora quente e úmido, agora um deserto gelado com calotas polares.',
+            water: 0, ice: 0.08, temp: 0.28, clouds: 0.08, atmos: 0.25, mountain: 0.65, warp: 0.5, cities: 0, emissive: 0,
+            rings: 0, moons: 2,
+            oceanDeep: [0.65, 0.35, 0.2], oceanShallow: [0.75, 0.4, 0.25], landA: [0.7, 0.4, 0.25], landB: [0.8, 0.45, 0.3],
+            desert: [0.85, 0.5, 0.35], snow: [0.95, 0.9, 0.85], lava: [1.0, 0.4, 0.1], atmosColor: [0.85, 0.55, 0.35], atmosColor2: [0.95, 0.65, 0.45],
+            ringColor: [0, 0, 0], seed: 104, cloudSeed: 104, aurora: 0,
+            orbit: 8.2, radius: 0.16, inclination: 0.03, orbitSpeed: 0.22, spin: 0.38, tilt: 0.44, phase: 3.8
+        },
+        {
+            kindId: 'gas',
+            kind: 1,
+            label: 'Gigante Gasoso',
+            name: 'Júpiter',
+            designation: 'V',
+            lore: 'O rei dos planetas, lar da Grande Mancha Vermelha e tempestades colossais.',
+            water: 0.45, ice: 0.2, temp: 0.4, clouds: 0.08, atmos: 0.95, mountain: 0.6, warp: 0.35, cities: 0, emissive: 0,
+            rings: 0.04, moons: 2,
+            oceanDeep: [0.6, 0.4, 0.3], oceanShallow: [0.7, 0.5, 0.35], landA: [0.8, 0.65, 0.5], landB: [0.85, 0.75, 0.6],
+            desert: [0.95, 0.85, 0.7], snow: [1.0, 0.9, 0.8], lava: [1.0, 0.5, 0.2], atmosColor: [0.85, 0.7, 0.55], atmosColor2: [0.95, 0.8, 0.65],
+            ringColor: [0.6, 0.5, 0.4], seed: 105, cloudSeed: 105, aurora: 0.7,
+            orbit: 12.8, radius: 0.68, inclination: 0.02, orbitSpeed: 0.12, spin: 0.9, tilt: 0.05, phase: 5.1
+        },
+        {
+            kindId: 'gas',
+            kind: 1,
+            label: 'Gigante Gasoso',
+            name: 'Saturno',
+            designation: 'VI',
+            lore: 'A joia do sistema solar, coroada por um sistema de anéis deslumbrante e complexo.',
+            water: 0.35, ice: 0.25, temp: 0.3, clouds: 0.05, atmos: 0.9, mountain: 0.4, warp: 0.25, cities: 0, emissive: 0,
+            rings: 0.92, moons: 2,
+            oceanDeep: [0.7, 0.6, 0.4], oceanShallow: [0.8, 0.7, 0.5], landA: [0.85, 0.75, 0.55], landB: [0.9, 0.85, 0.65],
+            desert: [0.95, 0.9, 0.75], snow: [1.0, 0.95, 0.85], lava: [1.0, 0.6, 0.3], atmosColor: [0.9, 0.85, 0.7], atmosColor2: [0.95, 0.9, 0.8],
+            ringColor: [0.85, 0.8, 0.7], seed: 106, cloudSeed: 106, aurora: 0.5,
+            orbit: 17.5, radius: 0.58, inclination: 0.04, orbitSpeed: 0.09, spin: 0.85, tilt: 0.47, phase: 0.4
+        },
+        {
+            kindId: 'icegiant',
+            kind: 1,
+            label: 'Gigante de Gelo',
+            name: 'Urano',
+            designation: 'VII',
+            lore: 'Um mundo gelado tombado de lado, orbitando o Sol como um barril rodopiante.',
+            water: 0.55, ice: 0.75, temp: 0.1, clouds: 0.02, atmos: 0.85, mountain: 0.35, warp: 0.25, cities: 0, emissive: 0,
+            rings: 0.18, moons: 2,
+            oceanDeep: [0.4, 0.7, 0.9], oceanShallow: [0.5, 0.8, 0.95], landA: [0.6, 0.85, 1.0], landB: [0.7, 0.9, 1.0],
+            desert: [0.8, 0.95, 1.0], snow: [0.9, 1.0, 1.0], lava: [0.5, 0.5, 0.9], atmosColor: [0.5, 0.8, 0.95], atmosColor2: [0.7, 0.9, 1.0],
+            ringColor: [0.6, 0.7, 0.8], seed: 107, cloudSeed: 107, aurora: 0.3,
+            orbit: 21.8, radius: 0.42, inclination: 0.01, orbitSpeed: 0.06, spin: -0.6, tilt: 1.71, phase: 1.8
+        },
+        {
+            kindId: 'icegiant',
+            kind: 1,
+            label: 'Gigante de Gelo',
+            name: 'Netuno',
+            designation: 'VIII',
+            lore: 'O planeta mais distante, de um azul profundo e varrido por ventos supersônicos.',
+            water: 0.6, ice: 0.65, temp: 0.05, clouds: 0.12, atmos: 0.9, mountain: 0.45, warp: 0.3, cities: 0, emissive: 0,
+            rings: 0.08, moons: 2,
+            oceanDeep: [0.1, 0.25, 0.85], oceanShallow: [0.2, 0.4, 0.95], landA: [0.25, 0.45, 1.0], landB: [0.35, 0.55, 1.0],
+            desert: [0.45, 0.65, 1.0], snow: [0.6, 0.8, 1.0], lava: [0.2, 0.3, 0.8], atmosColor: [0.15, 0.35, 0.95], atmosColor2: [0.25, 0.5, 1.0],
+            ringColor: [0.3, 0.4, 0.6], seed: 108, cloudSeed: 108, aurora: 0.25,
+            orbit: 26.0, radius: 0.4, inclination: 0.03, orbitSpeed: 0.05, spin: 0.65, tilt: 0.5, phase: 3.2
+        }
+    ];
+
+    return {
+        seed: 1,
+        name: 'Sistema Solar',
+        star,
+        planets,
+        belt: {
+            inner: 10.0,
+            outer: 11.2,
+            count: 1
+        }
+    };
+}

--- a/pr_body.txt
+++ b/pr_body.txt
@@ -1,0 +1,28 @@
+## 🎯 Objetivo
+
+Transformar o lab Orbis para exibir exclusivamente o nosso Sistema Solar em 3D hiper-realista.
+
+## ✨ O que mudou
+
+- Alteração do catálogo procedural para um catálogo fixo com Sol, Mercúrio, Vênus, Terra, Marte, Júpiter, Saturno, Urano e Netuno
+- Shaders e parâmetros ajustados para cada planeta imitando suas características reais (nuvens, atmosfera, relevo, anéis)
+- Atualização do título, meta tags e JSON-LD no `index.html` do lab para refletir o tema
+- Ocultação dos controles de seed e geração de novo sistema procedural da interface
+- Textos atualizados no README e na galeria de Labs
+
+## 🧪 Como testar
+
+1. Na raiz do repo: `python3 -m http.server 8000`
+2. Acessar `/labs/orbis/`
+3. Verificar a presença de todos os 8 planetas em órbita do Sol, com visuais realistas
+4. Clicar em cada planeta para ver de perto
+5. Responsividade no celular não foi afetada
+
+## ✅ Checklist
+
+- [x] Links conferidos: pasta do lab ↔ card da galeria ↔ README ↔ sitemap (e corrigidos se quebravam)
+- [x] README atualizado (linha na tabela + URL + contagem no badge/texto) — obrigatório em lab novo, renomeado ou removido
+- [x] SEO consistente: title, description, canonical, author, robots, OG, Twitter, JSON-LD (e contagem nos metas da galeria)
+- [x] Testado via HTTP na raiz, não via `file://`
+- [x] Responsivo: 375px / 390px / landscape — overflow, HUD, toque, safe-area (`viewport-fit=cover`)
+- [x] Nada fora do escopo foi quebrado


### PR DESCRIPTION
## 🎯 Objetivo

Transformar o lab Orbis para exibir exclusivamente o nosso Sistema Solar em 3D hiper-realista.

## ✨ O que mudou

- Alteração do catálogo procedural para um catálogo fixo com Sol, Mercúrio, Vênus, Terra, Marte, Júpiter, Saturno, Urano e Netuno
- Shaders e parâmetros ajustados para cada planeta imitando suas características reais (nuvens, atmosfera, relevo, anéis)
- Atualização do título, meta tags e JSON-LD no `index.html` do lab para refletir o tema
- Ocultação dos controles de seed e geração de novo sistema procedural da interface
- Textos atualizados no README e na galeria de Labs

## 🧪 Como testar

1. Na raiz do repo: `python3 -m http.server 8000`
2. Acessar `/labs/orbis/`
3. Verificar a presença de todos os 8 planetas em órbita do Sol, com visuais realistas
4. Clicar em cada planeta para ver de perto
5. Responsividade no celular não foi afetada

## ✅ Checklist

- [x] Links conferidos: pasta do lab ↔ card da galeria ↔ README ↔ sitemap (e corrigidos se quebravam)
- [x] README atualizado (linha na tabela + URL + contagem no badge/texto) — obrigatório em lab novo, renomeado ou removido
- [x] SEO consistente: title, description, canonical, author, robots, OG, Twitter, JSON-LD (e contagem nos metas da galeria)
- [x] Testado via HTTP na raiz, não via `file://`
- [x] Responsivo: 375px / 390px / landscape — overflow, HUD, toque, safe-area (`viewport-fit=cover`)
- [x] Nada fora do escopo foi quebrado
