### PR TITLE
✨ feat(joao): visual PBR realista e correção do crash ao germinar

### DIFF
--- a/labs/joao-e-o-pe-de-feijao/index.html
+++ b/labs/joao-e-o-pe-de-feijao/index.html
@@ -31,6 +31,8 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="preconnect" href="https://cdn.babylonjs.com" crossorigin>
+    <link rel="preconnect" href="https://dl.polyhaven.org" crossorigin>
+    <link rel="preconnect" href="https://assets.babylonjs.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;600;700;800&family=Nunito:wght@400;600;700;800&display=swap"
         rel="stylesheet">
     <link rel="stylesheet" href="/labs/shared.css?v=9">

--- a/labs/joao-e-o-pe-de-feijao/src/main.js
+++ b/labs/joao-e-o-pe-de-feijao/src/main.js
@@ -9,7 +9,8 @@ import { GameAudio } from './audio.js';
 import { Hud, statsBlock } from './hud.js';
 import { Player } from './player.js';
 import { createSky, applyChapterSky, createLights } from './sky.js';
-import { buildChapter } from './world.js';
+import { buildChapter, bindShadows } from './world.js';
+import { setModelQuality } from './models.js';
 import { nearestInteractable } from './npcs.js';
 
 const B = window.BABYLON;
@@ -69,6 +70,7 @@ class Game {
         this.hud.setLoading(0.1, 'Abrindo o livro do conto…');
         this.quality = this.resolveQuality();
         this.mobile = detectMobile();
+        setModelQuality(this.quality.id);
 
         try {
             this.engine = new B.Engine(this.canvas, true, {
@@ -282,6 +284,7 @@ class Game {
         const lights = createLights(this.scene, ch, this.quality);
         this.world = world;
         this.lights = lights;
+        bindShadows(world, lights);
 
         applyChapterSky(this.sky, ch, this.scene);
         this.audio.setTheme(ch.music);

--- a/labs/joao-e-o-pe-de-feijao/src/models.js
+++ b/labs/joao-e-o-pe-de-feijao/src/models.js
@@ -1,69 +1,167 @@
 /**
- * Modelos 3D construídos por código no Babylon.js — nenhum GLB externo.
- * João, mãe, mercador, Mimosa, gigante, cabana, pé de feijão, castelo e tesouros.
+ * Modelos do conto: cápsulas, tubos e lathe + PBR fotográfico.
+ * Nenhum GLB externo. Cache de material nunca serializa Texture (ciclo no engine).
  */
 
 import { hexToColor3 } from './sky.js';
 import {
-    grassTexture, barkTexture, leafTexture, thatchTexture, woodTexture,
-    stoneTexture, goldTexture, cloudTexture, clothTexture
+    surface, thatchTexture, goldTexture, cloudTexture, clothTexture,
+    leafTexture, skinTexture, cowHideTexture, bladeTexture, setTextureQuality
 } from './textures.js';
 
 const B = window.BABYLON;
 const matCache = new Map();
 
-function mat(scene, key, factory) {
-    const sceneKey = scene?.uid || 'default';
-    const fullKey = `${sceneKey}:${key}`;
-    if (!matCache.has(fullKey)) {
-        matCache.set(fullKey, factory());
-    }
-    return matCache.get(fullKey);
+let tess = 12;
+
+export function setModelQuality(id) {
+    tess = id === 'low' ? 6 : id === 'medium' ? 10 : 14;
+    setTextureQuality(id);
 }
 
 export function clearMaterialCache() {
     matCache.clear();
 }
 
+function extraKey(extra) {
+    return [
+        extra.map?.name || extra.mapKey || '',
+        extra.bump?.name || '',
+        extra.roughnessMap?.name || '',
+        extra.emissive ?? '',
+        extra.emissiveIntensity ?? '',
+        extra.alpha ?? '',
+        extra.alphaTest ? 1 : 0,
+        extra.doubleSided ? 1 : 0,
+        extra.bumpLevel ?? ''
+    ].join(':');
+}
+
+function mat(scene, key, factory) {
+    const fullKey = `${scene?.uid || 'default'}:${key}`;
+    if (!matCache.has(fullKey)) matCache.set(fullKey, factory());
+    return matCache.get(fullKey);
+}
+
 export function std(scene, hex, roughness = 0.78, metallic = 0.04, extra = {}) {
-    const colStr = typeof hex === 'number' ? hex.toString(16) : String(hex);
-    return mat(scene, `std:${colStr}:${roughness}:${metallic}:${JSON.stringify(extra)}`, () => {
+    const colStr = typeof hex === 'number' ? hex.toString(16).padStart(6, '0') : String(hex);
+    return mat(scene, `std:${colStr}:${roughness}:${metallic}:${extraKey(extra)}`, () => {
         const material = new B.PBRMaterial(`mat_${colStr}`, scene);
         material.albedoColor = hexToColor3(hex);
         material.roughness = roughness;
         material.metallic = metallic;
-
         if (extra.emissive) {
             material.emissiveColor = hexToColor3(extra.emissive);
             material.emissiveIntensity = extra.emissiveIntensity ?? 0.5;
         }
         if (extra.map) {
             material.albedoTexture = extra.map;
+            if (extra.map.hasAlpha || extra.alphaTest) {
+                material.albedoTexture.hasAlpha = true;
+                material.transparencyMode = B.PBRMaterial.PBRMATERIAL_ALPHATEST;
+                material.needAlphaTesting = true;
+                material.alphaCutOff = extra.alphaCutOff ?? 0.38;
+            }
         }
-        if (extra.alpha != null) {
+        if (extra.bump) {
+            material.bumpTexture = extra.bump;
+            material.bumpTexture.level = extra.bumpLevel ?? 0.5;
+        }
+        if (extra.roughnessMap) {
+            material.metallicTexture = extra.roughnessMap;
+            material.useRoughnessFromMetallicTextureAlpha = false;
+            material.useRoughnessFromMetallicTextureGreen = true;
+            material.useMetallnessFromMetallicTextureBlue = false;
+        }
+        if (extra.alpha != null && !extra.alphaTest) {
             material.alpha = extra.alpha;
             material.transparencyMode = B.PBRMaterial.PBRMATERIAL_ALPHABLEND;
         }
-        if (extra.doubleSided) {
-            material.backFaceCulling = false;
-        }
+        if (extra.doubleSided) material.backFaceCulling = false;
         return material;
+    });
+}
+
+export function surf(scene, kind, tint = 0xffffff, extra = {}) {
+    const maps = surface(scene, kind);
+    return std(scene, tint, extra.roughness ?? 0.82, extra.metallic ?? 0.04, {
+        ...extra,
+        map: maps.albedo,
+        bump: maps.bump,
+        roughnessMap: maps.rough,
+        mapKey: kind
     });
 }
 
 function limb(scene, name, type, options, material, parent, y = 0) {
     let mesh;
-    if (type === 'cylinder') {
-        mesh = B.MeshBuilder.CreateCylinder(name, options, scene);
-    } else if (type === 'box') {
-        mesh = B.MeshBuilder.CreateBox(name, options, scene);
-    } else if (type === 'sphere') {
-        mesh = B.MeshBuilder.CreateSphere(name, options, scene);
+    if (type === 'cylinder') mesh = B.MeshBuilder.CreateCylinder(name, options, scene);
+    else if (type === 'box') mesh = B.MeshBuilder.CreateBox(name, options, scene);
+    else if (type === 'sphere') mesh = B.MeshBuilder.CreateSphere(name, options, scene);
+    else if (type === 'capsule') mesh = B.MeshBuilder.CreateCapsule(name, options, scene);
+    else if (type === 'torus') mesh = B.MeshBuilder.CreateTorus(name, options, scene);
+    else if (type === 'disc') {
+        mesh = B.MeshBuilder.CreateDisc(name, options, scene);
+        mesh.rotation.x = Math.PI / 2;
+    } else {
+        throw new Error(`limb desconhecido: ${type}`);
     }
     mesh.material = material;
     if (parent) mesh.parent = parent;
     mesh.position.y = y;
+    mesh.isPickable = false;
     return mesh;
+}
+
+function lathe(scene, name, shape, tessellation, material, parent, y = 0) {
+    const mesh = B.MeshBuilder.CreateLathe(name, { shape, tessellation, cap: B.Mesh.CAP_END }, scene);
+    mesh.material = material;
+    if (parent) mesh.parent = parent;
+    mesh.position.y = y;
+    mesh.isPickable = false;
+    return mesh;
+}
+
+function leafMat(scene) {
+    return std(scene, 0xffffff, 0.72, 0.02, {
+        map: leafTexture(scene),
+        doubleSided: true,
+        alphaTest: true,
+        mapKey: 'leafAlpha'
+    });
+}
+
+function addHumanFace(scene, head, skin, opts = {}) {
+    const s = opts.scale ?? 1;
+    const eyeWhite = std(scene, 0xf7f2ea, 0.28, 0.02);
+    const iris = std(scene, opts.eyeHex ?? 0x2d5a1c, 0.32, 0.04);
+    const pupil = std(scene, 0x0a0806, 0.2);
+    const brow = std(scene, opts.browHex ?? 0x3a2414, 0.9);
+    const lip = std(scene, 0xc4786a, 0.55);
+    [-1, 1].forEach((sx, i) => {
+        const eye = limb(scene, `eyeW_${i}`, 'sphere', { diameter: 0.056 * s, segments: 8 }, eyeWhite, head, 0.02 * s);
+        eye.position.set(sx * 0.056 * s, 0.02 * s, 0.132 * s);
+        const ir = limb(scene, `iris_${i}`, 'sphere', { diameter: 0.028 * s, segments: 6 }, iris, head, 0.02 * s);
+        ir.position.set(sx * 0.056 * s, 0.02 * s, 0.15 * s);
+        const pu = limb(scene, `pupil_${i}`, 'sphere', { diameter: 0.014 * s, segments: 5 }, pupil, head, 0.018 * s);
+        pu.position.set(sx * 0.056 * s, 0.018 * s, 0.158 * s);
+        const br = limb(scene, `brow_${i}`, 'box', { width: 0.072 * s, height: 0.012 * s, depth: 0.018 * s }, brow, head, 0.058 * s);
+        br.position.set(sx * 0.056 * s, 0.058 * s, 0.122 * s);
+        br.rotation.z = sx * -0.14;
+        const ear = limb(scene, `ear_${i}`, 'sphere', {
+            diameterX: 0.042 * s, diameterY: 0.072 * s, diameterZ: 0.032 * s, segments: 6
+        }, skin, head, 0);
+        ear.position.set(sx * 0.158 * s, 0, 0);
+    });
+    const nose = limb(scene, 'nose', 'capsule', {
+        height: 0.072 * s, radius: 0.016 * s, tessellation: 6
+    }, skin, head, -0.008 * s);
+    nose.position.set(0, -0.008 * s, 0.148 * s);
+    nose.rotation.x = 0.55;
+    const mouth = limb(scene, 'mouth', 'sphere', {
+        diameterX: 0.07 * s, diameterY: 0.018 * s, diameterZ: 0.024 * s, segments: 6
+    }, lip, head, -0.052 * s);
+    mouth.position.set(0, -0.052 * s, 0.128 * s);
 }
 
 /* ------------------------------------------------------------------ */
@@ -72,119 +170,69 @@ function limb(scene, name, type, options, material, parent, y = 0) {
 
 export function buildJoao(scene) {
     const root = new B.TransformNode('joaoRoot', scene);
-    const skin = std(scene, 0xf0c49a, 0.65, 0.02);
-    const hair = std(scene, 0x5a3218, 0.88, 0.02);
-    const vest = std(scene, 0x2e7a3a, 0.84, 0.04);
-    const pants = std(scene, 0x6a4428, 0.86, 0.02);
-    const cap = std(scene, 0xc43a2a, 0.68, 0.05);
+    const skin = std(scene, 0xffffff, 0.62, 0.02, { map: skinTexture(scene), mapKey: 'skin' });
+    const hair = std(scene, 0x4a2a12, 0.9);
+    const vest = surf(scene, 'leather', 0x3d8a48, { roughness: 0.78 });
+    const pants = surf(scene, 'leather', 0x6a4428, { roughness: 0.86 });
+    const cap = std(scene, 0xc43a2a, 0.62, 0.05);
+    const boot = surf(scene, 'leather', 0x3a2414, { roughness: 0.8 });
 
     const hips = new B.TransformNode('joaoHips', scene);
     hips.parent = root;
-
     const parts = { legs: [], arms: [], feet: [] };
 
-    // Pernas e pés
     [-1, 1].forEach((sx, i) => {
         const leg = new B.TransformNode(`joaoLeg_${i}`, scene);
         leg.parent = hips;
-        leg.position.set(sx * 0.12, 0.42, 0);
-
-        const thigh = limb(scene, `joaoThigh_${i}`, 'cylinder', {
-            height: 0.38,
-            diameterTop: 0.15,
-            diameterBottom: 0.13,
-            tessellation: 8
-        }, pants, leg, -0.19);
-
+        leg.position.set(sx * 0.11, 0.46, 0);
+        limb(scene, `joaoThigh_${i}`, 'capsule', {
+            height: 0.44, radius: 0.07, tessellation: tess
+        }, pants, leg, -0.2);
         const foot = limb(scene, `joaoFoot_${i}`, 'sphere', {
-            diameterX: 0.16,
-            diameterY: 0.08,
-            diameterZ: 0.24,
-            segments: 8
-        }, std(scene, 0x3a2414, 0.82), leg, -0.4);
+            diameterX: 0.14, diameterY: 0.07, diameterZ: 0.22, segments: 8
+        }, boot, leg, -0.44);
         foot.position.z = 0.04;
-
         parts.legs.push(leg);
         parts.feet.push(foot);
     });
 
-    // Torso
     const torso = new B.TransformNode('joaoTorso', scene);
     torso.parent = hips;
-    torso.position.y = 0.44;
-
-    const body = limb(scene, 'joaoBody', 'cylinder', {
-        height: 0.42,
-        diameterTop: 0.32,
-        diameterBottom: 0.40,
-        tessellation: 10
+    torso.position.y = 0.46;
+    limb(scene, 'joaoBody', 'capsule', {
+        height: 0.48, radius: 0.16, tessellation: tess
     }, vest, torso, 0.28);
+    limb(scene, 'joaoShirt', 'cylinder', {
+        height: 0.1, diameterTop: 0.22, diameterBottom: 0.26, tessellation: 10
+    }, std(scene, 0xf2e8d0, 0.88), torso, 0.5);
+    const belt = limb(scene, 'joaoBelt', 'cylinder', {
+        height: 0.05, diameter: 0.34, tessellation: 10
+    }, surf(scene, 'leather', 0x4a2a14), torso, 0.1);
+    belt.position.z = 0;
 
-    const shirt = limb(scene, 'joaoShirt', 'cylinder', {
-        height: 0.12,
-        diameterTop: 0.24,
-        diameterBottom: 0.28,
-        tessellation: 8
-    }, std(scene, 0xf2e8d0, 0.9), torso, 0.48);
-
-    // Cabeça e chapéu
     const head = new B.TransformNode('joaoHead', scene);
     head.parent = torso;
-    head.position.y = 0.62;
-
-    const skull = limb(scene, 'joaoSkull', 'sphere', {
-        diameter: 0.31,
-        segments: 12
-    }, skin, head, 0);
-
-    // Olhos
-    [-1, 1].forEach((sx, i) => {
-        const eye = limb(scene, `joaoEye_${i}`, 'sphere', {
-            diameter: 0.048,
-            segments: 8
-        }, std(scene, 0xf7f2ea, 0.35), head, 0.02);
-        eye.position.set(sx * 0.05, 0.02, 0.135);
-
-        const iris = limb(scene, `joaoIris_${i}`, 'sphere', {
-            diameter: 0.026,
-            segments: 6
-        }, std(scene, 0x2a5a18, 0.4), head, 0.02);
-        iris.position.set(sx * 0.05, 0.02, 0.152);
-    });
-
-    const haircap = limb(scene, 'joaoHair', 'sphere', {
-        diameterX: 0.32,
-        diameterY: 0.22,
-        diameterZ: 0.32,
-        segments: 10
-    }, hair, head, 0.04);
-
-    const hat = limb(scene, 'joaoHat', 'cylinder', {
-        height: 0.1,
-        diameterTop: 0.32,
-        diameterBottom: 0.34,
-        tessellation: 12
+    head.position.y = 0.64;
+    limb(scene, 'joaoSkull', 'sphere', { diameter: 0.3, segments: tess }, skin, head, 0);
+    addHumanFace(scene, head, skin, { scale: 1, eyeHex: 0x2a5a18, browHex: 0x5a3218 });
+    limb(scene, 'joaoHair', 'sphere', {
+        diameterX: 0.31, diameterY: 0.2, diameterZ: 0.3, segments: 10
+    }, hair, head, 0.05);
+    limb(scene, 'joaoHat', 'cylinder', {
+        height: 0.1, diameterTop: 0.28, diameterBottom: 0.32, tessellation: 12
     }, cap, head, 0.16);
-
-    const brim = limb(scene, 'joaoBrim', 'cylinder', {
-        height: 0.03,
-        diameter: 0.44,
-        tessellation: 12
+    limb(scene, 'joaoBrim', 'cylinder', {
+        height: 0.025, diameter: 0.44, tessellation: 14
     }, cap, head, 0.12);
 
-    // Braços
     [-1, 1].forEach((sx, i) => {
         const arm = new B.TransformNode(`joaoArm_${i}`, scene);
         arm.parent = torso;
-        arm.position.set(sx * 0.22, 0.44, 0);
-
-        limb(scene, `joaoArmMesh_${i}`, 'cylinder', {
-            height: 0.34,
-            diameterTop: 0.10,
-            diameterBottom: 0.09,
-            tessellation: 8
+        arm.position.set(sx * 0.2, 0.42, 0);
+        limb(scene, `joaoArmMesh_${i}`, 'capsule', {
+            height: 0.38, radius: 0.05, tessellation: 8
         }, skin, arm, -0.16);
-
+        limb(scene, `joaoHand_${i}`, 'sphere', { diameter: 0.09, segments: 6 }, skin, arm, -0.36);
         parts.arms.push(arm);
     });
 
@@ -195,208 +243,130 @@ export function buildJoao(scene) {
 
 export function buildMother(scene) {
     const root = new B.TransformNode('motherRoot', scene);
-    const skin = std(scene, 0xe8b888, 0.7);
-    const dress = std(scene, 0x6a3a78, 0.85);
-    const apron = std(scene, 0xf0e4c8, 0.9);
+    const skin = std(scene, 0xffffff, 0.66, 0.02, { map: skinTexture(scene), mapKey: 'skin' });
+    const dress = std(scene, 0x6a3a78, 0.82, 0.02, { map: clothTexture(scene), mapKey: 'cloth' });
+    const apron = std(scene, 0xf0e4c8, 0.88);
     const hair = std(scene, 0x3a2414, 0.9);
 
-    const skirt = limb(scene, 'motherSkirt', 'cylinder', {
-        height: 0.85,
-        diameterTop: 0.1,
-        diameterBottom: 0.84,
-        tessellation: 12
-    }, dress, root, 0.42);
+    lathe(scene, 'motherSkirt', [
+        new B.Vector3(0.44, 0, 0),
+        new B.Vector3(0.4, 0.28, 0),
+        new B.Vector3(0.26, 0.7, 0),
+        new B.Vector3(0.2, 1.02, 0),
+        new B.Vector3(0.22, 1.18, 0)
+    ], 16, dress, root, 0);
 
-    const torso = limb(scene, 'motherTorso', 'cylinder', {
-        height: 0.4,
-        diameterTop: 0.36,
-        diameterBottom: 0.44,
-        tessellation: 10
-    }, dress, root, 0.95);
-
-    const ap = limb(scene, 'motherApron', 'box', {
-        width: 0.32,
-        height: 0.45,
-        depth: 0.02
-    }, apron, root, 0.72);
-    ap.position.z = 0.22;
+    const ap = limb(scene, 'motherApron', 'box', { width: 0.3, height: 0.48, depth: 0.03 }, apron, root, 0.7);
+    ap.position.z = 0.2;
 
     const head = new B.TransformNode('motherHead', scene);
     head.parent = root;
-    head.position.y = 1.28;
-
-    limb(scene, 'motherSkull', 'sphere', {
-        diameter: 0.32,
-        segments: 12
-    }, skin, head, 0);
-
-    const bun = limb(scene, 'motherBun', 'sphere', {
-        diameter: 0.18,
-        segments: 8
-    }, hair, head, 0.12);
+    head.position.y = 1.32;
+    limb(scene, 'motherSkull', 'sphere', { diameter: 0.3, segments: tess }, skin, head, 0);
+    addHumanFace(scene, head, skin, { scale: 1, eyeHex: 0x4a3020, browHex: 0x3a2414 });
+    const bun = limb(scene, 'motherBun', 'sphere', { diameter: 0.16, segments: 8 }, hair, head, 0.1);
     bun.position.z = -0.1;
+    limb(scene, 'motherHair', 'sphere', {
+        diameterX: 0.32, diameterY: 0.18, diameterZ: 0.3, segments: 8
+    }, hair, head, 0.04);
 
     [-1, 1].forEach((sx, i) => {
-        const eye = limb(scene, `motherEye_${i}`, 'sphere', {
-            diameter: 0.044,
-            segments: 6
-        }, std(scene, 0x2a2018, 0.4), head, 0.02);
-        eye.position.set(sx * 0.05, 0.02, 0.145);
-
-        const arm = limb(scene, `motherArm_${i}`, 'cylinder', {
-            height: 0.42,
-            diameterTop: 0.10,
-            diameterBottom: 0.09,
-            tessellation: 8
-        }, skin, root, 0.88);
-        arm.position.set(sx * 0.26, 0.88, 0.05);
-        arm.rotation.z = sx * 0.35;
+        const arm = limb(scene, `motherArm_${i}`, 'capsule', {
+            height: 0.46, radius: 0.05, tessellation: 8
+        }, skin, root, 0.95);
+        arm.position.set(sx * 0.24, 0.95, 0.04);
+        arm.rotation.z = sx * 0.38;
     });
-
     return root;
 }
 
 export function buildMerchant(scene) {
     const root = new B.TransformNode('merchantRoot', scene);
-    const robeTex = clothTexture(scene);
-    const robe = std(scene, 0xc8a0e0, 0.82, 0.02, { map: robeTex });
-    const skin = std(scene, 0xd4b08a, 0.7);
-    const hatMat = std(scene, 0x3a1848, 0.7, 0.05);
+    const robe = std(scene, 0xc8a0e0, 0.8, 0.02, { map: clothTexture(scene), mapKey: 'cloth' });
+    const skin = std(scene, 0xffffff, 0.66, 0.02, { map: skinTexture(scene), mapKey: 'skin' });
+    const hatMat = std(scene, 0x3a1848, 0.68, 0.05);
+    const hair = std(scene, 0xd8d0c0, 0.88);
 
-    const cloak = limb(scene, 'merchantCloak', 'cylinder', {
-        height: 1.35,
-        diameterTop: 0.12,
-        diameterBottom: 0.96,
-        tessellation: 12
-    }, robe, root, 0.68);
+    lathe(scene, 'merchantCloak', [
+        new B.Vector3(0.08, 0, 0),
+        new B.Vector3(0.42, 0.15, 0),
+        new B.Vector3(0.48, 0.7, 0),
+        new B.Vector3(0.28, 1.2, 0),
+        new B.Vector3(0.16, 1.38, 0)
+    ], 16, robe, root, 0);
 
-    const head = limb(scene, 'merchantHead', 'sphere', {
-        diameter: 0.32,
-        segments: 12
-    }, skin, root, 1.42);
-
-    const hat = limb(scene, 'merchantHat', 'cylinder', {
-        height: 0.55,
-        diameterTop: 0.02,
-        diameterBottom: 0.44,
-        tessellation: 10
-    }, hatMat, root, 1.72);
-
-    const brim = limb(scene, 'merchantBrim', 'cylinder', {
-        height: 0.04,
-        diameter: 0.64,
-        tessellation: 12
-    }, hatMat, root, 1.5);
-
+    const head = new B.TransformNode('merchantHead', scene);
+    head.parent = root;
+    head.position.y = 1.48;
+    limb(scene, 'merchantSkull', 'sphere', { diameter: 0.3, segments: tess }, skin, head, 0);
+    addHumanFace(scene, head, skin, { scale: 1, eyeHex: 0x3a2060, browHex: 0xc8c0b0 });
+    limb(scene, 'merchantHat', 'cylinder', {
+        height: 0.52, diameterTop: 0.02, diameterBottom: 0.42, tessellation: 12
+    }, hatMat, head, 0.28);
+    limb(scene, 'merchantBrim', 'cylinder', {
+        height: 0.035, diameter: 0.62, tessellation: 14
+    }, hatMat, head, 0.04);
     const beard = limb(scene, 'merchantBeard', 'cylinder', {
-        height: 0.24,
-        diameterTop: 0.20,
-        diameterBottom: 0.02,
-        tessellation: 8
-    }, std(scene, 0xd8d0c0, 0.9), root, 1.28);
-    beard.position.z = 0.12;
-    beard.rotation.x = 0.4;
+        height: 0.22, diameterTop: 0.18, diameterBottom: 0.02, tessellation: 8
+    }, hair, head, -0.16);
+    beard.position.z = 0.1;
+    beard.rotation.x = 0.35;
 
-    const pouch = limb(scene, 'merchantPouch', 'sphere', {
-        diameter: 0.24,
-        segments: 8
-    }, std(scene, 0x5a3a18, 0.85), root, 0.7);
+    const pouch = limb(scene, 'merchantPouch', 'sphere', { diameter: 0.22, segments: 8 }, surf(scene, 'leather'), root, 0.7);
     pouch.position.set(0.28, 0.7, 0.1);
-
     return root;
 }
 
 export function buildCow(scene) {
     const root = new B.TransformNode('cowRoot', scene);
-    const hide = std(scene, 0xf2efe8, 0.85);
-    const spot = std(scene, 0x5a3a22, 0.88);
+    const hide = std(scene, 0xffffff, 0.86, 0.02, { map: cowHideTexture(scene), bump: surface(scene, 'leather').bump, mapKey: 'cowHide' });
+    const hoof = std(scene, 0x2a1a10, 0.7);
+    const pink = std(scene, 0xe8c8b0, 0.75);
+    const horn = std(scene, 0xf0e8d0, 0.45, 0.18);
 
-    const body = limb(scene, 'cowBody', 'sphere', {
-        diameterX: 1.2,
-        diameterY: 0.75,
-        diameterZ: 0.7,
-        segments: 12
-    }, hide, root, 0.55);
+    limb(scene, 'cowBody', 'sphere', {
+        diameterX: 1.28, diameterY: 0.82, diameterZ: 0.72, segments: tess
+    }, hide, root, 0.58);
 
     const head = new B.TransformNode('cowHead', scene);
     head.parent = root;
-    head.position.set(0, 0.72, 0.52);
-
-    limb(scene, 'cowHeadMesh', 'sphere', {
-        diameter: 0.44,
-        segments: 10
-    }, hide, head, 0);
-
+    head.position.set(0, 0.78, 0.58);
+    limb(scene, 'cowHeadMesh', 'sphere', { diameter: 0.42, segments: 10 }, hide, head, 0);
     const snout = limb(scene, 'cowSnout', 'sphere', {
-        diameterX: 0.26,
-        diameterY: 0.17,
-        diameterZ: 0.28,
-        segments: 8
-    }, std(scene, 0xe8c8b0, 0.8), head, -0.08);
+        diameterX: 0.26, diameterY: 0.18, diameterZ: 0.3, segments: 8
+    }, pink, head, -0.08);
     snout.position.z = 0.18;
 
     [-1, 1].forEach((sx, i) => {
-        const horn = limb(scene, `cowHorn_${i}`, 'cylinder', {
-            height: 0.14,
-            diameterTop: 0.01,
-            diameterBottom: 0.06,
-            tessellation: 6
-        }, std(scene, 0xf0e8d0, 0.5, 0.2), head, 0.20);
-        horn.position.set(sx * 0.12, 0.20, -0.04);
-        horn.rotation.z = sx * -0.4;
-
+        const h = limb(scene, `cowHorn_${i}`, 'cylinder', {
+            height: 0.16, diameterTop: 0.012, diameterBottom: 0.055, tessellation: 6
+        }, horn, head, 0.2);
+        h.position.set(sx * 0.12, 0.2, -0.04);
+        h.rotation.z = sx * -0.42;
         const ear = limb(scene, `cowEar_${i}`, 'sphere', {
-            diameterX: 0.07,
-            diameterY: 0.14,
-            diameterZ: 0.10,
-            segments: 6
+            diameterX: 0.06, diameterY: 0.14, diameterZ: 0.09, segments: 6
         }, hide, head, 0.08);
-        ear.position.set(sx * 0.2, 0.08, -0.1);
-
-        const eye = limb(scene, `cowEye_${i}`, 'sphere', {
-            diameter: 0.06,
-            segments: 6
-        }, std(scene, 0x1a140e, 0.4), head, 0.06);
+        ear.position.set(sx * 0.2, 0.08, -0.08);
+        const eye = limb(scene, `cowEye_${i}`, 'sphere', { diameter: 0.055, segments: 6 }, std(scene, 0x1a140e, 0.35), head, 0.06);
         eye.position.set(sx * 0.1, 0.06, 0.16);
 
-        // Pernas
-        const legF = limb(scene, `cowLegF_${i}`, 'cylinder', {
-            height: 0.48,
-            diameterTop: 0.14,
-            diameterBottom: 0.11,
-            tessellation: 6
-        }, hide, root, 0.24);
-        legF.position.set(sx * 0.22, 0.24, 0.18);
-
-        const legB = limb(scene, `cowLegB_${i}`, 'cylinder', {
-            height: 0.48,
-            diameterTop: 0.14,
-            diameterBottom: 0.11,
-            tessellation: 6
-        }, hide, root, 0.24);
-        legB.position.set(sx * 0.22, 0.24, -0.22);
-
-        const blot = limb(scene, `cowBlot_${i}`, 'sphere', {
-            diameter: 0.32,
-            segments: 8
-        }, spot, root, 0.62);
-        blot.position.set(sx * 0.28, 0.62, sx * 0.05);
+        const legF = limb(scene, `cowLegF_${i}`, 'capsule', {
+            height: 0.5, radius: 0.065, tessellation: 6
+        }, hide, root, 0.26);
+        legF.position.set(sx * 0.22, 0.26, 0.2);
+        const legB = limb(scene, `cowLegB_${i}`, 'capsule', {
+            height: 0.5, radius: 0.065, tessellation: 6
+        }, hide, root, 0.26);
+        legB.position.set(sx * 0.22, 0.26, -0.22);
+        limb(scene, `cowHoofF_${i}`, 'sphere', { diameter: 0.12, segments: 5 }, hoof, legF, -0.26);
+        limb(scene, `cowHoofB_${i}`, 'sphere', { diameter: 0.12, segments: 5 }, hoof, legB, -0.26);
     });
 
-    const udder = limb(scene, 'cowUdder', 'sphere', {
-        diameter: 0.24,
-        segments: 8
-    }, std(scene, 0xf0c8c0, 0.8), root, 0.28);
-    udder.position.z = -0.05;
-
-    const tail = limb(scene, 'cowTail', 'cylinder', {
-        height: 0.4,
-        diameterTop: 0.06,
-        diameterBottom: 0.04,
-        tessellation: 5
-    }, hide, root, 0.55);
-    tail.position.z = -0.48;
-    tail.rotation.x = 0.6;
+    const udder = limb(scene, 'cowUdder', 'sphere', { diameter: 0.22, segments: 8 }, pink, root, 0.28);
+    udder.position.z = -0.04;
+    const tail = limb(scene, 'cowTail', 'capsule', { height: 0.42, radius: 0.03, tessellation: 5 }, hide, root, 0.62);
+    tail.position.z = -0.5;
+    tail.rotation.x = 0.55;
 
     root.userData = { parts: { head } };
     return root;
@@ -404,136 +374,69 @@ export function buildCow(scene) {
 
 export function buildGiant(scene) {
     const root = new B.TransformNode('giantRoot', scene);
-    const skin = std(scene, 0xc49a72, 0.72);
-    const cloth = std(scene, 0x4a3020, 0.88);
-    const hair = std(scene, 0x3a2010, 0.9);
+    const skin = std(scene, 0xffffff, 0.7, 0.02, { map: skinTexture(scene), mapKey: 'skin' });
+    const cloth = surf(scene, 'leather', 0x4a3020, { roughness: 0.88 });
+    const hair = std(scene, 0x3a2010, 0.92);
+    const boot = surf(scene, 'leather', 0x2a1810);
 
     const hips = new B.TransformNode('giantHips', scene);
     hips.parent = root;
-
     const parts = { legs: [], arms: [] };
 
-    // Pernas colossais
     [-1, 1].forEach((sx, i) => {
         const leg = new B.TransformNode(`giantLeg_${i}`, scene);
         leg.parent = hips;
-        leg.position.set(sx * 0.55, 1.6, 0);
-
-        limb(scene, `giantThigh_${i}`, 'cylinder', {
-            height: 1.5,
-            diameterTop: 0.64,
-            diameterBottom: 0.52,
-            tessellation: 8
-        }, cloth, leg, -0.75);
-
-        const boot = limb(scene, `giantBoot_${i}`, 'box', {
-            width: 0.42,
-            height: 0.28,
-            depth: 0.7
-        }, std(scene, 0x2a1810, 0.85), leg, -1.55);
-        boot.position.z = 0.12;
-
+        leg.position.set(sx * 0.52, 1.65, 0);
+        limb(scene, `giantThigh_${i}`, 'capsule', {
+            height: 1.55, radius: 0.28, tessellation: 8
+        }, cloth, leg, -0.72);
+        const bootM = limb(scene, `giantBoot_${i}`, 'sphere', {
+            diameterX: 0.42, diameterY: 0.26, diameterZ: 0.7, segments: 8
+        }, boot, leg, -1.52);
+        bootM.position.z = 0.12;
         parts.legs.push(leg);
     });
 
-    // Torso e Barriga
     const torso = new B.TransformNode('giantTorso', scene);
     torso.parent = hips;
     torso.position.y = 1.7;
-
     const belly = limb(scene, 'giantBelly', 'sphere', {
-        diameterX: 2.2,
-        diameterY: 1.8,
-        diameterZ: 1.7,
-        segments: 14
-    }, cloth, torso, 1.15);
+        diameterX: 2.15, diameterY: 1.7, diameterZ: 1.65, segments: tess
+    }, cloth, torso, 1.1);
+    limb(scene, 'giantChest', 'capsule', {
+        height: 1.35, radius: 0.72, tessellation: 10
+    }, cloth, torso, 1.85);
 
-    const chest = limb(scene, 'giantChest', 'cylinder', {
-        height: 1.1,
-        diameterTop: 1.4,
-        diameterBottom: 1.8,
-        tessellation: 10
-    }, cloth, torso, 1.7);
-
-    // Cabeça
     const head = new B.TransformNode('giantHead', scene);
     head.parent = torso;
-    head.position.y = 2.55;
-
-    limb(scene, 'giantSkull', 'sphere', {
-        diameter: 1.24,
-        segments: 12
-    }, skin, head, 0);
-
-    const brow = limb(scene, 'giantBrow', 'box', {
-        width: 0.9,
-        height: 0.12,
-        depth: 0.2
-    }, hair, head, 0.18);
-    brow.position.z = 0.48;
-
+    head.position.y = 2.7;
+    limb(scene, 'giantSkull', 'sphere', { diameter: 1.2, segments: tess }, skin, head, 0);
+    addHumanFace(scene, head, skin, { scale: 3.6, eyeHex: 0x3a2010, browHex: 0x2a1810 });
     const beard = limb(scene, 'giantBeard', 'cylinder', {
-        height: 0.7,
-        diameterTop: 0.7,
-        diameterBottom: 0.05,
-        tessellation: 8
-    }, hair, head, -0.45);
+        height: 0.7, diameterTop: 0.7, diameterBottom: 0.08, tessellation: 8
+    }, hair, head, -0.48);
     beard.position.z = 0.28;
-    beard.rotation.x = 0.25;
+    beard.rotation.x = 0.22;
+    limb(scene, 'giantHair', 'sphere', {
+        diameterX: 1.24, diameterY: 0.7, diameterZ: 1.2, segments: 10
+    }, hair, head, 0.22);
 
-    [-1, 1].forEach((sx, i) => {
-        const eye = limb(scene, `giantEye_${i}`, 'sphere', {
-            diameter: 0.18,
-            segments: 8
-        }, std(scene, 0xf0e8d8, 0.3), head, 0.08);
-        eye.position.set(sx * 0.18, 0.08, 0.52);
-
-        const iris = limb(scene, `giantIris_${i}`, 'sphere', {
-            diameter: 0.08,
-            segments: 6
-        }, std(scene, 0x3a2010, 0.4), head, 0.06);
-        iris.position.set(sx * 0.18, 0.06, 0.58);
-    });
-
-    const nose = limb(scene, 'giantNose', 'cylinder', {
-        height: 0.28,
-        diameterTop: 0.02,
-        diameterBottom: 0.24,
-        tessellation: 6
-    }, skin, head, -0.02);
-    nose.position.z = 0.62;
-    nose.rotation.x = Math.PI / 2;
-
-    // Braços
     [-1, 1].forEach((sx, i) => {
         const arm = new B.TransformNode(`giantArm_${i}`, scene);
         arm.parent = torso;
-        arm.position.set(sx * 1.05, 2.0, 0);
-
-        limb(scene, `giantArmMesh_${i}`, 'cylinder', {
-            height: 1.5,
-            diameterTop: 0.44,
-            diameterBottom: 0.36,
-            tessellation: 8
+        arm.position.set(sx * 1.02, 2.05, 0);
+        limb(scene, `giantArmMesh_${i}`, 'capsule', {
+            height: 1.55, radius: 0.2, tessellation: 8
         }, skin, arm, -0.7);
-
-        const fist = limb(scene, `giantFist_${i}`, 'sphere', {
-            diameter: 0.44,
-            segments: 8
-        }, skin, arm, -1.5);
-
+        limb(scene, `giantFist_${i}`, 'sphere', { diameter: 0.42, segments: 8 }, skin, arm, -1.48);
         parts.arms.push(arm);
     });
 
-    // Clava de madeira na mão direita
     const club = limb(scene, 'giantClub', 'cylinder', {
-        height: 2.2,
-        diameterTop: 0.24,
-        diameterBottom: 0.56,
-        tessellation: 8
-    }, std(scene, 0x5a3a18, 0.8), parts.arms[1], -1.4);
-    club.position.set(0.15, -1.4, 0.3);
-    club.rotation.z = 0.3;
+        height: 2.2, diameterTop: 0.2, diameterBottom: 0.52, tessellation: 8
+    }, surf(scene, 'bark'), parts.arms[1], -1.35);
+    club.position.set(0.18, -1.35, 0.28);
+    club.rotation.z = 0.28;
 
     const resultParts = { ...parts, torso, head, hips, belly, club, root };
     root.userData = { parts: resultParts };
@@ -541,188 +444,174 @@ export function buildGiant(scene) {
 }
 
 /* ------------------------------------------------------------------ */
-/* Arquitetura e Cenários                                              */
+/* Arquitetura                                                         */
 /* ------------------------------------------------------------------ */
 
 export function buildCottage(scene) {
     const root = new B.TransformNode('cottageRoot', scene);
-    const wallTex = woodTexture(scene);
-    const thatchTex = thatchTexture(scene);
-    const wall = std(scene, 0xe8d2a8, 0.9, 0.02, { map: wallTex });
-    const roofMat = std(scene, 0xc4a050, 0.95, 0.02, { map: thatchTex });
+    const plaster = surf(scene, 'wood', 0xf0d8b0, { roughness: 0.9 });
+    const timber = surf(scene, 'wood', 0x6a3e20, { roughness: 0.82 });
+    const thatch = std(scene, 0xffffff, 0.95, 0.02, { map: thatchTexture(scene), mapKey: 'thatch' });
+    const stone = surf(scene, 'stone');
 
-    const body = limb(scene, 'cottageBody', 'box', {
-        width: 5.2,
-        height: 2.6,
-        depth: 4.2
-    }, wall, root, 1.3);
+    limb(scene, 'cottageBase', 'box', { width: 5.5, height: 0.45, depth: 4.5 }, stone, root, 0.22);
+    limb(scene, 'cottageBody', 'box', { width: 5.2, height: 2.35, depth: 4.2 }, plaster, root, 1.4);
 
-    const roof = limb(scene, 'cottageRoof', 'cylinder', {
-        height: 2.2,
-        diameterTop: 0.2,
-        diameterBottom: 5.9,
-        tessellation: 4
-    }, roofMat, root, 3.5);
-    roof.rotation.y = Math.PI / 4;
-
-    const door = limb(scene, 'cottageDoor', 'box', {
-        width: 0.9,
-        height: 1.5,
-        depth: 0.12
-    }, std(scene, 0x5a3218, 0.8), root, 0.75);
-    door.position.z = 2.16;
-
-    const knob = limb(scene, 'cottageKnob', 'sphere', {
-        diameter: 0.1,
-        segments: 6
-    }, std(scene, 0xd4a020, 0.3, 0.8), root, 0.7);
-    knob.position.set(0.32, 0.7, 2.24);
-
-    [-1.4, 1.4].forEach((sx, i) => {
-        const win = limb(scene, `cottageWin_${i}`, 'box', {
-            width: 0.7,
-            height: 0.7,
-            depth: 0.08
-        }, std(scene, 0x88c8e8, 0.3, 0.1, {
-            emissive: 0xffcc66,
-            emissiveIntensity: 0.35
-        }), root, 1.55);
-        win.position.set(sx, 1.55, 2.14);
+    [[-2.5, 0], [2.5, 0], [0, -2.05], [0, 2.05]].forEach(([x, z], i) => {
+        const beam = limb(scene, `cottageBeam_${i}`, 'box', {
+            width: z === 0 ? 0.16 : 5.2, height: 2.35, depth: x === 0 ? 0.16 : 4.2
+        }, timber, root, 1.4);
+        beam.position.set(x * 0.02 + (z === 0 ? x : 0), 1.4, z === 0 ? 0 : z * 0.02 + (x === 0 ? z : 0));
+    });
+    [-1, 1].forEach((sx) => {
+        const post = limb(scene, 'cottagePost', 'box', { width: 0.18, height: 2.4, depth: 0.18 }, timber, root, 1.4);
+        post.position.set(sx * 2.45, 1.4, 2.05);
     });
 
-    const chimney = limb(scene, 'cottageChimney', 'box', {
-        width: 0.55,
-        height: 1.4,
-        depth: 0.55
-    }, std(scene, 0x8a7060, 0.9), root, 4.1);
-    chimney.position.set(1.6, 4.1, -0.6);
+    const slopeL = limb(scene, 'cottageRoofL', 'box', { width: 3.4, height: 0.28, depth: 5.0 }, thatch, root, 3.15);
+    slopeL.rotation.z = 0.52;
+    slopeL.position.set(-1.35, 3.15, 0);
+    const slopeR = limb(scene, 'cottageRoofR', 'box', { width: 3.4, height: 0.28, depth: 5.0 }, thatch, root, 3.15);
+    slopeR.rotation.z = -0.52;
+    slopeR.position.set(1.35, 3.15, 0);
+    limb(scene, 'cottageRidge', 'box', { width: 0.22, height: 0.18, depth: 5.1 }, timber, root, 3.85);
 
+    const door = limb(scene, 'cottageDoor', 'box', { width: 0.88, height: 1.55, depth: 0.1 }, timber, root, 0.9);
+    door.position.z = 2.16;
+    const knob = limb(scene, 'cottageKnob', 'sphere', { diameter: 0.09, segments: 6 }, std(scene, 0xd4a020, 0.28, 0.82), root, 0.85);
+    knob.position.set(0.3, 0.85, 2.24);
+
+    [-1.35, 1.35].forEach((sx, i) => {
+        const win = limb(scene, `cottageWin_${i}`, 'box', { width: 0.72, height: 0.72, depth: 0.08 },
+            std(scene, 0x88c8e8, 0.22, 0.08, { emissive: 0xffcc66, emissiveIntensity: 0.4 }), root, 1.62);
+        win.position.set(sx, 1.62, 2.12);
+        const frame = limb(scene, `cottageWinF_${i}`, 'box', { width: 0.82, height: 0.82, depth: 0.06 }, timber, root, 1.62);
+        frame.position.set(sx, 1.62, 2.1);
+    });
+
+    const chimney = limb(scene, 'cottageChimney', 'box', { width: 0.58, height: 1.55, depth: 0.58 }, stone, root, 4.2);
+    chimney.position.set(1.55, 4.2, -0.7);
     return root;
 }
 
 export function buildFence(scene, len = 6) {
     const root = new B.TransformNode('fenceRoot', scene);
-    const wood = std(scene, 0x8a6a40, 0.88);
-    const posts = Math.max(2, Math.round(len / 1.2));
-
+    const wood = surf(scene, 'wood', 0x8a6a40);
+    const posts = Math.max(2, Math.round(len / 1.15));
     for (let i = 0; i < posts; i++) {
         const x = (i / (posts - 1) - 0.5) * len;
-        const p = limb(scene, `fencePost_${i}`, 'box', {
-            width: 0.12,
-            height: 0.9,
-            depth: 0.12
-        }, wood, root, 0.45);
-        p.position.set(x, 0.45, 0);
+        const p = limb(scene, `fencePost_${i}`, 'cylinder', {
+            height: 0.95, diameterTop: 0.1, diameterBottom: 0.13, tessellation: 6
+        }, wood, root, 0.48);
+        p.position.set(x, 0.48, 0);
     }
-
-    [0.28, 0.62].forEach((y, i) => {
-        const rail = limb(scene, `fenceRail_${i}`, 'box', {
-            width: len,
-            height: 0.08,
-            depth: 0.08
-        }, wood, root, y);
+    [0.3, 0.64].forEach((y, i) => {
+        limb(scene, `fenceRail_${i}`, 'box', { width: len, height: 0.07, depth: 0.07 }, wood, root, y);
     });
-
     return root;
 }
 
 export function buildTree(scene, rng = Math.random) {
     const root = new B.TransformNode('treeRoot', scene);
-    const barkTex = barkTexture(scene);
-    const leafTex = leafTexture(scene);
-
-    const trunk = limb(scene, 'treeTrunk', 'cylinder', {
-        height: 2.2,
-        diameterTop: 0.36,
-        diameterBottom: 0.56,
-        tessellation: 8
-    }, std(scene, 0x6a4a28, 0.92, 0.02, { map: barkTex }), root, 1.1);
-
-    const leafMat = std(scene, 0x4aaa3a, 0.85, 0.02, { map: leafTex });
-
-    for (let i = 0; i < 4; i++) {
-        const s = limb(scene, `treeFoliage_${i}`, 'sphere', {
-            diameter: (1.4 + rng() * 0.7),
-            segments: 8
-        }, leafMat, root, 2.2 + i * 0.35);
-        s.position.set((rng() - 0.5) * 0.8, 2.2 + i * 0.35, (rng() - 0.5) * 0.8);
+    const barkMat = surf(scene, 'bark');
+    const foliage = leafMat(scene);
+    const lean = (rng() - 0.5) * 0.28;
+    const path = [];
+    for (let i = 0; i <= 7; i++) {
+        const t = i / 7;
+        path.push(new B.Vector3(lean * t * t * 1.4, t * 2.55, (rng() - 0.5) * 0.08));
     }
+    const trunk = B.MeshBuilder.CreateTube('treeTrunk', {
+        path,
+        radius: 0.2,
+        tessellation: Math.max(5, tess - 4),
+        cap: B.Mesh.CAP_ALL
+    }, scene);
+    trunk.material = barkMat;
+    trunk.parent = root;
+    trunk.isPickable = false;
 
+    const cards = tess < 8 ? 5 : 11;
+    for (let i = 0; i < cards; i++) {
+        const card = B.MeshBuilder.CreatePlane(`treeLeaf_${i}`, {
+            width: 1.1 + rng() * 0.7,
+            height: 1.3 + rng() * 0.6
+        }, scene);
+        card.material = foliage;
+        card.parent = root;
+        card.position.set((rng() - 0.5) * 1.5, 2.15 + rng() * 1.1, (rng() - 0.5) * 1.5);
+        card.rotation.set(rng() * 0.5, rng() * Math.PI * 2, rng() * 0.4);
+        card.isPickable = false;
+    }
     return root;
+}
+
+export function buildRock(scene, rng = Math.random) {
+    const mesh = B.MeshBuilder.CreateIcoSphere('rock', {
+        radius: 0.32 + rng() * 0.45,
+        subdivisions: 1
+    }, scene);
+    mesh.scaling.set(1 + rng() * 0.7, 0.4 + rng() * 0.45, 0.75 + rng() * 0.6);
+    mesh.material = surf(scene, 'rock');
+    mesh.rotation.y = rng() * Math.PI * 2;
+    mesh.isPickable = false;
+    return mesh;
 }
 
 export function buildStall(scene, color = 0xc45a2a) {
     const root = new B.TransformNode('stallRoot', scene);
-    const woodTex = woodTexture(scene);
-    const wood = std(scene, 0x8a5a32, 0.88, 0.02, { map: woodTex });
-
-    const table = limb(scene, 'stallTable', 'box', {
-        width: 2.2,
-        height: 0.12,
-        depth: 1.1
-    }, wood, root, 0.85);
-
-    [-0.9, 0.9].forEach(sx => {
-        [-0.4, 0.4].forEach(sz => {
-            const leg = limb(scene, 'stallLeg', 'box', {
-                width: 0.1,
-                height: 0.85,
-                depth: 0.1
-            }, wood, root, 0.42);
+    const wood = surf(scene, 'wood');
+    limb(scene, 'stallTable', 'box', { width: 2.2, height: 0.12, depth: 1.1 }, wood, root, 0.85);
+    [-0.9, 0.9].forEach((sx) => {
+        [-0.4, 0.4].forEach((sz) => {
+            const leg = limb(scene, 'stallLeg', 'box', { width: 0.1, height: 0.85, depth: 0.1 }, wood, root, 0.42);
             leg.position.set(sx, 0.42, sz);
         });
     });
-
-    const cloth = limb(scene, 'stallCloth', 'box', {
-        width: 2.4,
-        height: 0.06,
-        depth: 1.6
-    }, std(scene, color, 0.85), root, 1.85);
-
-    [-1.05, 1.05].forEach(sx => {
-        const pole = limb(scene, 'stallPole', 'cylinder', {
-            height: 2.0,
-            diameter: 0.1,
-            tessellation: 6
-        }, wood, root, 1.0);
-        pole.position.set(sx, 1.0, -0.5);
+    limb(scene, 'stallCloth', 'box', { width: 2.45, height: 0.06, depth: 1.65 }, std(scene, color, 0.82), root, 1.88);
+    [-1.05, 1.05].forEach((sx) => {
+        const pole = limb(scene, 'stallPole', 'cylinder', { height: 2.05, diameter: 0.09, tessellation: 6 }, wood, root, 1.02);
+        pole.position.set(sx, 1.02, -0.5);
     });
-
     return root;
 }
 
 export function buildBeanstalk(scene, height = 78, quality = 'high') {
     const root = new B.TransformNode('beanstalkRoot', scene);
-    const barkTex = barkTexture(scene);
-    const leafTex = leafTexture(scene);
-
-    const stemMat = std(scene, 0x3a8a32, 0.82, 0.04, { map: barkTex });
-    const leafMat = std(scene, 0x4cba40, 0.78, 0.02, { map: leafTex, doubleSided: true });
-
-    const twist = new B.TransformNode('beanstalkTwist', scene);
-    twist.parent = root;
-
-    const segs = quality === 'low' ? 10 : 18;
-    for (let i = 0; i < segs; i++) {
-        const y = (i / segs) * height;
-        const segHeight = height / segs + 0.4;
-        const vine = limb(scene, `stalkVine_${i}`, 'cylinder', {
-            height: segHeight,
-            diameterTop: 1.1,
-            diameterBottom: 1.4,
-            tessellation: 8
-        }, stemMat, twist, y + segHeight * 0.5);
-        vine.rotation.y = i * 0.45;
-        vine.rotation.z = 0.08;
-
-        const tendril = limb(scene, `stalkTendril_${i}`, 'cylinder', {
-            height: 0.24,
-            diameterTop: 1.7,
-            diameterBottom: 1.7,
-            tessellation: 8
-        }, stemMat, twist, y + 1.2);
-        tendril.rotation.z = i * 0.7;
+    const stemMat = surf(scene, 'bark', 0x3a8a32, { roughness: 0.8 });
+    const foliage = leafMat(scene);
+    const segs = quality === 'low' ? 28 : 52;
+    const path = [];
+    for (let i = 0; i <= segs; i++) {
+        const t = i / segs;
+        const a = t * Math.PI * 2 * 6.2;
+        const r = 0.42 + Math.sin(t * 11) * 0.1;
+        path.push(new B.Vector3(Math.cos(a) * r, t * height, Math.sin(a) * r));
     }
+    const vine = B.MeshBuilder.CreateTube('stalkVine', {
+        path,
+        radius: 0.55,
+        tessellation: quality === 'low' ? 6 : 9,
+        cap: B.Mesh.CAP_ALL
+    }, scene);
+    vine.material = stemMat;
+    vine.parent = root;
+    vine.isPickable = false;
+
+    const tendrilPath = path.map((p, i) => {
+        const t = i / segs;
+        const a = t * Math.PI * 2 * 6.2 + 0.9;
+        return new B.Vector3(Math.cos(a) * 0.85, p.y, Math.sin(a) * 0.85);
+    });
+    const tendril = B.MeshBuilder.CreateTube('stalkTendril', {
+        path: tendrilPath,
+        radius: 0.16,
+        tessellation: 5,
+        cap: B.Mesh.CAP_ALL
+    }, scene);
+    tendril.material = stemMat;
+    tendril.parent = root;
+    tendril.isPickable = false;
 
     const platforms = [];
     const count = quality === 'low' ? 12 : 18;
@@ -732,340 +621,238 @@ export function buildBeanstalk(scene, height = 78, quality = 'high') {
         const r = 3.15;
         const x = Math.cos(a) * r;
         const z = Math.sin(a) * r;
-
-        const pad = limb(scene, `stalkPad_${i}`, 'cylinder', {
-            height: 0.18,
-            diameterTop: 2.7,
-            diameterBottom: 2.9,
-            tessellation: 10
-        }, leafMat, root, y - 0.08);
-        pad.position.set(x, y - 0.08, z);
-
+        const pad = limb(scene, `stalkPad_${i}`, 'sphere', {
+            diameterX: 3.1, diameterY: 0.26, diameterZ: 2.4, segments: 10
+        }, foliage, root, y);
+        pad.position.set(x, y, z);
+        pad.rotation.y = a;
         platforms.push({ x, y, z, r: 1.45 });
     }
 
     const flower = limb(scene, 'stalkFlower', 'cylinder', {
-        height: 2.2,
-        diameterTop: 0.2,
-        diameterBottom: 2.8,
-        tessellation: 8
-    }, std(scene, 0x7a3aaa, 0.6, 0.05, {
-        emissive: 0x5a2088,
-        emissiveIntensity: 0.45
-    }), root, height + 0.4);
-
+        height: 2.1, diameterTop: 0.15, diameterBottom: 2.6, tessellation: 10
+    }, std(scene, 0x7a3aaa, 0.55, 0.05, { emissive: 0x5a2088, emissiveIntensity: 0.5 }), root, height + 0.35);
+    flower.position.y = height + 0.35;
     return { group: root, platforms, height };
 }
 
 export function buildCloudIsland(scene, radius = 28) {
     const root = new B.TransformNode('cloudIslandRoot', scene);
-    const cloudTex = cloudTexture(scene);
-    const cloudMat = std(scene, 0xf4f8fc, 0.92, 0.02, { map: cloudTex });
-
-    const top = limb(scene, 'cloudTop', 'cylinder', {
-        height: 2.2,
-        diameterTop: radius * 2,
-        diameterBottom: radius * 1.84,
-        tessellation: 24
+    const cloudMat = std(scene, 0xffffff, 0.95, 0.02, {
+        map: cloudTexture(scene),
+        emissive: 0xe8f0fa,
+        emissiveIntensity: 0.18,
+        mapKey: 'cloud'
+    });
+    limb(scene, 'cloudTop', 'cylinder', {
+        height: 2.0, diameterTop: radius * 2, diameterBottom: radius * 1.84, tessellation: 28
     }, cloudMat, root, 0);
-
-    for (let i = 0; i < 10; i++) {
-        const a = (i / 10) * Math.PI * 2;
+    const puffs = tess < 8 ? 8 : 14;
+    for (let i = 0; i < puffs; i++) {
+        const a = (i / puffs) * Math.PI * 2;
         const puff = limb(scene, `cloudPuff_${i}`, 'sphere', {
-            diameterX: 8 + (i % 3) * 2.8,
-            diameterY: 4 + (i % 3) * 1.4,
-            diameterZ: 8 + (i % 3) * 2.8,
-            segments: 8
-        }, cloudMat, root, -1.2);
-        puff.position.set(Math.cos(a) * (radius * 0.82), -1.2, Math.sin(a) * (radius * 0.82));
+            diameterX: 9 + (i % 4) * 2.4,
+            diameterY: 4.2 + (i % 3) * 1.2,
+            diameterZ: 9 + (i % 4) * 2.4,
+            segments: 10
+        }, cloudMat, root, -1.15);
+        puff.position.set(Math.cos(a) * (radius * 0.8), -1.15, Math.sin(a) * (radius * 0.8));
     }
-
     return root;
 }
 
 export function buildCastle(scene) {
     const root = new B.TransformNode('castleRoot', scene);
-    const stoneTex = stoneTexture(scene);
-    const stone = std(scene, 0xb8c0c8, 0.9, 0.05, { map: stoneTex });
-    const roofMat = std(scene, 0x5a2a68, 0.7, 0.05);
+    const stone = surf(scene, 'stone');
+    const roofMat = surf(scene, 'tiles', 0x8a4aaa, { roughness: 0.65 });
+    const wood = surf(scene, 'wood', 0x3a2414);
 
-    const keep = limb(scene, 'castleKeep', 'box', {
-        width: 16,
-        height: 10,
-        depth: 14
-    }, stone, root, 5);
+    limb(scene, 'castleKeep', 'box', { width: 16, height: 10, depth: 14 }, stone, root, 5);
+    limb(scene, 'castleHall', 'box', { width: 10, height: 6, depth: 12 }, stone, root, 3).position.z = 10;
 
-    const hall = limb(scene, 'castleHall', 'box', {
-        width: 10,
-        height: 6,
-        depth: 12
-    }, stone, root, 3);
-    hall.position.z = 10;
+    for (let i = -7; i <= 7; i += 2) {
+        const merlon = limb(scene, `castleMerlon_${i}`, 'box', { width: 1.1, height: 0.85, depth: 0.55 }, stone, root, 10.4);
+        merlon.position.set(i, 10.4, 7.05);
+        const merlonB = limb(scene, `castleMerlonB_${i}`, 'box', { width: 1.1, height: 0.85, depth: 0.55 }, stone, root, 10.4);
+        merlonB.position.set(i, 10.4, -7.05);
+    }
 
-    [
-        [-7, -6], [7, -6], [-7, 6], [7, 6], [-4, 15], [4, 15]
-    ].forEach(([x, z], i) => {
+    [[-7, -6], [7, -6], [-7, 6], [7, 6], [-4, 15], [4, 15]].forEach(([x, z], i) => {
         const t = limb(scene, `castleTower_${i}`, 'cylinder', {
-            height: 14,
-            diameterTop: 2.8,
-            diameterBottom: 3.2,
-            tessellation: 10
+            height: 14, diameterTop: 2.7, diameterBottom: 3.2, tessellation: 12
         }, stone, root, 7);
         t.position.set(x, 7, z);
-
         const cap = limb(scene, `castleCap_${i}`, 'cylinder', {
-            height: 2.4,
-            diameterTop: 0.2,
-            diameterBottom: 3.6,
-            tessellation: 8
-        }, roofMat, root, 15.1);
-        cap.position.set(x, 15.1, z);
+            height: 2.5, diameterTop: 0.15, diameterBottom: 3.5, tessellation: 10
+        }, roofMat, root, 15.15);
+        cap.position.set(x, 15.15, z);
     });
 
-    const door = limb(scene, 'castleDoor', 'box', {
-        width: 3.2,
-        height: 4.4,
-        depth: 0.4
-    }, std(scene, 0x3a2414, 0.8), root, 2.2);
-    door.position.z = 16.1;
+    [-5, 0, 5].forEach((x, i) => {
+        const win = limb(scene, `castleWin_${i}`, 'box', { width: 0.7, height: 1.4, depth: 0.12 },
+            std(scene, 0x1a2840, 0.3, 0.05, { emissive: 0xffaa55, emissiveIntensity: 0.25 }), root, 6.2);
+        win.position.set(x, 6.2, 7.05);
+    });
 
+    const door = limb(scene, 'castleDoor', 'box', { width: 3.2, height: 4.4, depth: 0.35 }, wood, root, 2.2);
+    door.position.z = 16.1;
     return root;
 }
 
 export function buildTable(scene) {
     const root = new B.TransformNode('tableRoot', scene);
-    const woodTex = woodTexture(scene);
-    const wood = std(scene, 0x8a5a32, 0.75, 0.04, { map: woodTex });
-
-    const top = limb(scene, 'tableTop', 'box', {
-        width: 8,
-        height: 0.35,
-        depth: 4.2
-    }, wood, root, 1.8);
-
-    [-3.4, 3.4].forEach(sx => {
-        [-1.6, 1.6].forEach(sz => {
-            const leg = limb(scene, 'tableLeg', 'box', {
-                width: 0.28,
-                height: 1.8,
-                depth: 0.28
-            }, wood, root, 0.9);
+    const wood = surf(scene, 'wood');
+    limb(scene, 'tableTop', 'box', { width: 8, height: 0.32, depth: 4.2 }, wood, root, 1.8);
+    [-3.4, 3.4].forEach((sx) => {
+        [-1.6, 1.6].forEach((sz) => {
+            const leg = limb(scene, 'tableLeg', 'box', { width: 0.28, height: 1.8, depth: 0.28 }, wood, root, 0.9);
             leg.position.set(sx, 0.9, sz);
         });
     });
-
     return root;
 }
 
 export function buildGoldBag(scene) {
     const root = new B.TransformNode('goldBagRoot', scene);
-    const goldTex = goldTexture(scene);
-    const goldMat = std(scene, 0xc4a030, 0.45, 0.65, {
-        map: goldTex,
+    const goldMat = std(scene, 0xffffff, 0.32, 0.72, {
+        map: goldTexture(scene),
         emissive: 0xaa7700,
-        emissiveIntensity: 0.4
+        emissiveIntensity: 0.42,
+        mapKey: 'gold'
     });
-
-    const bag = limb(scene, 'goldBagMesh', 'sphere', {
-        diameterX: 0.76,
-        diameterY: 0.88,
-        diameterZ: 0.76,
-        segments: 10
+    const sack = surf(scene, 'leather', 0x8a6a20, { roughness: 0.7 });
+    limb(scene, 'goldBagMesh', 'sphere', {
+        diameterX: 0.78, diameterY: 0.9, diameterZ: 0.78, segments: 12
     }, goldMat, root, 0);
-
-    const neck = limb(scene, 'goldBagNeck', 'cylinder', {
-        height: 0.22,
-        diameterTop: 0.24,
-        diameterBottom: 0.36,
-        tessellation: 8
-    }, std(scene, 0x8a6a20, 0.6, 0.4), root, 0.42);
-
+    limb(scene, 'goldBagNeck', 'cylinder', {
+        height: 0.22, diameterTop: 0.22, diameterBottom: 0.36, tessellation: 8
+    }, sack, root, 0.44);
+    for (let i = 0; i < 6; i++) {
+        const a = (i / 6) * Math.PI * 2;
+        const coin = limb(scene, `coin_${i}`, 'cylinder', {
+            height: 0.04, diameter: 0.14, tessellation: 10
+        }, goldMat, root, 0.18);
+        coin.position.set(Math.cos(a) * 0.22, 0.18 + (i % 2) * 0.08, Math.sin(a) * 0.22);
+        coin.rotation.x = Math.PI / 2;
+    }
     return root;
 }
 
 export function buildHen(scene) {
     const root = new B.TransformNode('henRoot', scene);
-    const goldTex = goldTexture(scene);
-    const gold = std(scene, 0xffe080, 0.32, 0.75, {
-        map: goldTex,
+    const gold = std(scene, 0xffffff, 0.28, 0.78, {
+        map: goldTexture(scene),
         emissive: 0xaa7700,
-        emissiveIntensity: 0.35
+        emissiveIntensity: 0.38,
+        mapKey: 'gold'
     });
-
-    const body = limb(scene, 'henBody', 'sphere', {
-        diameterX: 0.64,
-        diameterY: 0.50,
-        diameterZ: 0.56,
-        segments: 10
-    }, gold, root, 0.28);
-
-    const head = limb(scene, 'henHead', 'sphere', {
-        diameter: 0.28,
-        segments: 8
-    }, gold, root, 0.48);
-    head.position.x = 0.22;
-
+    limb(scene, 'henBody', 'sphere', {
+        diameterX: 0.68, diameterY: 0.5, diameterZ: 0.54, segments: 12
+    }, gold, root, 0.3);
+    const head = limb(scene, 'henHead', 'sphere', { diameter: 0.26, segments: 8 }, gold, root, 0.52);
+    head.position.x = 0.24;
     const beak = limb(scene, 'henBeak', 'cylinder', {
-        height: 0.12,
-        diameterTop: 0.01,
-        diameterBottom: 0.08,
-        tessellation: 6
-    }, std(scene, 0xffaa33, 0.4, 0.5), root, 0.46);
-    beak.position.x = 0.36;
+        height: 0.12, diameterTop: 0.01, diameterBottom: 0.07, tessellation: 6
+    }, std(scene, 0xffaa33, 0.4, 0.45), root, 0.5);
+    beak.position.x = 0.38;
     beak.rotation.z = -Math.PI / 2;
-
-    const comb = limb(scene, 'henComb', 'sphere', {
-        diameter: 0.12,
-        segments: 6
-    }, std(scene, 0xff6644, 0.5), root, 0.62);
+    const comb = limb(scene, 'henComb', 'sphere', { diameter: 0.12, segments: 6 }, std(scene, 0xff5533, 0.5), root, 0.66);
     comb.position.x = 0.2;
-
-    [-1, 1].forEach(sx => {
+    [-1, 1].forEach((sx) => {
         const wing = limb(scene, 'henWing', 'sphere', {
-            diameterX: 0.28,
-            diameterY: 0.20,
-            diameterZ: 0.08,
-            segments: 8
-        }, gold, root, 0.3);
-        wing.position.set(-0.05, 0.3, sx * 0.22);
+            diameterX: 0.3, diameterY: 0.18, diameterZ: 0.08, segments: 8
+        }, gold, root, 0.32);
+        wing.position.set(-0.04, 0.32, sx * 0.24);
     });
-
+    const tail = limb(scene, 'henTail', 'sphere', {
+        diameterX: 0.22, diameterY: 0.28, diameterZ: 0.08, segments: 8
+    }, gold, root, 0.4);
+    tail.position.set(-0.32, 0.4, 0);
+    tail.rotation.z = 0.5;
     return root;
 }
 
 export function buildHarp(scene) {
     const root = new B.TransformNode('harpRoot', scene);
-    const goldTex = goldTexture(scene);
-    const gold = std(scene, 0xffe080, 0.28, 0.8, {
-        map: goldTex,
+    const gold = std(scene, 0xffffff, 0.24, 0.82, {
+        map: goldTexture(scene),
         emissive: 0xaa8800,
-        emissiveIntensity: 0.45
+        emissiveIntensity: 0.48,
+        mapKey: 'gold'
     });
-
     const frame = limb(scene, 'harpFrame', 'torus', {
-        diameter: 1.1,
-        thickness: 0.14,
-        tessellation: 16
-    }, gold, root, 0.55);
+        diameter: 1.12, thickness: 0.12, tessellation: 24
+    }, gold, root, 0.58);
     frame.rotation.y = Math.PI / 2;
-
     const pillar = limb(scene, 'harpPillar', 'cylinder', {
-        height: 1.15,
-        diameter: 0.1,
-        tessellation: 8
-    }, gold, root, 0.55);
+        height: 1.18, diameter: 0.09, tessellation: 10
+    }, gold, root, 0.58);
     pillar.position.x = 0.55;
-
-    const base = limb(scene, 'harpBase', 'box', {
-        width: 0.7,
-        height: 0.1,
-        depth: 0.22
-    }, gold, root, 0.05);
-
-    for (let i = 0; i < 7; i++) {
+    limb(scene, 'harpBase', 'box', { width: 0.72, height: 0.1, depth: 0.22 }, gold, root, 0.05);
+    for (let i = 0; i < 8; i++) {
         const s = limb(scene, `harpString_${i}`, 'cylinder', {
-            height: 0.7 + i * 0.05,
-            diameter: 0.016,
-            tessellation: 4
-        }, std(scene, 0xfff8d0, 0.4, 0.1, {
-            emissive: 0xffeedd,
-            emissiveIntensity: 0.5
-        }), root, 0.5);
-        s.position.x = -0.2 + i * 0.1;
+            height: 0.68 + i * 0.05, diameter: 0.014, tessellation: 4
+        }, std(scene, 0xfff8d0, 0.35, 0.1, { emissive: 0xffeedd, emissiveIntensity: 0.55 }), root, 0.52);
+        s.position.x = -0.22 + i * 0.1;
     }
-
     return root;
 }
 
 export function buildAxe(scene) {
     const root = new B.TransformNode('axeRoot', scene);
-    const handle = limb(scene, 'axeHandle', 'cylinder', {
-        height: 1.1,
-        diameterTop: 0.08,
-        diameterBottom: 0.1,
-        tessellation: 8
-    }, std(scene, 0x6a3a18, 0.8), root, 0.55);
-
-    const head = limb(scene, 'axeHead', 'box', {
-        width: 0.45,
-        height: 0.28,
-        depth: 0.08
-    }, std(scene, 0xc8d0d8, 0.35, 0.7), root, 1.05);
+    limb(scene, 'axeHandle', 'cylinder', {
+        height: 1.12, diameterTop: 0.07, diameterBottom: 0.1, tessellation: 8
+    }, surf(scene, 'wood', 0x6a3a18), root, 0.55);
+    const head = limb(scene, 'axeHead', 'box', { width: 0.48, height: 0.28, depth: 0.07 },
+        std(scene, 0xc8d0d8, 0.28, 0.78), root, 1.05);
     head.position.x = 0.18;
-
+    const bit = limb(scene, 'axeBit', 'box', { width: 0.18, height: 0.34, depth: 0.04 },
+        std(scene, 0xe8eef2, 0.22, 0.85), root, 1.05);
+    bit.position.x = 0.38;
     return root;
 }
 
 export function buildWell(scene) {
     const root = new B.TransformNode('wellRoot', scene);
-    const stoneTex = stoneTexture(scene);
-    const stone = std(scene, 0x8a9098, 0.9, 0.04, { map: stoneTex });
-
-    const ring = limb(scene, 'wellRing', 'cylinder', {
-        height: 0.7,
-        diameterTop: 1.7,
-        diameterBottom: 1.9,
-        tessellation: 12
-    }, stone, root, 0.35);
-
-    const water = limb(scene, 'wellWater', 'cylinder', {
-        height: 0.02,
-        diameter: 1.4,
-        tessellation: 12
-    }, std(scene, 0x3a88aa, 0.2, 0.3, {
-        alpha: 0.75
-    }), root, 0.42);
-
+    const stone = surf(scene, 'stone', 0x9aa0a8);
+    const wood = surf(scene, 'wood');
+    limb(scene, 'wellRing', 'cylinder', {
+        height: 0.72, diameterTop: 1.65, diameterBottom: 1.9, tessellation: 16
+    }, stone, root, 0.36);
+    limb(scene, 'wellWater', 'cylinder', {
+        height: 0.02, diameter: 1.35, tessellation: 16
+    }, std(scene, 0x3a88aa, 0.12, 0.28, { alpha: 0.78 }), root, 0.42);
+    [-0.7, 0.7].forEach((sx) => {
+        const post = limb(scene, 'wellPost', 'cylinder', {
+            height: 1.15, diameter: 0.08, tessellation: 6
+        }, wood, root, 1.05);
+        post.position.set(sx, 1.05, 0);
+    });
+    limb(scene, 'wellBeam', 'cylinder', {
+        height: 1.5, diameter: 0.07, tessellation: 6
+    }, wood, root, 1.62).rotation.z = Math.PI / 2;
     return root;
 }
 
 export function buildGateArch(scene) {
     const root = new B.TransformNode('gateArchRoot', scene);
-    const wood = std(scene, 0x6a3e1c, 0.85);
-
-    [-1.6, 1.6].forEach(sx => {
-        const post = limb(scene, 'gatePost', 'box', {
-            width: 0.28,
-            height: 3.4,
-            depth: 0.28
-        }, wood, root, 1.7);
+    const wood = surf(scene, 'wood', 0x6a3e1c);
+    [-1.6, 1.6].forEach((sx) => {
+        const post = limb(scene, 'gatePost', 'box', { width: 0.28, height: 3.4, depth: 0.28 }, wood, root, 1.7);
         post.position.set(sx, 1.7, 0);
     });
-
-    const bar = limb(scene, 'gateBar', 'box', {
-        width: 3.6,
-        height: 0.28,
-        depth: 0.28
-    }, wood, root, 3.25);
-
-    const sign = limb(scene, 'gateSign', 'box', {
-        width: 1.6,
-        height: 0.55,
-        depth: 0.08
-    }, std(scene, 0xc4a050, 0.7), root, 3.7);
-
-    const glow = limb(scene, 'gateGlow', 'cylinder', {
-        height: 0.12,
-        diameterTop: 1.8,
-        diameterBottom: 2.2,
-        tessellation: 16
-    }, std(scene, 0xffee88, 0.4, 0.1, {
-        alpha: 0.6,
-        emissive: 0xffee88,
-        emissiveIntensity: 0.6
-    }), root, 0.08);
-
+    limb(scene, 'gateBar', 'box', { width: 3.6, height: 0.28, depth: 0.28 }, wood, root, 3.25);
+    limb(scene, 'gateSign', 'box', { width: 1.6, height: 0.55, depth: 0.08 }, std(scene, 0xc4a050, 0.65), root, 3.7);
+    limb(scene, 'gateGlow', 'cylinder', {
+        height: 0.12, diameterTop: 1.8, diameterBottom: 2.2, tessellation: 16
+    }, std(scene, 0xffee88, 0.4, 0.1, { alpha: 0.55, emissive: 0xffee88, emissiveIntensity: 0.55 }), root, 0.08);
     return root;
 }
 
 export function makeBeacon(scene, colorHex = 0xaaff66) {
     const beacon = B.MeshBuilder.CreateCylinder('beacon', {
-        height: 8.5,
-        diameterTop: 0.36,
-        diameterBottom: 1.1,
-        tessellation: 8
+        height: 8.5, diameterTop: 0.36, diameterBottom: 1.1, tessellation: 8
     }, scene);
-
     const mat = new B.StandardMaterial('beaconMat', scene);
     const col = hexToColor3(colorHex);
     mat.diffuseColor = col;
@@ -1075,7 +862,18 @@ export function makeBeacon(scene, colorHex = 0xaaff66) {
     mat.disableLighting = true;
     beacon.material = mat;
     beacon.isPickable = false;
-
     return beacon;
 }
 
+export function grassTuft(scene) {
+    const plane = B.MeshBuilder.CreatePlane('grassTuft', { width: 0.7, height: 0.85 }, scene);
+    plane.material = std(scene, 0xffffff, 0.85, 0.02, {
+        map: bladeTexture(scene),
+        doubleSided: true,
+        alphaTest: true,
+        mapKey: 'bladeAlpha'
+    });
+    plane.billboardMode = B.Mesh.BILLBOARDMODE_Y;
+    plane.isPickable = false;
+    return plane;
+}

--- a/labs/joao-e-o-pe-de-feijao/src/sky.js
+++ b/labs/joao-e-o-pe-de-feijao/src/sky.js
@@ -29,9 +29,19 @@ export function createSky(scene) {
     skyMat.backFaceCulling = false;
     skyMat.specularColor = new B.Color3(0, 0, 0);
 
-    const dynamicTex = new B.DynamicTexture('skyTex', { width: 128, height: 256 }, scene, false);
+    const dynamicTex = new B.DynamicTexture('skyTex', { width: 256, height: 512 }, scene, false);
     skyMat.emissiveTexture = dynamicTex;
     dome.material = skyMat;
+
+    try {
+        scene.environmentTexture = B.CubeTexture.CreateFromPrefilteredData(
+            'https://assets.babylonjs.com/environments/environmentSpecular.env',
+            scene
+        );
+        scene.environmentIntensity = 0.55;
+    } catch (err) {
+        /* IBL opcional: o conto segue com o sol direcional. */
+    }
 
     return {
         mesh: dome,
@@ -46,13 +56,43 @@ export function applyChapterSky(sky, chapter, scene) {
     const botCol = hexToColor3(chapter.hemi.ground);
 
     const ctx = sky.texture.getContext();
-    const grad = ctx.createLinearGradient(0, 0, 0, 256);
+    const h = 512;
+    const w = 256;
+    const grad = ctx.createLinearGradient(0, 0, 0, h);
     grad.addColorStop(0, topCol.toHexString());
-    grad.addColorStop(0.5, midCol.toHexString());
+    grad.addColorStop(0.42, midCol.toHexString());
     grad.addColorStop(1, botCol.toHexString());
-
     ctx.fillStyle = grad;
-    ctx.fillRect(0, 0, 128, 256);
+    ctx.fillRect(0, 0, w, h);
+
+    const night = chapter.id === 'night';
+    if (night) {
+        ctx.fillStyle = 'rgba(255,255,255,0.85)';
+        for (let i = 0; i < 80; i++) {
+            const x = (Math.sin(i * 12.7) * 0.5 + 0.5) * w;
+            const y = (Math.sin(i * 4.3) * 0.5 + 0.5) * h * 0.55;
+            ctx.globalAlpha = 0.35 + (i % 5) * 0.12;
+            ctx.beginPath();
+            ctx.arc(x, y, 0.6 + (i % 3) * 0.4, 0, Math.PI * 2);
+            ctx.fill();
+        }
+        ctx.globalAlpha = 1;
+        ctx.fillStyle = '#f4f7ff';
+        ctx.beginPath();
+        ctx.arc(w * 0.28, h * 0.18, 18, 0, Math.PI * 2);
+        ctx.fill();
+    } else {
+        ctx.fillStyle = chapter.id === 'escape' ? '#ffb060' : '#fff6c8';
+        ctx.beginPath();
+        ctx.arc(w * 0.7, h * 0.16, chapter.id === 'fair' ? 22 : 16, 0, Math.PI * 2);
+        ctx.fill();
+        ctx.fillStyle = 'rgba(255,255,255,0.16)';
+        for (let i = 0; i < 8; i++) {
+            ctx.beginPath();
+            ctx.ellipse(30 + i * 28, h * 0.38 + (i % 3) * 12, 28, 10, 0, 0, Math.PI * 2);
+            ctx.fill();
+        }
+    }
     sky.texture.update(false);
 
     if (scene) {
@@ -61,12 +101,13 @@ export function applyChapterSky(sky, chapter, scene) {
         scene.fogStart = chapter.fog.near;
         scene.fogEnd = chapter.fog.far;
         scene.fogColor = hexToColor3(chapter.fog.color);
+        scene.environmentIntensity = night ? 0.16 : Math.max(0.32, (chapter.exposure ?? 1) * 0.4);
 
         if (scene.imageProcessingConfiguration) {
             scene.imageProcessingConfiguration.toneMappingEnabled = true;
             scene.imageProcessingConfiguration.toneMappingType = B.ImageProcessingConfiguration.TONEMAPPING_ACES;
             scene.imageProcessingConfiguration.exposure = chapter.exposure ?? 1.15;
-            scene.imageProcessingConfiguration.contrast = 1.1;
+            scene.imageProcessingConfiguration.contrast = 1.12;
         }
     }
 }
@@ -95,11 +136,19 @@ export function createLights(scene, chapter, quality) {
     let shadow = null;
     if (quality.shadows) {
         shadow = new B.ShadowGenerator(quality.shadowSize, dir);
-        shadow.useBlurExponentialShadowMap = true;
-        shadow.blurKernel = quality.shadowSize >= 2048 ? 24 : 14;
-        shadow.bias = 0.0006;
-        shadow.normalBias = 0.03;
-        shadow.darkness = 0.35;
+        const webgl2 = scene.getEngine()?.webGLVersion >= 2;
+        if (webgl2) {
+            shadow.usePercentageCloserFiltering = true;
+            shadow.filteringQuality = quality.id === 'high'
+                ? B.ShadowGenerator.QUALITY_HIGH
+                : B.ShadowGenerator.QUALITY_MEDIUM;
+        } else {
+            shadow.useBlurExponentialShadowMap = true;
+            shadow.blurKernel = quality.shadowSize >= 2048 ? 24 : 14;
+        }
+        shadow.bias = 0.0008;
+        shadow.normalBias = 0.04;
+        shadow.darkness = 0.38;
     }
 
     return {

--- a/labs/joao-e-o-pe-de-feijao/src/textures.js
+++ b/labs/joao-e-o-pe-de-feijao/src/textures.js
@@ -1,11 +1,35 @@
 /**
- * Texturas procedurais em canvas para Babylon.js — sem dependência de PNGs externos.
+ * Texturas do conto: fotos PBR (Poly Haven, CC0) + canvas com alpha para folha, palha, pele e Mimosa.
+ * Nunca passe um Texture para JSON.stringify — o engine tem referências circulares.
  */
 
 import { hash2 } from './utils.js';
 
 const B = window.BABYLON;
+const POLY = 'https://dl.polyhaven.org/file/ph-assets/Textures/jpg/1k';
 const cache = new Map();
+
+let modelQuality = 'high';
+
+export function setTextureQuality(id) {
+    modelQuality = id || 'high';
+}
+
+export function clearTextureCache() {
+    cache.clear();
+}
+
+const SURFACES = {
+    grass: { name: 'aerial_grass_rock', albedo: 'diff', scale: 16 },
+    dirt: { name: 'brown_mud_03', albedo: 'diff', scale: 8 },
+    wood: { name: 'weathered_planks', albedo: 'diff', scale: 3 },
+    stone: { name: 'castle_brick_02_red', albedo: 'diff', scale: 4 },
+    rock: { name: 'rock_wall_02', albedo: 'diff', scale: 5 },
+    bark: { name: 'bark_brown_02', albedo: 'diff', scale: 2 },
+    leather: { name: 'brown_leather', albedo: 'albedo', scale: 3 },
+    tiles: { name: 'roof_09', albedo: 'diff', scale: 4 },
+    forest: { name: 'forrest_ground_01', albedo: 'diff', scale: 10 }
+};
 
 function grain(ctx, w, h, amount, seed = 0) {
     const img = ctx.getImageData(0, 0, w, h);
@@ -21,13 +45,9 @@ function grain(ctx, w, h, amount, seed = 0) {
     ctx.putImageData(img, 0, 0);
 }
 
-export function clearTextureCache() {
-    cache.clear();
-}
-
-function cachedTexture(scene, key, size, painter, { uScale = 1, vScale = 1 } = {}) {
+function cachedTexture(scene, key, size, painter, { uScale = 1, vScale = 1, alpha = false } = {}) {
     const sceneKey = scene?.uid || 'default';
-    const fullKey = `${sceneKey}:${key}`;
+    const fullKey = `${sceneKey}:canvas:${key}`;
     if (cache.has(fullKey)) return cache.get(fullKey);
 
     const dynamic = new B.DynamicTexture(key, { width: size, height: size }, scene, true);
@@ -38,168 +58,232 @@ function cachedTexture(scene, key, size, painter, { uScale = 1, vScale = 1 } = {
     dynamic.wrapV = B.Texture.WRAP_ADDRESSMODE;
     dynamic.uScale = uScale;
     dynamic.vScale = vScale;
-
+    dynamic.hasAlpha = Boolean(alpha);
     cache.set(fullKey, dynamic);
     return dynamic;
 }
 
+function photo(scene, url, scale, gammaSpace = true) {
+    const tex = new B.Texture(url, scene, false, false, B.Texture.TRILINEAR_SAMPLINGMODE);
+    tex.wrapU = B.Texture.WRAP_ADDRESSMODE;
+    tex.wrapV = B.Texture.WRAP_ADDRESSMODE;
+    tex.uScale = scale;
+    tex.vScale = scale;
+    tex.gammaSpace = gammaSpace;
+    tex.anisotropicFilteringLevel = 4;
+    return tex;
+}
+
+/** Albedo + normal (e roughness no high) de um material Poly Haven. */
+export function surface(scene, kind) {
+    const spec = SURFACES[kind];
+    if (!spec) return { albedo: null, bump: null, rough: null };
+    const sceneKey = scene?.uid || 'default';
+    const fullKey = `${sceneKey}:pbr:${kind}:${modelQuality}`;
+    if (cache.has(fullKey)) return cache.get(fullKey);
+
+    const base = `${POLY}/${spec.name}/${spec.name}`;
+    const maps = {
+        albedo: photo(scene, `${base}_${spec.albedo}_1k.jpg`, spec.scale, true),
+        bump: null,
+        rough: null
+    };
+    if (modelQuality !== 'low') {
+        maps.bump = photo(scene, `${base}_nor_gl_1k.jpg`, spec.scale, false);
+        maps.bump.level = 0.55;
+    }
+    if (modelQuality === 'high' && kind === 'grass') {
+        maps.rough = photo(scene, `${base}_rough_1k.jpg`, spec.scale, false);
+    }
+    cache.set(fullKey, maps);
+    return maps;
+}
+
 export function grassTexture(scene) {
-    return cachedTexture(scene, 'grass', 256, (ctx, size) => {
-        ctx.fillStyle = '#4a8a32';
-        ctx.fillRect(0, 0, size, size);
-        for (let i = 0; i < 1200; i++) {
-            const x = hash2(i, 2) * size;
-            const y = hash2(i, 9) * size;
-            ctx.strokeStyle = hash2(i, 4) > 0.5 ? '#6aaa42' : '#3a7018';
-            ctx.globalAlpha = 0.55;
-            ctx.beginPath();
-            ctx.moveTo(x, y);
-            ctx.lineTo(x + (hash2(i, 5) - 0.5) * 4, y - 6 - hash2(i, 6) * 8);
-            ctx.stroke();
-        }
-        grain(ctx, size, size, 22, 3);
-    }, { uScale: 16, vScale: 16 });
+    return surface(scene, 'grass').albedo;
 }
 
 export function dirtTexture(scene) {
-    return cachedTexture(scene, 'dirt', 256, (ctx, size) => {
-        ctx.fillStyle = '#6a4a28';
-        ctx.fillRect(0, 0, size, size);
-        for (let i = 0; i < 60; i++) {
-            ctx.fillStyle = hash2(i, 1) > 0.5 ? '#55361a' : '#7c5832';
-            ctx.globalAlpha = 0.4;
-            const rx = hash2(i, 2) * size;
-            const ry = hash2(i, 3) * size;
-            ctx.beginPath();
-            ctx.arc(rx, ry, 3 + hash2(i, 4) * 8, 0, Math.PI * 2);
-            ctx.fill();
-        }
-        grain(ctx, size, size, 52, 8);
-    }, { uScale: 8, vScale: 8 });
+    return surface(scene, 'dirt').albedo;
 }
 
 export function barkTexture(scene) {
-    return cachedTexture(scene, 'bark', 256, (ctx, size) => {
-        ctx.fillStyle = '#3a5a22';
-        ctx.fillRect(0, 0, size, size);
-        for (let i = 0; i < 48; i++) {
-            ctx.strokeStyle = hash2(i, 1) > 0.5 ? '#243e14' : '#4e7a2b';
-            ctx.lineWidth = 2 + hash2(i, 2) * 4;
-            ctx.globalAlpha = 0.6;
-            const x = hash2(i, 3) * size;
-            ctx.beginPath();
-            ctx.moveTo(x, 0);
-            ctx.quadraticCurveTo(x + 14, size * 0.5, x - 10, size);
-            ctx.stroke();
-        }
-        grain(ctx, size, size, 28, 5);
-    }, { uScale: 2, vScale: 6 });
-}
-
-export function leafTexture(scene) {
-    return cachedTexture(scene, 'leaf', 128, (ctx, size) => {
-        ctx.fillStyle = '#3d9a38';
-        ctx.fillRect(0, 0, size, size);
-        for (let i = 0; i < 90; i++) {
-            ctx.fillStyle = hash2(i, 2) > 0.5 ? '#5cba48' : '#2a7818';
-            ctx.globalAlpha = 0.5;
-            ctx.beginPath();
-            ctx.ellipse(hash2(i, 3) * size, hash2(i, 4) * size, 8, 14, hash2(i, 5) * 3, 0, Math.PI * 2);
-            ctx.fill();
-        }
-        grain(ctx, size, size, 16, 2);
-    }, { uScale: 2, vScale: 2 });
-}
-
-export function thatchTexture(scene) {
-    return cachedTexture(scene, 'thatch', 256, (ctx, size) => {
-        ctx.fillStyle = '#c4a050';
-        ctx.fillRect(0, 0, size, size);
-        for (let i = 0; i < 240; i++) {
-            ctx.strokeStyle = hash2(i, 1) > 0.5 ? '#a87830' : '#d8b868';
-            ctx.globalAlpha = 0.55;
-            const y = hash2(i, 2) * size;
-            ctx.beginPath();
-            ctx.moveTo(0, y);
-            ctx.lineTo(size, y + (hash2(i, 3) - 0.5) * 8);
-            ctx.stroke();
-        }
-        grain(ctx, size, size, 18, 2);
-    }, { uScale: 4, vScale: 4 });
+    return surface(scene, 'bark').albedo;
 }
 
 export function woodTexture(scene) {
-    return cachedTexture(scene, 'wood', 256, (ctx, size) => {
-        ctx.fillStyle = '#8a5a32';
-        ctx.fillRect(0, 0, size, size);
-        for (let i = 0; i < 32; i++) {
-            ctx.strokeStyle = hash2(i, 1) > 0.5 ? '#6a3e20' : '#b07848';
-            ctx.lineWidth = 3;
-            ctx.globalAlpha = 0.45;
-            const y = (i / 32) * size;
-            ctx.beginPath();
-            ctx.moveTo(0, y);
-            ctx.bezierCurveTo(80, y + 8, 160, y - 8, 256, y);
-            ctx.stroke();
-        }
-        grain(ctx, size, size, 24, 4);
-    }, { uScale: 3, vScale: 3 });
+    return surface(scene, 'wood').albedo;
 }
 
 export function stoneTexture(scene) {
-    return cachedTexture(scene, 'stone', 256, (ctx, size) => {
-        ctx.fillStyle = '#8a9098';
-        ctx.fillRect(0, 0, size, size);
-        for (let i = 0; i < 60; i++) {
-            ctx.fillStyle = hash2(i, 1) > 0.5 ? '#9aa0a8' : '#6a7078';
-            ctx.globalAlpha = 0.55;
-            const x = hash2(i, 2) * size;
-            const y = hash2(i, 3) * size;
-            ctx.fillRect(x, y, 18 + hash2(i, 4) * 40, 12 + hash2(i, 5) * 22);
-        }
-        grain(ctx, size, size, 30, 6);
-    }, { uScale: 6, vScale: 6 });
+    return surface(scene, 'stone').albedo;
 }
 
 export function goldTexture(scene) {
-    return cachedTexture(scene, 'gold', 128, (ctx, size) => {
+    return cachedTexture(scene, 'gold', 256, (ctx, size) => {
         const g = ctx.createLinearGradient(0, 0, size, size);
-        g.addColorStop(0, '#ffe680');
-        g.addColorStop(0.5, '#d4a020');
-        g.addColorStop(1, '#fff0a8');
+        g.addColorStop(0, '#fff3b0');
+        g.addColorStop(0.35, '#d4a020');
+        g.addColorStop(0.7, '#8a5a10');
+        g.addColorStop(1, '#ffe9a0');
         ctx.fillStyle = g;
         ctx.fillRect(0, 0, size, size);
-        grain(ctx, size, size, 20, 9);
+        for (let i = 0; i < 40; i++) {
+            ctx.strokeStyle = 'rgba(255, 240, 180, 0.25)';
+            ctx.lineWidth = 1;
+            const y = hash2(i, 2) * size;
+            ctx.beginPath();
+            ctx.moveTo(0, y);
+            ctx.lineTo(size, y + (hash2(i, 3) - 0.5) * 12);
+            ctx.stroke();
+        }
+        grain(ctx, size, size, 18, 9);
     }, { uScale: 2, vScale: 2 });
 }
 
 export function cloudTexture(scene) {
     return cachedTexture(scene, 'cloud', 256, (ctx, size) => {
-        ctx.fillStyle = '#e8f0f8';
+        ctx.fillStyle = '#eef4fb';
         ctx.fillRect(0, 0, size, size);
-        for (let i = 0; i < 50; i++) {
-            ctx.fillStyle = hash2(i, 1) > 0.5 ? '#ffffff' : '#d0dce8';
-            ctx.globalAlpha = 0.4;
+        for (let i = 0; i < 70; i++) {
+            ctx.fillStyle = hash2(i, 1) > 0.5 ? '#ffffff' : '#d5e2ef';
+            ctx.globalAlpha = 0.38;
             ctx.beginPath();
-            ctx.arc(hash2(i, 2) * size, hash2(i, 3) * size, 20 + hash2(i, 4) * 45, 0, Math.PI * 2);
+            ctx.arc(hash2(i, 2) * size, hash2(i, 3) * size, 16 + hash2(i, 4) * 48, 0, Math.PI * 2);
             ctx.fill();
         }
+    }, { uScale: 2, vScale: 2 });
+}
+
+export function thatchTexture(scene) {
+    return cachedTexture(scene, 'thatch', 512, (ctx, size) => {
+        ctx.fillStyle = '#c4923a';
+        ctx.fillRect(0, 0, size, size);
+        for (let i = 0; i < 1400; i++) {
+            const x = hash2(i, 1) * size;
+            const y = hash2(i, 2) * size;
+            ctx.strokeStyle = hash2(i, 3) > 0.55 ? '#e0b45a' : '#8a5a18';
+            ctx.globalAlpha = 0.5;
+            ctx.lineWidth = 1 + hash2(i, 4) * 2.2;
+            ctx.beginPath();
+            ctx.moveTo(x, y);
+            ctx.lineTo(x + (hash2(i, 5) - 0.5) * 8, y + 16 + hash2(i, 6) * 26);
+            ctx.stroke();
+        }
+        grain(ctx, size, size, 22, 2);
     }, { uScale: 3, vScale: 3 });
 }
 
 export function clothTexture(scene) {
-    return cachedTexture(scene, 'cloth', 128, (ctx, size) => {
-        ctx.fillStyle = '#6a2a88';
+    return cachedTexture(scene, 'cloth', 256, (ctx, size) => {
+        ctx.fillStyle = '#6e3a88';
         ctx.fillRect(0, 0, size, size);
-        for (let i = 0; i < 20; i++) {
-            ctx.strokeStyle = '#8a48a8';
-            ctx.globalAlpha = 0.35;
+        for (let x = 0; x < size; x += 3) {
+            ctx.strokeStyle = x % 6 ? 'rgba(30, 12, 40, 0.22)' : 'rgba(220, 180, 255, 0.16)';
             ctx.beginPath();
-            ctx.moveTo(0, i * 6.4);
-            ctx.lineTo(size, i * 6.4);
+            ctx.moveTo(x, 0);
+            ctx.lineTo(x + 4, size);
             ctx.stroke();
         }
-        grain(ctx, size, size, 16, 1);
+        for (let y = 0; y < size; y += 4) {
+            ctx.strokeStyle = 'rgba(255, 240, 255, 0.1)';
+            ctx.beginPath();
+            ctx.moveTo(0, y);
+            ctx.lineTo(size, y + 3);
+            ctx.stroke();
+        }
+        grain(ctx, size, size, 14, 1);
     }, { uScale: 4, vScale: 4 });
 }
 
+export function leafTexture(scene) {
+    return cachedTexture(scene, 'leafAlpha', 256, (ctx, size) => {
+        ctx.clearRect(0, 0, size, size);
+        ctx.save();
+        ctx.translate(size * 0.5, size * 0.52);
+        ctx.rotate(-0.35);
+        const g = ctx.createLinearGradient(0, -size * 0.46, 0, size * 0.46);
+        g.addColorStop(0, '#6dcc4a');
+        g.addColorStop(0.5, '#3d9a32');
+        g.addColorStop(1, '#246818');
+        ctx.fillStyle = g;
+        ctx.beginPath();
+        ctx.moveTo(0, -size * 0.46);
+        ctx.bezierCurveTo(size * 0.38, -size * 0.18, size * 0.36, size * 0.22, 0, size * 0.46);
+        ctx.bezierCurveTo(-size * 0.36, size * 0.22, -size * 0.38, -size * 0.18, 0, -size * 0.46);
+        ctx.fill();
+        ctx.strokeStyle = '#1e5a16';
+        ctx.lineWidth = 3;
+        ctx.beginPath();
+        ctx.moveTo(0, -size * 0.44);
+        ctx.lineTo(0, size * 0.44);
+        ctx.stroke();
+        ctx.lineWidth = 1.4;
+        ctx.globalAlpha = 0.55;
+        for (let i = -4; i <= 4; i++) {
+            if (i === 0) continue;
+            ctx.beginPath();
+            ctx.moveTo(0, i * 12);
+            ctx.quadraticCurveTo(i * 18, i * 12 + 10, i * 28, i * 18);
+            ctx.stroke();
+        }
+        ctx.restore();
+        grain(ctx, size, size, 12, 2);
+    }, { uScale: 1, vScale: 1, alpha: true });
+}
+
+export function bladeTexture(scene) {
+    return cachedTexture(scene, 'bladeAlpha', 128, (ctx, size) => {
+        ctx.clearRect(0, 0, size, size);
+        for (let i = 0; i < 9; i++) {
+            const x = 12 + i * 12 + (hash2(i, 1) - 0.5) * 6;
+            ctx.fillStyle = hash2(i, 2) > 0.5 ? '#4aaa38' : '#2e7a22';
+            ctx.beginPath();
+            ctx.moveTo(x - 3, size);
+            ctx.quadraticCurveTo(x + (hash2(i, 3) - 0.5) * 10, size * 0.45, x, 6);
+            ctx.quadraticCurveTo(x + 2, size * 0.45, x + 3, size);
+            ctx.fill();
+        }
+    }, { uScale: 1, vScale: 1, alpha: true });
+}
+
+export function skinTexture(scene) {
+    return cachedTexture(scene, 'skin', 128, (ctx, size) => {
+        ctx.fillStyle = '#e8bc96';
+        ctx.fillRect(0, 0, size, size);
+        for (let i = 0; i < 80; i++) {
+            ctx.fillStyle = hash2(i, 1) > 0.5 ? 'rgba(196, 110, 90, 0.12)' : 'rgba(255, 230, 200, 0.14)';
+            ctx.beginPath();
+            ctx.arc(hash2(i, 2) * size, hash2(i, 3) * size, 2 + hash2(i, 4) * 8, 0, Math.PI * 2);
+            ctx.fill();
+        }
+        grain(ctx, size, size, 10, 4);
+    }, { uScale: 2, vScale: 2 });
+}
+
+export function cowHideTexture(scene) {
+    return cachedTexture(scene, 'cowHide', 512, (ctx, size) => {
+        ctx.fillStyle = '#f3eee6';
+        ctx.fillRect(0, 0, size, size);
+        for (let i = 0; i < 18; i++) {
+            ctx.fillStyle = hash2(i, 1) > 0.4 ? '#5a3a22' : '#3a2414';
+            ctx.globalAlpha = 0.92;
+            const x = hash2(i, 2) * size;
+            const y = hash2(i, 3) * size;
+            ctx.beginPath();
+            ctx.ellipse(x, y, 28 + hash2(i, 4) * 50, 18 + hash2(i, 5) * 34, hash2(i, 6) * 3, 0, Math.PI * 2);
+            ctx.fill();
+        }
+        ctx.globalAlpha = 0.18;
+        for (let i = 0; i < 400; i++) {
+            ctx.strokeStyle = '#d8d0c4';
+            ctx.beginPath();
+            const x = hash2(i, 7) * size;
+            const y = hash2(i, 8) * size;
+            ctx.moveTo(x, y);
+            ctx.lineTo(x + 2, y + 6);
+            ctx.stroke();
+        }
+        grain(ctx, size, size, 16, 6);
+    }, { uScale: 2, vScale: 2 });
+}

--- a/labs/joao-e-o-pe-de-feijao/src/utils.js
+++ b/labs/joao-e-o-pe-de-feijao/src/utils.js
@@ -90,13 +90,8 @@ export function detectSoftwareGL() {
 }
 
 export function disposeNode(node) {
-    if (!node) return;
-    if (node.getChildren) {
-        const children = [...node.getChildren()];
-        children.forEach(disposeNode);
-    }
-    if (typeof node.dispose === 'function') {
-        node.dispose(false, true);
+    if (node && typeof node.dispose === 'function') {
+        node.dispose(false, false);
     }
 }
 

--- a/labs/joao-e-o-pe-de-feijao/src/world.js
+++ b/labs/joao-e-o-pe-de-feijao/src/world.js
@@ -3,12 +3,12 @@
  * Cada um devolve um ChapterWorld com colisores, plataformas, climbs e interações.
  */
 
-import { fbm, hash2, seeded, smoothstep, disposeNode } from './utils.js';
-import { grassTexture, dirtTexture, stoneTexture } from './textures.js';
+import { fbm, seeded, smoothstep, disposeNode } from './utils.js';
 import {
     buildCottage, buildFence, buildTree, buildStall, buildBeanstalk, buildCloudIsland,
     buildCastle, buildTable, buildGoldBag, buildHen, buildHarp, buildAxe, buildWell,
-    buildMother, buildMerchant, buildCow, buildGiant, makeBeacon, buildGateArch, std
+    buildMother, buildMerchant, buildCow, buildGiant, makeBeacon, buildGateArch,
+    buildRock, grassTuft, std, surf, setModelQuality
 } from './models.js';
 import { CowAI, GiantAI } from './npcs.js';
 
@@ -80,6 +80,43 @@ function terrainMesh(scene, heightAt, size, segs, material, ox = 0, oz = 0) {
     return ground;
 }
 
+function scatterRocks(scene, world, count, rng, avoid = []) {
+    for (let i = 0; i < count; i++) {
+        const a = rng() * Math.PI * 2;
+        const r = 6 + rng() * 28;
+        const x = Math.cos(a) * r;
+        const z = Math.sin(a) * r;
+        if (avoid.some((p) => Math.hypot(x - p.x, z - p.z) < p.r)) continue;
+        const rock = buildRock(scene, rng);
+        rock.parent = world.root;
+        rock.position.set(x, world.heightAt(x, z), z);
+        world.addCollider(x, z, 0.4);
+    }
+}
+
+function scatterGrass(scene, world, count, rng) {
+    for (let i = 0; i < count; i++) {
+        const x = (rng() - 0.5) * 32;
+        const z = (rng() - 0.5) * 32;
+        if (Math.hypot(x + 4, z + 2) < 3) continue;
+        const tuft = grassTuft(scene);
+        tuft.parent = world.root;
+        tuft.position.set(x, world.heightAt(x, z) + 0.38, z);
+        tuft.scaling.setAll(0.7 + rng() * 0.7);
+    }
+}
+
+export function bindShadows(world, lights) {
+    if (!lights?.shadow || !world?.root) return;
+    world.root.getChildMeshes().forEach((mesh) => {
+        const n = mesh.name || '';
+        if (/beacon|flame|firefly|moon|glow|smoke|grassTuft|treeLeaf|harpString|coin_/i.test(n)) return;
+        const ground = /terrain|ground|floor|path|plaza|patchDirt|cloudTop/i.test(n);
+        if (!ground) lights.shadow.addShadowCaster(mesh);
+        mesh.receiveShadows = true;
+    });
+}
+
 function scatterTrees(scene, world, count, rng, opts) {
     const { minR = 10, maxR = 42, avoid = [] } = opts;
     for (let i = 0; i < count; i++) {
@@ -116,8 +153,7 @@ function addPath(scene, world, from, to, width = 2.4) {
     pathMesh.rotation.y = Math.atan2(dx, dz);
     pathMesh.position.set((from.x + to.x) / 2, 0.04, (from.z + to.z) / 2);
 
-    const dirtTex = dirtTexture(scene);
-    pathMesh.material = std(scene, 0xc4a06a, 0.95, 0.02, { map: dirtTex });
+    pathMesh.material = surf(scene, 'dirt');
     pathMesh.receiveShadows = true;
     return pathMesh;
 }
@@ -142,11 +178,7 @@ export function buildCottageChapter(scene, quality) {
     };
 
     const segs = quality.id === 'low' ? 36 : 64;
-    const grassTex = grassTexture(scene);
-    const ground = terrainMesh(
-        scene, world.heightAt, 100, segs,
-        std(scene, 0x8fbc5a, 0.95, 0.02, { map: grassTex })
-    );
+    const ground = terrainMesh(scene, world.heightAt, 100, segs, surf(scene, 'grass'));
     ground.parent = world.root;
 
     const cottage = buildCottage(scene);
@@ -211,6 +243,10 @@ export function buildCottageChapter(scene, quality) {
     scatterTrees(scene, world, Math.round(18 * quality.trees), rng, {
         minR: 16, maxR: 42, avoid: [{ x: -6, z: -4, r: 8 }, { x: 4.5, z: 3.2, r: 4 }, { x: 16, z: 9, r: 7 }]
     });
+    scatterRocks(scene, world, Math.round(10 * quality.trees), rng, [
+        { x: -6, z: -4, r: 6 }, { x: 16, z: 9, r: 5 }
+    ]);
+    if (quality.id !== 'low') scatterGrass(scene, world, Math.round(48 * quality.grass), rng);
     addPath(scene, world, { x: -2, z: 0 }, { x: 16, z: 9 });
 
     for (let i = 1; i <= 4; i++) {
@@ -265,19 +301,14 @@ export function buildFairChapter(scene, quality) {
 
     world.heightAt = (x, z) => fbm(x * 0.03, z * 0.03, 8) * 1.1 * (1 - smoothstep(6, 18, Math.hypot(x, z)) * 0.4);
 
-    const grassTex = grassTexture(scene);
-    const ground = terrainMesh(
-        scene, world.heightAt, 90, quality.id === 'low' ? 36 : 64,
-        std(scene, 0xc4b070, 0.92, 0.02, { map: grassTex })
-    );
+    const ground = terrainMesh(scene, world.heightAt, 90, quality.id === 'low' ? 36 : 64, surf(scene, 'dirt', 0xe8d2a0));
     ground.parent = world.root;
 
-    const dirtTex = dirtTexture(scene);
     const plaza = B.MeshBuilder.CreateDisc('plaza', { radius: 11, tessellation: 24 }, scene);
     plaza.parent = world.root;
     plaza.rotation.x = Math.PI / 2;
     plaza.position.y = 0.05;
-    plaza.material = std(scene, 0xd8b878, 0.9, 0.02, { map: dirtTex });
+    plaza.material = surf(scene, 'dirt');
     plaza.receiveShadows = true;
 
     const colors = [0xc43a2a, 0x2a6aaa, 0xd4a020, 0x2e7a3a, 0x7a3aaa];
@@ -296,7 +327,6 @@ export function buildFairChapter(scene, quality) {
         world.addCollider(s.x, s.z, 1.15);
     });
 
-    const stoneTex = stoneTexture(scene);
     const fountain = B.MeshBuilder.CreateCylinder('fountain', {
         height: 0.5,
         diameterTop: 2.8,
@@ -305,7 +335,7 @@ export function buildFairChapter(scene, quality) {
     }, scene);
     fountain.parent = world.root;
     fountain.position.y = 0.25;
-    fountain.material = std(scene, 0x8a9098, 0.7, 0.04, { map: stoneTex });
+    fountain.material = surf(scene, 'stone');
 
     const water = B.MeshBuilder.CreateDisc('fountainWater', { radius: 1.1, tessellation: 16 }, scene);
     water.parent = world.root;
@@ -371,11 +401,7 @@ export function buildNightChapter(scene, quality) {
         return hills * (1 - yard * 0.75);
     };
 
-    const grassTex = grassTexture(scene);
-    const ground = terrainMesh(
-        scene, world.heightAt, 80, quality.id === 'low' ? 36 : 64,
-        std(scene, 0x2a5a28, 0.95, 0.02, { map: grassTex })
-    );
+    const ground = terrainMesh(scene, world.heightAt, 80, quality.id === 'low' ? 36 : 64, surf(scene, 'grass', 0x6a8a58));
     ground.parent = world.root;
 
     const cottage = buildCottage(scene);
@@ -401,12 +427,11 @@ export function buildNightChapter(scene, quality) {
 
     const patchX = 2.2;
     const patchZ = 4.5;
-    const dirtTex = dirtTexture(scene);
     const dirt = B.MeshBuilder.CreateDisc('patchDirt', { radius: 1.6, tessellation: 16 }, scene);
     dirt.parent = world.root;
     dirt.rotation.x = Math.PI / 2;
     dirt.position.set(patchX, world.heightAt(patchX, patchZ) + 0.05, patchZ);
-    dirt.material = std(scene, 0x5a3a18, 0.95, 0.02, { map: dirtTex });
+    dirt.material = surf(scene, 'dirt', 0x6a4a28);
 
     const beans = [];
     for (let i = 0; i < 5; i++) {
@@ -540,12 +565,11 @@ export function buildCastleChapter(scene, quality) {
     const island = buildCloudIsland(scene, 30);
     island.parent = world.root;
 
-    const stoneTex = stoneTexture(scene);
     const floor = B.MeshBuilder.CreateDisc('castleFloor', { radius: 22, tessellation: 28 }, scene);
     floor.parent = world.root;
     floor.rotation.x = Math.PI / 2;
     floor.position.y = 1.15;
-    floor.material = std(scene, 0xd0d6dc, 0.88, 0.05, { map: stoneTex });
+    floor.material = surf(scene, 'stone', 0xd8dee4);
     floor.receiveShadows = true;
 
     const castle = buildCastle(scene);
@@ -559,7 +583,7 @@ export function buildCastleChapter(scene, quality) {
     hallFloor.parent = world.root;
     hallFloor.rotation.x = Math.PI / 2;
     hallFloor.position.set(0, 1.18, 8);
-    hallFloor.material = std(scene, 0xc8b090, 0.8, 0.04, { map: stoneTex });
+    hallFloor.material = surf(scene, 'wood', 0xc8b090);
     hallFloor.receiveShadows = true;
 
     const table = buildTable(scene);
@@ -661,11 +685,7 @@ export function buildEscapeChapter(scene, quality) {
         return hills * (1 - yard * 0.7);
     };
 
-    const grassTex = grassTexture(scene);
-    const ground = terrainMesh(
-        scene, world.heightAt, 80, quality.id === 'low' ? 36 : 64,
-        std(scene, 0x7aaa48, 0.95, 0.02, { map: grassTex })
-    );
+    const ground = terrainMesh(scene, world.heightAt, 80, quality.id === 'low' ? 36 : 64, surf(scene, 'grass', 0xc4a060));
     ground.parent = world.root;
 
     const cottage = buildCottage(scene);
@@ -734,6 +754,7 @@ export function buildEscapeChapter(scene, quality) {
 }
 
 export function buildChapter(id, scene, quality) {
+    setModelQuality(quality.id);
     switch (id) {
         case 'cottage': return buildCottageChapter(scene, quality);
         case 'fair': return buildFairChapter(scene, quality);


### PR DESCRIPTION
## 🎯 Objetivo

O lab no ar caía ao abrir (`JSON.stringify` em Texture do Babylon) e o mundo ainda era caixa/esfera/cilindro. Esta PR faz o conto voltar a abrir e troca o visual geométrico por PBR fotográfico e malhas orgânicas.

## ✨ O que mudou

- Corrige o crash **Converting circular structure to JSON** no cache de materiais (não serializa mais Texture)
- Personagens, Mimosa, gigante, cabana, árvores, pé de feijão e castelo deixam de ser primitivas empilhadas (cápsulas, tubos em hélice, lathe, folhas com alpha)
- Texturas PBR do Poly Haven (grama, terra, madeira, pedra, casca, telha) + IBL e sombras PCF
- Materiais compartilhados deixam de ser destruídos na troca de capítulo

## 🧪 Como testar

1. Na raiz do repo: `python3 -m http.server 8000`
2. Abrir [http://localhost:8000/](http://localhost:8000/) (home) e [http://localhost:8000/labs/](http://localhost:8000/labs/) (galeria)
3. Abrir [http://localhost:8000/labs/joao-e-o-pe-de-feijao/](http://localhost:8000/labs/joao-e-o-pe-de-feijao/) — o menu precisa aparecer **sem** o overlay “Os feijões não germinaram”
4. Começar o conto: cabana com telhado de palha, Mimosa manchada, caminho de terra; não deve haver blocos cinza no lugar de textura
5. Responsivo: DevTools em **375×667**, **390×844** e landscape curto (~667×375) — sem overflow horizontal, HUD/controles utilizáveis, alvos ≥ 44px
6. Slug inalterado: pasta ↔ card da galeria ↔ README ↔ `sitemap.xml` ↔ canonical/OG

## ✅ Checklist

- [x] Links conferidos: pasta do lab ↔ card da galeria ↔ README ↔ sitemap (e corrigidos se quebravam)
- [x] README atualizado (linha na tabela + URL + contagem no badge/texto) — obrigatório em lab novo, renomeado ou removido
- [x] SEO consistente: title, description, canonical, author, robots, OG, Twitter, JSON-LD (e contagem nos metas da galeria)
- [x] Testado via HTTP na raiz, não via `file://`
- [x] Responsivo: 375px / 390px / landscape — overflow, HUD, toque, safe-area (`viewport-fit=cover`)
- [x] Nada fora do escopo foi quebrado


Made with [Cursor](https://cursor.com)