### PR TITLE
🎨 UI: Jornada do Anel mais realista, sem geometria crua

### DIFF
--- a/labs/jornada-do-anel/index.html
+++ b/labs/jornada-do-anel/index.html
@@ -313,7 +313,7 @@
             }
         })();
     </script>
-    <script type="module" src="src/main.js?v=2"></script>
+    <script type="module" src="src/main.js?v=3"></script>
 </body>
 
 </html>

--- a/labs/jornada-do-anel/src/audio.js
+++ b/labs/jornada-do-anel/src/audio.js
@@ -2,7 +2,7 @@
  * Trilha e efeitos — Web Audio, temas originais (nada da trilha do filme).
  */
 
-import { clamp } from './utils.js';
+import { clamp } from './utils.js?v=3';
 
 const THEMES = {
     shire: { base: 196, mode: [0, 2, 4, 7, 9], tempo: 0.9, filter: 900, drone: 98 },

--- a/labs/jornada-do-anel/src/hud.js
+++ b/labs/jornada-do-anel/src/hud.js
@@ -2,8 +2,8 @@
  * HUD, menus e overlays — tudo que é DOM.
  */
 
-import { CHAPTERS } from './config.js';
-import { formatTime } from './utils.js';
+import { CHAPTERS } from './config.js?v=3';
+import { formatTime } from './utils.js?v=3';
 
 const $ = (id) => document.getElementById(id);
 

--- a/labs/jornada-do-anel/src/input.js
+++ b/labs/jornada-do-anel/src/input.js
@@ -2,7 +2,7 @@
  * Teclado, mouse (pointer lock), toque e atalhos de HUD.
  */
 
-import { clamp } from './utils.js';
+import { clamp } from './utils.js?v=3';
 
 const MOVE = {
     KeyW: 'forward',

--- a/labs/jornada-do-anel/src/main.js
+++ b/labs/jornada-do-anel/src/main.js
@@ -3,15 +3,17 @@
  */
 
 import * as THREE from 'three';
-import { CHAPTERS, QUALITY, STORAGE_KEY } from './config.js';
-import { clamp, detectMobile, detectSoftwareGL, rendererIsSoftware, formatTime } from './utils.js';
-import { Input } from './input.js';
-import { GameAudio } from './audio.js';
-import { Hud, statsBlock } from './hud.js';
-import { Player } from './player.js';
-import { createSky, applyChapterSky, createLights } from './sky.js';
-import { buildChapter } from './world.js';
-import { nearestInteractable } from './npcs.js';
+import { RoomEnvironment } from 'three/addons/environments/RoomEnvironment.js';
+import { CHAPTERS, QUALITY, STORAGE_KEY } from './config.js?v=3';
+import { clamp, detectMobile, detectSoftwareGL, rendererIsSoftware, formatTime, disposeObject } from './utils.js?v=3';
+import { Input } from './input.js?v=3';
+import { GameAudio } from './audio.js?v=3';
+import { Hud, statsBlock } from './hud.js?v=3';
+import { Player } from './player.js?v=3';
+import { createSky, applyChapterSky, createLights, tickSky } from './sky.js?v=3';
+import { buildChapter } from './world.js?v=3';
+import { nearestInteractable } from './npcs.js?v=3';
+import { tickMaterials } from './models.js?v=3';
 
 const LOOK = new THREE.Vector3();
 const CAM = new THREE.Vector3();
@@ -104,6 +106,10 @@ class Game {
 
         this.scene = new THREE.Scene();
         this.camera = new THREE.PerspectiveCamera(52, window.innerWidth / window.innerHeight, 0.12, 520);
+        const pmrem = new THREE.PMREMGenerator(this.renderer);
+        this.scene.environment = pmrem.fromScene(new RoomEnvironment(), 0.04).texture;
+        this.scene.environmentIntensity = 0.42;
+        pmrem.dispose();
         this.sky = createSky();
         this.scene.add(this.sky.mesh);
 
@@ -277,13 +283,17 @@ class Game {
 
         const world = buildChapter(ch.id, this.quality);
         const lights = createLights(this.scene, ch, this.quality);
-        if (this.world) this.scene.remove(this.world.group);
+        if (this.world) {
+            this.scene.remove(this.world.group);
+            disposeObject(this.world.group);
+        }
         if (this.lights) this.scene.remove(this.lights.group);
         this.world = world;
         this.lights = lights;
         this.scene.add(this.world.group);
         applyChapterSky(this.sky, ch);
         this.scene.fog = new THREE.Fog(ch.fog.color, ch.fog.near, ch.fog.far);
+        this.scene.environmentIntensity = ch.id === 'moria' ? 0.12 : ch.id === 'forest' ? 0.2 : 0.42;
         this.renderer.setClearColor(ch.clear);
         this.renderer.toneMappingExposure = ch.exposure ?? 1.15;
         this.audio.setTheme(ch.music);
@@ -409,11 +419,12 @@ class Game {
     _update(dt) {
         this.hud.tick(dt);
         this.audio.update(dt);
+        tickMaterials(this.time);
+        tickSky(this.sky, this.time);
         this.world?.updateFns.forEach((fn) => fn(this.time, dt));
         for (const w of this.world?.waterMeshes || []) {
-            if (w.userData.baseY == null) w.userData.baseY = w.position.y;
-            if (w.material.map) w.material.map.offset.x = this.time * 0.02;
-            w.position.y = w.userData.baseY + Math.sin(this.time * 1.4) * 0.05;
+            if (w.material.map) w.material.map.offset.x = this.time * 0.03;
+            if (w.material.normalMap) w.material.normalMap.offset.set(this.time * 0.04, this.time * 0.02);
         }
 
         this.fade = clamp(this.fade + this.fadeDir * dt * 0.85, 0, 1);

--- a/labs/jornada-do-anel/src/models.js
+++ b/labs/jornada-do-anel/src/models.js
@@ -1,19 +1,38 @@
 /**
  * Modelos 3D construídos por código — nenhum GLB externo.
- * Hobbit, mago, cavaleiro negro, goblin, tocas, árvores e arquitetura.
+ * Silhuetas em lathe, deslocamento de vértices e PBR com normal map.
+ * Geometria primitiva crua (cone/esfera isolados) só entra como volume interno.
  */
 
 import * as THREE from 'three';
+import { mergeGeometries } from 'three/addons/utils/BufferGeometryUtils.js';
 import {
     grassTexture, barkTexture, leafTexture, stoneTexture, marbleTexture,
-    woodTexture, goldTexture, doorTexture, brickTexture
-} from './textures.js';
+    woodTexture, goldTexture, doorTexture, brickTexture, skinTexture,
+    clothTexture, leatherTexture, grassBladeTexture, faceTexture, applyMaps
+} from './textures.js?v=3';
+import { hash2 } from './utils.js?v=3';
 
 const matCache = new Map();
+const geoCache = new Map();
+const animatedMats = [];
 
 function mat(key, factory) {
-    if (!matCache.has(key)) matCache.set(key, factory());
+    if (!matCache.has(key)) {
+        const m = factory();
+        m.userData.shared = true;
+        matCache.set(key, m);
+    }
     return matCache.get(key);
+}
+
+function geo(key, factory) {
+    if (!geoCache.has(key)) {
+        const g = factory();
+        g.userData.shared = true;
+        geoCache.set(key, g);
+    }
+    return geoCache.get(key);
 }
 
 export function std(color, roughness = 0.78, metalness = 0.04, extra = {}) {
@@ -21,8 +40,13 @@ export function std(color, roughness = 0.78, metalness = 0.04, extra = {}) {
         new THREE.MeshStandardMaterial({ color, roughness, metalness, ...extra }));
 }
 
-function mapped(map, color = 0xffffff, roughness = 0.88) {
-    return new THREE.MeshStandardMaterial({ map, color, roughness, metalness: 0.02 });
+function mapped(maps, color = 0xffffff, roughness = 0.86, metalness = 0.02, normalScale = 0.9) {
+    const key = `map:${maps?.map?.uuid}:${color}:${roughness}:${metalness}:${normalScale}`;
+    return mat(key, () => {
+        const m = new THREE.MeshStandardMaterial({ color, roughness, metalness });
+        applyMaps(m, maps, { color, roughness, metalness, normalScale });
+        return m;
+    });
 }
 
 function enableShadows(root) {
@@ -34,34 +58,150 @@ function enableShadows(root) {
     });
 }
 
+/** Empurra vértices com ruído determinístico — quebra a silhueta de primitiva. */
+function warp(geometry, seed = 1, amount = 0.1, yBias = 0.55) {
+    const pos = geometry.attributes.position;
+    for (let i = 0; i < pos.count; i++) {
+        const x = pos.getX(i);
+        const y = pos.getY(i);
+        const z = pos.getZ(i);
+        const n = hash2(x * 13.7 + seed, z * 8.3 + y * 4.1);
+        const k = 1 + (n - 0.5) * amount;
+        pos.setXYZ(i, x * k, y * (1 + (n - yBias) * amount * 0.55), z * k);
+    }
+    geometry.computeVertexNormals();
+    return geometry;
+}
+
+function lathe(pts, segs = 16, key) {
+    const factory = () => {
+        const g = new THREE.LatheGeometry(pts.map(([x, y]) => new THREE.Vector2(x, y)), segs);
+        g.computeVertexNormals();
+        return g;
+    };
+    return key ? geo(key, factory) : factory();
+}
+
+function clothMat({ color = 0x9aa3ad, maps = null, wind = 0.18, key = 'cloth' } = {}) {
+    return mat(`${key}:${color}:${wind}`, () => {
+        const m = new THREE.MeshStandardMaterial({
+            color,
+            roughness: 0.88,
+            metalness: 0,
+            side: THREE.DoubleSide
+        });
+        if (maps) applyMaps(m, maps, { color, roughness: 0.88, metalness: 0, normalScale: 0.6 });
+        m.userData.uTime = { value: 0 };
+        m.userData.uWind = { value: wind };
+        m.onBeforeCompile = (shader) => {
+            shader.uniforms.uTime = m.userData.uTime;
+            shader.uniforms.uWind = m.userData.uWind;
+            shader.vertexShader = shader.vertexShader
+                .replace(
+                    '#include <common>',
+                    /* glsl */ `#include <common>
+                    uniform float uTime;
+                    uniform float uWind;`
+                )
+                .replace(
+                    '#include <begin_vertex>',
+                    /* glsl */ `#include <begin_vertex>
+                    float free = uv.y;
+                    float flap = sin(uv.x * 6.1 + uTime * 1.7) * 0.45
+                               + sin(uv.y * 4.2 - uTime * 1.3) * 0.28;
+                    transformed.x += flap * free * free * uWind;
+                    transformed.z += flap * free * 0.55 * uWind;`
+                );
+        };
+        m.customProgramCacheKey = () => `anel-cloth:${wind}`;
+        animatedMats.push(m);
+        return m;
+    });
+}
+
+export function tickMaterials(t) {
+    for (const m of animatedMats) {
+        if (m.userData.uTime) m.userData.uTime.value = t;
+    }
+}
+
+function vegWind(material, amount = 0.11) {
+    if (material.userData.uTime) return material;
+    material.userData.uTime = { value: 0 };
+    material.userData.uWind = { value: amount };
+    material.onBeforeCompile = (shader) => {
+        shader.uniforms.uTime = material.userData.uTime;
+        shader.uniforms.uWind = material.userData.uWind;
+        shader.vertexShader = shader.vertexShader
+            .replace(
+                '#include <common>',
+                /* glsl */ `#include <common>
+                uniform float uTime;
+                uniform float uWind;`
+            )
+            .replace(
+                '#include <begin_vertex>',
+                /* glsl */ `#include <begin_vertex>
+                float h = max(transformed.y, 0.0);
+                #ifdef USE_INSTANCING
+                vec3 orig = instanceMatrix[3].xyz;
+                #else
+                vec3 orig = vec3(0.0);
+                #endif
+                float b = sin(uTime * 1.25 + orig.x * 0.14 + orig.z * 0.11) * uWind * h;
+                transformed.x += b;
+                transformed.z += b * 0.55;`
+            );
+    };
+    material.customProgramCacheKey = () => `anel-veg:${amount}`;
+    animatedMats.push(material);
+    return material;
+}
+
 /* ------------------------------------------------------------------ */
 /* Personagens                                                         */
 /* ------------------------------------------------------------------ */
 
 export function buildHobbit({ vest = 0xc45a2a, pants = 0x3d4a28 } = {}) {
     const group = new THREE.Group();
-    const skin = std(0xe8b889, 0.72);
-    const hair = std(0x6b3a18, 0.9);
-    const clothV = std(vest, 0.86);
-    const clothP = std(pants, 0.88);
-    const foot = std(0xd4a07a, 0.8);
+    const skinMaps = skinTexture();
+    const skin = mapped(skinMaps, 0xf0c49a, 0.62, 0.02, 0.45);
+    const hair = std(0x6b3a18, 0.92);
+    const clothV = mapped(clothTexture('#c45a2a'), vest, 0.86);
+    const clothP = mapped(clothTexture('#3d4a28'), pants, 0.88);
+    const leather = mapped(leatherTexture(), 0x5a3a18, 0.72);
+    const foot = mapped(skinMaps, 0xd4a07a, 0.78, 0.02, 0.5);
 
     const hips = new THREE.Group();
     group.add(hips);
-
     const parts = { legs: [], arms: [], feet: [] };
 
     for (const sx of [-1, 1]) {
         const leg = new THREE.Group();
-        leg.position.set(sx * 0.12, 0.38, 0);
+        leg.position.set(sx * 0.11, 0.4, 0);
         hips.add(leg);
-        const thigh = new THREE.Mesh(new THREE.CylinderGeometry(0.08, 0.07, 0.34, 8), clothP);
-        thigh.position.y = -0.17;
+        const thigh = new THREE.Mesh(geo('hob-thigh', () => new THREE.CapsuleGeometry(0.075, 0.2, 5, 10)), clothP);
+        thigh.position.y = -0.14;
         leg.add(thigh);
-        const footM = new THREE.Mesh(new THREE.SphereGeometry(0.09, 8, 6), foot);
-        footM.scale.set(1.15, 0.55, 1.55);
-        footM.position.set(0, -0.36, 0.05);
-        leg.add(footM);
+        const shin = new THREE.Group();
+        shin.position.y = -0.28;
+        leg.add(shin);
+        const shinM = new THREE.Mesh(geo('hob-shin', () => new THREE.CapsuleGeometry(0.065, 0.16, 4, 8)), clothP);
+        shinM.position.y = -0.1;
+        shin.add(shinM);
+        const footG = new THREE.Group();
+        footG.position.set(0, -0.22, 0.04);
+        shin.add(footG);
+        const footM = new THREE.Mesh(geo('hob-foot', () => warp(new THREE.SphereGeometry(0.09, 10, 8), 4, 0.12, 0.4)), foot);
+        footM.scale.set(1.2, 0.52, 1.7);
+        footG.add(footM);
+        for (let i = 0; i < 5; i++) {
+            const tuft = new THREE.Mesh(geo('hob-tuft', () => new THREE.SphereGeometry(0.028, 6, 5)), hair);
+            tuft.position.set((i - 2) * 0.022, 0.03, 0.08 + (i % 2) * 0.02);
+            tuft.scale.set(1.1, 0.55, 0.9);
+            footG.add(tuft);
+        }
+        leg.userData.shin = shin;
         parts.legs.push(leg);
         parts.feet.push(footM);
     }
@@ -70,69 +210,107 @@ export function buildHobbit({ vest = 0xc45a2a, pants = 0x3d4a28 } = {}) {
     torso.position.y = 0.4;
     hips.add(torso);
 
-    const belly = new THREE.Mesh(new THREE.SphereGeometry(0.28, 12, 10), clothV);
-    belly.scale.set(1.05, 0.85, 0.9);
+    const belly = new THREE.Mesh(
+        geo('hob-belly', () => warp(new THREE.SphereGeometry(0.27, 14, 12), 2, 0.08, 0.45)),
+        clothV
+    );
+    belly.scale.set(1.08, 0.88, 0.92);
     belly.position.y = 0.22;
     torso.add(belly);
 
-    const shirt = new THREE.Mesh(new THREE.CylinderGeometry(0.2, 0.24, 0.18, 10), std(0xf2e4c4, 0.9));
-    shirt.position.y = 0.38;
+    const shirt = new THREE.Mesh(
+        geo('hob-shirt', () => new THREE.CylinderGeometry(0.18, 0.23, 0.2, 12)),
+        mapped(clothTexture('#f2e4c4'), 0xf2e4c4, 0.9)
+    );
+    shirt.position.y = 0.4;
     torso.add(shirt);
 
-    const belt = new THREE.Mesh(new THREE.TorusGeometry(0.22, 0.03, 6, 14), std(0x5a3a18, 0.7, 0.1));
+    const collar = new THREE.Mesh(
+        geo('hob-collar', () => new THREE.TorusGeometry(0.16, 0.025, 6, 14)),
+        mapped(clothTexture('#f2e4c4'), 0xeee0c0, 0.88)
+    );
+    collar.rotation.x = Math.PI / 2;
+    collar.position.y = 0.5;
+    torso.add(collar);
+
+    const belt = new THREE.Mesh(geo('hob-belt', () => new THREE.TorusGeometry(0.21, 0.028, 6, 16)), leather);
     belt.rotation.x = Math.PI / 2;
     belt.position.y = 0.12;
     torso.add(belt);
+    const buckle = new THREE.Mesh(geo('hob-buckle', () => new THREE.BoxGeometry(0.08, 0.06, 0.03)), mapped(goldTexture(), 0xffe08a, 0.28, 0.9, 0.4));
+    buckle.position.set(0, 0.12, 0.22);
+    torso.add(buckle);
 
     const head = new THREE.Group();
-    head.position.y = 0.58;
+    head.position.y = 0.6;
     torso.add(head);
-    const skull = new THREE.Mesh(new THREE.SphereGeometry(0.16, 12, 10), skin);
+    const skull = new THREE.Mesh(geo('hob-skull', () => warp(new THREE.SphereGeometry(0.155, 14, 12), 7, 0.06, 0.5)), skin);
     head.add(skull);
+    const face = new THREE.Mesh(
+        geo('hob-face', () => new THREE.SphereGeometry(0.152, 14, 12, 0, Math.PI * 2, 0.35, 1.4)),
+        new THREE.MeshStandardMaterial({ map: faceTexture(), roughness: 0.58, metalness: 0.02 })
+    );
+    face.material.userData.shared = true;
+    head.add(face);
+    const nose = new THREE.Mesh(geo('hob-nose', () => new THREE.SphereGeometry(0.035, 8, 6)), skin);
+    nose.scale.set(0.85, 0.9, 1.25);
+    nose.position.set(0, -0.01, 0.15);
+    head.add(nose);
 
     for (const sx of [-1, 1]) {
-        const ear = new THREE.Mesh(new THREE.SphereGeometry(0.055, 8, 6), skin);
-        ear.scale.set(0.7, 1.1, 0.5);
-        ear.position.set(sx * 0.16, 0.02, 0);
+        const ear = new THREE.Mesh(geo('hob-ear', () => warp(new THREE.SphereGeometry(0.05, 8, 6), 9, 0.15)), skin);
+        ear.scale.set(0.65, 1.15, 0.45);
+        ear.position.set(sx * 0.155, 0.02, -0.01);
         head.add(ear);
-        const eye = new THREE.Mesh(new THREE.SphereGeometry(0.025, 8, 6), std(0xf7f2ea, 0.4));
-        eye.position.set(sx * 0.05, 0.02, 0.14);
-        head.add(eye);
-        const iris = new THREE.Mesh(new THREE.SphereGeometry(0.014, 6, 5), std(0x2a4a18, 0.45));
-        iris.position.set(sx * 0.05, 0.02, 0.16);
-        head.add(iris);
     }
 
-    for (let i = 0; i < 14; i++) {
-        const curl = new THREE.Mesh(new THREE.SphereGeometry(0.055, 8, 6), hair);
-        const a = (i / 14) * Math.PI * 2;
-        curl.position.set(Math.cos(a) * 0.14, 0.1 + Math.sin(i * 2.1) * 0.04, Math.sin(a) * 0.12);
+    for (let i = 0; i < 22; i++) {
+        const curl = new THREE.Mesh(geo('hob-curl', () => new THREE.SphereGeometry(0.05, 8, 6)), hair);
+        const a = (i / 22) * Math.PI * 2;
+        curl.position.set(Math.cos(a) * 0.135, 0.09 + Math.sin(i * 1.7) * 0.045, Math.sin(a) * 0.12);
+        curl.scale.setScalar(0.85 + (i % 3) * 0.12);
         head.add(curl);
     }
-    const bang = new THREE.Mesh(new THREE.SphereGeometry(0.08, 8, 6), hair);
-    bang.position.set(0, 0.12, 0.1);
+    const bang = new THREE.Mesh(geo('hob-bang', () => new THREE.SphereGeometry(0.075, 8, 6)), hair);
+    bang.position.set(0, 0.1, 0.1);
+    bang.scale.set(1.15, 0.7, 0.9);
     head.add(bang);
 
-    const armGeo = new THREE.CylinderGeometry(0.055, 0.048, 0.32, 8);
     for (const sx of [-1, 1]) {
         const arm = new THREE.Group();
-        arm.position.set(sx * 0.26, 0.42, 0);
+        arm.position.set(sx * 0.26, 0.44, 0);
         torso.add(arm);
-        const mesh = new THREE.Mesh(armGeo, skin);
-        mesh.position.y = -0.16;
-        arm.add(mesh);
+        const upper = new THREE.Mesh(geo('hob-upper', () => new THREE.CapsuleGeometry(0.05, 0.14, 4, 8)), skin);
+        upper.position.y = -0.1;
+        arm.add(upper);
+        const forearm = new THREE.Group();
+        forearm.position.y = -0.2;
+        arm.add(forearm);
+        const foreM = new THREE.Mesh(geo('hob-fore', () => new THREE.CapsuleGeometry(0.045, 0.13, 4, 8)), skin);
+        foreM.position.y = -0.08;
+        forearm.add(foreM);
+        const hand = new THREE.Mesh(geo('hob-hand', () => new THREE.SphereGeometry(0.045, 8, 6)), skin);
+        hand.scale.set(1.05, 0.7, 1.15);
+        hand.position.y = -0.18;
+        forearm.add(hand);
+        arm.userData.forearm = forearm;
         parts.arms.push(arm);
     }
 
     const ringGlow = new THREE.Mesh(
-        new THREE.TorusGeometry(0.07, 0.018, 8, 20),
-        new THREE.MeshStandardMaterial({
-            map: goldTexture(),
-            color: 0xffe08a,
-            emissive: 0xffaa22,
-            emissiveIntensity: 0.8,
-            metalness: 1,
-            roughness: 0.22
+        geo('hob-ring', () => new THREE.TorusGeometry(0.065, 0.016, 10, 28)),
+        mat('ring-glow', () => {
+            const m = new THREE.MeshStandardMaterial({
+                color: 0xffe08a,
+                emissive: 0xffaa22,
+                emissiveIntensity: 0.85,
+                metalness: 1,
+                roughness: 0.18
+            });
+            applyMaps(m, goldTexture(), { color: 0xffe08a, roughness: 0.18, metalness: 1, normalScale: 0.4 });
+            m.emissive.set(0xffaa22);
+            m.emissiveIntensity = 0.85;
+            return m;
         })
     );
     ringGlow.rotation.x = Math.PI / 2;
@@ -147,48 +325,83 @@ export function buildHobbit({ vest = 0xc45a2a, pants = 0x3d4a28 } = {}) {
 
 export function buildWizard() {
     const group = new THREE.Group();
-    const robe = std(0x9aa3ad, 0.9);
-    const skin = std(0xe0c4a0, 0.7);
-    const beard = std(0xe8e4d8, 0.92);
+    const robeMaps = clothTexture('#9aa3ad');
+    const robe = mapped(robeMaps, 0xa8b0ba, 0.9, 0, 0.55);
+    const skin = mapped(skinTexture(), 0xe8d0b0, 0.64, 0.02, 0.4);
+    const beard = std(0xece8dc, 0.94);
 
-    const body = new THREE.Mesh(new THREE.ConeGeometry(0.42, 1.7, 10), robe);
-    body.position.y = 0.85;
+    const body = new THREE.Mesh(
+        lathe([[0.08, 0], [0.48, 0.04], [0.42, 0.55], [0.3, 1.15], [0.22, 1.55], [0.16, 1.68]], 18, 'wiz-robe'),
+        robe
+    );
     group.add(body);
 
-    const head = new THREE.Mesh(new THREE.SphereGeometry(0.16, 10, 8), skin);
+    const cloak = new THREE.Mesh(
+        geo('wiz-cloak', () => {
+            const g = new THREE.CylinderGeometry(0.52, 0.22, 1.35, 16, 8, true, Math.PI * 0.15, Math.PI * 1.7);
+            g.translate(0, 0.7, -0.05);
+            return g;
+        }),
+        clothMat({ color: 0x8e96a0, maps: robeMaps, wind: 0.22, key: 'wiz-cloak' })
+    );
+    group.add(cloak);
+
+    const head = new THREE.Group();
     head.position.y = 1.72;
     group.add(head);
+    const skull = new THREE.Mesh(geo('wiz-skull', () => warp(new THREE.SphereGeometry(0.15, 12, 10), 11, 0.05)), skin);
+    head.add(skull);
+    const nose = new THREE.Mesh(geo('wiz-nose', () => new THREE.SphereGeometry(0.03, 6, 5)), skin);
+    nose.scale.set(0.7, 0.9, 1.4);
+    nose.position.set(0, -0.01, 0.14);
+    head.add(nose);
+    for (const sx of [-1, 1]) {
+        const brow = new THREE.Mesh(geo('wiz-brow', () => new THREE.SphereGeometry(0.04, 6, 4)), beard);
+        brow.scale.set(1.2, 0.35, 0.5);
+        brow.position.set(sx * 0.05, 0.04, 0.12);
+        head.add(brow);
+    }
 
-    const hat = new THREE.Mesh(new THREE.ConeGeometry(0.22, 0.7, 8), robe);
-    hat.position.y = 2.12;
-    hat.rotation.z = 0.12;
+    const hat = new THREE.Mesh(
+        lathe([[0.02, 0.72], [0.08, 0.5], [0.16, 0.18], [0.22, 0.02], [0.4, 0], [0.4, -0.03], [0.02, -0.03]], 14, 'wiz-hat'),
+        robe
+    );
+    hat.position.y = 1.84;
+    hat.rotation.z = 0.1;
     group.add(hat);
-    const brim = new THREE.Mesh(new THREE.CylinderGeometry(0.38, 0.38, 0.04, 12), robe);
-    brim.position.y = 1.82;
-    group.add(brim);
 
-    const beardM = new THREE.Mesh(new THREE.ConeGeometry(0.14, 0.55, 8), beard);
-    beardM.position.set(0, 1.42, 0.08);
-    beardM.rotation.x = Math.PI;
-    group.add(beardM);
+    const beardG = new THREE.Mesh(
+        lathe([[0.02, 0], [0.14, 0.02], [0.12, 0.22], [0.07, 0.48], [0.02, 0.62]], 10, 'wiz-beard'),
+        beard
+    );
+    beardG.position.set(0, 1.68, 0.08);
+    beardG.rotation.x = Math.PI;
+    group.add(beardG);
 
     const staff = new THREE.Group();
-    staff.position.set(0.38, 0, 0.1);
+    staff.position.set(0.4, 0, 0.08);
     group.add(staff);
-    const shaft = new THREE.Mesh(new THREE.CylinderGeometry(0.03, 0.04, 2.15, 6), std(0x5a3a22, 0.85));
-    shaft.position.y = 1.05;
+    const shaft = new THREE.Mesh(
+        geo('wiz-shaft', () => warp(new THREE.CylinderGeometry(0.028, 0.042, 2.18, 8), 13, 0.18, 0.5)),
+        mapped(barkTexture(), 0x6a4a30, 0.86)
+    );
+    shaft.position.y = 1.08;
     staff.add(shaft);
     const crystal = new THREE.Mesh(
-        new THREE.OctahedronGeometry(0.1),
-        new THREE.MeshStandardMaterial({
+        geo('wiz-crystal', () => new THREE.OctahedronGeometry(0.1, 1)),
+        mat('wiz-crystal', () => new THREE.MeshPhysicalMaterial({
             color: 0xa8d8ff,
             emissive: 0x4aa0ff,
-            emissiveIntensity: 2.2,
-            roughness: 0.2,
-            metalness: 0.3
-        })
+            emissiveIntensity: 1.6,
+            roughness: 0.12,
+            metalness: 0.15,
+            transmission: 0.35,
+            thickness: 0.4,
+            transparent: true,
+            opacity: 0.92
+        }))
     );
-    crystal.position.y = 2.18;
+    crystal.position.y = 2.2;
     staff.add(crystal);
 
     enableShadows(group);
@@ -198,26 +411,48 @@ export function buildWizard() {
 
 export function buildElf({ robe = 0xc8d8c0 } = {}) {
     const group = new THREE.Group();
-    const skin = std(0xf0d8c0, 0.65);
-    const cloth = std(robe, 0.82);
-    const hair = std(0xe8d080, 0.55);
+    const skin = mapped(skinTexture(), 0xf4dcc8, 0.55, 0.02, 0.35);
+    const cloth = mapped(clothTexture('#c8d8c0'), robe, 0.78, 0, 0.5);
+    const hair = std(0xe8d080, 0.48, 0.08);
 
-    const body = new THREE.Mesh(new THREE.CylinderGeometry(0.16, 0.2, 1.35, 8), cloth);
-    body.position.y = 0.72;
+    const body = new THREE.Mesh(
+        lathe([[0.06, 0], [0.22, 0.04], [0.2, 0.55], [0.16, 1.05], [0.14, 1.38]], 14, `elf-body:${robe}`),
+        cloth
+    );
     group.add(body);
-    const head = new THREE.Mesh(new THREE.SphereGeometry(0.13, 10, 8), skin);
-    head.position.y = 1.52;
+
+    const head = new THREE.Group();
+    head.position.y = 1.5;
     group.add(head);
+    const skull = new THREE.Mesh(geo('elf-skull', () => new THREE.SphereGeometry(0.125, 12, 10)), skin);
+    skull.scale.set(0.92, 1.08, 0.95);
+    head.add(skull);
     for (const sx of [-1, 1]) {
-        const ear = new THREE.Mesh(new THREE.ConeGeometry(0.03, 0.14, 6), skin);
-        ear.position.set(sx * 0.12, 1.54, 0);
-        ear.rotation.z = sx * -0.9;
-        group.add(ear);
+        const ear = new THREE.Mesh(geo('elf-ear', () => new THREE.ConeGeometry(0.028, 0.16, 6)), skin);
+        ear.position.set(sx * 0.12, 0.04, -0.02);
+        ear.rotation.z = sx * -0.95;
+        ear.rotation.x = -0.25;
+        head.add(ear);
+        const eye = new THREE.Mesh(geo('elf-eye', () => new THREE.SphereGeometry(0.018, 6, 5)), std(0x88a0c8, 0.25, 0.2));
+        eye.position.set(sx * 0.04, 0.01, 0.11);
+        head.add(eye);
     }
-    const hairM = new THREE.Mesh(new THREE.SphereGeometry(0.14, 8, 8), hair);
-    hairM.position.y = 1.6;
-    hairM.scale.set(1, 0.7, 1.1);
-    group.add(hairM);
+    const hairM = new THREE.Mesh(geo('elf-hair', () => warp(new THREE.SphereGeometry(0.14, 10, 8), 15, 0.08)), hair);
+    hairM.position.y = 0.06;
+    hairM.scale.set(1.05, 0.85, 1.2);
+    head.add(hairM);
+    const fall = new THREE.Mesh(geo('elf-fall', () => new THREE.CylinderGeometry(0.04, 0.03, 0.55, 6)), hair);
+    fall.position.set(0.08, -0.18, -0.06);
+    head.add(fall);
+
+    const circlet = new THREE.Mesh(
+        geo('elf-circlet', () => new THREE.TorusGeometry(0.12, 0.012, 6, 18)),
+        mapped(goldTexture(), 0xe8d8a0, 0.3, 0.85, 0.3)
+    );
+    circlet.rotation.x = Math.PI / 2;
+    circlet.position.y = 0.08;
+    head.add(circlet);
+
     enableShadows(group);
     return { group };
 }
@@ -228,36 +463,59 @@ export function buildCompanion() {
 
 export function buildGoblin() {
     const group = new THREE.Group();
-    const skin = std(0x5a7a3a, 0.8);
-    const dark = std(0x2a2218, 0.9);
+    const skin = mapped(skinTexture(), 0x6a8a42, 0.82, 0.02, 0.7);
+    const dark = mapped(clothTexture('#2a2218'), 0x2a2218, 0.92);
 
-    const body = new THREE.Mesh(new THREE.SphereGeometry(0.28, 8, 6), dark);
-    body.position.y = 0.55;
-    body.scale.set(1, 1.2, 0.8);
+    const body = new THREE.Mesh(
+        geo('gob-body', () => warp(new THREE.SphereGeometry(0.26, 10, 8), 17, 0.14, 0.4)),
+        dark
+    );
+    body.position.y = 0.52;
+    body.scale.set(1.05, 1.25, 0.82);
     group.add(body);
-    const head = new THREE.Mesh(new THREE.SphereGeometry(0.2, 8, 6), skin);
-    head.position.y = 0.95;
+
+    const head = new THREE.Group();
+    head.position.y = 0.92;
     group.add(head);
+    const skull = new THREE.Mesh(geo('gob-skull', () => warp(new THREE.SphereGeometry(0.19, 10, 8), 18, 0.12)), skin);
+    skull.scale.set(1.05, 0.9, 1.1);
+    head.add(skull);
     for (const sx of [-1, 1]) {
-        const ear = new THREE.Mesh(new THREE.ConeGeometry(0.06, 0.18, 5), skin);
-        ear.position.set(sx * 0.18, 1.05, 0);
-        ear.rotation.z = sx * -0.7;
-        group.add(ear);
+        const ear = new THREE.Mesh(geo('gob-ear', () => warp(new THREE.ConeGeometry(0.055, 0.2, 6), 19, 0.2)), skin);
+        ear.position.set(sx * 0.17, 0.12, -0.02);
+        ear.rotation.z = sx * -0.75;
+        head.add(ear);
         const eye = new THREE.Mesh(
-            new THREE.SphereGeometry(0.04, 6, 5),
-            new THREE.MeshStandardMaterial({ color: 0xffee88, emissive: 0xffcc33, emissiveIntensity: 2 })
+            geo('gob-eye', () => new THREE.SphereGeometry(0.038, 8, 6)),
+            mat('gob-eye', () => new THREE.MeshStandardMaterial({
+                color: 0xffee88, emissive: 0xffcc33, emissiveIntensity: 2.2, roughness: 0.3
+            }))
         );
-        eye.position.set(sx * 0.07, 0.98, 0.16);
-        group.add(eye);
-        const arm = new THREE.Mesh(new THREE.CylinderGeometry(0.05, 0.04, 0.4, 6), skin);
-        arm.position.set(sx * 0.28, 0.55, 0);
-        arm.rotation.z = sx * 0.4;
+        eye.position.set(sx * 0.06, 0.04, 0.16);
+        head.add(eye);
+        const arm = new THREE.Mesh(geo('gob-arm', () => new THREE.CapsuleGeometry(0.045, 0.32, 4, 8)), skin);
+        arm.position.set(sx * 0.28, 0.55, 0.04);
+        arm.rotation.z = sx * 0.45;
+        arm.rotation.x = -0.35;
         group.add(arm);
     }
-    const blade = new THREE.Mesh(new THREE.ConeGeometry(0.04, 0.45, 5), std(0xb0b8c0, 0.3, 0.85));
-    blade.position.set(0.38, 0.45, 0.1);
-    blade.rotation.x = 0.4;
+    const jaw = new THREE.Mesh(geo('gob-jaw', () => new THREE.SphereGeometry(0.1, 8, 6)), skin);
+    jaw.scale.set(1, 0.45, 0.9);
+    jaw.position.set(0, -0.08, 0.08);
+    head.add(jaw);
+
+    const blade = new THREE.Mesh(
+        geo('gob-blade', () => {
+            const g = new THREE.ConeGeometry(0.035, 0.48, 6);
+            warp(g, 20, 0.12);
+            return g;
+        }),
+        std(0xb0b8c0, 0.28, 0.88)
+    );
+    blade.position.set(0.38, 0.42, 0.12);
+    blade.rotation.x = 0.55;
     group.add(blade);
+
     enableShadows(group);
     group.userData.hp = 2;
     return { group };
@@ -265,54 +523,114 @@ export function buildGoblin() {
 
 export function buildNazgul() {
     const group = new THREE.Group();
-    const black = std(0x0a0a0c, 0.95, 0.05, { emissive: 0x050508, emissiveIntensity: 0.2 });
+    const black = mapped(clothTexture('#0a0a0c'), 0x0c0c10, 0.94, 0.06, 0.4);
+    black.emissive = new THREE.Color(0x050508);
+    black.emissiveIntensity = 0.15;
+    const hide = mapped(leatherTexture(), 0x121014, 0.9, 0.08, 0.7);
 
     const horse = new THREE.Group();
     group.add(horse);
-    const body = new THREE.Mesh(new THREE.SphereGeometry(0.55, 10, 8), black);
-    body.scale.set(1.6, 0.85, 0.7);
-    body.position.y = 0.85;
+
+    const body = new THREE.Mesh(
+        geo('naz-body', () => warp(new THREE.SphereGeometry(0.52, 14, 10), 21, 0.1, 0.5)),
+        hide
+    );
+    body.scale.set(0.72, 0.82, 1.7);
+    body.position.set(0, 0.88, 0);
     horse.add(body);
-    const neck = new THREE.Mesh(new THREE.CylinderGeometry(0.14, 0.18, 0.7, 8), black);
-    neck.position.set(0.7, 1.2, 0);
-    neck.rotation.z = -0.7;
+
+    const chest = new THREE.Mesh(geo('naz-chest', () => warp(new THREE.SphereGeometry(0.32, 10, 8), 22, 0.1)), hide);
+    chest.scale.set(0.85, 0.95, 1.1);
+    chest.position.set(0, 0.92, 0.55);
+    horse.add(chest);
+
+    const neck = new THREE.Mesh(geo('naz-neck', () => new THREE.CapsuleGeometry(0.13, 0.55, 5, 8)), hide);
+    neck.position.set(0, 1.22, 0.72);
+    neck.rotation.x = 0.7;
     horse.add(neck);
-    const head = new THREE.Mesh(new THREE.SphereGeometry(0.18, 8, 6), black);
-    head.scale.set(1.4, 0.7, 0.6);
-    head.position.set(1.05, 1.48, 0);
+
+    const head = new THREE.Mesh(geo('naz-head', () => warp(new THREE.SphereGeometry(0.16, 10, 8), 23, 0.12)), hide);
+    head.scale.set(0.7, 0.72, 1.55);
+    head.position.set(0, 1.52, 1.08);
     horse.add(head);
     for (const sx of [-1, 1]) {
-        for (const z of [-0.22, 0.22]) {
-            const leg = new THREE.Mesh(new THREE.CylinderGeometry(0.07, 0.05, 0.85, 6), black);
-            leg.position.set(sx * 0.35, 0.42, z);
+        const ear = new THREE.Mesh(geo('naz-ear', () => new THREE.ConeGeometry(0.04, 0.14, 5)), hide);
+        ear.position.set(sx * 0.07, 1.68, 1.0);
+        ear.rotation.x = -0.4;
+        horse.add(ear);
+    }
+    const snout = new THREE.Mesh(geo('naz-snout', () => new THREE.CylinderGeometry(0.05, 0.09, 0.22, 8)), hide);
+    snout.rotation.x = Math.PI / 2;
+    snout.position.set(0, 1.46, 1.28);
+    horse.add(snout);
+
+    const tail = new THREE.Mesh(geo('naz-tail', () => new THREE.ConeGeometry(0.07, 0.7, 6)), black);
+    tail.position.set(0, 0.85, -0.95);
+    tail.rotation.x = 2.4;
+    horse.add(tail);
+
+    const horseLegs = [];
+    const gaitSign = [1, -1, -1, 1];
+    let li = 0;
+    for (const sx of [-1, 1]) {
+        for (const z of [0.42, -0.42]) {
+            const leg = new THREE.Group();
+            leg.position.set(sx * 0.22, 0.72, z);
             horse.add(leg);
+            const upper = new THREE.Mesh(geo('naz-legu', () => new THREE.CapsuleGeometry(0.055, 0.32, 4, 6)), hide);
+            upper.position.y = -0.18;
+            leg.add(upper);
+            const lower = new THREE.Group();
+            lower.position.y = -0.36;
+            leg.add(lower);
+            const lowM = new THREE.Mesh(geo('naz-legl', () => new THREE.CapsuleGeometry(0.042, 0.28, 3, 6)), hide);
+            lowM.position.y = -0.14;
+            lower.add(lowM);
+            const hoof = new THREE.Mesh(geo('naz-hoof', () => new THREE.SphereGeometry(0.055, 6, 5)), std(0x080808, 0.5, 0.15));
+            hoof.scale.set(1.1, 0.55, 1.2);
+            hoof.position.y = -0.32;
+            lower.add(hoof);
+            leg.userData.lower = lower;
+            leg.userData.sign = gaitSign[li++];
+            horseLegs.push(leg);
         }
     }
 
     const rider = new THREE.Group();
-    rider.position.set(-0.05, 1.15, 0);
+    rider.position.set(0, 1.12, -0.08);
     group.add(rider);
-    const cloak = new THREE.Mesh(new THREE.ConeGeometry(0.42, 1.15, 8), black);
-    cloak.position.y = 0.55;
+
+    const cloak = new THREE.Mesh(
+        lathe([[0.08, 0], [0.48, 0.04], [0.4, 0.55], [0.22, 1.05], [0.14, 1.18]], 16, 'naz-cloak'),
+        clothMat({ color: 0x0a0a0c, maps: clothTexture('#0a0a0c'), wind: 0.28, key: 'naz-cloak' })
+    );
     rider.add(cloak);
-    const hood = new THREE.Mesh(new THREE.SphereGeometry(0.2, 8, 6), black);
+
+    const hood = new THREE.Mesh(
+        lathe([[0.02, 0.22], [0.18, 0.18], [0.2, 0.04], [0.12, 0]], 12, 'naz-hood'),
+        black
+    );
     hood.position.y = 1.12;
     rider.add(hood);
+
     for (const sx of [-1, 1]) {
         const eye = new THREE.Mesh(
-            new THREE.SphereGeometry(0.035, 6, 5),
-            new THREE.MeshStandardMaterial({
-                color: 0xffe8a0,
-                emissive: 0xffcc66,
-                emissiveIntensity: 3.5
-            })
+            geo('naz-eye', () => new THREE.SphereGeometry(0.032, 8, 6)),
+            mat('naz-eye', () => new THREE.MeshStandardMaterial({
+                color: 0xffe8a0, emissive: 0xffcc66, emissiveIntensity: 3.6, roughness: 0.25
+            }))
         );
-        eye.position.set(sx * 0.06, 1.14, 0.16);
+        eye.position.set(sx * 0.055, 1.16, 0.12);
         rider.add(eye);
     }
 
+    const blade = new THREE.Mesh(geo('naz-blade', () => new THREE.BoxGeometry(0.04, 0.85, 0.08)), std(0xc8d0d8, 0.22, 0.92));
+    blade.position.set(0.32, 0.7, 0.15);
+    blade.rotation.z = -0.35;
+    rider.add(blade);
+
     enableShadows(group);
-    group.userData.parts = { horse, rider };
+    group.userData.parts = { horse, rider, horseLegs };
     return { group, parts: group.userData.parts };
 }
 
@@ -322,53 +640,86 @@ export function buildNazgul() {
 
 export function buildHobbitHole({ doorColor = '#2d6b38', scale = 1 } = {}) {
     const group = new THREE.Group();
+    const grass = mapped(grassTexture(), 0x7aab48, 0.94, 0.02, 1.1);
+    const wood = mapped(woodTexture(), 0xc4a06a, 0.78);
+    const doorMaps = doorTexture(doorColor);
+
     const hill = new THREE.Mesh(
-        new THREE.SphereGeometry(2.4, 16, 12),
-        mapped(grassTexture(), 0x7aab48)
+        geo(`hill:${scale.toFixed(2)}`, () => warp(new THREE.SphereGeometry(2.4, 22, 16), 30 + scale * 10, 0.16, 0.35)),
+        grass
     );
-    hill.scale.set(1.35, 0.72, 1.15);
-    hill.position.y = 0.4;
+    hill.scale.set(1.4, 0.78, 1.18);
+    hill.position.y = 0.45;
     group.add(hill);
 
     const facade = new THREE.Mesh(
-        new THREE.CylinderGeometry(1.05, 1.05, 0.18, 20),
-        mapped(woodTexture(), 0xc4a06a)
+        geo('hole-facade', () => new THREE.CylinderGeometry(1.08, 1.08, 0.22, 28)),
+        wood
     );
     facade.rotation.x = Math.PI / 2;
-    facade.position.set(0, 0.85, 1.55);
+    facade.position.set(0, 0.88, 1.52);
     group.add(facade);
 
+    const frame = new THREE.Mesh(
+        geo('hole-frame', () => new THREE.TorusGeometry(0.78, 0.07, 8, 28)),
+        mapped(woodTexture(), 0x8a6238, 0.8)
+    );
+    frame.position.set(0, 0.88, 1.64);
+    group.add(frame);
+
     const door = new THREE.Mesh(
-        new THREE.CylinderGeometry(0.72, 0.72, 0.08, 22),
-        new THREE.MeshStandardMaterial({ map: doorTexture(doorColor), roughness: 0.7 })
+        geo('hole-door', () => new THREE.CylinderGeometry(0.72, 0.72, 0.08, 28)),
+        mat(`door-mat:${doorColor}`, () => {
+            const m = new THREE.MeshStandardMaterial({ roughness: 0.68, metalness: 0.04 });
+            applyMaps(m, doorMaps, { roughness: 0.68, metalness: 0.04, normalScale: 1.1 });
+            return m;
+        })
     );
     door.rotation.x = Math.PI / 2;
-    door.position.set(0, 0.85, 1.66);
+    door.position.set(0, 0.88, 1.66);
     group.add(door);
 
     const window = new THREE.Mesh(
-        new THREE.CylinderGeometry(0.22, 0.22, 0.06, 12),
-        new THREE.MeshStandardMaterial({
-            color: 0xffe8a8,
-            emissive: 0xffcc66,
-            emissiveIntensity: 0.7,
-            roughness: 0.3
-        })
+        geo('hole-win', () => new THREE.CylinderGeometry(0.2, 0.2, 0.06, 16)),
+        mat('hole-win', () => new THREE.MeshStandardMaterial({
+            color: 0xffe8a8, emissive: 0xffcc66, emissiveIntensity: 0.85, roughness: 0.22, metalness: 0.1
+        }))
     );
     window.rotation.x = Math.PI / 2;
-    window.position.set(1.15, 1.15, 0.9);
+    window.position.set(1.18, 1.18, 0.88);
     group.add(window);
+    const winFrame = new THREE.Mesh(geo('hole-winf', () => new THREE.TorusGeometry(0.22, 0.03, 6, 16)), wood);
+    winFrame.position.copy(window.position);
+    group.add(winFrame);
 
-    const chimney = new THREE.Mesh(new THREE.CylinderGeometry(0.12, 0.14, 0.7, 8), mapped(brickTexture()));
-    chimney.position.set(-0.6, 2.0, -0.2);
+    const chimney = new THREE.Mesh(
+        geo('hole-chim', () => new THREE.CylinderGeometry(0.12, 0.15, 0.78, 10)),
+        mapped(brickTexture(), 0xffffff, 0.9)
+    );
+    chimney.position.set(-0.62, 2.05, -0.18);
     group.add(chimney);
+    const pot = new THREE.Mesh(geo('hole-pot', () => new THREE.TorusGeometry(0.14, 0.03, 6, 10)), mapped(brickTexture()));
+    pot.position.set(-0.62, 2.44, -0.18);
+    pot.rotation.x = Math.PI / 2;
+    group.add(pot);
 
     const smoke = new THREE.Mesh(
-        new THREE.SphereGeometry(0.22, 8, 6),
-        new THREE.MeshStandardMaterial({ color: 0xccc8c0, transparent: true, opacity: 0.35, depthWrite: false })
+        geo('hole-smoke', () => new THREE.SphereGeometry(0.22, 8, 6)),
+        mat('smoke', () => new THREE.MeshStandardMaterial({
+            color: 0xccc8c0, transparent: true, opacity: 0.32, depthWrite: false, roughness: 1
+        }))
     );
-    smoke.position.set(-0.6, 2.5, -0.2);
+    smoke.position.set(-0.62, 2.58, -0.18);
     group.add(smoke);
+
+    for (let i = 0; i < 5; i++) {
+        const flower = new THREE.Mesh(
+            geo('hole-flw', () => new THREE.SphereGeometry(0.05, 6, 5)),
+            std([0xe07080, 0xf0d060, 0xd060a0, 0xf2e8c8, 0x88c060][i], 0.55)
+        );
+        flower.position.set(-1.1 + i * 0.22, 0.72, 1.55);
+        group.add(flower);
+    }
 
     group.scale.setScalar(scale);
     enableShadows(group);
@@ -376,40 +727,104 @@ export function buildHobbitHole({ doorColor = '#2d6b38', scale = 1 } = {}) {
     return { group, parts: group.userData.parts };
 }
 
+function oakCanopyGeo(autumn) {
+    return geo(`oak-canopy:${autumn}`, () => {
+        const blobs = [];
+        const specs = [
+            [0, 1.55, 0, 1.45, 1.05, 1.35],
+            [0.7, 1.15, 0.35, 1.05, 0.9, 1.0],
+            [-0.55, 1.25, -0.25, 0.95, 0.85, 0.95],
+            [0.15, 1.85, -0.5, 0.85, 0.75, 0.9]
+        ];
+        for (let i = 0; i < specs.length; i++) {
+            const [x, y, z, sx, sy, sz] = specs[i];
+            const g = warp(new THREE.IcosahedronGeometry(1, 1), 40 + i, 0.18, 0.45);
+            g.scale(sx, sy, sz);
+            g.translate(x, y, z);
+            blobs.push(g);
+        }
+        const merged = mergeGeometries(blobs, false);
+        blobs.forEach((g) => g.dispose());
+        if (!merged) return new THREE.IcosahedronGeometry(1.4, 1);
+        merged.computeVertexNormals();
+        return merged;
+    });
+}
+
+function oakTrunkGeo() {
+    return geo('oak-trunk', () => {
+        const trunk = warp(new THREE.CylinderGeometry(0.22, 0.42, 2.5, 10), 41, 0.14, 0.5);
+        trunk.translate(0, 1.25, 0);
+        const roots = [];
+        for (let i = 0; i < 4; i++) {
+            const a = (i / 4) * Math.PI * 2;
+            const r = new THREE.CylinderGeometry(0.06, 0.14, 0.7, 6);
+            r.rotateZ(0.9);
+            r.translate(Math.cos(a) * 0.45, 0.18, Math.sin(a) * 0.45);
+            roots.push(r);
+        }
+        const merged = mergeGeometries([trunk, ...roots], false);
+        [trunk, ...roots].forEach((g) => g.dispose());
+        if (!merged) return new THREE.CylinderGeometry(0.22, 0.42, 2.5, 10);
+        merged.computeVertexNormals();
+        return merged;
+    });
+}
+
+export function getOakAssets(autumn = false) {
+    const leaf = mapped(leafTexture(autumn ? '#c45a22' : '#2f6a24'), autumn ? 0xd47830 : 0x4a8a32, 0.8, 0.02, 0.7);
+    vegWind(leaf, 0.09);
+    return {
+        trunkGeo: oakTrunkGeo(),
+        canopyGeo: oakCanopyGeo(autumn),
+        trunkMat: mapped(barkTexture(), 0x8a6a48, 0.9, 0.02, 1.2),
+        canopyMat: leaf
+    };
+}
+
 export function buildOak({ autumn = false } = {}) {
     const group = new THREE.Group();
-    const trunk = new THREE.Mesh(
-        new THREE.CylinderGeometry(0.28, 0.4, 2.4, 8),
-        mapped(barkTexture(), 0x8a6a48)
-    );
-    trunk.position.y = 1.2;
+    const a = getOakAssets(autumn);
+    const trunk = new THREE.Mesh(a.trunkGeo, a.trunkMat);
     group.add(trunk);
-    const leafMat = mapped(leafTexture(autumn ? '#c45a22' : '#2f6a24'), autumn ? 0xd47830 : 0x4a8a32);
-    const canopy = new THREE.Mesh(new THREE.IcosahedronGeometry(1.55, 1), leafMat);
-    canopy.position.y = 2.7;
-    canopy.scale.set(1.2, 0.9, 1.15);
+    const canopy = new THREE.Mesh(a.canopyGeo, a.canopyMat);
+    canopy.position.y = 1.35;
     group.add(canopy);
-    const canopy2 = new THREE.Mesh(new THREE.IcosahedronGeometry(1.1, 1), leafMat);
-    canopy2.position.set(0.6, 2.4, 0.3);
-    group.add(canopy2);
     enableShadows(group);
     return group;
 }
 
+function pineGeo() {
+    return geo('pine-full', () => {
+        const parts = [];
+        const trunk = warp(new THREE.CylinderGeometry(0.14, 0.22, 2.15, 8), 50, 0.12);
+        trunk.translate(0, 1.07, 0);
+        parts.push(trunk);
+        for (let i = 0; i < 5; i++) {
+            const cone = warp(new THREE.ConeGeometry(1.2 - i * 0.18, 1.2, 10), 51 + i, 0.12, 0.4);
+            cone.translate(0, 1.55 + i * 0.62, 0);
+            parts.push(cone);
+        }
+        const merged = mergeGeometries(parts, false);
+        parts.forEach((g) => g.dispose());
+        if (!merged) return new THREE.ConeGeometry(1.0, 4.2, 8);
+        merged.computeVertexNormals();
+        return merged;
+    });
+}
+
+export function getPineAssets() {
+    return {
+        geo: pineGeo(),
+        mat: mapped(leafTexture('#1e4a28'), 0x2a5a30, 0.84, 0.02, 0.8)
+    };
+}
+
 export function buildPine() {
     const group = new THREE.Group();
-    const trunk = new THREE.Mesh(
-        new THREE.CylinderGeometry(0.16, 0.22, 2.1, 7),
-        mapped(barkTexture(), 0x6a4a32)
-    );
-    trunk.position.y = 1.05;
-    group.add(trunk);
-    const leaf = mapped(leafTexture('#1e4a28'), 0x2a5a30);
-    for (let i = 0; i < 4; i++) {
-        const cone = new THREE.Mesh(new THREE.ConeGeometry(1.15 - i * 0.18, 1.15, 8), leaf);
-        cone.position.y = 1.7 + i * 0.7;
-        group.add(cone);
-    }
+    const a = getPineAssets();
+    const mesh = new THREE.Mesh(a.geo, a.mat);
+    group.add(mesh);
     enableShadows(group);
     return group;
 }
@@ -417,32 +832,35 @@ export function buildPine() {
 export function buildPartyTree() {
     const group = new THREE.Group();
     const trunk = new THREE.Mesh(
-        new THREE.CylinderGeometry(0.55, 0.8, 4.2, 10),
-        mapped(barkTexture(), 0x8a6a48)
+        geo('party-trunk', () => warp(new THREE.CylinderGeometry(0.5, 0.82, 4.3, 14), 60, 0.12)),
+        mapped(barkTexture(), 0x8a6a48, 0.9, 0.02, 1.15)
     );
-    trunk.position.y = 2.1;
+    trunk.position.y = 2.15;
     group.add(trunk);
-    const leaf = mapped(leafTexture('#2f6a24'), 0x4a8a32);
-    for (let i = 0; i < 5; i++) {
-        const blob = new THREE.Mesh(new THREE.IcosahedronGeometry(1.8, 1), leaf);
-        const a = (i / 5) * Math.PI * 2;
-        blob.position.set(Math.cos(a) * 1.3, 4.4 + (i % 2) * 0.5, Math.sin(a) * 1.3);
-        blob.scale.setScalar(0.85 + (i % 3) * 0.12);
+
+    const leaf = mapped(leafTexture('#2f6a24'), 0x4a8a32, 0.8);
+    vegWind(leaf, 0.07);
+    for (let i = 0; i < 6; i++) {
+        const blob = new THREE.Mesh(
+            geo(`party-blob:${i}`, () => warp(new THREE.IcosahedronGeometry(1.75, 1), 61 + i, 0.16)),
+            leaf
+        );
+        const a = (i / 6) * Math.PI * 2;
+        blob.position.set(Math.cos(a) * 1.35, 4.35 + (i % 2) * 0.55, Math.sin(a) * 1.35);
+        blob.scale.setScalar(0.88 + (i % 3) * 0.1);
         group.add(blob);
     }
+
     const lanterns = [];
     for (let i = 0; i < 8; i++) {
         const a = (i / 8) * Math.PI * 2;
         const lantern = new THREE.Mesh(
-            new THREE.SphereGeometry(0.12, 8, 6),
-            new THREE.MeshStandardMaterial({
-                color: 0xffe8a0,
-                emissive: 0xffaa44,
-                emissiveIntensity: 1.8,
-                roughness: 0.3
-            })
+            geo('party-lan', () => new THREE.SphereGeometry(0.11, 10, 8)),
+            mat('party-lan', () => new THREE.MeshStandardMaterial({
+                color: 0xffe8a0, emissive: 0xffaa44, emissiveIntensity: 2, roughness: 0.28
+            }))
         );
-        lantern.position.set(Math.cos(a) * 2.1, 3.1, Math.sin(a) * 2.1);
+        lantern.position.set(Math.cos(a) * 2.15, 3.15, Math.sin(a) * 2.15);
         group.add(lantern);
         lanterns.push(lantern);
     }
@@ -453,28 +871,27 @@ export function buildPartyTree() {
 
 export function buildRing(scale = 1) {
     const group = new THREE.Group();
+    const gold = goldTexture();
     const torus = new THREE.Mesh(
-        new THREE.TorusGeometry(0.28, 0.07, 12, 32),
-        new THREE.MeshStandardMaterial({
-            map: goldTexture(),
-            color: 0xffe08a,
-            metalness: 1,
-            roughness: 0.18,
-            emissive: 0xffaa22,
-            emissiveIntensity: 0.65
+        geo('ring-torus', () => new THREE.TorusGeometry(0.28, 0.065, 16, 48)),
+        mat('ring-gold', () => {
+            const m = new THREE.MeshStandardMaterial({
+                color: 0xffe08a, metalness: 1, roughness: 0.14,
+                emissive: 0xffaa22, emissiveIntensity: 0.55
+            });
+            applyMaps(m, gold, { color: 0xffe08a, roughness: 0.14, metalness: 1, normalScale: 0.35 });
+            m.emissive.set(0xffaa22);
+            m.emissiveIntensity = 0.55;
+            return m;
         })
     );
     torus.rotation.x = Math.PI / 2;
     group.add(torus);
     const glow = new THREE.Mesh(
-        new THREE.TorusGeometry(0.32, 0.12, 8, 24),
-        new THREE.MeshBasicMaterial({
-            color: 0xffcc55,
-            transparent: true,
-            opacity: 0.22,
-            depthWrite: false,
-            side: THREE.DoubleSide
-        })
+        geo('ring-glow-t', () => new THREE.TorusGeometry(0.32, 0.12, 10, 28)),
+        mat('ring-glow-m', () => new THREE.MeshBasicMaterial({
+            color: 0xffcc55, transparent: true, opacity: 0.22, depthWrite: false, side: THREE.DoubleSide
+        }))
     );
     glow.rotation.x = Math.PI / 2;
     group.add(glow);
@@ -484,49 +901,79 @@ export function buildRing(scale = 1) {
 }
 
 export function buildRock(seed = 1) {
-    const geo = new THREE.IcosahedronGeometry(1, 1);
-    const pos = geo.attributes.position;
-    for (let i = 0; i < pos.count; i++) {
-        const n = 0.82 + ((Math.sin(i * 12.9898 + seed) * 43758.5453) % 1) * 0.35;
-        pos.setXYZ(i, pos.getX(i) * n, pos.getY(i) * n * 0.7, pos.getZ(i) * n);
-    }
-    geo.computeVertexNormals();
-    const mesh = new THREE.Mesh(geo, mapped(stoneTexture(), 0x8a8680));
+    const geoR = warp(new THREE.IcosahedronGeometry(1, 2), seed * 17, 0.38, 0.55);
+    const mesh = new THREE.Mesh(geoR, mapped(stoneTexture(), 0x8a8680, 0.9, 0.04, 1.15));
     mesh.castShadow = true;
     mesh.receiveShadow = true;
     return mesh;
 }
 
+export function getPillarAssets(height = 14) {
+    const stone = mapped(stoneTexture('#6a5a48'), 0x7a6a58, 0.9, 0.03, 1.1);
+    const g = geo(`pillar:${height}`, () => {
+        const col = new THREE.CylinderGeometry(0.62, 0.78, height, 12);
+        col.translate(0, height / 2, 0);
+        const base = new THREE.BoxGeometry(2.05, 0.48, 2.05);
+        base.translate(0, 0.24, 0);
+        const cap = new THREE.BoxGeometry(1.85, 0.38, 1.85);
+        cap.translate(0, height, 0);
+        const ring = new THREE.TorusGeometry(0.72, 0.08, 6, 16);
+        ring.rotateX(Math.PI / 2);
+        ring.translate(0, height - 0.35, 0);
+        [col, base, cap, ring].forEach((g) => g.clearGroups());
+        const merged = mergeGeometries([col, base, cap, ring], false);
+        [col, base, cap, ring].forEach((g) => g.dispose());
+        if (!merged) return new THREE.CylinderGeometry(0.62, 0.78, height, 12);
+        return merged;
+    });
+    return { geo: g, mat: stone };
+}
+
+export function buildPillar(height = 14) {
+    const a = getPillarAssets(height);
+    const mesh = new THREE.Mesh(a.geo, a.mat);
+    mesh.castShadow = true;
+    mesh.receiveShadow = true;
+    const group = new THREE.Group();
+    group.add(mesh);
+    return group;
+}
+
 export function buildPavilion() {
     const group = new THREE.Group();
-    const marble = mapped(marbleTexture(), 0xf2eee4, 0.45);
-    const gold = new THREE.MeshStandardMaterial({
-        map: goldTexture(),
-        metalness: 0.85,
-        roughness: 0.28,
-        color: 0xffe8a8
-    });
+    const marble = mapped(marbleTexture(), 0xf2eee4, 0.38, 0.08, 0.55);
+    const gold = mapped(goldTexture(), 0xffe8a8, 0.28, 0.85, 0.4);
 
-    const floor = new THREE.Mesh(new THREE.CylinderGeometry(6.5, 6.5, 0.25, 16), marble);
-    floor.position.y = 0.12;
+    const floor = new THREE.Mesh(geo('pav-floor', () => new THREE.CylinderGeometry(6.5, 6.5, 0.22, 24)), marble);
+    floor.position.y = 0.11;
     group.add(floor);
+    const inlay = new THREE.Mesh(geo('pav-inlay', () => new THREE.TorusGeometry(4.2, 0.08, 6, 32)), gold);
+    inlay.rotation.x = Math.PI / 2;
+    inlay.position.y = 0.23;
+    group.add(inlay);
 
     for (let i = 0; i < 8; i++) {
         const a = (i / 8) * Math.PI * 2;
-        const col = new THREE.Mesh(new THREE.CylinderGeometry(0.18, 0.22, 4.2, 10), marble);
-        col.position.set(Math.cos(a) * 5.2, 2.2, Math.sin(a) * 5.2);
+        const col = new THREE.Mesh(
+            lathe([[0.16, 0], [0.22, 0.08], [0.16, 0.2], [0.15, 3.7], [0.22, 3.9], [0.05, 4.15]], 12, 'pav-col'),
+            marble
+        );
+        col.position.set(Math.cos(a) * 5.2, 0, Math.sin(a) * 5.2);
         group.add(col);
-        const cap = new THREE.Mesh(new THREE.SphereGeometry(0.28, 8, 6), gold);
-        cap.position.set(Math.cos(a) * 5.2, 4.4, Math.sin(a) * 5.2);
+        const cap = new THREE.Mesh(geo('pav-cap', () => new THREE.SphereGeometry(0.22, 10, 8)), gold);
+        cap.position.set(Math.cos(a) * 5.2, 4.28, Math.sin(a) * 5.2);
         group.add(cap);
     }
 
-    const roof = new THREE.Mesh(new THREE.ConeGeometry(6.8, 2.4, 8), gold);
-    roof.position.y = 5.4;
+    const roof = new THREE.Mesh(
+        lathe([[0.05, 2.35], [1.4, 1.7], [4.2, 0.55], [6.9, 0.08], [6.9, 0]], 16, 'pav-roof'),
+        gold
+    );
+    roof.position.y = 4.15;
     group.add(roof);
 
-    const arch = new THREE.Mesh(new THREE.TorusGeometry(1.6, 0.12, 8, 16, Math.PI), marble);
-    arch.position.set(0, 2.2, 6.3);
+    const arch = new THREE.Mesh(geo('pav-arch', () => new THREE.TorusGeometry(1.55, 0.1, 8, 20, Math.PI)), marble);
+    arch.position.set(0, 2.15, 6.25);
     arch.rotation.x = Math.PI;
     group.add(arch);
 
@@ -536,50 +983,45 @@ export function buildPavilion() {
 
 export function buildCouncilRing() {
     const group = new THREE.Group();
-    const stone = mapped(marbleTexture(), 0xe8e0d0);
-    const ring = new THREE.Mesh(new THREE.TorusGeometry(4.2, 0.22, 8, 32), stone);
+    const stone = mapped(marbleTexture(), 0xe8e0d0, 0.55, 0.06, 0.5);
+    const ring = new THREE.Mesh(geo('council-ring', () => new THREE.TorusGeometry(4.2, 0.2, 10, 40)), stone);
     ring.rotation.x = Math.PI / 2;
-    ring.position.y = 0.2;
+    ring.position.y = 0.18;
     group.add(ring);
     for (let i = 0; i < 9; i++) {
         const a = (i / 9) * Math.PI * 2;
-        const seat = new THREE.Mesh(new THREE.BoxGeometry(0.7, 0.55, 0.7), stone);
-        seat.position.set(Math.cos(a) * 3.4, 0.28, Math.sin(a) * 3.4);
-        seat.lookAt(0, 0.28, 0);
+        const seat = new THREE.Mesh(
+            lathe([[0.08, 0], [0.38, 0.02], [0.36, 0.28], [0.22, 0.32]], 10, 'council-seat'),
+            stone
+        );
+        seat.position.set(Math.cos(a) * 3.4, 0.02, Math.sin(a) * 3.4);
         group.add(seat);
+        const back = new THREE.Mesh(geo('council-back', () => new THREE.BoxGeometry(0.55, 0.7, 0.12)), stone);
+        back.position.set(Math.cos(a) * 3.72, 0.5, Math.sin(a) * 3.72);
+        back.lookAt(0, 0.5, 0);
+        group.add(back);
     }
-    enableShadows(group);
-    return group;
-}
-
-export function buildPillar(height = 14) {
-    const group = new THREE.Group();
-    const stone = mapped(stoneTexture('#6a5a48'), 0x7a6a58);
-    const col = new THREE.Mesh(new THREE.CylinderGeometry(0.7, 0.85, height, 8), stone);
-    col.position.y = height / 2;
-    group.add(col);
-    const base = new THREE.Mesh(new THREE.BoxGeometry(2.1, 0.5, 2.1), stone);
-    base.position.y = 0.25;
-    group.add(base);
-    const cap = new THREE.Mesh(new THREE.BoxGeometry(1.9, 0.4, 1.9), stone);
-    cap.position.y = height;
-    group.add(cap);
     enableShadows(group);
     return group;
 }
 
 export function buildBridge() {
     const group = new THREE.Group();
-    const stone = mapped(stoneTexture('#5a5048'), 0x6a6058);
-    const plank = new THREE.Mesh(new THREE.BoxGeometry(2.4, 0.28, 16), stone);
-    plank.position.y = 0.14;
-    group.add(plank);
-    for (const z of [-7, 7]) {
-        for (const x of [-1.1, 1.1]) {
-            const post = new THREE.Mesh(new THREE.BoxGeometry(0.18, 1.1, 0.18), stone);
+    const stone = mapped(stoneTexture('#5a5048'), 0x6a6058, 0.88, 0.04, 1.05);
+    for (let i = 0; i < 10; i++) {
+        const slab = new THREE.Mesh(geo('br-slab', () => new THREE.BoxGeometry(2.35, 0.26, 1.55)), stone);
+        slab.position.set((i % 2) * 0.06, 0.13, -7.2 + i * 1.6);
+        group.add(slab);
+    }
+    for (const z of [-7.2, 7.2]) {
+        for (const x of [-1.12, 1.12]) {
+            const post = new THREE.Mesh(geo('br-post', () => new THREE.BoxGeometry(0.16, 1.15, 0.16)), stone);
             post.position.set(x, 0.7, z);
             group.add(post);
         }
+        const rail = new THREE.Mesh(geo('br-rail', () => new THREE.BoxGeometry(2.4, 0.08, 0.1)), stone);
+        rail.position.set(0, 1.15, z);
+        group.add(rail);
     }
     enableShadows(group);
     return group;
@@ -587,31 +1029,56 @@ export function buildBridge() {
 
 export function buildSeat() {
     const group = new THREE.Group();
-    const stone = mapped(stoneTexture('#9a8a78'), 0xb0a090);
-    const base = new THREE.Mesh(new THREE.CylinderGeometry(1.6, 1.8, 0.5, 12), stone);
-    base.position.y = 0.25;
+    const stone = mapped(stoneTexture('#9a8a78'), 0xb0a090, 0.86, 0.04, 1.0);
+    const base = new THREE.Mesh(
+        lathe([[0.2, 0], [1.75, 0.02], [1.55, 0.42], [1.4, 0.5]], 16, 'seat-base'),
+        stone
+    );
     group.add(base);
-    const back = new THREE.Mesh(new THREE.BoxGeometry(1.5, 2.2, 0.28), stone);
-    back.position.set(0, 1.4, -0.55);
+    const back = new THREE.Mesh(
+        geo('seat-back', () => warp(new THREE.BoxGeometry(1.45, 2.25, 0.32), 70, 0.08, 0.5)),
+        stone
+    );
+    back.position.set(0, 1.45, -0.52);
     group.add(back);
-    const sit = new THREE.Mesh(new THREE.BoxGeometry(1.4, 0.28, 1.1), stone);
-    sit.position.set(0, 0.62, 0.1);
+    const sit = new THREE.Mesh(geo('seat-sit', () => new THREE.BoxGeometry(1.35, 0.22, 1.05)), stone);
+    sit.position.set(0, 0.62, 0.12);
     group.add(sit);
+    const arms = mapped(stoneTexture('#9a8a78'), 0xb0a090);
+    for (const sx of [-1, 1]) {
+        const arm = new THREE.Mesh(geo('seat-arm', () => new THREE.BoxGeometry(0.18, 0.55, 0.9)), arms);
+        arm.position.set(sx * 0.72, 0.85, 0.05);
+        group.add(arm);
+    }
     enableShadows(group);
     return group;
 }
 
 export function buildRuinArch() {
     const group = new THREE.Group();
-    const stone = mapped(stoneTexture('#8a7a68'), 0x9a8a78);
+    const stone = mapped(stoneTexture('#8a7a68'), 0x9a8a78, 0.9, 0.04, 1.15);
     for (const sx of [-1, 1]) {
-        const p = new THREE.Mesh(new THREE.BoxGeometry(0.55, 3.4, 0.55), stone);
-        p.position.set(sx * 1.4, 1.7, 0);
+        const p = new THREE.Mesh(
+            geo('ruin-p', () => warp(new THREE.BoxGeometry(0.58, 3.45, 0.58), 71, 0.1)),
+            stone
+        );
+        p.position.set(sx * 1.4, 1.72, 0);
         group.add(p);
     }
-    const lintel = new THREE.Mesh(new THREE.BoxGeometry(3.4, 0.45, 0.6), stone);
-    lintel.position.y = 3.5;
+    const lintel = new THREE.Mesh(
+        geo('ruin-lintel', () => warp(new THREE.BoxGeometry(3.45, 0.48, 0.62), 72, 0.08)),
+        stone
+    );
+    lintel.position.y = 3.52;
+    lintel.rotation.z = 0.04;
     group.add(lintel);
+    const ivy = mapped(leafTexture('#2f6a24'), 0x3a6a32, 0.85);
+    for (let i = 0; i < 6; i++) {
+        const leaf = new THREE.Mesh(geo('ruin-ivy', () => new THREE.SphereGeometry(0.12, 6, 5)), ivy);
+        leaf.position.set((i % 2 ? 1.4 : -1.4) + (hash2(i, 1) - 0.5) * 0.2, 0.4 + i * 0.45, 0.28);
+        leaf.scale.set(1.2, 0.5, 0.8);
+        group.add(leaf);
+    }
     enableShadows(group);
     return group;
 }
@@ -619,42 +1086,146 @@ export function buildRuinArch() {
 export function buildSword() {
     const group = new THREE.Group();
     const blade = new THREE.Mesh(
-        new THREE.BoxGeometry(0.05, 0.7, 0.12),
-        std(0xd8dee8, 0.25, 0.9)
+        geo('sw-blade', () => {
+            const g = new THREE.BoxGeometry(0.045, 0.72, 0.11);
+            const pos = g.attributes.position;
+            for (let i = 0; i < pos.count; i++) {
+                if (pos.getY(i) > 0.25) pos.setX(i, pos.getX(i) * 0.45);
+            }
+            g.computeVertexNormals();
+            return g;
+        }),
+        std(0xd8dee8, 0.22, 0.92)
     );
     blade.position.y = 0.4;
     group.add(blade);
-    const guard = new THREE.Mesh(new THREE.BoxGeometry(0.28, 0.05, 0.08), std(0xc9a227, 0.35, 0.8));
+    const guard = new THREE.Mesh(geo('sw-guard', () => new THREE.BoxGeometry(0.3, 0.045, 0.07)), mapped(goldTexture(), 0xc9a227, 0.32, 0.82, 0.3));
     group.add(guard);
-    const hilt = new THREE.Mesh(new THREE.CylinderGeometry(0.03, 0.035, 0.22, 8), std(0x4a3020, 0.8));
+    const hilt = new THREE.Mesh(geo('sw-hilt', () => new THREE.CylinderGeometry(0.028, 0.034, 0.22, 10)), mapped(leatherTexture(), 0x4a3020, 0.8));
     hilt.position.y = -0.12;
     group.add(hilt);
+    const pommel = new THREE.Mesh(geo('sw-pommel', () => new THREE.SphereGeometry(0.04, 8, 6)), mapped(goldTexture(), 0xc9a227, 0.3, 0.85));
+    pommel.position.y = -0.24;
+    group.add(pommel);
     return group;
 }
 
-/** Geometria de tufo de grama (dois planos cruzados) para InstancedMesh. */
+export function buildBalrog() {
+    const group = new THREE.Group();
+    const body = new THREE.Mesh(
+        lathe([[0.2, 0], [2.2, 0.2], [1.8, 2.4], [1.1, 5.2], [0.7, 7.2], [0.2, 8]], 10, 'balrog-body'),
+        mat('balrog', () => new THREE.MeshStandardMaterial({
+            color: 0x1a0804, emissive: 0xff3300, emissiveIntensity: 0.55, roughness: 0.72, metalness: 0.08
+        }))
+    );
+    group.add(body);
+    for (const sx of [-1, 1]) {
+        const horn = new THREE.Mesh(
+            geo('bal-horn', () => warp(new THREE.ConeGeometry(0.32, 2.4, 7), 80, 0.15)),
+            std(0x2a1008, 0.78)
+        );
+        horn.position.set(sx * 1.05, 8.1, 0.1);
+        horn.rotation.z = sx * 0.55;
+        horn.rotation.x = -0.25;
+        group.add(horn);
+        const wing = new THREE.Mesh(
+            geo('bal-wing', () => new THREE.PlaneGeometry(3.2, 4.4, 4, 4)),
+            mat('bal-wing', () => new THREE.MeshStandardMaterial({
+                color: 0x120804, emissive: 0x881100, emissiveIntensity: 0.35,
+                side: THREE.DoubleSide, transparent: true, opacity: 0.72, roughness: 0.9
+            }))
+        );
+        wing.position.set(sx * 2.1, 5.2, -0.4);
+        wing.rotation.y = sx * 0.7;
+        group.add(wing);
+    }
+    const eye = new THREE.Mesh(
+        geo('bal-eye', () => new THREE.SphereGeometry(0.32, 10, 8)),
+        mat('bal-eye', () => new THREE.MeshStandardMaterial({
+            color: 0xffee88, emissive: 0xffaa00, emissiveIntensity: 4.2, roughness: 0.2
+        }))
+    );
+    eye.position.set(0, 6.15, 1.35);
+    group.add(eye);
+    const whip = new THREE.Mesh(
+        geo('bal-whip', () => new THREE.CylinderGeometry(0.04, 0.09, 6.5, 6)),
+        mat('bal-whip', () => new THREE.MeshStandardMaterial({
+            color: 0xff6611, emissive: 0xff3300, emissiveIntensity: 2.2, roughness: 0.4
+        }))
+    );
+    whip.position.set(2.2, 3.2, 0.8);
+    whip.rotation.z = -0.9;
+    whip.rotation.x = 0.4;
+    group.add(whip);
+    group.userData.eye = eye;
+    group.userData.whip = whip;
+    enableShadows(group);
+    return group;
+}
+
 export function grassBladeGeometry() {
-    const geo = new THREE.PlaneGeometry(0.35, 0.55);
-    geo.translate(0, 0.27, 0);
-    return geo;
+    return geo('grass-cross', () => {
+        const a = new THREE.PlaneGeometry(0.38, 0.72);
+        a.translate(0, 0.36, 0);
+        const b = a.clone();
+        b.rotateY(Math.PI / 2);
+        const merged = mergeGeometries([a, b], false);
+        a.dispose();
+        b.dispose();
+        return merged;
+    });
+}
+
+export function grassBladeMaterial() {
+    return mat('grass-blade', () => {
+        const m = new THREE.MeshStandardMaterial({
+            map: grassBladeTexture(),
+            color: 0xb8d878,
+            side: THREE.DoubleSide,
+            transparent: true,
+            alphaTest: 0.28,
+            roughness: 0.92,
+            metalness: 0
+        });
+        vegWind(m, 0.16);
+        return m;
+    });
 }
 
 export function applyGrassWind(material, strength = 1) {
-    material.userData.uTime = { value: 0 };
-    material.onBeforeCompile = (shader) => {
-        shader.uniforms.uTime = material.userData.uTime;
-        shader.vertexShader = shader.vertexShader
-            .replace(
-                '#include <common>',
-                /* glsl */ `#include <common>
-                uniform float uTime;`
-            )
-            .replace(
-                '#include <begin_vertex>',
-                /* glsl */ `#include <begin_vertex>
-                float h = uv.y;
-                transformed.x += sin(uTime * 1.6 + position.x * 0.4) * 0.12 * h * ${strength.toFixed(2)};
-                transformed.z += cos(uTime * 1.3 + position.z * 0.35) * 0.08 * h * ${strength.toFixed(2)};`
-            );
-    };
+    vegWind(material, 0.12 * strength);
+}
+
+export function waterMaterial(color = 0x3a8aaa) {
+    const maps = waterTexture();
+    return mat(`water:${color}`, () => {
+        const m = new THREE.MeshStandardMaterial({
+            color,
+            transparent: true,
+            opacity: 0.78,
+            roughness: 0.12,
+            metalness: 0.45,
+            side: THREE.DoubleSide
+        });
+        applyMaps(m, maps, { color, roughness: 0.12, metalness: 0.45, normalScale: 1.4 });
+        m.userData.uTime = { value: 0 };
+        m.onBeforeCompile = (shader) => {
+            shader.uniforms.uTime = m.userData.uTime;
+            shader.vertexShader = shader.vertexShader
+                .replace(
+                    '#include <common>',
+                    /* glsl */ `#include <common>
+                    uniform float uTime;`
+                )
+                .replace(
+                    '#include <begin_vertex>',
+                    /* glsl */ `#include <begin_vertex>
+                    transformed.y += sin(uTime * 1.4 + position.x * 0.18 + position.z * 0.14) * 0.08
+                                   + sin(uTime * 0.9 + position.z * 0.22) * 0.05;`
+                );
+        };
+        m.customProgramCacheKey = () => 'anel-water';
+        animatedMats.push(m);
+        return m;
+    });
 }

--- a/labs/jornada-do-anel/src/npcs.js
+++ b/labs/jornada-do-anel/src/npcs.js
@@ -2,7 +2,7 @@
  * IA dos Cavaleiros Negros (visão + perseguição) e dos goblins (aggro).
  */
 
-import { clamp } from './utils.js';
+import { clamp } from './utils.js?v=3';
 
 export class Rider {
     constructor(group, x, z, waypoints) {
@@ -20,6 +20,7 @@ export class Rider {
         this.alive = true;
         this.catchR = 1.35;
         this.alert = 0;
+        this.walkPhase = 0;
     }
 
     update(dt, player, heightAt) {
@@ -63,10 +64,18 @@ export class Rider {
         this.alert = Math.max(0, this.alert - dt * 0.35);
 
         const y = heightAt(this.x, this.z);
-        this.group.position.set(this.x, y, this.z);
+        this.walkPhase += dt * sp * 2.1;
+        this.group.position.set(this.x, y + Math.abs(Math.sin(this.walkPhase)) * 0.07, this.z);
         this.group.rotation.y = this.yaw;
-        const gait = Date.now() * 0.008;
-        this.group.position.y = y + Math.abs(Math.sin(gait)) * 0.06;
+        const legs = this.group.userData.parts?.horseLegs;
+        if (legs) {
+            const wave = Math.sin(this.walkPhase);
+            for (const leg of legs) {
+                const g = wave * 0.42 * (leg.userData.sign || 1);
+                leg.rotation.x = g;
+                if (leg.userData.lower) leg.userData.lower.rotation.x = Math.max(0, -g * 0.55);
+            }
+        }
 
         if (dist < this.catchR) return 'caught';
         if (this.state === 'chase') return 'chase';

--- a/labs/jornada-do-anel/src/player.js
+++ b/labs/jornada-do-anel/src/player.js
@@ -4,9 +4,9 @@
  */
 
 import * as THREE from 'three';
-import { PLAYER, CAMERA } from './config.js';
-import { clamp, damp } from './utils.js';
-import { buildHobbit, buildSword } from './models.js';
+import { PLAYER, CAMERA } from './config.js?v=3';
+import { clamp, damp } from './utils.js?v=3';
+import { buildHobbit, buildSword } from './models.js?v=3';
 
 export class Player {
     constructor(scene) {
@@ -150,8 +150,16 @@ export class Player {
         const gait = len > 0.08 ? Math.sin(this.walkPhase) : 0;
         this.parts.legs[0].rotation.x = gait * 0.7;
         this.parts.legs[1].rotation.x = -gait * 0.7;
+        const shin0 = this.parts.legs[0].userData.shin;
+        const shin1 = this.parts.legs[1].userData.shin;
+        if (shin0) shin0.rotation.x = Math.max(0, -gait * 0.55);
+        if (shin1) shin1.rotation.x = Math.max(0, gait * 0.55);
         this.parts.arms[0].rotation.x = -gait * 0.5;
         this.parts.arms[1].rotation.x = gait * 0.5 - swing * 1.4;
+        const fore0 = this.parts.arms[0].userData.forearm;
+        const fore1 = this.parts.arms[1].userData.forearm;
+        if (fore0) fore0.rotation.x = Math.max(0, gait * 0.22);
+        if (fore1) fore1.rotation.x = Math.max(0, -gait * 0.22) - swing * 0.35;
         this.parts.torso.rotation.y = gait * 0.08;
         this.parts.head.rotation.y = gait * 0.06;
 

--- a/labs/jornada-do-anel/src/sky.js
+++ b/labs/jornada-do-anel/src/sky.js
@@ -1,15 +1,19 @@
 /**
- * Céu procedural (gradiente em esfera) e rig de iluminação por capítulo.
+ * Céu procedural com sol, nuvens e estrelas — cada capítulo troca a paleta.
  */
 
 import * as THREE from 'three';
+import { cloudTexture } from './textures.js?v=3';
 
 export function createSky() {
-    const geo = new THREE.SphereGeometry(420, 24, 16);
+    const geo = new THREE.SphereGeometry(420, 32, 20);
     const uniforms = {
         top: { value: new THREE.Color(0x87b8e0) },
         mid: { value: new THREE.Color(0xc8dce8) },
-        bot: { value: new THREE.Color(0xe8d8b0) }
+        bot: { value: new THREE.Color(0xe8d8b0) },
+        sunDir: { value: new THREE.Vector3(0.4, 0.8, 0.3).normalize() },
+        sunColor: { value: new THREE.Color(0xffe8b0) },
+        sunSize: { value: 0.035 }
     };
     const mat = new THREE.ShaderMaterial({
         uniforms,
@@ -27,25 +31,97 @@ export function createSky() {
             uniform vec3 top;
             uniform vec3 mid;
             uniform vec3 bot;
+            uniform vec3 sunDir;
+            uniform vec3 sunColor;
+            uniform float sunSize;
             void main() {
-                float h = normalize(vPos).y * 0.5 + 0.5;
-                vec3 col = mix(bot, mid, smoothstep(0.0, 0.45, h));
-                col = mix(col, top, smoothstep(0.4, 1.0, h));
+                vec3 n = normalize(vPos);
+                float h = n.y * 0.5 + 0.5;
+                vec3 col = mix(bot, mid, smoothstep(0.0, 0.42, h));
+                col = mix(col, top, smoothstep(0.38, 1.0, h));
+                float sun = pow(max(dot(n, sunDir), 0.0), 8.0);
+                float disc = smoothstep(1.0 - sunSize * 3.5, 1.0 - sunSize, max(dot(n, sunDir), 0.0));
+                col += sunColor * sun * 0.35;
+                col += sunColor * disc * 1.4;
+                float haze = pow(1.0 - abs(n.y), 4.0);
+                col = mix(col, mix(bot, sunColor, 0.35), haze * 0.35);
                 gl_FragColor = vec4(col, 1.0);
             }
         `
     });
     const mesh = new THREE.Mesh(geo, mat);
     mesh.frustumCulled = false;
-    return { mesh, uniforms };
+
+    const clouds = new THREE.Group();
+    const cTex = cloudTexture();
+    const cMat = new THREE.MeshBasicMaterial({
+        map: cTex,
+        transparent: true,
+        opacity: 0.72,
+        depthWrite: false,
+        side: THREE.DoubleSide
+    });
+    for (let i = 0; i < 10; i++) {
+        const p = new THREE.Mesh(new THREE.PlaneGeometry(48 + (i % 3) * 18, 22 + (i % 2) * 10), cMat);
+        const a = (i / 10) * Math.PI * 2;
+        p.position.set(Math.cos(a) * 90, 28 + (i % 4) * 8, Math.sin(a) * 90);
+        p.lookAt(0, 20, 0);
+        p.userData.speed = 0.015 + (i % 5) * 0.004;
+        p.userData.radius = 90 + (i % 3) * 12;
+        p.userData.base = a;
+        clouds.add(p);
+    }
+    mesh.add(clouds);
+
+    const starGeo = new THREE.BufferGeometry();
+    const starN = 420;
+    const starPos = new Float32Array(starN * 3);
+    for (let i = 0; i < starN; i++) {
+        const a = Math.random() * Math.PI * 2;
+        const h = 0.15 + Math.random() * 0.85;
+        const r = 380;
+        starPos[i * 3] = Math.cos(a) * r * Math.sqrt(1 - h * h);
+        starPos[i * 3 + 1] = h * r;
+        starPos[i * 3 + 2] = Math.sin(a) * r * Math.sqrt(1 - h * h);
+    }
+    starGeo.setAttribute('position', new THREE.BufferAttribute(starPos, 3));
+    const stars = new THREE.Points(
+        starGeo,
+        new THREE.PointsMaterial({ color: 0xdce8ff, size: 1.6, sizeAttenuation: false, transparent: true, opacity: 0.85, depthWrite: false })
+    );
+    stars.visible = false;
+    mesh.add(stars);
+
+    return { mesh, uniforms, clouds, stars, cloudMat: cMat };
 }
 
 export function applyChapterSky(sky, chapter) {
     const fog = new THREE.Color(chapter.fog.color);
     const sun = new THREE.Color(chapter.sun.color);
-    sky.uniforms.top.value.copy(new THREE.Color(chapter.clear)).multiplyScalar(1.05);
-    sky.uniforms.mid.value.copy(fog).lerp(sun, 0.25);
-    sky.uniforms.bot.value.copy(fog).lerp(new THREE.Color(chapter.hemi.ground), 0.35);
+    sky.uniforms.top.value.copy(new THREE.Color(chapter.clear)).multiplyScalar(1.08);
+    sky.uniforms.mid.value.copy(fog).lerp(sun, 0.28);
+    sky.uniforms.bot.value.copy(fog).lerp(new THREE.Color(chapter.hemi.ground), 0.4);
+    const d = chapter.sun.dir;
+    sky.uniforms.sunDir.value.set(d[0], d[1], d[2]).normalize();
+    sky.uniforms.sunColor.value.copy(sun);
+    sky.uniforms.sunSize.value = chapter.id === 'amonhen' ? 0.055 : chapter.id === 'forest' || chapter.id === 'moria' ? 0.012 : 0.032;
+    const night = chapter.id === 'forest' || chapter.id === 'moria';
+    sky.stars.visible = night;
+    sky.clouds.visible = !night;
+    sky.cloudMat.opacity = chapter.id === 'rivendell' ? 0.55 : chapter.id === 'amonhen' ? 0.4 : 0.7;
+    sky.cloudMat.color.set(chapter.id === 'amonhen' ? 0xffc090 : 0xffffff);
+}
+
+export function tickSky(sky, t) {
+    if (!sky.clouds.visible) return;
+    const origin = sky.mesh.position;
+    sky.clouds.children.forEach((p) => {
+        const a = p.userData.base + t * p.userData.speed;
+        const r = p.userData.radius;
+        p.position.x = Math.cos(a) * r;
+        p.position.z = Math.sin(a) * r;
+        p.lookAt(origin);
+    });
 }
 
 export function createLights(scene, chapter, quality) {
@@ -64,17 +140,22 @@ export function createLights(scene, chapter, quality) {
     dir.castShadow = quality.shadows;
     if (quality.shadows) {
         dir.shadow.mapSize.set(quality.shadowSize, quality.shadowSize);
-        const s = 48;
+        const s = 42;
         dir.shadow.camera.left = -s;
         dir.shadow.camera.right = s;
         dir.shadow.camera.top = s;
         dir.shadow.camera.bottom = -s;
-        dir.shadow.camera.near = 10;
-        dir.shadow.camera.far = 180;
-        dir.shadow.bias = -0.0008;
+        dir.shadow.camera.near = 8;
+        dir.shadow.camera.far = 160;
+        dir.shadow.bias = -0.0006;
+        dir.shadow.normalBias = 0.04;
     }
     group.add(dir);
     group.add(dir.target);
 
-    return { group, dir, hemi, amb };
+    const fill = new THREE.DirectionalLight(chapter.hemi.sky, chapter.sun.intensity * 0.18);
+    fill.position.set(-d[0] * 40, Math.max(12, d[1] * 20), -d[2] * 40);
+    group.add(fill);
+
+    return { group, dir, hemi, amb, fill };
 }

--- a/labs/jornada-do-anel/src/textures.js
+++ b/labs/jornada-do-anel/src/textures.js
@@ -1,9 +1,10 @@
 /**
  * Texturas procedurais em canvas — o lab não depende de PNG externos.
+ * Albedo + normal + roughness para o PBR não parecer plástico liso.
  */
 
 import * as THREE from 'three';
-import { hash2 } from './utils.js';
+import { hash2 } from './utils.js?v=3';
 
 const cache = new Map();
 
@@ -20,7 +21,9 @@ function toTexture(el, { repeat = [1, 1], srgb = true, aniso = 4 } = {}) {
     tex.repeat.set(repeat[0], repeat[1]);
     tex.anisotropy = aniso;
     if (srgb) tex.colorSpace = THREE.SRGBColorSpace;
+    else tex.colorSpace = THREE.LinearSRGBColorSpace;
     tex.needsUpdate = true;
+    tex.userData.shared = true;
     return tex;
 }
 
@@ -43,25 +46,94 @@ function grain(ctx, w, h, amount, seed = 0) {
     ctx.putImageData(img, 0, 0);
 }
 
+/** Normal map a partir da luminância do albedo (não sRGB). */
+function normalFrom(src, scale = 2.4) {
+    const w = src.width;
+    const h = src.height;
+    const sctx = src.getContext('2d');
+    const srcData = sctx.getImageData(0, 0, w, h).data;
+    const el = canvas(w, h);
+    const ctx = el.getContext('2d');
+    const out = ctx.createImageData(w, h);
+    const d = out.data;
+    const lum = (x, y) => {
+        const i = (((y + h) % h) * w + ((x + w) % w)) * 4;
+        return srcData[i] * 0.3 + srcData[i + 1] * 0.59 + srcData[i + 2] * 0.11;
+    };
+    for (let y = 0; y < h; y++) {
+        for (let x = 0; x < w; x++) {
+            const nx = (lum(x - 1, y) - lum(x + 1, y)) / 255 * scale;
+            const ny = (lum(x, y - 1) - lum(x, y + 1)) / 255 * scale;
+            const nz = 1;
+            const len = Math.hypot(nx, ny, nz) || 1;
+            const i = (y * w + x) * 4;
+            d[i] = (nx / len * 0.5 + 0.5) * 255;
+            d[i + 1] = (ny / len * 0.5 + 0.5) * 255;
+            d[i + 2] = (nz / len * 0.5 + 0.5) * 255;
+            d[i + 3] = 255;
+        }
+    }
+    ctx.putImageData(out, 0, 0);
+    return el;
+}
+
+function roughnessFrom(src, base = 0.72, contrast = 0.35) {
+    const w = src.width;
+    const h = src.height;
+    const sctx = src.getContext('2d');
+    const srcData = sctx.getImageData(0, 0, w, h).data;
+    const el = canvas(w, h);
+    const ctx = el.getContext('2d');
+    const out = ctx.createImageData(w, h);
+    const d = out.data;
+    for (let i = 0; i < srcData.length; i += 4) {
+        const l = (srcData[i] * 0.3 + srcData[i + 1] * 0.59 + srcData[i + 2] * 0.11) / 255;
+        const r = Math.max(0, Math.min(1, base + (0.5 - l) * contrast));
+        const v = r * 255;
+        d[i] = d[i + 1] = d[i + 2] = v;
+        d[i + 3] = 255;
+    }
+    ctx.putImageData(out, 0, 0);
+    return el;
+}
+
+function packMaps(albedoEl, { repeat = [1, 1], bump = 2.2, roughBase = 0.75, aniso = 4 } = {}) {
+    const map = toTexture(albedoEl, { repeat, srgb: true, aniso });
+    const normalMap = toTexture(normalFrom(albedoEl, bump), { repeat, srgb: false, aniso });
+    const roughnessMap = toTexture(roughnessFrom(albedoEl, roughBase), { repeat, srgb: false, aniso });
+    return { map, normalMap, roughnessMap };
+}
+
 export function grassTexture() {
     return cached('grass', () => {
         const size = 256;
         const el = canvas(size);
         const ctx = el.getContext('2d');
-        ctx.fillStyle = '#4a7a28';
+        const g = ctx.createLinearGradient(0, 0, size, size);
+        g.addColorStop(0, '#3d6a22');
+        g.addColorStop(0.5, '#4e7e2c');
+        g.addColorStop(1, '#355c1c');
+        ctx.fillStyle = g;
         ctx.fillRect(0, 0, size, size);
-        for (let i = 0; i < 900; i++) {
+        for (let i = 0; i < 1400; i++) {
             const x = hash2(i, 2) * size;
             const y = hash2(i, 9) * size;
-            ctx.strokeStyle = hash2(i, 4) > 0.5 ? '#6a9a38' : '#3a6218';
-            ctx.globalAlpha = 0.45;
+            ctx.strokeStyle = hash2(i, 4) > 0.55 ? '#6ea83c' : '#2d5414';
+            ctx.globalAlpha = 0.38 + hash2(i, 7) * 0.25;
+            ctx.lineWidth = 1 + hash2(i, 8);
             ctx.beginPath();
             ctx.moveTo(x, y);
-            ctx.lineTo(x + (hash2(i, 5) - 0.5) * 4, y - 6 - hash2(i, 6) * 8);
+            ctx.quadraticCurveTo(
+                x + (hash2(i, 5) - 0.5) * 6,
+                y - 5,
+                x + (hash2(i, 11) - 0.5) * 5,
+                y - 8 - hash2(i, 6) * 12
+            );
             ctx.stroke();
         }
-        grain(ctx, size, size, 22, 3);
-        return toTexture(el, { repeat: [18, 18] });
+        ctx.globalAlpha = 1;
+        grain(ctx, size, size, 18, 3);
+        return packMaps(el, { repeat: [22, 22], bump: 1.8, roughBase: 0.92 });
     });
 }
 
@@ -72,8 +144,14 @@ export function dirtTexture() {
         const ctx = el.getContext('2d');
         ctx.fillStyle = '#6a4a2c';
         ctx.fillRect(0, 0, size, size);
-        grain(ctx, size, size, 48, 8);
-        return toTexture(el, { repeat: [10, 10] });
+        for (let i = 0; i < 80; i++) {
+            ctx.fillStyle = `rgba(${90 + hash2(i, 1) * 40},${60 + hash2(i, 2) * 30},${30},0.25)`;
+            ctx.beginPath();
+            ctx.ellipse(hash2(i, 3) * size, hash2(i, 4) * size, 6 + hash2(i, 5) * 18, 4 + hash2(i, 6) * 10, hash2(i, 7) * 4, 0, Math.PI * 2);
+            ctx.fill();
+        }
+        grain(ctx, size, size, 42, 8);
+        return packMaps(el, { repeat: [10, 10], bump: 2.6, roughBase: 0.94 });
     });
 }
 
@@ -82,16 +160,16 @@ export function mossTexture() {
         const size = 256;
         const el = canvas(size);
         const ctx = el.getContext('2d');
-        ctx.fillStyle = '#3d5a28';
+        ctx.fillStyle = '#2f4a22';
         ctx.fillRect(0, 0, size, size);
-        for (let i = 0; i < 80; i++) {
-            ctx.fillStyle = `rgba(${40 + hash2(i, 1) * 40},${90 + hash2(i, 2) * 50},${20},0.4)`;
+        for (let i = 0; i < 110; i++) {
+            ctx.fillStyle = `rgba(${36 + hash2(i, 1) * 50},${80 + hash2(i, 2) * 70},${18},0.45)`;
             ctx.beginPath();
-            ctx.arc(hash2(i, 3) * size, hash2(i, 4) * size, 8 + hash2(i, 5) * 22, 0, Math.PI * 2);
+            ctx.arc(hash2(i, 3) * size, hash2(i, 4) * size, 6 + hash2(i, 5) * 26, 0, Math.PI * 2);
             ctx.fill();
         }
-        grain(ctx, size, size, 30, 2);
-        return toTexture(el, { repeat: [6, 6] });
+        grain(ctx, size, size, 26, 2);
+        return packMaps(el, { repeat: [8, 8], bump: 2.1, roughBase: 0.9 });
     });
 }
 
@@ -102,16 +180,27 @@ export function barkTexture() {
         const ctx = el.getContext('2d');
         ctx.fillStyle = '#3a2618';
         ctx.fillRect(0, 0, size, size);
-        for (let x = 0; x < size; x += 7) {
-            ctx.strokeStyle = hash2(x, 1) > 0.5 ? '#5a3a24' : '#2a1810';
-            ctx.lineWidth = 2 + hash2(x, 2) * 3;
+        for (let x = 0; x < size; x += 6) {
+            ctx.strokeStyle = hash2(x, 1) > 0.5 ? '#5c3c26' : '#24140c';
+            ctx.lineWidth = 2 + hash2(x, 2) * 4;
             ctx.beginPath();
             ctx.moveTo(x, 0);
-            ctx.lineTo(x + (hash2(x, 3) - 0.5) * 8, size);
+            let y = 0;
+            while (y < size) {
+                const nx = x + (hash2(x, y + 3) - 0.5) * 10;
+                ctx.lineTo(nx, y + 18);
+                y += 18;
+            }
             ctx.stroke();
         }
-        grain(ctx, size, size, 28, 4);
-        return toTexture(el, { repeat: [2, 4] });
+        for (let i = 0; i < 40; i++) {
+            ctx.strokeStyle = 'rgba(20,10,6,0.45)';
+            ctx.beginPath();
+            ctx.ellipse(hash2(i, 8) * size, hash2(i, 9) * size, 4, 14, 0.2, 0, Math.PI * 2);
+            ctx.stroke();
+        }
+        grain(ctx, size, size, 24, 4);
+        return packMaps(el, { repeat: [2, 5], bump: 3.4, roughBase: 0.92 });
     });
 }
 
@@ -122,15 +211,16 @@ export function leafTexture(tint = '#2f6a24') {
         const ctx = el.getContext('2d');
         ctx.fillStyle = tint;
         ctx.fillRect(0, 0, size, size);
-        for (let i = 0; i < 400; i++) {
-            ctx.fillStyle = hash2(i, 1) > 0.5 ? '#4a8a32' : '#1e4a16';
-            ctx.globalAlpha = 0.35;
+        for (let i = 0; i < 520; i++) {
+            ctx.fillStyle = hash2(i, 1) > 0.5 ? '#4a8a32' : '#1a4214';
+            ctx.globalAlpha = 0.32;
             ctx.beginPath();
-            ctx.ellipse(hash2(i, 2) * size, hash2(i, 3) * size, 4, 8, hash2(i, 4) * 6, 0, Math.PI * 2);
+            ctx.ellipse(hash2(i, 2) * size, hash2(i, 3) * size, 3 + hash2(i, 8) * 5, 7 + hash2(i, 9) * 8, hash2(i, 4) * 6, 0, Math.PI * 2);
             ctx.fill();
         }
-        grain(ctx, size, size, 24, 5);
-        return toTexture(el, { repeat: [2, 2] });
+        ctx.globalAlpha = 1;
+        grain(ctx, size, size, 20, 5);
+        return packMaps(el, { repeat: [2, 2], bump: 1.6, roughBase: 0.78 });
     });
 }
 
@@ -141,15 +231,25 @@ export function stoneTexture(tint = '#8a8680') {
         const ctx = el.getContext('2d');
         ctx.fillStyle = tint;
         ctx.fillRect(0, 0, size, size);
-        for (let i = 0; i < 40; i++) {
-            ctx.strokeStyle = `rgba(0,0,0,${0.08 + hash2(i, 1) * 0.12})`;
+        for (let i = 0; i < 55; i++) {
+            ctx.strokeStyle = `rgba(0,0,0,${0.08 + hash2(i, 1) * 0.16})`;
+            ctx.lineWidth = 1 + hash2(i, 8) * 2;
             ctx.beginPath();
             ctx.moveTo(hash2(i, 2) * size, hash2(i, 3) * size);
-            ctx.lineTo(hash2(i, 4) * size, hash2(i, 5) * size);
+            ctx.quadraticCurveTo(
+                hash2(i, 6) * size, hash2(i, 7) * size,
+                hash2(i, 4) * size, hash2(i, 5) * size
+            );
             ctx.stroke();
         }
-        grain(ctx, size, size, 36, 6);
-        return toTexture(el, { repeat: [4, 4] });
+        for (let i = 0; i < 24; i++) {
+            ctx.fillStyle = `rgba(255,255,255,${0.03 + hash2(i, 12) * 0.05})`;
+            ctx.beginPath();
+            ctx.arc(hash2(i, 13) * size, hash2(i, 14) * size, 4 + hash2(i, 15) * 12, 0, Math.PI * 2);
+            ctx.fill();
+        }
+        grain(ctx, size, size, 32, 6);
+        return packMaps(el, { repeat: [4, 4], bump: 2.8, roughBase: 0.88 });
     });
 }
 
@@ -158,22 +258,22 @@ export function marbleTexture() {
         const size = 256;
         const el = canvas(size);
         const ctx = el.getContext('2d');
-        ctx.fillStyle = '#e8e4d8';
+        ctx.fillStyle = '#efeae0';
         ctx.fillRect(0, 0, size, size);
-        for (let i = 0; i < 18; i++) {
-            ctx.strokeStyle = `rgba(160,150,120,${0.15 + hash2(i, 1) * 0.2})`;
-            ctx.lineWidth = 1 + hash2(i, 2) * 2;
+        for (let i = 0; i < 22; i++) {
+            ctx.strokeStyle = `rgba(150,140,112,${0.12 + hash2(i, 1) * 0.22})`;
+            ctx.lineWidth = 1 + hash2(i, 2) * 2.4;
             ctx.beginPath();
             ctx.moveTo(0, hash2(i, 3) * size);
             ctx.bezierCurveTo(
                 size * 0.3, hash2(i, 4) * size,
-                size * 0.6, hash2(i, 5) * size,
+                size * 0.65, hash2(i, 5) * size,
                 size, hash2(i, 6) * size
             );
             ctx.stroke();
         }
-        grain(ctx, size, size, 18, 7);
-        return toTexture(el, { repeat: [3, 3] });
+        grain(ctx, size, size, 14, 7);
+        return packMaps(el, { repeat: [3, 3], bump: 1.2, roughBase: 0.38 });
     });
 }
 
@@ -184,14 +284,26 @@ export function woodTexture() {
         const ctx = el.getContext('2d');
         ctx.fillStyle = '#6b4428';
         ctx.fillRect(0, 0, size, size);
-        const planks = 6;
+        const planks = 7;
         const ph = size / planks;
         for (let i = 0; i < planks; i++) {
-            ctx.fillStyle = i % 2 ? '#7a5130' : '#5c3a20';
+            ctx.fillStyle = i % 2 ? '#7e5634' : '#5a3820';
             ctx.fillRect(0, i * ph + 1, size, ph - 2);
+            ctx.strokeStyle = 'rgba(30,16,8,0.35)';
+            ctx.beginPath();
+            ctx.moveTo(0, i * ph);
+            ctx.lineTo(size, i * ph);
+            ctx.stroke();
+            for (let x = 0; x < size; x += 18) {
+                ctx.strokeStyle = `rgba(40,22,10,${0.08 + hash2(i, x) * 0.12})`;
+                ctx.beginPath();
+                ctx.moveTo(x, i * ph + 2);
+                ctx.lineTo(x + (hash2(x, i) - 0.5) * 8, (i + 1) * ph - 2);
+                ctx.stroke();
+            }
         }
-        grain(ctx, size, size, 26, 9);
-        return toTexture(el, { repeat: [2, 2] });
+        grain(ctx, size, size, 22, 9);
+        return packMaps(el, { repeat: [2, 2], bump: 2.2, roughBase: 0.78 });
     });
 }
 
@@ -201,14 +313,22 @@ export function goldTexture() {
         const el = canvas(size);
         const ctx = el.getContext('2d');
         const g = ctx.createLinearGradient(0, 0, size, size);
-        g.addColorStop(0, '#fff3b0');
-        g.addColorStop(0.4, '#d4a017');
-        g.addColorStop(0.7, '#8a5a10');
-        g.addColorStop(1, '#f0d060');
+        g.addColorStop(0, '#fff6c4');
+        g.addColorStop(0.28, '#e8c04a');
+        g.addColorStop(0.55, '#c48a18');
+        g.addColorStop(0.78, '#8a5a10');
+        g.addColorStop(1, '#f2d56a');
         ctx.fillStyle = g;
         ctx.fillRect(0, 0, size, size);
-        grain(ctx, size, size, 20, 11);
-        return toTexture(el, { repeat: [1, 1] });
+        for (let i = 0; i < 18; i++) {
+            ctx.strokeStyle = `rgba(255,240,180,${0.12 + hash2(i, 2) * 0.18})`;
+            ctx.beginPath();
+            ctx.moveTo(hash2(i, 3) * size, 0);
+            ctx.lineTo(hash2(i, 4) * size, size);
+            ctx.stroke();
+        }
+        grain(ctx, size, size, 16, 11);
+        return packMaps(el, { repeat: [1, 1], bump: 1.4, roughBase: 0.22 });
     });
 }
 
@@ -219,19 +339,30 @@ export function doorTexture(color = '#2d6b38') {
         const ctx = el.getContext('2d');
         ctx.fillStyle = color;
         ctx.fillRect(0, 0, size, size);
-        ctx.strokeStyle = 'rgba(0,0,0,0.25)';
-        ctx.lineWidth = 6;
-        for (let i = 1; i < 5; i++) {
+        ctx.strokeStyle = 'rgba(20,12,6,0.32)';
+        ctx.lineWidth = 7;
+        for (let i = 1; i < 6; i++) {
             ctx.beginPath();
-            ctx.arc(size / 2, size / 2, (size / 2) * (i / 5), 0, Math.PI * 2);
+            ctx.arc(size / 2, size / 2, (size / 2) * (i / 6), 0, Math.PI * 2);
             ctx.stroke();
         }
-        ctx.fillStyle = '#c9a227';
+        for (let a = 0; a < 8; a++) {
+            const ang = (a / 8) * Math.PI * 2;
+            ctx.beginPath();
+            ctx.moveTo(size / 2, size / 2);
+            ctx.lineTo(size / 2 + Math.cos(ang) * size * 0.48, size / 2 + Math.sin(ang) * size * 0.48);
+            ctx.stroke();
+        }
+        ctx.fillStyle = '#d4b24a';
         ctx.beginPath();
-        ctx.arc(size * 0.72, size * 0.5, 10, 0, Math.PI * 2);
+        ctx.arc(size * 0.74, size * 0.5, 11, 0, Math.PI * 2);
         ctx.fill();
-        grain(ctx, size, size, 18, 12);
-        return toTexture(el, { repeat: [1, 1] });
+        ctx.fillStyle = '#6a4a18';
+        ctx.beginPath();
+        ctx.arc(size * 0.74, size * 0.5, 3, 0, Math.PI * 2);
+        ctx.fill();
+        grain(ctx, size, size, 16, 12);
+        return packMaps(el, { repeat: [1, 1], bump: 2.0, roughBase: 0.62 });
     });
 }
 
@@ -241,19 +372,20 @@ export function waterTexture() {
         const el = canvas(size);
         const ctx = el.getContext('2d');
         const g = ctx.createLinearGradient(0, 0, size, size);
-        g.addColorStop(0, '#1a4a6a');
-        g.addColorStop(0.5, '#2a7a88');
-        g.addColorStop(1, '#163a58');
+        g.addColorStop(0, '#163a58');
+        g.addColorStop(0.45, '#2a7a88');
+        g.addColorStop(1, '#0e2a44');
         ctx.fillStyle = g;
         ctx.fillRect(0, 0, size, size);
-        for (let i = 0; i < 20; i++) {
-            ctx.strokeStyle = `rgba(200,230,255,${0.08 + hash2(i, 1) * 0.1})`;
+        for (let i = 0; i < 28; i++) {
+            ctx.strokeStyle = `rgba(200,230,255,${0.07 + hash2(i, 1) * 0.12})`;
+            ctx.lineWidth = 1 + hash2(i, 8) * 2;
             ctx.beginPath();
             ctx.moveTo(0, hash2(i, 2) * size);
-            ctx.bezierCurveTo(size * 0.4, hash2(i, 3) * size, size * 0.7, hash2(i, 4) * size, size, hash2(i, 5) * size);
+            ctx.bezierCurveTo(size * 0.35, hash2(i, 3) * size, size * 0.7, hash2(i, 4) * size, size, hash2(i, 5) * size);
             ctx.stroke();
         }
-        return toTexture(el, { repeat: [8, 8] });
+        return packMaps(el, { repeat: [10, 10], bump: 3.6, roughBase: 0.12 });
     });
 }
 
@@ -262,18 +394,178 @@ export function brickTexture() {
         const size = 256;
         const el = canvas(size);
         const ctx = el.getContext('2d');
-        ctx.fillStyle = '#4a4038';
+        ctx.fillStyle = '#3a342c';
         ctx.fillRect(0, 0, size, size);
         const bw = 42;
         const bh = 18;
         for (let y = 0, row = 0; y < size; y += bh, row++) {
             const off = row % 2 ? bw / 2 : 0;
             for (let x = -bw; x < size; x += bw) {
-                ctx.fillStyle = hash2(x, y) > 0.5 ? '#6a5a4a' : '#5a4a3a';
+                const shade = hash2(x, y);
+                ctx.fillStyle = shade > 0.55 ? '#6e5c4a' : shade > 0.25 ? '#5a4a3a' : '#4a3c30';
                 ctx.fillRect(x + off + 1, y + 1, bw - 2, bh - 2);
             }
         }
-        grain(ctx, size, size, 22, 14);
-        return toTexture(el, { repeat: [4, 4] });
+        grain(ctx, size, size, 20, 14);
+        return packMaps(el, { repeat: [4, 4], bump: 2.4, roughBase: 0.9 });
     });
+}
+
+export function skinTexture() {
+    return cached('skin', () => {
+        const size = 128;
+        const el = canvas(size);
+        const ctx = el.getContext('2d');
+        ctx.fillStyle = '#e8b889';
+        ctx.fillRect(0, 0, size, size);
+        for (let i = 0; i < 80; i++) {
+            ctx.fillStyle = `rgba(${200 + hash2(i, 1) * 30},${140 + hash2(i, 2) * 30},${100},0.12)`;
+            ctx.beginPath();
+            ctx.arc(hash2(i, 3) * size, hash2(i, 4) * size, 2 + hash2(i, 5) * 8, 0, Math.PI * 2);
+            ctx.fill();
+        }
+        grain(ctx, size, size, 12, 20);
+        return packMaps(el, { repeat: [2, 2], bump: 0.9, roughBase: 0.62 });
+    });
+}
+
+export function clothTexture(tint = '#9aa3ad') {
+    return cached(`cloth:${tint}`, () => {
+        const size = 256;
+        const el = canvas(size);
+        const ctx = el.getContext('2d');
+        ctx.fillStyle = tint;
+        ctx.fillRect(0, 0, size, size);
+        for (let y = 0; y < size; y += 3) {
+            ctx.strokeStyle = `rgba(0,0,0,${0.04 + hash2(y, 1) * 0.06})`;
+            ctx.beginPath();
+            ctx.moveTo(0, y);
+            ctx.lineTo(size, y + (hash2(y, 2) - 0.5) * 2);
+            ctx.stroke();
+        }
+        grain(ctx, size, size, 14, 21);
+        return packMaps(el, { repeat: [3, 3], bump: 1.1, roughBase: 0.86 });
+    });
+}
+
+export function leatherTexture() {
+    return cached('leather', () => {
+        const size = 128;
+        const el = canvas(size);
+        const ctx = el.getContext('2d');
+        ctx.fillStyle = '#5a3a18';
+        ctx.fillRect(0, 0, size, size);
+        grain(ctx, size, size, 28, 22);
+        return packMaps(el, { repeat: [2, 2], bump: 1.8, roughBase: 0.7 });
+    });
+}
+
+/** Folha de grama com alpha — dois planos cruzados usam o mesmo mapa. */
+export function grassBladeTexture() {
+    return cached('grassBlade', () => {
+        const el = canvas(64, 128);
+        const ctx = el.getContext('2d');
+        ctx.clearRect(0, 0, 64, 128);
+        const g = ctx.createLinearGradient(32, 128, 32, 0);
+        g.addColorStop(0, '#2a4a14');
+        g.addColorStop(0.45, '#4a7a28');
+        g.addColorStop(1, '#8aba48');
+        ctx.fillStyle = g;
+        ctx.beginPath();
+        ctx.moveTo(32, 4);
+        ctx.quadraticCurveTo(48, 50, 40, 128);
+        ctx.lineTo(24, 128);
+        ctx.quadraticCurveTo(16, 50, 32, 4);
+        ctx.fill();
+        ctx.fillStyle = 'rgba(180,220,80,0.35)';
+        ctx.beginPath();
+        ctx.moveTo(32, 8);
+        ctx.quadraticCurveTo(36, 60, 33, 120);
+        ctx.lineTo(31, 120);
+        ctx.fill();
+        const tex = toTexture(el, { repeat: [1, 1], srgb: true, aniso: 2 });
+        tex.wrapS = tex.wrapT = THREE.ClampToEdgeWrapping;
+        return tex;
+    });
+}
+
+export function cloudTexture() {
+    return cached('cloud', () => {
+        const size = 256;
+        const el = canvas(size);
+        const ctx = el.getContext('2d');
+        ctx.clearRect(0, 0, size, size);
+        for (let i = 0; i < 18; i++) {
+            const x = 40 + hash2(i, 1) * 176;
+            const y = 50 + hash2(i, 2) * 140;
+            const r = 28 + hash2(i, 3) * 46;
+            const grd = ctx.createRadialGradient(x, y, 4, x, y, r);
+            grd.addColorStop(0, 'rgba(255,255,255,0.55)');
+            grd.addColorStop(1, 'rgba(255,255,255,0)');
+            ctx.fillStyle = grd;
+            ctx.beginPath();
+            ctx.arc(x, y, r, 0, Math.PI * 2);
+            ctx.fill();
+        }
+        const tex = toTexture(el, { repeat: [1, 1], srgb: true, aniso: 1 });
+        tex.wrapS = tex.wrapT = THREE.ClampToEdgeWrapping;
+        return tex;
+    });
+}
+
+export function faceTexture() {
+    return cached('face', () => {
+        const size = 128;
+        const el = canvas(size);
+        const ctx = el.getContext('2d');
+        ctx.fillStyle = '#e8b889';
+        ctx.fillRect(0, 0, size, size);
+        ctx.fillStyle = '#c48a68';
+        ctx.beginPath();
+        ctx.ellipse(64, 78, 22, 16, 0, 0, Math.PI * 2);
+        ctx.fill();
+        for (const sx of [-1, 1]) {
+            ctx.fillStyle = '#f7f2ea';
+            ctx.beginPath();
+            ctx.ellipse(64 + sx * 16, 54, 8, 6, 0, 0, Math.PI * 2);
+            ctx.fill();
+            ctx.fillStyle = '#2a4a18';
+            ctx.beginPath();
+            ctx.arc(64 + sx * 16, 54, 3.2, 0, Math.PI * 2);
+            ctx.fill();
+            ctx.fillStyle = '#1a1a12';
+            ctx.beginPath();
+            ctx.arc(64 + sx * 16, 54, 1.4, 0, Math.PI * 2);
+            ctx.fill();
+            ctx.strokeStyle = '#5a3a18';
+            ctx.lineWidth = 2;
+            ctx.beginPath();
+            ctx.arc(64 + sx * 16, 46, 8, Math.PI, 0);
+            ctx.stroke();
+        }
+        ctx.fillStyle = '#d4a07a';
+        ctx.beginPath();
+        ctx.ellipse(64, 66, 6, 8, 0, 0, Math.PI * 2);
+        ctx.fill();
+        ctx.strokeStyle = '#a06050';
+        ctx.lineWidth = 2;
+        ctx.beginPath();
+        ctx.arc(64, 84, 8, 0.15, Math.PI - 0.15);
+        ctx.stroke();
+        grain(ctx, size, size, 10, 30);
+        return toTexture(el, { repeat: [1, 1], srgb: true, aniso: 2 });
+    });
+}
+
+export function applyMaps(material, maps, { color = 0xffffff, roughness = 0.82, metalness = 0.02, normalScale = 0.85 } = {}) {
+    if (!maps) return material;
+    material.map = maps.map;
+    material.normalMap = maps.normalMap;
+    material.roughnessMap = maps.roughnessMap;
+    material.color.set(color);
+    material.roughness = roughness;
+    material.metalness = metalness;
+    if (material.normalScale) material.normalScale.set(normalScale, normalScale);
+    material.needsUpdate = true;
+    return material;
 }

--- a/labs/jornada-do-anel/src/utils.js
+++ b/labs/jornada-do-anel/src/utils.js
@@ -101,10 +101,12 @@ export function rendererIsSoftware(renderer) {
 
 export function disposeObject(obj) {
     obj.traverse((child) => {
-        if (child.geometry) child.geometry.dispose();
-        const mat = child.material;
-        if (Array.isArray(mat)) mat.forEach((m) => m.dispose());
-        else if (mat) mat.dispose();
+        if (child.geometry && !child.geometry.userData?.shared) child.geometry.dispose();
+        const mats = child.material;
+        const list = Array.isArray(mats) ? mats : mats ? [mats] : [];
+        for (const m of list) {
+            if (!m.userData?.shared) m.dispose();
+        }
     });
     obj.parent?.remove(obj);
 }

--- a/labs/jornada-do-anel/src/world.js
+++ b/labs/jornada-do-anel/src/world.js
@@ -1,20 +1,19 @@
 /**
  * Constrói cada capítulo: terreno, vegetação, marcos e objetivos.
- * Tudo vive num Group para poder ser trocado com fade entre cenas.
+ * Árvores e pilares entram como InstancedMesh para cortar draw calls.
  */
 
 import * as THREE from 'three';
-import { fbm, hash2, seeded, smoothstep } from './utils.js';
+import { fbm, hash2, seeded, smoothstep } from './utils.js?v=3';
+import { grassTexture, mossTexture, stoneTexture, brickTexture, applyMaps } from './textures.js?v=3';
 import {
-    grassTexture, mossTexture, stoneTexture, waterTexture, brickTexture
-} from './textures.js';
-import {
-    buildHobbitHole, buildOak, buildPine, buildPartyTree, buildRing,
-    buildRock, buildPavilion, buildCouncilRing, buildPillar, buildBridge,
+    buildHobbitHole, buildPartyTree, buildRing,
+    buildRock, buildPavilion, buildCouncilRing, buildBridge,
     buildSeat, buildRuinArch, buildWizard, buildElf, buildNazgul, buildGoblin,
-    buildCompanion, grassBladeGeometry, applyGrassWind, std
-} from './models.js';
-import { Rider, GoblinAI } from './npcs.js';
+    buildCompanion, grassBladeGeometry, grassBladeMaterial, waterMaterial,
+    getOakAssets, getPineAssets, getPillarAssets, buildBalrog, std
+} from './models.js?v=3';
+import { Rider, GoblinAI } from './npcs.js?v=3';
 
 export class ChapterWorld {
     constructor() {
@@ -45,7 +44,16 @@ export class ChapterWorld {
     }
 }
 
-function terrainMesh(heightAt, size, segs, material, ox = 0, oz = 0) {
+function groundMat(maps, color) {
+    const m = new THREE.MeshStandardMaterial({
+        color, roughness: 0.94, metalness: 0.02, vertexColors: true
+    });
+    applyMaps(m, maps, { color, roughness: 0.94, metalness: 0.02, normalScale: 1.05 });
+    m.vertexColors = true;
+    return m;
+}
+
+function terrainMesh(heightAt, size, segs, material, ox = 0, oz = 0, colorFn = null) {
     const geo = new THREE.PlaneGeometry(size, size, segs, segs);
     geo.rotateX(-Math.PI / 2);
     const pos = geo.attributes.position;
@@ -54,6 +62,18 @@ function terrainMesh(heightAt, size, segs, material, ox = 0, oz = 0) {
         const z = pos.getZ(i);
         pos.setY(i, heightAt(x + ox, z + oz));
     }
+    if (colorFn) {
+        const colors = new Float32Array(pos.count * 3);
+        const c = new THREE.Color();
+        for (let i = 0; i < pos.count; i++) {
+            colorFn(pos.getX(i) + ox, pos.getZ(i) + oz, pos.getY(i), c);
+            colors[i * 3] = c.r;
+            colors[i * 3 + 1] = c.g;
+            colors[i * 3 + 2] = c.b;
+        }
+        geo.setAttribute('color', new THREE.BufferAttribute(colors, 3));
+        material.vertexColors = true;
+    }
     geo.computeVertexNormals();
     const mesh = new THREE.Mesh(geo, material);
     mesh.position.set(ox, 0, oz);
@@ -61,62 +81,73 @@ function terrainMesh(heightAt, size, segs, material, ox = 0, oz = 0) {
     return mesh;
 }
 
-function scatterTrees(world, proto, count, rng, opts) {
-    const { minR = 8, maxR = 48, minScale = 0.8, maxScale = 1.5, avoid = [] } = opts;
-    for (let i = 0; i < count; i++) {
-        const a = rng() * Math.PI * 2;
-        const r = minR + rng() * (maxR - minR);
-        const x = Math.cos(a) * r + (opts.cx || 0);
-        const z = Math.sin(a) * r + (opts.cz || 0);
-        if (avoid.some((p) => Math.hypot(x - p.x, z - p.z) < p.r)) continue;
-        if (x < world.bounds.minX + 2 || x > world.bounds.maxX - 2) continue;
-        const tree = proto();
-        const s = minScale + rng() * (maxScale - minScale);
-        tree.scale.setScalar(s);
-        const y = world.heightAt(x, z);
-        tree.position.set(x, y, z);
-        tree.rotation.y = rng() * Math.PI * 2;
-        world.group.add(tree);
-        world.addCollider(x, z, 0.55 * s);
-    }
+const _dummy = new THREE.Object3D();
+
+function placeTree(world, rng, opts) {
+    const { minR = 8, maxR = 48, avoid = [] } = opts;
+    const a = rng() * Math.PI * 2;
+    const r = minR + rng() * (maxR - minR);
+    const x = Math.cos(a) * r + (opts.cx || 0);
+    const z = Math.sin(a) * r + (opts.cz || 0);
+    if (avoid.some((p) => Math.hypot(x - p.x, z - p.z) < p.r)) return null;
+    if (x < world.bounds.minX + 2 || x > world.bounds.maxX - 2) return null;
+    if (z < world.bounds.minZ + 2 || z > world.bounds.maxZ - 2) return null;
+    return { x, z, s: (opts.minScale || 0.8) + rng() * ((opts.maxScale || 1.5) - (opts.minScale || 0.8)), rot: rng() * Math.PI * 2 };
 }
 
-function scatterGrass(world, count, quality) {
+function scatterInstancedOaks(world, count, rng, opts, autumn = false) {
+    const { trunkGeo, canopyGeo, trunkMat, canopyMat } = getOakAssets(autumn);
+    const trunks = new THREE.InstancedMesh(trunkGeo, trunkMat, count);
+    const canopies = new THREE.InstancedMesh(canopyGeo, canopyMat, count);
+    trunks.castShadow = canopies.castShadow = true;
+    trunks.receiveShadow = canopies.receiveShadow = true;
+    let n = 0;
+    for (let i = 0; i < count; i++) {
+        const p = placeTree(world, rng, opts);
+        if (!p) continue;
+        _dummy.position.set(p.x, world.heightAt(p.x, p.z), p.z);
+        _dummy.rotation.set(0, p.rot, 0);
+        _dummy.scale.setScalar(p.s);
+        _dummy.updateMatrix();
+        trunks.setMatrixAt(n, _dummy.matrix);
+        _dummy.position.y += 1.35 * p.s;
+        _dummy.updateMatrix();
+        canopies.setMatrixAt(n, _dummy.matrix);
+        world.addCollider(p.x, p.z, 0.55 * p.s);
+        n++;
+    }
+    trunks.count = n;
+    canopies.count = n;
+    world.group.add(trunks);
+    world.group.add(canopies);
+}
+
+function scatterGrass(world, count) {
     const geo = grassBladeGeometry();
-    const mat = new THREE.MeshStandardMaterial({
-        color: 0x5a8a32,
-        side: THREE.DoubleSide,
-        roughness: 0.95
-    });
-    applyGrassWind(mat, 1);
+    const mat = grassBladeMaterial();
     const mesh = new THREE.InstancedMesh(geo, mat, count);
-    mesh.instanceMatrix.setUsage(THREE.DynamicDrawUsage);
-    const dummy = new THREE.Object3D();
     const b = world.bounds;
     for (let i = 0; i < count; i++) {
         const x = b.minX + hash2(i, 1) * (b.maxX - b.minX);
         const z = b.minZ + hash2(i, 2) * (b.maxZ - b.minZ);
-        dummy.position.set(x, world.heightAt(x, z), z);
-        dummy.rotation.y = hash2(i, 3) * Math.PI * 2;
-        dummy.scale.setScalar(0.7 + hash2(i, 4) * 0.8);
-        dummy.updateMatrix();
-        mesh.setMatrixAt(i, dummy.matrix);
+        _dummy.position.set(x, world.heightAt(x, z), z);
+        _dummy.rotation.set((hash2(i, 5) - 0.5) * 0.25, hash2(i, 3) * Math.PI * 2, 0);
+        _dummy.scale.setScalar(0.75 + hash2(i, 4) * 0.95);
+        _dummy.updateMatrix();
+        mesh.setMatrixAt(i, _dummy.matrix);
     }
     mesh.receiveShadow = true;
     world.group.add(mesh);
-    world.updateFns.push((t) => {
-        if (mat.userData.uTime) mat.userData.uTime.value = t;
-    });
-    return mesh;
 }
 
 function makePage(world, x, z, id) {
     const mesh = new THREE.Mesh(
-        new THREE.BoxGeometry(0.35, 0.02, 0.5),
+        new THREE.BoxGeometry(0.32, 0.015, 0.46),
         new THREE.MeshStandardMaterial({
             color: 0xf2e4c0,
             emissive: 0xc8a050,
-            emissiveIntensity: 0.45
+            emissiveIntensity: 0.4,
+            roughness: 0.7
         })
     );
     const y = world.heightAt(x, z) + 0.7;
@@ -129,6 +160,18 @@ function makePage(world, x, z, id) {
         mesh.position.y = y + Math.sin(t * 2.2) * 0.12;
         mesh.rotation.y = t * 0.8;
     });
+}
+
+function addWater(world, w, h, color, x, y, z, segs = 24) {
+    const water = new THREE.Mesh(
+        new THREE.PlaneGeometry(w, h, segs, Math.max(8, (segs * h / w) | 0)),
+        waterMaterial(color)
+    );
+    water.rotation.x = -Math.PI / 2;
+    water.position.set(x, y, z);
+    world.group.add(water);
+    world.waterMeshes.push(water);
+    return water;
 }
 
 /* ================================================================== */
@@ -152,9 +195,20 @@ export function buildShire(quality) {
         return hills * flat + mound;
     };
 
+    const dirt = new THREE.Color(0x8a6a38);
+    const lush = new THREE.Color(0x8fbc5a);
+    const deep = new THREE.Color(0x6a8a38);
     const ground = terrainMesh(
-        world.heightAt, 120, quality.id === 'low' ? 48 : 96,
-        new THREE.MeshStandardMaterial({ map: grassTexture(), roughness: 0.95, color: 0x8fbc5a })
+        world.heightAt, 120, quality.id === 'low' ? 56 : 110,
+        groundMat(grassTexture(), 0x8fbc5a),
+        0, 0,
+        (x, z, y, c) => {
+            const toBag = Math.abs((x + 20) * 0.55 + (z + 6) * 0.45);
+            const along = smoothstep(40, 8, Math.hypot(x + 1, z + 8));
+            const pathAmt = smoothstep(3.2, 1.1, toBag) * along;
+            const slope = Math.min(1, y * 0.08);
+            c.copy(lush).lerp(deep, slope * 0.35).lerp(dirt, pathAmt * 0.7);
+        }
     );
     world.group.add(ground);
 
@@ -181,13 +235,10 @@ export function buildShire(quality) {
     world.addInteract(ringIt);
     world.goal = 'ring';
     const beacon = new THREE.Mesh(
-        new THREE.CylinderGeometry(0.12, 0.45, 6.5, 8, 1, true),
+        new THREE.CylinderGeometry(0.12, 0.45, 6.5, 10, 1, true),
         new THREE.MeshBasicMaterial({
-            color: 0xffcc55,
-            transparent: true,
-            opacity: 0.18,
-            side: THREE.DoubleSide,
-            depthWrite: false
+            color: 0xffcc55, transparent: true, opacity: 0.16,
+            side: THREE.DoubleSide, depthWrite: false
         })
     );
     beacon.position.set(doorX, world.heightAt(doorX, doorZ) + 3.4, doorZ);
@@ -199,7 +250,7 @@ export function buildShire(quality) {
         }
         ring.rotation.y = t * 0.9;
         ring.position.y = world.heightAt(doorX, doorZ) + 1.15 + Math.sin(t * 2) * 0.08;
-        beacon.material.opacity = 0.12 + Math.sin(t * 2.4) * 0.06;
+        beacon.material.opacity = 0.1 + Math.sin(t * 2.4) * 0.05;
     });
 
     const colors = ['#2d6b38', '#6b3a2d', '#3a4a8a', '#8a5a2a', '#4a6b3a'];
@@ -231,16 +282,18 @@ export function buildShire(quality) {
     });
 
     const fireworks = [];
-    const fGeo = new THREE.SphereGeometry(0.08, 6, 5);
-    for (let i = 0; i < Math.floor(28 * quality.particles); i++) {
+    const fGeo = new THREE.SphereGeometry(0.07, 6, 5);
+    for (let i = 0; i < Math.floor(36 * quality.particles); i++) {
         const p = new THREE.Mesh(fGeo, new THREE.MeshBasicMaterial({
-            color: new THREE.Color().setHSL(hash2(i, 2), 0.75, 0.6)
+            color: new THREE.Color().setHSL(hash2(i, 2), 0.75, 0.62),
+            transparent: true
         }));
         world.group.add(p);
         fireworks.push({ mesh: p, t: rng() * 4, life: 2 + rng() * 2 });
     }
     world.updateFns.push((t) => {
         wiz.parts.crystal.rotation.y = t * 2;
+        wiz.parts.crystal.rotation.z = Math.sin(t * 1.4) * 0.2;
         for (const fw of fireworks) {
             const u = (t + fw.t) % fw.life;
             const k = u / fw.life;
@@ -252,14 +305,13 @@ export function buildShire(quality) {
             );
             fw.mesh.scale.setScalar(1 - k);
             fw.mesh.material.opacity = 1 - k;
-            fw.mesh.material.transparent = true;
         }
     });
 
-    scatterTrees(world, () => buildOak(), Math.floor(38 * quality.trees), rng, {
+    scatterInstancedOaks(world, Math.floor(42 * quality.trees), rng, {
         minR: 12, maxR: 48, avoid: [{ x: 0, z: 0, r: 8 }, { x: -20, z: -6, r: 8 }, { x: 18, z: 22, r: 6 }]
     });
-    scatterGrass(world, Math.floor(900 * quality.grass), quality);
+    scatterGrass(world, Math.floor(1100 * quality.grass));
     makePage(world, 4, 10, 'shire-page');
     return world;
 }
@@ -280,34 +332,77 @@ export function buildForest(quality) {
         return bumps * path;
     };
 
+    const mossDark = new THREE.Color(0x2a4224);
+    const mossPath = new THREE.Color(0x5a6a40);
+    const mossDeep = new THREE.Color(0x1a2a14);
     world.group.add(terrainMesh(
-        world.heightAt, 140, quality.id === 'low' ? 40 : 80,
-        new THREE.MeshStandardMaterial({ map: mossTexture(), color: 0x3a5a32, roughness: 0.96 }),
-        0, 62
+        world.heightAt, 140, quality.id === 'low' ? 48 : 88,
+        groundMat(mossTexture(), 0x3a5a32),
+        0, 62,
+        (x, z, y, c) => {
+            const path = smoothstep(6.5, 2.2, Math.abs(x));
+            c.copy(mossDark).lerp(mossPath, path).lerp(mossDeep, Math.min(1, Math.abs(x) * 0.04));
+            void y;
+            void z;
+        }
     ));
 
     const rng = seeded(99);
-    const protoPine = () => buildPine();
-    const protoOak = () => buildOak();
-    const treeCount = Math.floor(90 * quality.trees);
-    for (let i = 0; i < treeCount; i++) {
+    const pineCount = Math.floor(58 * quality.trees);
+    const oakCount = Math.floor(32 * quality.trees);
+
+    const pine = getPineAssets();
+    const pineMesh = new THREE.InstancedMesh(pine.geo, pine.mat, pineCount);
+    pineMesh.castShadow = true;
+    pineMesh.receiveShadow = true;
+    let pn = 0;
+    for (let i = 0; i < pineCount; i++) {
         const z = rng() * 120 + 4;
         const side = rng() < 0.5 ? -1 : 1;
         const x = side * (7 + rng() * 12);
-        const tree = rng() < 0.65 ? protoPine() : protoOak();
-        tree.scale.setScalar(0.9 + rng() * 1.1);
-        tree.position.set(x, world.heightAt(x, z), z);
-        tree.rotation.y = rng() * 6;
-        world.group.add(tree);
+        const s = 0.9 + rng() * 1.15;
+        _dummy.position.set(x, world.heightAt(x, z), z);
+        _dummy.rotation.set(0, rng() * 6, 0);
+        _dummy.scale.setScalar(s);
+        _dummy.updateMatrix();
+        pineMesh.setMatrixAt(pn++, _dummy.matrix);
         world.addCollider(x, z, 0.7);
     }
+    pineMesh.count = pn;
+    world.group.add(pineMesh);
 
-    for (let i = 0; i < 10; i++) {
+    const oak = getOakAssets(false);
+    const oakTrunk = new THREE.InstancedMesh(oak.trunkGeo, oak.trunkMat, oakCount);
+    const oakCan = new THREE.InstancedMesh(oak.canopyGeo, oak.canopyMat, oakCount);
+    oakTrunk.castShadow = oakCan.castShadow = true;
+    let on = 0;
+    for (let i = 0; i < oakCount; i++) {
+        const z = rng() * 120 + 4;
+        const side = rng() < 0.5 ? -1 : 1;
+        const x = side * (7.5 + rng() * 11);
+        const s = 0.85 + rng() * 1.05;
+        _dummy.position.set(x, world.heightAt(x, z), z);
+        _dummy.rotation.set(0, rng() * 6, 0);
+        _dummy.scale.setScalar(s);
+        _dummy.updateMatrix();
+        oakTrunk.setMatrixAt(on, _dummy.matrix);
+        _dummy.position.y += 1.35 * s;
+        _dummy.updateMatrix();
+        oakCan.setMatrixAt(on, _dummy.matrix);
+        world.addCollider(x, z, 0.7);
+        on++;
+    }
+    oakTrunk.count = oakCan.count = on;
+    world.group.add(oakTrunk);
+    world.group.add(oakCan);
+
+    for (let i = 0; i < 12; i++) {
         const rock = buildRock(i + 3);
         const x = (rng() - 0.5) * 16;
         const z = 10 + rng() * 100;
         rock.position.set(x, world.heightAt(x, z), z);
-        rock.scale.setScalar(0.5 + rng() * 0.9);
+        rock.scale.setScalar(0.5 + rng() * 0.95);
+        rock.rotation.set(rng(), rng() * 6, rng() * 0.4);
         world.group.add(rock);
         world.addCollider(x, z, 0.6);
     }
@@ -324,28 +419,13 @@ export function buildForest(quality) {
         world.riders.push(new Rider(n.group, s.x, s.z, s.wps));
     }
 
-    // Vau
-    const water = new THREE.Mesh(
-        new THREE.PlaneGeometry(48, 22),
-        new THREE.MeshStandardMaterial({
-            map: waterTexture(),
-            color: 0x4aa0c8,
-            transparent: true,
-            opacity: 0.78,
-            roughness: 0.2,
-            metalness: 0.3
-        })
-    );
-    water.rotation.x = -Math.PI / 2;
-    water.position.set(0, -0.15, 122);
-    world.group.add(water);
-    world.waterMeshes.push(water);
+    addWater(world, 48, 22, 0x3a88b0, 0, -0.12, 122, 20);
 
     const fordMarker = new THREE.Mesh(
-        new THREE.CylinderGeometry(0.2, 0.2, 2.2, 8),
-        new THREE.MeshStandardMaterial({ color: 0xd8e8ff, emissive: 0x88aaff, emissiveIntensity: 1.2 })
+        new THREE.CylinderGeometry(0.16, 0.22, 1.8, 10),
+        new THREE.MeshStandardMaterial({ color: 0xd8e8ff, emissive: 0x88aaff, emissiveIntensity: 1.1, roughness: 0.35 })
     );
-    fordMarker.position.set(0, 1.4, 124);
+    fordMarker.position.set(0, 1.2, 124);
     world.group.add(fordMarker);
     world.addInteract({
         x: 0, z: 124, r: 3.2, id: 'ford', kind: 'goal',
@@ -357,7 +437,7 @@ export function buildForest(quality) {
     elf.group.position.set(3.5, world.heightAt(3.5, 126), 126);
     world.group.add(elf.group);
 
-    scatterGrass(world, Math.floor(400 * quality.grass), quality);
+    scatterGrass(world, Math.floor(480 * quality.grass));
     makePage(world, -8, 20, 'forest-page');
     return world;
 }
@@ -379,26 +459,21 @@ export function buildRivendell(quality) {
         return valley + rise + noise * 0.5;
     };
 
+    const valleyGreen = new THREE.Color(0x5a8a48);
+    const waterEdge = new THREE.Color(0x8ab868);
+    const highStone = new THREE.Color(0xc8d0c0);
     world.group.add(terrainMesh(
-        world.heightAt, 120, quality.id === 'low' ? 48 : 90,
-        new THREE.MeshStandardMaterial({ map: mossTexture(), color: 0x6a9a58, roughness: 0.9 })
+        world.heightAt, 120, quality.id === 'low' ? 56 : 96,
+        groundMat(mossTexture(), 0x6a9a58),
+        0, 0,
+        (x, z, y, c) => {
+            const nearWater = smoothstep(6, 1.2, Math.abs(x));
+            c.copy(valleyGreen).lerp(waterEdge, nearWater).lerp(highStone, Math.min(1, y * 0.06));
+            void z;
+        }
     ));
 
-    const stream = new THREE.Mesh(
-        new THREE.PlaneGeometry(8, 90),
-        new THREE.MeshStandardMaterial({
-            map: waterTexture(),
-            color: 0x6ad0e0,
-            transparent: true,
-            opacity: 0.8,
-            roughness: 0.15,
-            metalness: 0.25
-        })
-    );
-    stream.rotation.x = -Math.PI / 2;
-    stream.position.set(0, 0.05, 0);
-    world.group.add(stream);
-    world.waterMeshes.push(stream);
+    addWater(world, 8.5, 90, 0x6ad0e0, 0, 0.06, 0, 16);
 
     const pav = buildPavilion();
     pav.position.set(0, world.heightAt(0, 8), 8);
@@ -433,11 +508,22 @@ export function buildRivendell(quality) {
         world.group.add(elf.group);
     }
 
-    // Quedas — partículas.
-    const dropGeo = new THREE.SphereGeometry(0.07, 4, 4);
+    const fallTex = new THREE.MeshBasicMaterial({
+        color: 0xc8f0ff, transparent: true, opacity: 0.35, side: THREE.DoubleSide, depthWrite: false
+    });
+    for (const sx of [-1, 1]) {
+        const sheet = new THREE.Mesh(new THREE.PlaneGeometry(7, 18, 1, 8), fallTex);
+        sheet.position.set(sx * 36, 8, -4);
+        world.group.add(sheet);
+        world.updateFns.push((t) => {
+            sheet.material.opacity = 0.28 + Math.sin(t * 4 + sx) * 0.08;
+        });
+    }
+
+    const dropGeo = new THREE.SphereGeometry(0.06, 4, 4);
     const dropMat = new THREE.MeshBasicMaterial({ color: 0xc8f0ff, transparent: true, opacity: 0.55 });
     const drops = [];
-    const nDrops = Math.floor(80 * quality.particles);
+    const nDrops = Math.floor(90 * quality.particles);
     for (let i = 0; i < nDrops; i++) {
         const m = new THREE.Mesh(dropGeo, dropMat);
         world.group.add(m);
@@ -446,27 +532,25 @@ export function buildRivendell(quality) {
     world.updateFns.push((t) => {
         for (const d of drops) {
             const u = (t * 0.35 + d.t) % 1;
-            const x = d.side * 36;
-            const y = 16 - u * 18;
-            const z = -4 + Math.sin((d.t + t) * 8) * 0.4;
-            d.mesh.position.set(x, y, z);
+            d.mesh.position.set(d.side * 36, 16 - u * 18, -4 + Math.sin((d.t + t) * 8) * 0.4);
         }
     });
 
     for (const sx of [-1, 1]) {
         const cliff = new THREE.Mesh(
             new THREE.BoxGeometry(8, 18, 28),
-            new THREE.MeshStandardMaterial({ map: stoneTexture('#8aa0a8'), color: 0xc8d8d0, roughness: 0.85 })
+            new THREE.MeshStandardMaterial({ color: 0xc8d8d0, roughness: 0.85 })
         );
+        applyMaps(cliff.material, stoneTexture('#8aa0a8'), { color: 0xc8d8d0, roughness: 0.85, normalScale: 1.2 });
         cliff.position.set(sx * 40, 6, 0);
         world.group.add(cliff);
     }
 
     const rng = seeded(21);
-    scatterTrees(world, () => buildOak({ autumn: true }), Math.floor(28 * quality.trees), rng, {
+    scatterInstancedOaks(world, Math.floor(30 * quality.trees), rng, {
         minR: 14, maxR: 42, cx: 0, cz: 0, avoid: [{ x: 0, z: 8, r: 10 }, { x: 0, z: 18, r: 8 }]
-    });
-    scatterGrass(world, Math.floor(500 * quality.grass), quality);
+    }, true);
+    scatterGrass(world, Math.floor(560 * quality.grass));
     makePage(world, -12, -16, 'rivendell-page');
     return world;
 }
@@ -486,11 +570,9 @@ export function buildMoria(quality) {
         return 0;
     };
 
-    const floorMat = new THREE.MeshStandardMaterial({
-        map: brickTexture(),
-        color: 0x5a4a3a,
-        roughness: 0.92
-    });
+    const floorMaps = brickTexture();
+    const floorMat = new THREE.MeshStandardMaterial({ color: 0x5a4a3a, roughness: 0.92 });
+    applyMaps(floorMat, floorMaps, { color: 0x5a4a3a, roughness: 0.92, normalScale: 1.1 });
     const floor = new THREE.Mesh(new THREE.PlaneGeometry(36, 78), floorMat);
     floor.rotation.x = -Math.PI / 2;
     floor.position.set(0, 0, 36);
@@ -503,12 +585,8 @@ export function buildMoria(quality) {
     exitFloor.receiveShadow = true;
     world.group.add(exitFloor);
 
-    // Paredes e teto
-    const wallMat = new THREE.MeshStandardMaterial({
-        map: stoneTexture('#3a3028'),
-        color: 0x3a3028,
-        roughness: 0.95
-    });
+    const wallMat = new THREE.MeshStandardMaterial({ color: 0x3a3028, roughness: 0.95 });
+    applyMaps(wallMat, stoneTexture('#3a3028'), { color: 0x3a3028, roughness: 0.95, normalScale: 1.25 });
     for (const sx of [-1, 1]) {
         const wall = new THREE.Mesh(new THREE.BoxGeometry(2, 16, 110), wallMat);
         wall.position.set(sx * 18, 8, 50);
@@ -520,36 +598,49 @@ export function buildMoria(quality) {
     world.group.add(ceiling);
 
     const pillarN = quality.id === 'low' ? 8 : 12;
+    const pillar = getPillarAssets(13);
+    const pillars = new THREE.InstancedMesh(pillar.geo, pillar.mat, pillarN * 2);
+    pillars.castShadow = true;
+    pillars.receiveShadow = true;
+    let pi = 0;
     for (let i = 0; i < pillarN; i++) {
         const z = 8 + i * 5.5;
         for (const sx of [-1, 1]) {
-            const p = buildPillar(13);
-            p.position.set(sx * 8.5, 0, z);
-            world.group.add(p);
+            _dummy.position.set(sx * 8.5, 0, z);
+            _dummy.rotation.set(0, 0, 0);
+            _dummy.scale.set(1, 1, 1);
+            _dummy.updateMatrix();
+            pillars.setMatrixAt(pi++, _dummy.matrix);
             world.addCollider(sx * 8.5, z, 1.0);
         }
     }
+    pillars.count = pi;
+    world.group.add(pillars);
 
-    // Tochas
     const torchCount = quality.lights ? 10 : 4;
     for (let i = 0; i < torchCount; i++) {
         const z = 6 + i * 9;
         const sx = i % 2 ? 1 : -1;
         const flame = new THREE.Mesh(
-            new THREE.SphereGeometry(0.18, 8, 6),
+            new THREE.SphereGeometry(0.16, 8, 6),
             new THREE.MeshStandardMaterial({
-                color: 0xffaa44,
-                emissive: 0xff6622,
-                emissiveIntensity: 3
+                color: 0xffaa44, emissive: 0xff6622, emissiveIntensity: 3.2, roughness: 0.4
             })
         );
         flame.position.set(sx * 15.5, 3.4, z);
         world.group.add(flame);
+        const bowl = new THREE.Mesh(new THREE.CylinderGeometry(0.08, 0.12, 0.2, 8), std(0x3a2a18, 0.8));
+        bowl.position.set(sx * 15.5, 3.18, z);
+        world.group.add(bowl);
         if (quality.lights) {
-            const light = new THREE.PointLight(0xff7a30, 2.2, 16, 2);
+            const light = new THREE.PointLight(0xff7a30, 2.35, 17, 2);
             light.position.copy(flame.position);
             world.group.add(light);
         }
+        world.updateFns.push((t) => {
+            const k = 1 + Math.sin(t * 11 + i) * 0.12;
+            flame.scale.setScalar(k);
+        });
     }
 
     const goblinSpawns = [
@@ -562,10 +653,9 @@ export function buildMoria(quality) {
         world.goblins.push(new GoblinAI(g.group, s.x, s.z));
     }
 
-    // Abismo
     const glow = new THREE.Mesh(
         new THREE.PlaneGeometry(40, 20),
-        new THREE.MeshBasicMaterial({ color: 0xff4a12, transparent: true, opacity: 0.35, side: THREE.DoubleSide })
+        new THREE.MeshBasicMaterial({ color: 0xff4a12, transparent: true, opacity: 0.38, side: THREE.DoubleSide })
     );
     glow.rotation.x = -Math.PI / 2;
     glow.position.set(0, -8, 82);
@@ -578,9 +668,7 @@ export function buildMoria(quality) {
     const exit = new THREE.Mesh(
         new THREE.BoxGeometry(4, 5, 0.4),
         new THREE.MeshStandardMaterial({
-            color: 0xffe8a0,
-            emissive: 0xffaa44,
-            emissiveIntensity: 0.8
+            color: 0xffe8a0, emissive: 0xffaa44, emissiveIntensity: 0.85, roughness: 0.4
         })
     );
     exit.position.set(0, 2.5, 104);
@@ -591,33 +679,7 @@ export function buildMoria(quality) {
     });
     world.goal = 'exit';
 
-    // A Sombra — aparece quando o jogador pisa na ponte.
-    const shadow = new THREE.Group();
-    const body = new THREE.Mesh(
-        new THREE.ConeGeometry(2.4, 8, 6),
-        new THREE.MeshStandardMaterial({
-            color: 0x1a0804,
-            emissive: 0xff3300,
-            emissiveIntensity: 0.45,
-            roughness: 0.9
-        })
-    );
-    body.position.y = 4;
-    shadow.add(body);
-    const hornL = new THREE.Mesh(new THREE.ConeGeometry(0.35, 2.2, 6), std(0x2a1008, 0.8));
-    hornL.position.set(-1.1, 8.2, 0);
-    hornL.rotation.z = 0.5;
-    shadow.add(hornL);
-    const hornR = hornL.clone();
-    hornR.position.x = 1.1;
-    hornR.rotation.z = -0.5;
-    shadow.add(hornR);
-    const eye = new THREE.Mesh(
-        new THREE.SphereGeometry(0.35, 8, 6),
-        new THREE.MeshStandardMaterial({ color: 0xffee88, emissive: 0xffaa00, emissiveIntensity: 4 })
-    );
-    eye.position.set(0, 6.2, 1.4);
-    shadow.add(eye);
+    const shadow = buildBalrog();
     shadow.position.set(0, -12, 70);
     shadow.visible = false;
     world.group.add(shadow);
@@ -628,7 +690,10 @@ export function buildMoria(quality) {
         const k = 1 - Math.exp(-1.8 * dt);
         shadow.position.z += (78 - shadow.position.z) * k;
         shadow.position.y += (0 - shadow.position.y) * k;
-        eye.scale.setScalar(1 + Math.sin(t * 8) * 0.15);
+        const eye = shadow.userData.eye;
+        if (eye) eye.scale.setScalar(1 + Math.sin(t * 8) * 0.15);
+        const whip = shadow.userData.whip;
+        if (whip) whip.rotation.z = -0.9 + Math.sin(t * 3.5) * 0.25;
     });
 
     makePage(world, 5, 14, 'moria-page');
@@ -653,26 +718,21 @@ export function buildAmonHen(quality) {
         return Math.max(river, hill + noise * 0.4);
     };
 
+    const henLow = new THREE.Color(0x7a6a38);
+    const henHigh = new THREE.Color(0xb89868);
+    const henRock = new THREE.Color(0x8a8a80);
     world.group.add(terrainMesh(
-        world.heightAt, 130, quality.id === 'low' ? 48 : 90,
-        new THREE.MeshStandardMaterial({ map: grassTexture(), color: 0x8a7a48, roughness: 0.92 })
+        world.heightAt, 130, quality.id === 'low' ? 56 : 96,
+        groundMat(grassTexture(), 0x8a7a48),
+        0, 0,
+        (x, z, y, c) => {
+            const d = Math.hypot(x, z);
+            c.copy(henLow).lerp(henHigh, smoothstep(28, 4, d)).lerp(henRock, Math.min(1, y * 0.08));
+            void z;
+        }
     ));
 
-    const river = new THREE.Mesh(
-        new THREE.PlaneGeometry(40, 130),
-        new THREE.MeshStandardMaterial({
-            map: waterTexture(),
-            color: 0x3a7aaa,
-            transparent: true,
-            opacity: 0.85,
-            roughness: 0.18,
-            metalness: 0.3
-        })
-    );
-    river.rotation.x = -Math.PI / 2;
-    river.position.set(-42, -0.4, 0);
-    world.group.add(river);
-    world.waterMeshes.push(river);
+    addWater(world, 40, 130, 0x3a7aaa, -42, -0.35, 0, 18);
 
     const seat = buildSeat();
     seat.position.set(0, world.heightAt(0, 0), 0);
@@ -707,10 +767,10 @@ export function buildAmonHen(quality) {
     });
 
     const rng = seeded(5);
-    scatterTrees(world, () => buildOak({ autumn: true }), Math.floor(22 * quality.trees), rng, {
+    scatterInstancedOaks(world, Math.floor(24 * quality.trees), rng, {
         minR: 12, maxR: 36, avoid: [{ x: 0, z: 0, r: 8 }]
-    });
-    scatterGrass(world, Math.floor(600 * quality.grass), quality);
+    }, true);
+    scatterGrass(world, Math.floor(680 * quality.grass));
     makePage(world, -6, 16, 'hen-page');
     return world;
 }


### PR DESCRIPTION
## 🎯 Objetivo

Tirar o visual de esfera/cone/caixa da Jornada do Anel e deixar o mundo, os personagens e o céu com silhueta orgânica, PBR e menos draw calls — sem mudar as regras da aventura.

## ✨ O que mudou

- Personagens (hobbit, mago, elfo, goblin, Nazgûl, Sombra) passam a usar lathe, cápsulas e deslocamento de vértices; capa e manto oscilam no vertex shader
- Texturas procedurais ganham normal e roughness; grama em cards com alpha; água com ondas
- Árvores, pinheiros e pilares das minas entram como InstancedMesh; o mundo antigo é disposed na troca de capítulo
- Céu com disco solar, nuvens e estrelas; environment map para ouro e cristal
- Cavalo dos Cavaleiros agora olha para a direção do movimento e articula as pernas

## 🧪 Como testar

1. Na raiz do repo: `python3 -m http.server 8000`
2. Abrir [http://localhost:8000/](http://localhost:8000/) (home) e [http://localhost:8000/labs/](http://localhost:8000/labs/) (galeria)
3. Abrir [http://localhost:8000/labs/jornada-do-anel/](http://localhost:8000/labs/jornada-do-anel/) — o Condado no menu já deve mostrar colinas, tocas redondas e copas irregulares, não bolas e cones
4. Seguir a estrada: andar até a toca verde, pegar o Anel; na Fuga, os Cavaleiros devem parecer cavalos de capa (não uma esfera com cone)
5. Responsivo: DevTools em **375×667**, **390×844** e landscape curto (~667×375) — sem overflow horizontal, HUD/controles utilizáveis, alvos ≥ 44px
6. Trocar qualidade (Performance / Equilibrada / Cinemática) e recomeçar: vegetação e sombras devem acompanhar o preset

## ✅ Checklist

- [x] Links conferidos: pasta do lab ↔ card da galeria ↔ README ↔ sitemap (e corrigidos se quebravam)
- [x] README atualizado (linha na tabela + URL + contagem no badge/texto) — obrigatório em lab novo, renomeado ou removido
- [x] SEO consistente: title, description, canonical, author, robots, OG, Twitter, JSON-LD (e contagem nos metas da galeria)
- [x] Testado via HTTP na raiz, não via `file://`
- [x] Responsivo: 375px / 390px / landscape — overflow, HUD, toque, safe-area (`viewport-fit=cover`)
- [x] Nada fora do escopo foi quebrado

Made with [Cursor](https://cursor.com)