### PR TITLE
🎨 Kong Kong: mais suco visual e feedback de impacto

### DIFF
--- a/labs/kong-kong/src/game.js
+++ b/labs/kong-kong/src/game.js
@@ -166,6 +166,8 @@ export class KongGame {
     this.bananas = 0;
     this.particles = [];
     this.shake = 0;
+    this.hitFlash = 0;
+    this.hitStop = 0;
     this.camX = 0;
     this.camY = 0;
     this.announce = '';
@@ -234,7 +236,9 @@ export class KongGame {
       scarf: withScarf,
       swimming: false,
       dead: false,
-      winT: 0
+      winT: 0,
+      squash: 0,
+      rollDustT: 0
     };
   }
 
@@ -247,6 +251,13 @@ export class KongGame {
         life: 0.4 + Math.random() * 0.4, color, size: 1.5 + Math.random() * 2
       });
     }
+  }
+
+  landingImpact(vy) {
+    const p = this.player;
+    const n = clamp(Math.floor(vy / 90), 4, 10);
+    this.burst(p.x + p.w / 2, p.y + p.h, n, 'rgba(110,80,45,0.6)', 42);
+    p.squash = clamp(vy / PHYS.MAX_FALL, 0.35, 1);
   }
 
   addBananas(n) {
@@ -361,6 +372,7 @@ export class KongGame {
     }
 
     p.invuln = Math.max(0, p.invuln - dt);
+    p.squash = Math.max(0, p.squash - dt * 7);
     if (p.rollT > 0) p.rollT -= dt;
 
     if (this.input.consume('jump')) p.jumpBuf = PHYS.JUMP_BUF;
@@ -415,6 +427,11 @@ export class KongGame {
     if (rolling) {
       p.vx = p.facing * PHYS.ROLL_SPEED;
       p.state = 'roll';
+      p.rollDustT -= dt;
+      if (p.rollDustT <= 0 && p.onGround) {
+        p.rollDustT = 0.05;
+        this.burst(p.x + p.w / 2 - p.facing * 4, p.y + p.h - 2, 2, '#c07838', 30);
+      }
     } else {
       const wish = (inpt.left() ? -1 : 0) + (inpt.right() ? 1 : 0);
       if (wish) p.facing = wish;
@@ -457,7 +474,13 @@ export class KongGame {
       }
     }
 
+    const wasGrounded = p.onGround;
+    const fallSpeed = p.vy;
     this.moveActor(p, dt, { ignoreOneWay: inpt.downHeld() && p.vy >= 0 && this.overlapsTile(p, '-') });
+
+    if (!wasGrounded && p.onGround && fallSpeed > 260 && !rolling) {
+      this.landingImpact(fallSpeed);
+    }
 
     if (p.y > this.level.h * TILE + 8) {
       this.hurt(true);
@@ -579,6 +602,7 @@ export class KongGame {
   explode(x, y) {
     this.audio.play('boom');
     this.shake = 0.35;
+    this.hitStop = 0.05;
     this.burst(x, y, 22, '#f06b4f', 140);
     this.burst(x, y, 10, '#f6d03a', 80);
     this.breakCrates(x, y, 40);
@@ -648,12 +672,14 @@ export class KongGame {
       const stomp = p.vy > 40 && p.y + p.h - 6 < e.y + 8;
       if (p.rollT > 0) {
         this.killEnemy(e);
+        this.hitStop = 0.035;
         continue;
       }
       if (stomp && e.type !== 'quill') {
         this.killEnemy(e);
         p.vy = PHYS.STOMP_VEL;
         this.audio.play('stomp');
+        this.hitStop = 0.045;
         continue;
       }
       if (p.invuln <= 0) this.hurt(false);
@@ -680,6 +706,7 @@ export class KongGame {
       p.vy = PHYS.STOMP_VEL;
       this.audio.play('boss');
       this.shake = 0.25;
+      this.hitStop = 0.07;
       this.burst(b.x + b.w / 2, b.y + 8, 14, '#f6d03a', 90);
       if (b.hp <= 0) {
         b.alive = false;
@@ -688,6 +715,7 @@ export class KongGame {
         this.toastMsg('Rei Croco derrotado!');
         this.burst(b.x + b.w / 2, b.y, 28, '#e31b23', 120);
         this.player.winT = 1.8;
+        this.hitStop = 0.12;
       }
       return;
     }
@@ -707,6 +735,7 @@ export class KongGame {
       p.rollT = 0;
       this.audio.play('hurt');
       this.shake = 0.18;
+      this.hitFlash = 0.22;
       this.scarfDrop = {
         x: p.x + p.w / 2,
         y: p.y,
@@ -867,6 +896,7 @@ export class KongGame {
   update(dt) {
     this.t += dt;
     if (this.toastT > 0) this.toastT -= dt;
+    if (this.hitFlash > 0) this.hitFlash = Math.max(0, this.hitFlash - dt);
     this.audio.tick();
 
     if (this.input.consume('mute')) {
@@ -941,6 +971,12 @@ export class KongGame {
     if (this.input.consume('pause') || this.input.consume('start')) {
       this.mode = 'pause';
       this.setAnnounce('Pausa');
+      return;
+    }
+
+    if (this.hitStop > 0) {
+      this.hitStop = Math.max(0, this.hitStop - dt);
+      this.updateParticles(dt);
       return;
     }
 
@@ -1021,7 +1057,11 @@ export class KongGame {
     }
     for (const b of level.barrels) {
       if (b.used) continue;
-      drawBarrel(ctx, b.x, b.y, b.kind === 'cannon' ? 'cannon' : b.kind, this.t, b.angle || 0);
+      const chargeMax = b.kind === 'tnt' ? 1.05 : 0.85;
+      const charge = b.occupied && (b.kind === 'tnt' || b.kind === 'cannon')
+        ? clamp(1 - b.fuse / chargeMax, 0, 1)
+        : 0;
+      drawBarrel(ctx, b.x, b.y, b.kind === 'cannon' ? 'cannon' : b.kind, this.t, b.angle || 0, charge);
     }
     for (const e of level.enemies) {
       if (e.alive) drawEnemy(ctx, e, this.t);
@@ -1040,7 +1080,8 @@ export class KongGame {
         t: this.t,
         state: p.state,
         scarf: p.scarf,
-        flash: p.invuln > 0 && !p.dead
+        flash: p.invuln > 0 && !p.dead,
+        squash: p.squash
       });
     }
 
@@ -1053,6 +1094,11 @@ export class KongGame {
 
     ctx.restore();
     drawForeground(ctx, theme, this.camX, this.t);
+
+    if (this.hitFlash > 0) {
+      ctx.fillStyle = `rgba(227,27,35,${this.hitFlash * 0.85})`;
+      ctx.fillRect(0, 0, VIEW_W, VIEW_H);
+    }
 
     if (this.mode === 'play' || this.mode === 'pause' || this.mode === 'dying' || this.mode === 'clear') {
       drawHud(ctx, {

--- a/labs/kong-kong/src/sprites.js
+++ b/labs/kong-kong/src/sprites.js
@@ -89,10 +89,11 @@ export function drawKong(ctx, x, y, opt) {
     : 0;
   const roll = state === 'roll';
   const wind = facing * (state === 'run' || roll ? 2.2 : 0.4);
+  const squash = opt.squash || 0;
 
   ctx.save();
   ctx.translate(x, y);
-  ctx.scale(facing, 1);
+  ctx.scale(facing * (1 + squash * 0.16), 1 - squash * 0.22);
   if (roll) ctx.rotate(t * 18);
 
   ctx.fillStyle = 'rgba(0,0,0,0.22)';
@@ -275,11 +276,16 @@ export function drawBalloon(ctx, x, y, t) {
   ctx.restore();
 }
 
-export function drawBarrel(ctx, x, y, kind, t, angle = 0) {
+export function drawBarrel(ctx, x, y, kind, t, angle = 0, charge = 0) {
   ctx.save();
   ctx.translate(x, y);
   if (kind === 'cannon' || kind === 'cannonUp' || kind === 'cannonDiag') {
     ctx.rotate(angle);
+    if (charge > 0) {
+      const pulse = 0.35 + 0.4 * (0.5 + 0.5 * Math.sin(t * (10 + charge * 26)));
+      ctx.fillStyle = `rgba(255,210,80,${pulse * charge})`;
+      ellipse(ctx, 16, 0, 5 + charge * 5, 7 + charge * 5);
+    }
     ctx.fillStyle = '#4a2a12';
     roundRect(ctx, -6, -8, 22, 16, 4);
     ctx.fill();
@@ -297,6 +303,11 @@ export function drawBarrel(ctx, x, y, kind, t, angle = 0) {
   }
   const body = kind === 'tnt' ? '#b43a28' : kind === 'bounce' ? '#3a8a48' : '#c07838';
   const band = kind === 'tnt' ? '#f0e0a0' : '#5a3418';
+  if (kind === 'tnt' && charge > 0) {
+    const pulse = 0.3 + 0.45 * (0.5 + 0.5 * Math.sin(t * (8 + charge * 30)));
+    ctx.fillStyle = `rgba(255,90,40,${pulse * charge})`;
+    ellipse(ctx, 0, 0, 13 + charge * 4, 14 + charge * 4);
+  }
   ctx.fillStyle = '#4a2a10';
   ellipse(ctx, 0, 1, 11, 12);
   ctx.fillStyle = body;
@@ -555,6 +566,26 @@ export function drawBackground(ctx, themeName, camX, camY, t) {
     ctx.beginPath();
     ctx.arc(360, 40, 50, 0, Math.PI * 2);
     ctx.fill();
+  }
+
+  const cloudColors = {
+    jungle: 'rgba(255,255,255,0.4)',
+    canopy: 'rgba(255,255,255,0.32)',
+    ruins: 'rgba(255,235,205,0.28)',
+    falls: 'rgba(255,255,255,0.45)',
+    throne: 'rgba(255,160,120,0.12)'
+  };
+  const cloudColor = cloudColors[themeName];
+  if (cloudColor) {
+    ctx.fillStyle = cloudColor;
+    const parC = camX * 0.08;
+    for (let i = -1; i < 6; i++) {
+      const cx = i * 160 - (parC % 160);
+      const cy = 26 + (i % 3) * 14;
+      ellipse(ctx, cx + 30, cy, 26, 9);
+      ellipse(ctx, cx + 55, cy + 4, 18, 7);
+      ellipse(ctx, cx + 10, cy + 5, 16, 6);
+    }
   }
 
   ctx.fillStyle = theme.far;


### PR DESCRIPTION
## 🎯 Objetivo

Melhorar o gráfico e a sensação de jogabilidade do Kong Kong (`/labs/kong-kong/`) com feedback visual de impacto, sem mexer em física/balanceamento core.

## ✨ O que mudou

- Squash & stretch + poeira no pouso do Kong (impacto proporcional à velocidade de queda)
- Trilha de poeira contínua durante o rolamento
- Hit-stop (micro-pausa) em stomp, rolamento matando inimigo, acerto no Rei Croco e explosão de TNT — dá mais "peso" aos golpes
- Flash vermelho de tela ao perder o lenço (feedback de dano além do screen shake já existente)
- Telegraph pulsante em barris TNT e canhão enquanto carregam, antes de explodir/disparar — mais justo e legível
- Camada de nuvens em parallax no céu (jungle/canopy/ruins/falls/throne, cor por tema; mina fica sem, por ser caverna)

## 🧪 Como testar

1. Na raiz do repo: `python3 -m http.server 8000`
2. Abrir [http://localhost:8000/labs/kong-kong/](http://localhost:8000/labs/kong-kong/)
3. Jogar a Trilha do Lenço: pular, rolar em inimigos, cair de alturas (checar poeira/squash no pouso), levar hit de inimigo (checar flash vermelho)
4. Fase Mina/Canyon dos Canhões: entrar em TNT e canhão e observar o brilho pulsante crescendo antes de disparar/explodir
5. Responsivo: DevTools em **375×667**, **390×844** e landscape curto (~667×375) — sem overflow, HUD/controles utilizáveis (não alterado nesta PR, mas confirmado sem regressão)

## ✅ Checklist

- [x] Nada fora do escopo foi quebrado (lab existente, sem mudança de slug — checklist de catálogo/README/sitemap não se aplica)
- [x] Testado via HTTP na raiz, não via `file://`
- [x] Responsivo: sem alteração de layout/CSS; confirmado sem regressão nos breakpoints
- [x] SEO: inalterado (nenhuma mudança de título/slug/meta)