### PR TITLE
🎨 lab: Aurora Flow como noite polar com fiorde e cortinas

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Cada pasta em `/labs/<slug>/` é o mesmo slug do card da galeria, da linha abaix
 | :--- | :--- |
 | 💻 **[CyberOS Terminal](https://diogopaulino.com.br/labs/cyberos/)** | SO hacker no browser: terminal, firewall, Oracle e cipher |
 | 🟢 **[Matrix](https://diogopaulino.com.br/labs/matrix/)** | Chuva Katakana com glow CRT |
-| 🌌 **[Aurora Flow](https://diogopaulino.com.br/labs/aurora-flow/)** | Aurora boreal em flow fields |
+| 🌌 **[Aurora Flow](https://diogopaulino.com.br/labs/aurora-flow/)** | Noite polar generativa — cortinas, fiorde e campo magnético |
 | 🎨 **[Paint Lab](https://diogopaulino.com.br/labs/paint/)** | Editor de arte digital na web |
 | 🪐 **[Gravity](https://diogopaulino.com.br/labs/gravity/)** | Sandbox gravitacional e física |
 

--- a/labs/aurora-flow/index.html
+++ b/labs/aurora-flow/index.html
@@ -4,12 +4,13 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
-    <title>Aurora Flow | Diogo Paulino</title>
+    <title>Aurora Flow — noite polar generativa | Diogo Paulino</title>
     <meta name="description"
-        content="Aurora generativa: cortinas de luz, vórtices e tempestades de partículas que reagem ao seu movimento.">
+        content="Noite polar no browser: cortinas de oxigênio, fitas de plasma e um fiorde que reflete o céu. Arraste o campo magnético — por Diogo Paulino.">
     <link rel="canonical" href="https://diogopaulino.com.br/labs/aurora-flow/">
     <meta name="author" content="Diogo Paulino">
     <meta name="robots" content="index, follow">
+    <meta name="theme-color" content="#02060e">
     <link rel="icon" href="/favicon.ico" sizes="any">
     <meta property="og:image" content="https://diogopaulino.com.br/assets/img/diogo.jpeg">
     <meta property="og:image:alt" content="Diogo Paulino">
@@ -18,14 +19,16 @@
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="Diogo Paulino · Labs">
     <meta property="og:url" content="https://diogopaulino.com.br/labs/aurora-flow/">
-    <meta property="og:title" content="Aurora Flow | Diogo Paulino">
-    <meta property="og:description" content="Aurora generativa: cortinas de luz, vórtices e tempestades de partículas que reagem ao seu movimento.">
+    <meta property="og:title" content="Aurora Flow — noite polar generativa | Diogo Paulino">
+    <meta property="og:description"
+        content="Noite polar no browser: cortinas de oxigênio, fitas de plasma e um fiorde que reflete o céu. Arraste o campo magnético — por Diogo Paulino.">
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Aurora Flow | Diogo Paulino">
-    <meta name="twitter:description" content="Aurora generativa: cortinas de luz, vórtices e tempestades de partículas que reagem ao seu movimento.">
+    <meta name="twitter:title" content="Aurora Flow — noite polar generativa | Diogo Paulino">
+    <meta name="twitter:description"
+        content="Noite polar no browser: cortinas de oxigênio, fitas de plasma e um fiorde que reflete o céu.">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Oxanium:wght@400;600;700;800&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600;700;800&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/labs/shared.css?v=9">
     <link rel="stylesheet" href="style.css">
     <script type="application/ld+json">
@@ -36,7 +39,7 @@
           "@type": "WebApplication",
           "name": "Aurora Flow",
           "url": "https://diogopaulino.com.br/labs/aurora-flow/",
-          "description": "Aurora generativa: cortinas de luz, vórtices e tempestades de partículas que reagem ao seu movimento.",
+          "description": "Noite polar no browser: cortinas de oxigênio, fitas de plasma e um fiorde que reflete o céu. Arraste o campo magnético — por Diogo Paulino.",
           "applicationCategory": "WebApplication",
           "operatingSystem": "Any",
           "inLanguage": "pt-BR",
@@ -81,7 +84,8 @@
         <header data-lab-header data-title="Aurora Flow">
             <template data-slot="logo">
                 <div class="app-logo">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                        aria-hidden="true">
                         <path d="M12 3c.132 0 .263 0 .393 0a7.5 7.5 0 0 0 7.92 12.446a9 9 0 1 1 -8.313 -12.454z" />
                         <path d="M17 4a2 2 0 0 0 2 2a2 2 0 0 0 -2 2a2 2 0 0 0 -2 -2a2 2 0 0 0 2 -2" />
                         <path d="M19 11h2m-1 -1v2" />
@@ -97,30 +101,35 @@
                             d="M8 3H5a2 2 0 0 0-2 2v3m18 0V5a2 2 0 0 0-2-2h-3m0 18h3a2 2 0 0 0 2-2v-3M3 16v3a2 2 0 0 0 2 2h3" />
                     </svg>
                     <svg class="fullscreen-exit" width="20" height="20" viewBox="0 0 24 24" fill="none"
-                        stroke="currentColor" stroke-width="2" style="display:none">
-                        <path
-                            d="M8 3v3a2 2 0 0 1-2 2H3m0 18v-3a2 2 0 0 1 2-2h3M3 16h3a2 2 0 0 1 2 2v3" />
+                        stroke="currentColor" stroke-width="2" hidden>
+                        <path d="M8 3v3a2 2 0 0 1-2 2H3m18 0v-3a2 2 0 0 0-2-2h-3M3 16h3a2 2 0 0 1 2 2v3m18 0h-3a2 2 0 0 1-2-2v-3" />
                     </svg>
                 </button>
             </template>
         </header>
 
-        <canvas id="canvas"></canvas>
+        <canvas id="canvas" aria-label="Céu polar interativo"></canvas>
+        <div class="vignette" aria-hidden="true"></div>
 
         <div class="hud" aria-live="polite">
+            <span class="hud-kicker" id="hudTag">Cortinas</span>
             <span class="hud-scene" id="hudScene">Boreal</span>
-            <span class="hud-meta"><span id="fps">60</span> fps · <span id="particleCount">0</span></span>
+            <span class="hud-meta">
+                Kp <span id="kpIndex">3.2</span>
+                · <span id="fps">60</span> fps
+                · <span id="particleCount">0</span>
+            </span>
         </div>
 
         <div class="hint" id="hint">
-            <p>Arraste para guiar · clique para um pulso · <kbd>1</kbd>–<kbd>6</kbd> cenas</p>
+            <p>Arraste o campo magnético · toque para uma flare · <kbd>1</kbd>–<kbd>6</kbd> cenas</p>
         </div>
 
         <div class="dock">
             <div class="scene-rail" id="sceneRail" role="listbox" aria-label="Cenas"></div>
 
             <div class="dock-tools">
-                <div class="tool-group" role="group" aria-label="Interação">
+                <div class="tool-group" role="group" aria-label="Campo magnético">
                     <button class="tool-btn active" data-mode="attract" title="Atrair (A)" aria-label="Atrair">
                         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor"
                             stroke-width="2">
@@ -153,7 +162,15 @@
                 </div>
 
                 <div class="tool-group">
-                    <button id="random" class="tool-btn accent" title="Cena aleatória (R)" aria-label="Aleatório">
+                    <button id="meteor" class="tool-btn accent" title="Meteoro (M)" aria-label="Meteoro">
+                        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                            stroke-width="2">
+                            <path d="M4 20 20 4" />
+                            <path d="M14 4h6v6" />
+                            <circle cx="7" cy="17" r="2.2" />
+                        </svg>
+                    </button>
+                    <button id="random" class="tool-btn" title="Cena aleatória (R)" aria-label="Aleatório">
                         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor"
                             stroke-width="2">
                             <path d="M2 18h1.4c1.3 0 2.5-.6 3.3-1.7l6.1-8.6c.7-1.1 2-1.7 3.3-1.7H22" />
@@ -168,8 +185,7 @@
                             <rect x="6" y="4" width="4" height="16" rx="1" />
                             <rect x="14" y="4" width="4" height="16" rx="1" />
                         </svg>
-                        <svg class="play-icon" width="18" height="18" viewBox="0 0 24 24" fill="currentColor"
-                            style="display:none">
+                        <svg class="play-icon" width="18" height="18" viewBox="0 0 24 24" fill="currentColor" hidden>
                             <path d="M7 4l13 8-13 8V4z" />
                         </svg>
                     </button>
@@ -198,16 +214,24 @@
                     <input type="range" id="flowSpeed" min="0.2" max="2.5" step="0.1" value="1">
                 </div>
                 <div class="slider-row">
-                    <label for="density">Densidade <span id="densityValue">2200</span></label>
-                    <input type="range" id="density" min="400" max="6000" step="100" value="2200">
+                    <label for="density">Densidade <span id="densityValue">1600</span></label>
+                    <input type="range" id="density" min="300" max="4200" step="100" value="1600">
                 </div>
                 <div class="slider-row">
-                    <label for="trailLength">Rastro <span id="trailValue">94%</span></label>
-                    <input type="range" id="trailLength" min="82" max="98" step="1" value="94">
+                    <label for="trailLength">Rastro <span id="trailValue">93%</span></label>
+                    <input type="range" id="trailLength" min="80" max="97" step="1" value="93">
                 </div>
                 <div class="slider-row">
                     <label for="force">Força <span id="forceValue">3.5</span></label>
                     <input type="range" id="force" min="1" max="10" step="0.5" value="3.5">
+                </div>
+                <div class="slider-row">
+                    <label for="altitude">Altitude <span id="altitudeValue">70%</span></label>
+                    <input type="range" id="altitude" min="30" max="100" step="1" value="70">
+                </div>
+                <div class="slider-row">
+                    <label for="glow">Brilho <span id="glowValue">80%</span></label>
+                    <input type="range" id="glow" min="0" max="100" step="1" value="80">
                 </div>
             </div>
         </div>

--- a/labs/aurora-flow/script.js
+++ b/labs/aurora-flow/script.js
@@ -1,31 +1,55 @@
+/**
+ * Aurora Flow — noite polar generativa
+ *
+ * Camadas (fundo → frente):
+ *   céu → via láctea → estrelas → lua → cortinas (OI 557.7 nm / N2+ 427.8 nm)
+ *   → fitas de plasma (flow field) → meteoros → reflexo no fiorde → montanhas
+ *
+ * Campo: θ = noise3D(x·τ, y·τ, z) misturado com um dipolo 2D no ponteiro.
+ * Cortinas: fibras verticais com envelope fBm; rosa no topo, verde na base.
+ * Partículas: Euler + damping 0.97; ribbon = histórico de N pontos.
+ */
+
 const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d', { alpha: false });
+const sky = document.createElement('canvas');
+const skyCtx = sky.getContext('2d', { alpha: false });
+const land = document.createElement('canvas');
+const landCtx = land.getContext('2d', { alpha: true });
+
+const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+const coarse = window.matchMedia('(pointer: coarse)').matches;
+const isMobile = window.matchMedia('(max-width: 768px)').matches || coarse;
 
 let width = 0;
 let height = 0;
+let dpr = 1;
+let horizon = 0;
+
 let particles = [];
 let flowField = [];
 let cols = 0;
 let rows = 0;
-const scale = 22;
+const SCALE = isMobile ? 28 : 22;
+
 let zoff = 0;
-let curtainTime = 0;
-let breath = 0;
+let time = 0;
+let curtainT = 0;
+let kpBreath = 0;
 
 let flowSpeed = 1;
-let particleCount = 2200;
-let turbulence = 0.004;
+let particleCount = isMobile ? 700 : 1600;
+let turbulence = 0.0038;
 let interactionMode = 'attract';
 let interactionForce = 3.5;
-let particleSize = 1.4;
-let trailLength = 0.94;
+let particleSize = 1.35;
+let trailLength = 0.93;
 let blendMode = 'lighter';
-let particleShape = 'ribbon';
-let bgEffect = 'stars';
-let auroraIntensity = 75;
+let auroraIntensity = 80;
+let auroraAltitude = 0.7;
 let flowStyle = 'drift';
-let connectDist = 0;
 let paused = false;
+let flash = 0;
 
 let mouseX = -1000;
 let mouseY = -1000;
@@ -37,131 +61,152 @@ let mouseVelocityY = 0;
 let painting = false;
 
 let stars = [];
+let milky = [];
+let meteors = [];
 let ripples = [];
 let wakes = [];
-let nebulaOffset = 0;
-const isMobile = window.matchMedia('(max-width: 768px)').matches;
+let iceSpark = [];
+
+const TRAIL = isMobile ? 4 : 8;
 
 const scenes = {
     boreal: {
         name: 'Boreal',
         tag: 'Cortinas',
-        colors: ['#3dffb5', '#4ecfff', '#8b7cff', '#7ef9c5', '#9ad7ff'],
-        bg: 'rgba(2, 8, 18, 1)',
-        glow: 'rgba(61, 255, 181, 0.18)',
-        shape: 'ribbon',
+        colors: ['#3dffb5', '#7cf4ff', '#c084fc', '#ff8ac4', '#9dffd0'],
+        bg: '#02060e',
+        glow: 'rgba(61, 255, 181, 0.22)',
         flow: 'drift',
         interaction: 'attract',
         blend: 'lighter',
-        bgFx: 'stars',
-        speed: 1,
-        size: 1.35,
-        density: 2400,
-        trail: 95,
-        turb: 0.0035,
+        terrain: 'fjord',
+        sky: 'night',
+        fieldLines: false,
+        speed: 0.95,
+        size: 1.3,
+        density: 1700,
+        trail: 93,
+        turb: 0.0034,
         force: 3.2,
-        aurora: 80,
-        connect: 0
+        aurora: 86,
+        altitude: 72,
+        horizon: 0.7,
+        sheets: 4
     },
     tempest: {
         name: 'Tempestade',
-        tag: 'Caos',
+        tag: 'CME',
         colors: ['#ff4d6d', '#ff9f1c', '#ffe66d', '#ff6b35', '#ffd60a'],
-        bg: 'rgba(12, 4, 6, 1)',
-        glow: 'rgba(255, 77, 109, 0.2)',
-        shape: 'spark',
+        bg: '#0c0406',
+        glow: 'rgba(255, 77, 109, 0.24)',
         flow: 'chaos',
         interaction: 'repel',
         blend: 'lighter',
-        bgFx: 'none',
-        speed: 1.9,
-        size: 1.7,
-        density: 1800,
-        trail: 90,
-        turb: 0.012,
-        force: 6.5,
-        aurora: 25,
-        connect: 0
+        terrain: 'ice',
+        sky: 'storm',
+        fieldLines: false,
+        speed: 1.85,
+        size: 1.55,
+        density: 1400,
+        trail: 88,
+        turb: 0.011,
+        force: 6.4,
+        aurora: 55,
+        altitude: 88,
+        horizon: 0.74,
+        sheets: 3
     },
-    vortex: {
-        name: 'Vórtice',
-        tag: 'Espiral',
+    corona: {
+        name: 'Coroa',
+        tag: 'Zênite',
         colors: ['#a78bfa', '#f472b6', '#60a5fa', '#c084fc', '#e879f9'],
-        bg: 'rgba(8, 4, 16, 1)',
-        glow: 'rgba(167, 139, 250, 0.2)',
-        shape: 'line',
+        bg: '#070414',
+        glow: 'rgba(167, 139, 250, 0.24)',
         flow: 'spiral',
         interaction: 'vortex',
         blend: 'screen',
-        bgFx: 'nebula',
-        speed: 1.35,
-        size: 1.5,
-        density: 2000,
-        trail: 93,
-        turb: 0.005,
-        force: 5,
-        aurora: 35,
-        connect: 0
+        terrain: 'void',
+        sky: 'zenith',
+        fieldLines: true,
+        speed: 1.28,
+        size: 1.4,
+        density: 1500,
+        trail: 92,
+        turb: 0.0048,
+        force: 5.2,
+        aurora: 48,
+        altitude: 95,
+        horizon: 1,
+        sheets: 3
     },
-    tide: {
-        name: 'Maré',
-        tag: 'Ondas',
+    fjord: {
+        name: 'Fjord',
+        tag: 'Reflexo',
         colors: ['#22d3ee', '#38bdf8', '#67e8f9', '#2dd4bf', '#a5f3fc'],
-        bg: 'rgba(2, 12, 22, 1)',
-        glow: 'rgba(34, 211, 238, 0.18)',
-        shape: 'circle',
+        bg: '#021018',
+        glow: 'rgba(34, 211, 238, 0.22)',
         flow: 'waves',
         interaction: 'attract',
         blend: 'lighter',
-        bgFx: 'none',
-        speed: 0.75,
-        size: 1.8,
-        density: 2800,
-        trail: 96,
-        turb: 0.0028,
+        terrain: 'fjord',
+        sky: 'night',
+        fieldLines: false,
+        speed: 0.72,
+        size: 1.6,
+        density: 1900,
+        trail: 95,
+        turb: 0.0026,
         force: 2.8,
-        aurora: 45,
-        connect: 55
+        aurora: 70,
+        altitude: 62,
+        horizon: 0.66,
+        sheets: 4
     },
-    ember: {
-        name: 'Ember',
-        tag: 'Ascensão',
-        colors: ['#fb923c', '#f97316', '#fbbf24', '#ef4444', '#fdba74'],
-        bg: 'rgba(10, 4, 2, 1)',
-        glow: 'rgba(251, 146, 60, 0.2)',
-        shape: 'glow',
+    plasma: {
+        name: 'Plasma',
+        tag: 'Elétrica',
+        colors: ['#67e8f9', '#c084fc', '#22d3ee', '#e879f9', '#a5b4fc'],
+        bg: '#040816',
+        glow: 'rgba(103, 232, 249, 0.22)',
+        flow: 'grid',
+        interaction: 'paint',
+        blend: 'lighter',
+        terrain: 'void',
+        sky: 'void',
+        fieldLines: true,
+        speed: 1.12,
+        size: 1.25,
+        density: 1300,
+        trail: 90,
+        turb: 0.0055,
+        force: 4.6,
+        aurora: 22,
+        altitude: 80,
+        horizon: 1,
+        sheets: 2
+    },
+    dawn: {
+        name: 'Alvorada',
+        tag: 'Crepúsculo',
+        colors: ['#fb923c', '#fbbf24', '#34d399', '#f472b6', '#fdba74'],
+        bg: '#120814',
+        glow: 'rgba(251, 146, 60, 0.22)',
         flow: 'rise',
         interaction: 'attract',
         blend: 'lighter',
-        bgFx: 'none',
-        speed: 1.15,
-        size: 2.1,
-        density: 1400,
+        terrain: 'fjord',
+        sky: 'dawn',
+        fieldLines: false,
+        speed: 0.82,
+        size: 1.7,
+        density: 1200,
         trail: 94,
-        turb: 0.0045,
-        force: 3.8,
-        aurora: 20,
-        connect: 0
-    },
-    lattice: {
-        name: 'Lattice',
-        tag: 'Rede',
-        colors: ['#34d399', '#a3e635', '#4ade80', '#86efac', '#bef264'],
-        bg: 'rgba(3, 10, 8, 1)',
-        glow: 'rgba(52, 211, 153, 0.18)',
-        shape: 'dot',
-        flow: 'grid',
-        interaction: 'paint',
-        blend: 'source-over',
-        bgFx: 'grid',
-        speed: 0.9,
-        size: 1.2,
-        density: 1600,
-        trail: 88,
         turb: 0.003,
-        force: 4.2,
-        aurora: 0,
-        connect: 78
+        force: 3.4,
+        aurora: 42,
+        altitude: 58,
+        horizon: 0.72,
+        sheets: 3
     }
 };
 
@@ -171,9 +216,20 @@ let current = scenes.boreal;
 let frameCount = 0;
 let lastTime = performance.now();
 let fps = 60;
+let meteorTimer = 0;
+let warmFrames = 0;
 
 function fade(t) { return t * t * t * (t * (t * 6 - 15) + 10); }
 function lerp(t, a, b) { return a + t * (b - a); }
+function clamp(v, a, b) { return Math.max(a, Math.min(b, v)); }
+function hexAlpha(hex, a) {
+    const n = hex.replace('#', '');
+    const r = parseInt(n.slice(0, 2), 16);
+    const g = parseInt(n.slice(2, 4), 16);
+    const b = parseInt(n.slice(4, 6), 16);
+    return `rgba(${r},${g},${b},${a})`;
+}
+
 function grad(hash, x, y, z) {
     const h = hash & 15;
     const u = h < 8 ? x : y;
@@ -220,66 +276,215 @@ function noise3D(x, y, z) {
             lerp(u, grad(p[AB + 1], x, y - 1, z - 1), grad(p[BB + 1], x - 1, y - 1, z - 1))));
 }
 
+function fbm(x, y, z) {
+    let v = 0;
+    let a = 0.5;
+    for (let i = 0; i < 4; i++) {
+        v += a * noise3D(x, y, z);
+        x *= 2.02;
+        y *= 2.02;
+        z *= 2.02;
+        a *= 0.5;
+    }
+    return v;
+}
+
+function sizeLayer(layer) {
+    layer.width = Math.max(1, Math.floor(width * dpr));
+    layer.height = Math.max(1, Math.floor(height * dpr));
+    const c = layer.getContext('2d');
+    c.setTransform(dpr, 0, 0, dpr, 0, 0);
+}
+
 function resize() {
-    width = canvas.width = window.innerWidth;
-    height = canvas.height = window.innerHeight;
-    cols = Math.floor(width / scale) + 1;
-    rows = Math.floor(height / scale) + 1;
+    width = window.innerWidth;
+    height = window.innerHeight;
+    dpr = Math.min(window.devicePixelRatio || 1, isMobile ? 1.5 : 2);
+    sizeLayer(canvas);
+    sizeLayer(sky);
+    sizeLayer(land);
+    horizon = horizonY();
+    cols = Math.floor(width / SCALE) + 1;
+    rows = Math.floor(height / SCALE) + 1;
     flowField = new Float32Array(cols * rows);
     initStars();
-    initParticles();
+    initIce();
+    buildTerrain();
+    if (!particles.length) initParticles();
 }
 
 function initStars() {
     stars = [];
-    const count = Math.floor((width * height) / 6500);
+    milky = [];
+    const count = Math.floor((width * height) / (isMobile ? 9000 : 5200));
     for (let i = 0; i < count; i++) {
         stars.push({
             x: Math.random() * width,
             y: Math.random() * height,
-            size: Math.random() * 1.4 + 0.3,
+            size: Math.random() * 1.35 + 0.25,
             twinkle: Math.random() * Math.PI * 2,
-            speed: Math.random() * 0.025 + 0.008,
+            speed: Math.random() * 0.03 + 0.006,
             layer: Math.random()
+        });
+    }
+    const band = Math.floor(count * 0.35);
+    const angle = -0.42;
+    const ca = Math.cos(angle);
+    const sa = Math.sin(angle);
+    for (let i = 0; i < band; i++) {
+        const u = (Math.random() - 0.5) * width * 1.4;
+        const v = (Math.random() - 0.5) * height * 0.18;
+        milky.push({
+            x: width * 0.48 + u * ca - v * sa,
+            y: height * 0.28 + u * sa + v * ca,
+            size: Math.random() * 1.1 + 0.2,
+            a: Math.random() * 0.45 + 0.12
         });
     }
 }
 
+function initIce() {
+    iceSpark = [];
+    const n = Math.floor(width / 14);
+    for (let i = 0; i < n; i++) {
+        iceSpark.push({
+            x: Math.random() * width,
+            y: Math.random(),
+            w: Math.random() * 18 + 4,
+            a: Math.random() * 0.25 + 0.05,
+            s: Math.random() * 0.02 + 0.004
+        });
+    }
+}
+
+function drawPine(c, x, y, h) {
+    const w = h * 0.52;
+    c.fillStyle = '#05080f';
+    for (let t = 0; t < 3; t++) {
+        c.beginPath();
+        c.moveTo(x, y - h + t * h * 0.2);
+        c.lineTo(x - w * (1 - t * 0.2), y - h * 0.42 + t * h * 0.26);
+        c.lineTo(x + w * (1 - t * 0.2), y - h * 0.42 + t * h * 0.26);
+        c.closePath();
+        c.fill();
+    }
+    c.fillRect(x - 1.4, y - h * 0.12, 2.8, h * 0.18);
+}
+
+function buildTerrain() {
+    landCtx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    landCtx.clearRect(0, 0, width, height);
+    if (current.terrain === 'void') return;
+
+    const hzn = horizonY();
+    const layers = current.terrain === 'ice' ? 2 : 3;
+
+    for (let layer = 0; layer < layers; layer++) {
+        const base = hzn + 6 - layer * 10;
+        landCtx.beginPath();
+        landCtx.moveTo(-20, height);
+        landCtx.lineTo(-20, base);
+        for (let x = 0; x <= width + 20; x += 7) {
+            const n = noise3D(x * 0.0028 + layer * 31, layer * 9.1, 0.21);
+            const n2 = noise3D(x * 0.011 + layer * 7, 3.2, 0.4);
+            const peak = Math.max(0, n * 0.55 + 0.42) * (70 + layer * 54) * (layer === layers - 1 ? 1.2 : 0.72);
+            landCtx.lineTo(x, base - peak + n2 * 10);
+        }
+        landCtx.lineTo(width + 20, height);
+        landCtx.closePath();
+        const g = landCtx.createLinearGradient(0, hzn - 200, 0, height);
+        if (current.sky === 'dawn' && layer === layers - 1) {
+            g.addColorStop(0, '#0c0814');
+            g.addColorStop(1, '#1a0c10');
+        } else {
+            g.addColorStop(0, layer === layers - 1 ? '#070b14' : `rgba(${5 + layer * 3},${9 + layer * 4},${18 + layer * 5},0.92)`);
+            g.addColorStop(1, '#02040a');
+        }
+        landCtx.fillStyle = g;
+        landCtx.fill();
+
+        if (layer === layers - 1) {
+            landCtx.save();
+            landCtx.clip();
+            landCtx.strokeStyle = 'rgba(214, 228, 255, 0.22)';
+            landCtx.lineWidth = 1.6;
+            landCtx.beginPath();
+            for (let x = 0; x <= width + 20; x += 7) {
+                const n = noise3D(x * 0.0028 + layer * 31, layer * 9.1, 0.21);
+                const n2 = noise3D(x * 0.011 + layer * 7, 3.2, 0.4);
+                const peak = Math.max(0, n * 0.55 + 0.42) * (70 + layer * 54) * 1.2;
+                const y = base - peak + n2 * 10;
+                if (x === 0) landCtx.moveTo(x, y);
+                else landCtx.lineTo(x, y);
+            }
+            landCtx.stroke();
+            landCtx.restore();
+        }
+    }
+
+    const pineCount = Math.floor(width / (isMobile ? 52 : 36));
+    for (let i = 0; i < pineCount; i++) {
+        const nx = noise3D(i * 0.73, 4.2, 0.5);
+        const x = (i + 0.25 + nx * 0.4) * (width / pineCount);
+        const y = hzn + 10 + nx * 8;
+        drawPine(landCtx, x, y, 16 + Math.abs(nx) * 22);
+    }
+
+    landCtx.fillStyle = current.terrain === 'ice' ? '#0a121c' : '#050910';
+    landCtx.fillRect(0, hzn + 8, width, 16);
+}
+
 class Particle {
     constructor() {
+        this.trail = new Float32Array(TRAIL * 2);
         this.reset(true);
     }
 
     reset(initial) {
+        const hzn = horizonY();
+        const skyH = Math.max(80, hzn);
         if (flowStyle === 'rise') {
             this.x = Math.random() * width;
-            this.y = initial ? Math.random() * height : height + Math.random() * 40;
+            this.y = initial ? Math.random() * skyH : skyH + Math.random() * 20;
         } else if (flowStyle === 'spiral') {
             const a = Math.random() * Math.PI * 2;
-            const r = Math.random() * Math.min(width, height) * 0.48;
+            const r = Math.random() * Math.min(width, height) * 0.46;
             this.x = width * 0.5 + Math.cos(a) * r;
-            this.y = height * 0.5 + Math.sin(a) * r;
+            this.y = height * 0.42 + Math.sin(a) * r;
         } else {
             this.x = Math.random() * width;
-            this.y = Math.random() * height;
+            this.y = Math.random() * skyH;
         }
-        this.prevX = this.x;
-        this.prevY = this.y;
         this.vx = 0;
         this.vy = 0;
         this.color = current.colors[(Math.random() * current.colors.length) | 0];
-        this.alpha = Math.random() * 0.45 + 0.35;
-        this.size = (Math.random() * 1.4 + 0.5) * particleSize;
-        this.life = Math.random() * 220 + 90;
+        this.alpha = Math.random() * 0.4 + 0.4;
+        this.size = (Math.random() * 1.2 + 0.55) * particleSize;
+        this.life = Math.random() * 240 + 80;
         this.maxLife = this.life;
-        this.hueShift = Math.random();
+        this.glow = !isMobile && Math.random() < 0.08;
+        this.ti = 0;
+        this.tn = 0;
+        for (let i = 0; i < this.trail.length; i += 2) {
+            this.trail[i] = this.x;
+            this.trail[i + 1] = this.y;
+        }
+        this.tn = TRAIL;
+        this.ti = 0;
+    }
+
+    pushTrail() {
+        this.trail[this.ti] = this.x;
+        this.trail[this.ti + 1] = this.y;
+        this.ti = (this.ti + 2) % this.trail.length;
+        this.tn = Math.min(this.tn + 1, TRAIL);
     }
 
     update() {
-        const col = Math.max(0, Math.min(cols - 1, (this.x / scale) | 0));
-        const row = Math.max(0, Math.min(rows - 1, (this.y / scale) | 0));
+        const col = clamp((this.x / SCALE) | 0, 0, cols - 1);
+        const row = clamp((this.y / SCALE) | 0, 0, rows - 1);
         const angle = flowField[col + row * cols];
-        const force = 0.42 * flowSpeed;
+        const force = 0.4 * flowSpeed;
         this.vx += Math.cos(angle) * force;
         this.vy += Math.sin(angle) * force;
 
@@ -287,27 +492,26 @@ class Particle {
             const dx = mouseX - this.x;
             const dy = mouseY - this.y;
             const dist = Math.hypot(dx, dy) || 1;
-            const maxDist = interactionMode === 'paint' ? 110 : 210;
-
+            const maxDist = interactionMode === 'paint' ? 120 : 220;
             if (dist < maxDist) {
                 const strength = (1 - dist / maxDist) * interactionForce;
                 const nx = dx / dist;
                 const ny = dy / dist;
-
                 if (interactionMode === 'attract') {
                     this.vx += nx * strength;
                     this.vy += ny * strength;
                 } else if (interactionMode === 'repel') {
-                    this.vx -= nx * strength * 2.1;
-                    this.vy -= ny * strength * 2.1;
+                    this.vx -= nx * strength * 2.15;
+                    this.vy -= ny * strength * 2.15;
                 } else if (interactionMode === 'vortex') {
                     this.vx += -ny * strength + mouseVelocityX * 0.12;
                     this.vy += nx * strength + mouseVelocityY * 0.12;
                 } else if (interactionMode === 'paint') {
-                    const speed = Math.hypot(mouseVelocityX, mouseVelocityY);
-                    this.vx += mouseVelocityX * 0.18 * strength + nx * strength * 0.2;
-                    this.vy += mouseVelocityY * 0.18 * strength + ny * strength * 0.2;
-                    if (speed > 2) this.life = Math.min(this.maxLife, this.life + 4);
+                    this.vx += mouseVelocityX * 0.2 * strength + nx * strength * 0.18;
+                    this.vy += mouseVelocityY * 0.2 * strength + ny * strength * 0.18;
+                    if (Math.hypot(mouseVelocityX, mouseVelocityY) > 2) {
+                        this.life = Math.min(this.maxLife, this.life + 5);
+                    }
                 }
             }
         }
@@ -324,72 +528,42 @@ class Particle {
             }
         }
 
-        this.vx *= 0.975;
-        this.vy *= 0.975;
-
-        const maxSpeed = flowStyle === 'chaos' ? 9 : 6.2;
+        this.vx *= 0.972;
+        this.vy *= 0.972;
+        const maxSpeed = flowStyle === 'chaos' ? 9.2 : 6.1;
         const speed = Math.hypot(this.vx, this.vy);
         if (speed > maxSpeed) {
             this.vx = (this.vx / speed) * maxSpeed;
             this.vy = (this.vy / speed) * maxSpeed;
         }
 
-        this.prevX = this.x;
-        this.prevY = this.y;
+        this.pushTrail();
         this.x += this.vx;
         this.y += this.vy;
         this.life--;
 
-        const margin = 40;
+        const hzn = horizonY();
+        const margin = 36;
         if (
             this.x < -margin || this.x > width + margin ||
-            this.y < -margin || this.y > height + margin ||
+            this.y < -margin || this.y > hzn + margin ||
             this.life <= 0
         ) {
             this.reset(false);
         }
     }
 
-    draw() {
-        const lifeRatio = this.life / this.maxLife;
-        const alpha = this.alpha * lifeRatio;
-        ctx.globalAlpha = alpha;
-        ctx.strokeStyle = this.color;
-        ctx.fillStyle = this.color;
-        ctx.lineWidth = this.size;
-        ctx.lineCap = 'round';
-
-        if (particleShape === 'ribbon' || particleShape === 'line') {
-            ctx.beginPath();
-            ctx.moveTo(this.prevX, this.prevY);
-            ctx.lineTo(this.x, this.y);
-            ctx.stroke();
-        } else if (particleShape === 'circle' || particleShape === 'dot') {
-            ctx.beginPath();
-            ctx.arc(this.x, this.y, this.size * (particleShape === 'dot' ? 1.4 : 2.1), 0, Math.PI * 2);
-            ctx.fill();
-        } else if (particleShape === 'spark') {
-            const len = this.size * 3.4;
-            const ang = Math.atan2(this.vy, this.vx);
-            ctx.beginPath();
-            ctx.moveTo(this.x - Math.cos(ang) * len, this.y - Math.sin(ang) * len);
-            ctx.lineTo(this.x + Math.cos(ang) * len, this.y + Math.sin(ang) * len);
-            ctx.moveTo(this.x - Math.sin(ang) * len * 0.45, this.y + Math.cos(ang) * len * 0.45);
-            ctx.lineTo(this.x + Math.sin(ang) * len * 0.45, this.y - Math.cos(ang) * len * 0.45);
-            ctx.stroke();
-        } else if (particleShape === 'glow') {
-            const r = this.size * 5.5;
-            const g = ctx.createRadialGradient(this.x, this.y, 0, this.x, this.y, r);
-            g.addColorStop(0, this.color);
-            g.addColorStop(0.45, this.color + '55');
-            g.addColorStop(1, 'transparent');
-            ctx.fillStyle = g;
-            ctx.beginPath();
-            ctx.arc(this.x, this.y, r, 0, Math.PI * 2);
-            ctx.fill();
+    trace(c) {
+        const n = this.tn;
+        if (n < 2) return;
+        const len = this.trail.length;
+        const start = (this.ti - n * 2 + len) % len;
+        c.moveTo(this.trail[start], this.trail[start + 1]);
+        for (let i = 1; i < n; i++) {
+            const idx = (start + i * 2) % len;
+            c.lineTo(this.trail[idx], this.trail[idx + 1]);
         }
-
-        ctx.globalAlpha = 1;
+        c.lineTo(this.x, this.y);
     }
 }
 
@@ -415,175 +589,297 @@ function setDensity(n) {
 function fieldAngle(x, y, cx, cy) {
     const n = noise3D(x * turbulence * 12, y * turbulence * 12, zoff);
     if (flowStyle === 'drift') {
-        return n * Math.PI * 3.2 + Math.sin(y * 0.004 + curtainTime) * 0.35;
+        return n * Math.PI * 3.1 + Math.sin(y * 0.004 + curtainT) * 0.38;
     }
     if (flowStyle === 'chaos') {
-        return n * Math.PI * 8 + Math.sin(zoff * 20 + x) * 0.8;
+        return n * Math.PI * 8 + Math.sin(zoff * 20 + x) * 0.85;
     }
     if (flowStyle === 'spiral') {
-        const dx = x * scale - cx;
-        const dy = y * scale - cy;
-        return Math.atan2(dy, dx) + Math.PI * 0.5 + n * 0.9;
+        const dx = x * SCALE - cx;
+        const dy = y * SCALE - cy;
+        return Math.atan2(dy, dx) + Math.PI * 0.5 + n * 0.85;
     }
     if (flowStyle === 'waves') {
-        return Math.sin(y * 0.035 + curtainTime * 2.2) * 0.9 + n * Math.PI + Math.cos(x * 0.02) * 0.25;
+        return Math.sin(y * 0.034 + curtainT * 2.1) * 0.95 + n * Math.PI + Math.cos(x * 0.02) * 0.22;
     }
     if (flowStyle === 'rise') {
-        return -Math.PI * 0.5 + n * 1.4 + Math.sin(x * 0.01 + curtainTime) * 0.4;
+        return -Math.PI * 0.5 + n * 1.35 + Math.sin(x * 0.01 + curtainT) * 0.42;
     }
     if (flowStyle === 'grid') {
         const cell = ((x / 3) | 0) + ((y / 3) | 0);
-        return (cell % 2 === 0 ? 0 : Math.PI * 0.5) + n * 0.7;
+        return (cell % 2 === 0 ? 0 : Math.PI * 0.5) + n * 0.65;
     }
     return n * Math.PI * 4;
 }
 
 function updateFlowField() {
     const cx = width * 0.5;
-    const cy = height * 0.5;
+    const cy = height * (current.terrain === 'void' ? 0.45 : 0.38);
     let i = 0;
     for (let y = 0; y < rows; y++) {
         for (let x = 0; x < cols; x++) {
             flowField[i++] = fieldAngle(x, y, cx, cy);
         }
     }
-    zoff += 0.0018 * flowSpeed;
+    zoff += 0.0017 * flowSpeed;
 }
 
-function drawBackground() {
-    if (bgEffect === 'stars') {
-        const parallaxX = (mouseActive ? (mouseX - width / 2) : 0) * 0.01;
-        const parallaxY = (mouseActive ? (mouseY - height / 2) : 0) * 0.01;
-        for (const star of stars) {
-            star.twinkle += star.speed;
-            const alpha = (Math.sin(star.twinkle) + 1) * 0.35 + 0.15;
-            const px = star.x + parallaxX * (0.4 + star.layer);
-            const py = star.y + parallaxY * (0.4 + star.layer);
-            ctx.fillStyle = `rgba(255,255,255,${alpha * 0.7})`;
-            ctx.beginPath();
-            ctx.arc(px, py, star.size, 0, Math.PI * 2);
-            ctx.fill();
-        }
-    } else if (bgEffect === 'grid') {
-        ctx.strokeStyle = current.colors[0] + '14';
-        ctx.lineWidth = 1;
-        const size = 48;
-        const offset = (curtainTime * 18) % size;
-        for (let x = -size + offset; x < width; x += size) {
-            ctx.beginPath();
-            ctx.moveTo(x, 0);
-            ctx.lineTo(x, height);
-            ctx.stroke();
-        }
-        for (let y = -size + offset * 0.6; y < height; y += size) {
-            ctx.beginPath();
-            ctx.moveTo(0, y);
-            ctx.lineTo(width, y);
-            ctx.stroke();
-        }
-    } else if (bgEffect === 'nebula') {
-        nebulaOffset += 0.002 * flowSpeed;
-        const g = ctx.createRadialGradient(
-            width * 0.5 + Math.sin(nebulaOffset) * 120,
-            height * 0.5 + Math.cos(nebulaOffset * 0.8) * 90,
-            0,
-            width * 0.5,
-            height * 0.5,
-            Math.max(width, height) * 0.55
-        );
-        g.addColorStop(0, current.colors[0] + '12');
-        g.addColorStop(0.4, current.colors[1] + '08');
-        g.addColorStop(0.75, current.colors[2] + '04');
-        g.addColorStop(1, 'transparent');
-        ctx.fillStyle = g;
-        ctx.fillRect(0, 0, width, height);
+function fillSky(alpha) {
+    const hzn = Math.max(1, horizonY());
+    skyCtx.globalAlpha = alpha;
+    skyCtx.globalCompositeOperation = 'source-over';
+    if (current.sky === 'dawn') {
+        const g = skyCtx.createLinearGradient(0, 0, 0, hzn);
+        g.addColorStop(0, '#070414');
+        g.addColorStop(0.48, '#1a0c22');
+        g.addColorStop(0.78, '#c45c3a');
+        g.addColorStop(1, '#f0a060');
+        skyCtx.fillStyle = g;
+    } else if (current.sky === 'storm') {
+        const g = skyCtx.createLinearGradient(0, 0, 0, height);
+        g.addColorStop(0, '#14060a');
+        g.addColorStop(1, '#080204');
+        skyCtx.fillStyle = g;
+    } else if (current.sky === 'zenith') {
+        const g = skyCtx.createRadialGradient(width * 0.5, height * 0.42, 20, width * 0.5, height * 0.42, Math.max(width, height) * 0.7);
+        g.addColorStop(0, '#140820');
+        g.addColorStop(1, current.bg);
+        skyCtx.fillStyle = g;
+    } else {
+        const g = skyCtx.createLinearGradient(0, 0, 0, hzn);
+        g.addColorStop(0, '#01040a');
+        g.addColorStop(0.7, current.bg);
+        g.addColorStop(1, current.bg);
+        skyCtx.fillStyle = g;
     }
+    skyCtx.fillRect(0, 0, width, height);
+    skyCtx.globalAlpha = 1;
 }
 
-function drawAuroraCurtains() {
-    if (auroraIntensity <= 0) return;
+function drawStars() {
+    const hzn = horizonY();
+    const parallaxX = (mouseActive ? (mouseX - width / 2) : 0) * 0.012;
+    const parallaxY = (mouseActive ? (mouseY - height / 2) : 0) * 0.012;
+
+    skyCtx.save();
+    skyCtx.globalCompositeOperation = 'lighter';
+    for (const s of milky) {
+        if (s.y > hzn) continue;
+        skyCtx.fillStyle = `rgba(190,210,255,${s.a * 0.55})`;
+        skyCtx.fillRect(s.x, s.y, s.size, s.size);
+    }
+    for (const star of stars) {
+        if (star.y > hzn) continue;
+        star.twinkle += star.speed * flowSpeed;
+        const alpha = (Math.sin(star.twinkle) + 1) * 0.32 + 0.18;
+        const px = star.x + parallaxX * (0.35 + star.layer);
+        const py = star.y + parallaxY * (0.35 + star.layer);
+        skyCtx.fillStyle = `rgba(255,255,255,${alpha * 0.75})`;
+        skyCtx.beginPath();
+        skyCtx.arc(px, py, star.size, 0, Math.PI * 2);
+        skyCtx.fill();
+    }
+    skyCtx.restore();
+}
+
+function drawMoon() {
+    if (current.sky === 'dawn') return;
+    const mx = width * 0.78;
+    const my = height * 0.16;
+    const r = Math.min(width, height) * 0.028;
+    const halo = skyCtx.createRadialGradient(mx, my, r, mx, my, r * 14);
+    halo.addColorStop(0, 'rgba(220,230,255,0.16)');
+    halo.addColorStop(0.35, hexAlpha(current.colors[1], 0.06));
+    halo.addColorStop(1, 'transparent');
+    skyCtx.fillStyle = halo;
+    skyCtx.fillRect(mx - r * 14, my - r * 14, r * 28, r * 28);
+
+    const g = skyCtx.createRadialGradient(mx - r * 0.3, my - r * 0.3, 0, mx, my, r);
+    g.addColorStop(0, '#f4f7ff');
+    g.addColorStop(1, '#c5d0e8');
+    skyCtx.fillStyle = g;
+    skyCtx.beginPath();
+    skyCtx.arc(mx, my, r, 0, Math.PI * 2);
+    skyCtx.fill();
+}
+
+function horizonY() {
+    if (current.terrain === 'void') return height;
+    let t = current.horizon;
+    if (height < 520 && width > height) t = Math.min(0.84, t + 0.12);
+    return height * t;
+}
+
+function drawAurora() {
     const intensity = auroraIntensity / 100;
-    curtainTime += 0.0022 * flowSpeed;
-    breath = 0.85 + Math.sin(curtainTime * 1.4) * 0.15;
+    if (intensity <= 0.02) return;
+    const hzn = horizonY();
+    const skyH = Math.max(90, hzn);
+    const short = height < 520;
+    const sheets = short || isMobile ? Math.min(current.sheets, 3) : current.sheets;
+    const step = short ? 6 : isMobile ? 4 : 2;
 
-    ctx.save();
-    const bands = flowStyle === 'chaos' ? 2 : 4;
-    const step = Math.max(8, (width / 160) | 0);
+    curtainT += 0.002 * flowSpeed;
+    kpBreath = 0.82 + Math.sin(curtainT * 1.3) * 0.18;
 
-    for (let b = 0; b < bands; b++) {
-        const baseY = height * (0.04 + b * 0.13);
-        const amplitude = (48 + b * 18) * (0.55 + intensity * 0.55) * breath;
-        const curtainHeight = height * (0.22 + b * 0.05);
-        const color = current.colors[b % current.colors.length];
+    skyCtx.save();
+    skyCtx.globalCompositeOperation = 'lighter';
+    skyCtx.lineCap = 'round';
 
-        ctx.beginPath();
-        for (let x = 0; x <= width; x += step) {
-            const n = noise3D(x * 0.002 + b * 18, curtainTime + b * 4, 0.5);
-            const wave = Math.sin(x * 0.0028 + curtainTime * 1.7 + b) * amplitude * 0.45;
-            const y = baseY + n * amplitude + wave;
-            if (x === 0) ctx.moveTo(x, y);
-            else ctx.lineTo(x, y);
+    for (let s = 0; s < sheets; s++) {
+        const phase = s * 19.7;
+        const topC = current.colors[(s + 2) % current.colors.length];
+        const botC = current.colors[s % current.colors.length];
+        const grad = skyCtx.createLinearGradient(0, 0, 0, hzn);
+        grad.addColorStop(0, hexAlpha(topC, 0.92));
+        grad.addColorStop(0.35, hexAlpha(current.colors[1], 0.7));
+        grad.addColorStop(0.78, hexAlpha(botC, 0.38));
+        grad.addColorStop(1, hexAlpha(botC, 0));
+        skyCtx.strokeStyle = grad;
+        skyCtx.lineWidth = (isMobile ? 2.2 : 3.1) + s * 0.35;
+        skyCtx.globalAlpha = intensity * (0.9 - s * 0.14) * kpBreath;
+        skyCtx.beginPath();
+
+        for (let x = 0; x < width; x += step) {
+            const env = fbm(x * 0.0016 + phase, curtainT * 0.5 + s, s * 0.4);
+            const fold = Math.pow(clamp(Math.sin(x * 0.007 + curtainT + phase) * 0.5 + 0.5, 0, 1), 1.6);
+            const envelope = Math.pow(clamp(env * 0.5 + 0.5, 0, 1), 1.25) * (0.28 + fold * 0.85);
+            if (envelope < 0.16) continue;
+            const flicker = 0.62 + noise3D(x * 0.02, curtainT * 1.6, s) * 0.38;
+            const h = envelope * skyH * auroraAltitude * (0.55 + s * 0.1) * flicker;
+            const wobble = noise3D(x * 0.028, curtainT * 0.8, s + 2) * 14;
+            const yTop = hzn - h - skyH * 0.04 * s;
+            skyCtx.moveTo(x + wobble, yTop);
+            skyCtx.lineTo(x, hzn - 2);
         }
-        ctx.lineTo(width, baseY + curtainHeight);
-        ctx.lineTo(0, baseY + curtainHeight);
-        ctx.closePath();
-
-        const gradient = ctx.createLinearGradient(0, baseY - amplitude, 0, baseY + curtainHeight);
-        gradient.addColorStop(0, color + 'aa');
-        gradient.addColorStop(0.4, color + '40');
-        gradient.addColorStop(1, 'transparent');
-        ctx.fillStyle = gradient;
-        ctx.globalAlpha = intensity * (0.55 - b * 0.08) * breath;
-        ctx.shadowBlur = 36;
-        ctx.shadowColor = color;
-        ctx.fill();
-        ctx.shadowBlur = 0;
+        skyCtx.stroke();
     }
-    ctx.restore();
+    skyCtx.restore();
 }
 
-function drawConnections() {
-    if (connectDist <= 0 || particles.length > 3200) return;
-    const max = connectDist;
-    const step = particles.length > 2000 ? 3 : 2;
-    ctx.save();
-    ctx.globalCompositeOperation = 'lighter';
-    ctx.lineWidth = 0.6;
-
-    for (let i = 0; i < particles.length; i += step) {
-        const a = particles[i];
-        for (let j = i + step; j < Math.min(particles.length, i + 28); j += step) {
-            const b = particles[j];
-            const dx = a.x - b.x;
-            const dy = a.y - b.y;
-            const d = Math.hypot(dx, dy);
-            if (d < max) {
-                ctx.globalAlpha = (1 - d / max) * 0.18;
-                ctx.strokeStyle = a.color;
-                ctx.beginPath();
-                ctx.moveTo(a.x, a.y);
-                ctx.lineTo(b.x, b.y);
-                ctx.stroke();
-            }
+function drawFieldLines() {
+    if (!current.fieldLines || height < 520) return;
+    skyCtx.save();
+    skyCtx.globalCompositeOperation = 'lighter';
+    skyCtx.strokeStyle = hexAlpha(current.colors[1], 0.22);
+    skyCtx.lineWidth = 0.8;
+    const count = isMobile ? 10 : 16;
+    for (let i = 0; i < count; i++) {
+        let x = ((i + 0.5) / count) * width;
+        let y = height * 0.12 + (i % 3) * 18;
+        skyCtx.beginPath();
+        skyCtx.moveTo(x, y);
+        for (let s = 0; s < 36; s++) {
+            const col = clamp((x / SCALE) | 0, 0, cols - 1);
+            const row = clamp((y / SCALE) | 0, 0, rows - 1);
+            const a = flowField[col + row * cols];
+            x += Math.cos(a) * 9;
+            y += Math.sin(a) * 9;
+            skyCtx.lineTo(x, y);
         }
+        skyCtx.stroke();
     }
-    ctx.restore();
+    skyCtx.restore();
+}
+
+function drawParticles() {
+    skyCtx.save();
+    skyCtx.globalCompositeOperation = blendMode;
+    skyCtx.lineCap = 'round';
+    skyCtx.lineJoin = 'round';
+    skyCtx.lineWidth = particleSize;
+
+    const groups = new Map();
+    for (const p of particles) {
+        p.update();
+        let g = groups.get(p.color);
+        if (!g) {
+            g = [];
+            groups.set(p.color, g);
+        }
+        g.push(p);
+    }
+
+    for (const [color, group] of groups) {
+        skyCtx.strokeStyle = color;
+        skyCtx.globalAlpha = 0.48;
+        skyCtx.beginPath();
+        for (const p of group) p.trace(skyCtx);
+        skyCtx.stroke();
+    }
+
+    skyCtx.globalAlpha = 0.55;
+    for (const p of particles) {
+        if (!p.glow) continue;
+        const r = p.size * 4.2;
+        const g = skyCtx.createRadialGradient(p.x, p.y, 0, p.x, p.y, r);
+        g.addColorStop(0, p.color);
+        g.addColorStop(1, 'transparent');
+        skyCtx.fillStyle = g;
+        skyCtx.beginPath();
+        skyCtx.arc(p.x, p.y, r, 0, Math.PI * 2);
+        skyCtx.fill();
+    }
+    skyCtx.restore();
+}
+
+function spawnMeteor(fromUser) {
+    const x = fromUser && mouseActive ? mouseX : Math.random() * width * 0.85;
+    const y = fromUser && mouseActive ? Math.min(mouseY, height * 0.35) : Math.random() * height * 0.28;
+    meteors.push({
+        x,
+        y,
+        vx: 7 + Math.random() * 5,
+        vy: 4 + Math.random() * 3,
+        life: 1,
+        color: current.colors[0]
+    });
+}
+
+function drawMeteors() {
+    if (!meteors.length) return;
+    skyCtx.save();
+    skyCtx.globalCompositeOperation = 'lighter';
+    skyCtx.lineCap = 'round';
+    for (let i = meteors.length - 1; i >= 0; i--) {
+        const m = meteors[i];
+        m.x += m.vx * flowSpeed;
+        m.y += m.vy * flowSpeed;
+        m.life *= 0.965;
+        if (m.life < 0.04 || m.y > horizonY()) {
+            meteors.splice(i, 1);
+            continue;
+        }
+        skyCtx.strokeStyle = hexAlpha(m.color, m.life);
+        skyCtx.lineWidth = 2.2;
+        skyCtx.beginPath();
+        skyCtx.moveTo(m.x, m.y);
+        skyCtx.lineTo(m.x - m.vx * 6, m.y - m.vy * 6);
+        skyCtx.stroke();
+        skyCtx.fillStyle = `rgba(255,255,255,${m.life})`;
+        skyCtx.beginPath();
+        skyCtx.arc(m.x, m.y, 2.1, 0, Math.PI * 2);
+        skyCtx.fill();
+    }
+    skyCtx.restore();
 }
 
 function spawnRipple(x, y) {
-    ripples.push({ x, y, radius: 6, maxRadius: 260, alpha: 1 });
-    wakes.push({ x, y, radius: 40, power: 10, life: 0.9 });
+    ripples.push({ x, y, radius: 8, maxRadius: 280, alpha: 1 });
+    wakes.push({ x, y, radius: 46, power: 12, life: 0.95 });
+    flash = Math.min(1, flash + 0.45);
+    auroraIntensity = clamp(auroraIntensity + 8, 0, 100);
 
-    const burst = 260;
+    const burst = 280;
     for (const particle of particles) {
         const dx = particle.x - x;
         const dy = particle.y - y;
         const dist = Math.hypot(dx, dy) || 1;
         if (dist < burst) {
-            const strength = (1 - dist / burst) * 18;
+            const strength = (1 - dist / burst) * 20;
             particle.vx += (dx / dist) * strength;
             particle.vy += (dy / dist) * strength;
-            particle.life = Math.min(particle.maxLife, particle.life + 30);
+            particle.life = Math.min(particle.maxLife, particle.life + 36);
         }
     }
 }
@@ -594,8 +890,8 @@ function updateRipplesAndWakes() {
         ctx.globalCompositeOperation = 'lighter';
         for (let i = ripples.length - 1; i >= 0; i--) {
             const r = ripples[i];
-            r.radius += (r.maxRadius - r.radius) * 0.09 + 2.5;
-            r.alpha *= 0.9;
+            r.radius += (r.maxRadius - r.radius) * 0.08 + 2.4;
+            r.alpha *= 0.91;
             if (r.alpha < 0.03) {
                 ripples.splice(i, 1);
                 continue;
@@ -606,10 +902,9 @@ function updateRipplesAndWakes() {
             ctx.globalAlpha = r.alpha * 0.55;
             ctx.lineWidth = 2;
             ctx.stroke();
-
             ctx.beginPath();
             ctx.arc(r.x, r.y, r.radius * 0.55, 0, Math.PI * 2);
-            ctx.globalAlpha = r.alpha * 0.25;
+            ctx.globalAlpha = r.alpha * 0.22;
             ctx.stroke();
         }
         ctx.restore();
@@ -624,52 +919,129 @@ function updateRipplesAndWakes() {
     }
 }
 
-function drawMouseGlow() {
-    if (!mouseActive) return;
-    const radius = interactionMode === 'paint' ? 90 : 140;
+function drawReticle() {
+    if (!mouseActive || coarse) return;
+    const radius = interactionMode === 'paint' ? 78 : 118;
+    ctx.save();
+    ctx.globalCompositeOperation = 'lighter';
     const g = ctx.createRadialGradient(mouseX, mouseY, 0, mouseX, mouseY, radius);
     g.addColorStop(0, current.glow);
     g.addColorStop(1, 'transparent');
     ctx.fillStyle = g;
     ctx.fillRect(mouseX - radius, mouseY - radius, radius * 2, radius * 2);
 
-    if (interactionMode === 'paint' && painting) {
-        ctx.save();
-        ctx.globalCompositeOperation = 'lighter';
-        ctx.strokeStyle = current.colors[0] + '55';
-        ctx.lineWidth = 2;
+    ctx.strokeStyle = hexAlpha(current.colors[0], 0.55);
+    ctx.lineWidth = 1.2;
+    ctx.beginPath();
+    ctx.arc(mouseX, mouseY, 16 + Math.hypot(mouseVelocityX, mouseVelocityY) * 0.35, 0, Math.PI * 2);
+    ctx.stroke();
+    ctx.beginPath();
+    ctx.moveTo(mouseX - 22, mouseY);
+    ctx.lineTo(mouseX - 8, mouseY);
+    ctx.moveTo(mouseX + 8, mouseY);
+    ctx.lineTo(mouseX + 22, mouseY);
+    ctx.moveTo(mouseX, mouseY - 22);
+    ctx.lineTo(mouseX, mouseY - 8);
+    ctx.moveTo(mouseX, mouseY + 8);
+    ctx.lineTo(mouseX, mouseY + 22);
+    ctx.stroke();
+    ctx.restore();
+}
+
+function drawLake() {
+    const hzn = horizonY();
+    if (current.terrain === 'void' || hzn >= height - 8) return;
+
+    ctx.save();
+    ctx.beginPath();
+    ctx.rect(0, hzn, width, height - hzn);
+    ctx.clip();
+    ctx.translate(0, hzn);
+    ctx.scale(1, -0.36);
+    ctx.globalAlpha = 0.28;
+    ctx.drawImage(sky, 0, 0, sky.width, sky.height * (hzn / height), 0, -hzn, width, hzn);
+    ctx.restore();
+
+    ctx.fillStyle = current.terrain === 'ice' ? 'rgba(8, 16, 28, 0.52)' : 'rgba(2, 10, 18, 0.58)';
+    ctx.fillRect(0, hzn, width, height - hzn);
+
+    ctx.save();
+    ctx.globalCompositeOperation = 'lighter';
+    ctx.strokeStyle = 'rgba(180, 210, 255, 0.08)';
+    ctx.lineWidth = 1;
+    const wobble = Math.sin(time * 0.8) * 3;
+    for (let i = 0; i < 5; i++) {
+        const y = hzn + 18 + i * ((height - hzn) / 6) + wobble * (i % 2 ? 1 : -1);
         ctx.beginPath();
-        ctx.arc(mouseX, mouseY, 18 + Math.hypot(mouseVelocityX, mouseVelocityY) * 0.4, 0, Math.PI * 2);
+        ctx.moveTo(0, y);
+        ctx.bezierCurveTo(width * 0.3, y + 4, width * 0.7, y - 3, width, y + 2);
         ctx.stroke();
-        ctx.restore();
     }
+    for (const ice of iceSpark) {
+        ice.x += ice.s * 8;
+        if (ice.x > width) ice.x = 0;
+        const y = hzn + ice.y * (height - hzn);
+        ctx.globalAlpha = ice.a * (0.5 + Math.sin(time * 2 + ice.x) * 0.5);
+        ctx.fillStyle = '#dce9ff';
+        ctx.fillRect(ice.x, y, ice.w, 1);
+    }
+    ctx.restore();
+
+    const fog = ctx.createLinearGradient(0, hzn - 28, 0, hzn + 36);
+    fog.addColorStop(0, 'transparent');
+    fog.addColorStop(0.5, 'rgba(6, 12, 22, 0.35)');
+    fog.addColorStop(1, 'transparent');
+    ctx.fillStyle = fog;
+    ctx.fillRect(0, hzn - 28, width, 64);
+}
+
+function drawKp() {
+    const kp = clamp(turbulence * 420 + auroraIntensity / 18 + flowSpeed * 0.6 + kpBreath, 0.4, 9);
+    const el = document.getElementById('kpIndex');
+    if (el) el.textContent = kp.toFixed(1);
 }
 
 function animate() {
     requestAnimationFrame(animate);
     if (paused) return;
 
-    ctx.globalCompositeOperation = 'source-over';
-    ctx.fillStyle = current.bg;
-    ctx.globalAlpha = 1 - trailLength;
-    ctx.fillRect(0, 0, width, height);
-    ctx.globalAlpha = 1;
-
-    drawBackground();
-    drawAuroraCurtains();
-
-    updateFlowField();
-
-    ctx.globalCompositeOperation = blendMode;
-    for (const particle of particles) {
-        particle.update();
-        particle.draw();
+    time += 0.016 * flowSpeed;
+    flash *= 0.9;
+    if (auroraIntensity > current.aurora) {
+        auroraIntensity += (current.aurora - auroraIntensity) * 0.02;
     }
 
+    fillSky(warmFrames < 4 ? 1 : 1 - trailLength);
+    warmFrames++;
+    drawStars();
+    drawMoon();
+    updateFlowField();
+    drawAurora();
+    drawFieldLines();
+    drawParticles();
+
+    meteorTimer++;
+    if (!reducedMotion && meteorTimer > 220 + Math.random() * 400) {
+        meteorTimer = 0;
+        if (Math.random() < 0.55) spawnMeteor(false);
+    }
+    drawMeteors();
+
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
     ctx.globalCompositeOperation = 'source-over';
-    drawConnections();
+    ctx.globalAlpha = 1;
+    ctx.drawImage(sky, 0, 0, sky.width, sky.height, 0, 0, width, height);
+    drawLake();
+    ctx.drawImage(land, 0, 0, land.width, land.height, 0, 0, width, height);
+
+    if (flash > 0.02) {
+        ctx.fillStyle = hexAlpha(current.colors[0], flash * 0.18);
+        ctx.fillRect(0, 0, width, height);
+    }
+
     updateRipplesAndWakes();
-    drawMouseGlow();
+    drawReticle();
+    drawKp();
 
     frameCount++;
     const now = performance.now();
@@ -679,9 +1051,8 @@ function animate() {
         if (fpsEl) fpsEl.textContent = fps;
         frameCount = 0;
         lastTime = now;
-
-        if (fps < 28 && particleCount > 900) {
-            setDensity(Math.max(900, particleCount - 200));
+        if (fps < 28 && particleCount > 700) {
+            setDensity(Math.max(700, particleCount - 220));
         }
     }
 
@@ -702,20 +1073,19 @@ function applyScene(key, silent) {
     currentKey = key;
     current = scene;
 
-    particleShape = scene.shape;
     flowStyle = scene.flow;
     interactionMode = scene.interaction;
     blendMode = scene.blend;
-    bgEffect = scene.bgFx;
     flowSpeed = scene.speed;
     particleSize = scene.size;
     trailLength = scene.trail / 100;
     turbulence = scene.turb;
     interactionForce = scene.force;
     auroraIntensity = scene.aurora;
-    connectDist = scene.connect;
+    auroraAltitude = scene.altitude / 100;
+    horizon = height * scene.horizon;
 
-    const density = isMobile ? Math.max(500, Math.round(scene.density * 0.5)) : scene.density;
+    const density = isMobile ? Math.max(420, Math.round(scene.density * 0.48)) : scene.density;
     setDensity(density);
 
     const setVal = (id, v) => { const el = document.getElementById(id); if (el) el.value = v; };
@@ -726,6 +1096,10 @@ function applyScene(key, silent) {
     setText('trailValue', scene.trail + '%');
     setVal('force', interactionForce);
     setText('forceValue', interactionForce.toFixed(1));
+    setVal('altitude', scene.altitude);
+    setText('altitudeValue', scene.altitude + '%');
+    setVal('glow', scene.aurora);
+    setText('glowValue', scene.aurora + '%');
 
     document.querySelectorAll('.scene-chip').forEach((c) => {
         c.classList.toggle('active', c.dataset.scene === key);
@@ -736,16 +1110,20 @@ function applyScene(key, silent) {
     });
 
     const hud = document.getElementById('hudScene');
+    const tag = document.getElementById('hudTag');
     if (hud) hud.textContent = scene.name;
+    if (tag) tag.textContent = scene.tag;
 
     applyThemeVars();
+    buildTerrain();
     for (const particle of particles) {
         particle.color = current.colors[(Math.random() * current.colors.length) | 0];
-        particle.size = (Math.random() * 1.4 + 0.5) * particleSize;
+        particle.size = (Math.random() * 1.2 + 0.55) * particleSize;
     }
 
-    ctx.fillStyle = current.bg;
-    ctx.fillRect(0, 0, width, height);
+    fillSky(1);
+    warmFrames = 0;
+    flash = 0.65;
     if (!silent) showToast(`${scene.name} · ${scene.tag}`);
 }
 
@@ -759,10 +1137,8 @@ function buildSceneRail() {
         btn.dataset.scene = key;
         btn.setAttribute('role', 'option');
         btn.setAttribute('aria-selected', key === currentKey ? 'true' : 'false');
-        btn.style.setProperty(
-            '--chip-gradient',
-            `linear-gradient(135deg, ${scene.colors[0]}, ${scene.colors[1]})`
-        );
+        btn.style.setProperty('--chip-gradient', `linear-gradient(135deg, ${scene.colors[0]}, ${scene.colors[1]})`);
+        btn.style.setProperty('--chip-glow', hexAlpha(scene.colors[0], 0.55));
         btn.innerHTML = `<span class="scene-swatch" aria-hidden="true"></span><span>${scene.name}</span>`;
         btn.addEventListener('click', () => applyScene(key));
         rail.appendChild(btn);
@@ -807,8 +1183,8 @@ function handlePointer(x, y) {
             x,
             y,
             radius: 28 + Math.hypot(mouseVelocityX, mouseVelocityY) * 0.5,
-            power: 2.2,
-            life: 0.7
+            power: 2.3,
+            life: 0.72
         });
         if (wakes.length > 40) wakes.shift();
     }
@@ -883,14 +1259,18 @@ document.querySelectorAll('.tool-btn[data-mode]').forEach((btn) => {
 });
 
 document.getElementById('random')?.addEventListener('click', randomize);
+document.getElementById('meteor')?.addEventListener('click', () => {
+    spawnMeteor(true);
+    showToast('Meteoro');
+});
 
 function togglePause() {
     paused = !paused;
     const pauseIcon = document.querySelector('.pause-icon');
     const playIcon = document.querySelector('.play-icon');
     if (pauseIcon && playIcon) {
-        pauseIcon.style.display = paused ? 'none' : 'block';
-        playIcon.style.display = paused ? 'block' : 'none';
+        pauseIcon.hidden = paused;
+        playIcon.hidden = !paused;
     }
     showToast(paused ? 'Pausado' : 'Retomado');
 }
@@ -924,38 +1304,42 @@ document.getElementById('flowSpeed')?.addEventListener('input', (e) => {
     flowSpeed = parseFloat(e.target.value);
     document.getElementById('speedValue').textContent = flowSpeed.toFixed(1);
 });
-
 document.getElementById('density')?.addEventListener('input', (e) => {
     setDensity(parseInt(e.target.value, 10));
 });
-
 document.getElementById('trailLength')?.addEventListener('input', (e) => {
     trailLength = parseInt(e.target.value, 10) / 100;
     document.getElementById('trailValue').textContent = e.target.value + '%';
 });
-
 document.getElementById('force')?.addEventListener('input', (e) => {
     interactionForce = parseFloat(e.target.value);
     document.getElementById('forceValue').textContent = interactionForce.toFixed(1);
+});
+document.getElementById('altitude')?.addEventListener('input', (e) => {
+    auroraAltitude = parseInt(e.target.value, 10) / 100;
+    document.getElementById('altitudeValue').textContent = e.target.value + '%';
+});
+document.getElementById('glow')?.addEventListener('input', (e) => {
+    auroraIntensity = parseInt(e.target.value, 10);
+    current.aurora = auroraIntensity;
+    document.getElementById('glowValue').textContent = e.target.value + '%';
 });
 
 function toggleFullscreen() {
     if (!document.fullscreenElement) {
         document.documentElement.requestFullscreen().catch(() => {});
-        document.querySelector('.fullscreen-enter').style.display = 'none';
-        document.querySelector('.fullscreen-exit').style.display = 'block';
     } else {
         document.exitFullscreen();
-        document.querySelector('.fullscreen-enter').style.display = 'block';
-        document.querySelector('.fullscreen-exit').style.display = 'none';
     }
 }
 
 document.getElementById('fullscreen')?.addEventListener('click', toggleFullscreen);
 document.addEventListener('fullscreenchange', () => {
     const on = !!document.fullscreenElement;
-    document.querySelector('.fullscreen-enter').style.display = on ? 'none' : 'block';
-    document.querySelector('.fullscreen-exit').style.display = on ? 'block' : 'none';
+    const enter = document.querySelector('.fullscreen-enter');
+    const exit = document.querySelector('.fullscreen-exit');
+    if (enter) enter.hidden = on;
+    if (exit) exit.hidden = !on;
 });
 
 document.addEventListener('keydown', (e) => {
@@ -975,6 +1359,9 @@ document.addEventListener('keydown', (e) => {
         toggleFullscreen();
     } else if (key === 'c') {
         setTuneOpen(tunePanel.hidden);
+    } else if (key === 'm') {
+        spawnMeteor(true);
+        showToast('Meteoro');
     } else if (key === 'escape') {
         setTuneOpen(false);
     } else if (key === 'a') {
@@ -992,6 +1379,10 @@ document.addEventListener('keydown', (e) => {
 });
 
 window.addEventListener('resize', resize);
+
+if (reducedMotion) {
+    flowSpeed = 0.35;
+}
 
 buildSceneRail();
 resize();

--- a/labs/aurora-flow/style.css
+++ b/labs/aurora-flow/style.css
@@ -1,30 +1,32 @@
 :root {
     --a1: #3dffb5;
-    --a2: #4ecfff;
-    --a3: #8b7cff;
-    --panel: rgba(6, 10, 18, 0.78);
-    --panel-solid: rgba(8, 12, 22, 0.94);
+    --a2: #7cf4ff;
+    --a3: #c084fc;
+    --panel: rgba(6, 10, 18, 0.72);
+    --panel-solid: rgba(7, 11, 20, 0.94);
     --border: rgba(255, 255, 255, 0.1);
-    --text: rgba(255, 255, 255, 0.94);
-    --muted: rgba(255, 255, 255, 0.48);
-    --glow: rgba(61, 255, 181, 0.35);
-    --accent: linear-gradient(135deg, var(--a1), var(--a2));
+    --text: rgba(245, 250, 255, 0.94);
+    --muted: rgba(220, 230, 245, 0.48);
+    --glow: rgba(61, 255, 181, 0.4);
+    --accent: linear-gradient(135deg, var(--a1), var(--a2) 55%, var(--a3));
     --dock-radius: 22px;
+    --safe-top: env(safe-area-inset-top, 0px);
+    --safe-right: env(safe-area-inset-right, 0px);
+    --safe-bottom: env(safe-area-inset-bottom, 0px);
+    --safe-left: env(safe-area-inset-left, 0px);
+    --ease: cubic-bezier(0.16, 1, 0.3, 1);
 }
 
 [data-theme="dark"] {
-    --panel: rgba(6, 10, 18, 0.78);
-    --panel-solid: rgba(8, 12, 22, 0.94);
+    --panel: rgba(6, 10, 18, 0.72);
+    --panel-solid: rgba(7, 11, 20, 0.94);
     --border: rgba(255, 255, 255, 0.1);
-    --text: rgba(255, 255, 255, 0.94);
-    --muted: rgba(255, 255, 255, 0.48);
+    --text: rgba(245, 250, 255, 0.94);
+    --muted: rgba(220, 230, 245, 0.48);
 }
 
 [data-theme="light"] {
-    --a1: #00a86b;
-    --a2: #0284c7;
-    --a3: #6d28d9;
-    --panel: rgba(255, 255, 255, 0.82);
+    --panel: rgba(255, 255, 255, 0.78);
     --panel-solid: rgba(255, 255, 255, 0.94);
     --border: rgba(0, 0, 0, 0.1);
     --text: rgba(10, 16, 28, 0.92);
@@ -32,21 +34,37 @@
     --glow: rgba(0, 168, 107, 0.28);
 }
 
-* {
+*,
+*::before,
+*::after {
     margin: 0;
     padding: 0;
     box-sizing: border-box;
+    -webkit-tap-highlight-color: transparent;
+}
+
+html,
+body {
+    overflow: clip;
+    overflow-x: clip;
+    overscroll-behavior: none;
+}
+
+html {
+    background: #02060e;
 }
 
 body {
-    font-family: 'Oxanium', sans-serif;
+    font-family: Outfit, system-ui, sans-serif;
     padding: 0 !important;
     display: block !important;
-    overflow: hidden;
-    width: 100vw;
-    height: 100vh;
-    background: #02060c;
+    width: 100%;
+    min-height: 100dvh;
+    height: 100dvh;
+    background: #02060e;
     color: var(--text);
+    user-select: none;
+    -webkit-user-select: none;
 }
 
 .container {
@@ -64,8 +82,24 @@ body {
     width: 100%;
     height: 100%;
     display: block;
-    cursor: crosshair;
+    cursor: none;
     touch-action: none;
+}
+
+@media (pointer: coarse) {
+    #canvas {
+        cursor: crosshair;
+    }
+}
+
+.vignette {
+    position: absolute;
+    inset: 0;
+    z-index: 5;
+    pointer-events: none;
+    background:
+        radial-gradient(ellipse at 50% 38%, transparent 42%, rgba(0, 0, 0, 0.42) 100%),
+        linear-gradient(to top, rgba(0, 0, 0, 0.28), transparent 22%);
 }
 
 header {
@@ -74,13 +108,13 @@ header {
     left: 0;
     right: 0;
     z-index: 20;
-    padding: max(1.1rem, env(safe-area-inset-top)) max(1.35rem, env(safe-area-inset-right)) 1.1rem max(1.35rem, env(safe-area-inset-left)) !important;
-    background: linear-gradient(to bottom, rgba(0, 0, 0, 0.72), transparent);
+    padding: max(0.85rem, var(--safe-top)) max(1.1rem, var(--safe-right)) 0.9rem max(1.1rem, var(--safe-left)) !important;
+    background: linear-gradient(to bottom, rgba(2, 6, 14, 0.78), transparent);
     margin: 0 !important;
     display: grid !important;
-    grid-template-columns: auto 1fr auto !important;
+    grid-template-columns: auto minmax(0, 1fr) auto !important;
     align-items: center !important;
-    gap: 1rem !important;
+    gap: 0.75rem !important;
     max-width: none !important;
     width: auto !important;
     pointer-events: none;
@@ -109,7 +143,8 @@ header .app-logo {
     display: flex;
     align-items: center;
     gap: 0.45rem;
-    font-size: 1.28rem;
+    min-width: 0;
+    font-size: clamp(1rem, 2.4vw, 1.28rem);
     font-weight: 700;
     letter-spacing: 0.02em;
     background: var(--accent) !important;
@@ -117,16 +152,21 @@ header .app-logo {
     -webkit-text-fill-color: transparent !important;
     background-clip: text !important;
     filter: drop-shadow(0 0 18px var(--glow));
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 header .app-logo svg {
+    flex-shrink: 0;
     stroke: var(--a1);
     filter: drop-shadow(0 0 8px var(--a1));
 }
 
 .header-actions {
     display: flex;
-    gap: 0.45rem;
+    gap: 0.4rem;
+    align-items: center;
 }
 
 .icon-btn {
@@ -134,7 +174,9 @@ header .app-logo svg {
     border: 1px solid var(--border);
     color: rgba(255, 255, 255, 0.82);
     padding: 0.5rem;
-    border-radius: 10px;
+    min-width: 44px;
+    min-height: 44px;
+    border-radius: 12px;
     cursor: pointer;
     display: flex;
     align-items: center;
@@ -150,7 +192,7 @@ header .app-logo svg {
 
 .hud {
     position: absolute;
-    top: 78px;
+    top: calc(72px + var(--safe-top));
     left: 50%;
     transform: translateX(-50%);
     z-index: 8;
@@ -158,22 +200,32 @@ header .app-logo svg {
     flex-direction: column;
     align-items: center;
     gap: 2px;
+    max-width: min(92vw, 420px);
     pointer-events: none;
     text-align: center;
-    animation: hudIn 0.8s ease both;
+    animation: hudIn 0.9s var(--ease) both;
+}
+
+.hud-kicker {
+    font-size: 0.62rem;
+    font-weight: 700;
+    letter-spacing: 0.28em;
+    text-transform: uppercase;
+    color: var(--muted);
 }
 
 .hud-scene {
-    font-size: 0.72rem;
-    font-weight: 700;
-    letter-spacing: 0.22em;
-    text-transform: uppercase;
-    color: var(--a1);
-    text-shadow: 0 0 24px var(--glow);
+    font-size: clamp(1.35rem, 4.5vw, 2.1rem);
+    font-weight: 800;
+    letter-spacing: 0.04em;
+    line-height: 1.05;
+    color: var(--text);
+    text-shadow: 0 0 28px var(--glow), 0 8px 24px rgba(0, 0, 0, 0.45);
 }
 
 .hud-meta {
-    font-size: 0.62rem;
+    margin-top: 4px;
+    font-size: 0.68rem;
     letter-spacing: 0.08em;
     color: var(--muted);
     font-variant-numeric: tabular-nums;
@@ -181,21 +233,23 @@ header .app-logo svg {
 
 .hint {
     position: absolute;
-    top: 42%;
+    top: 40%;
     left: 50%;
     transform: translate(-50%, -50%);
     z-index: 6;
+    width: min(92vw, 520px);
     pointer-events: none;
     text-align: center;
-    animation: hintOut 5s ease forwards;
+    animation: hintOut 5.4s ease forwards;
 }
 
 .hint p {
-    font-size: 0.95rem;
+    font-size: clamp(0.82rem, 2.6vw, 0.98rem);
     font-weight: 600;
-    letter-spacing: 0.04em;
-    color: rgba(255, 255, 255, 0.55);
+    letter-spacing: 0.03em;
+    color: rgba(255, 255, 255, 0.58);
     text-shadow: 0 0 28px var(--glow);
+    overflow-wrap: anywhere;
 }
 
 .hint kbd {
@@ -212,14 +266,14 @@ header .app-logo svg {
 .dock {
     position: absolute;
     left: 50%;
-    bottom: 22px;
+    bottom: max(16px, var(--safe-bottom));
     transform: translateX(-50%);
     z-index: 15;
-    width: min(720px, calc(100% - 28px));
+    width: min(760px, calc(100% - 24px));
     display: flex;
     flex-direction: column;
     gap: 10px;
-    animation: dockIn 0.7s cubic-bezier(0.16, 1, 0.3, 1) both;
+    animation: dockIn 0.7s var(--ease) both;
 }
 
 .scene-rail {
@@ -242,7 +296,8 @@ header .app-logo svg {
     display: flex;
     align-items: center;
     gap: 8px;
-    padding: 9px 14px 9px 10px;
+    min-height: 44px;
+    padding: 8px 14px 8px 10px;
     border-radius: 999px;
     border: 1px solid var(--border);
     background: var(--panel);
@@ -276,7 +331,7 @@ header .app-logo svg {
     height: 14px;
     border-radius: 50%;
     background: var(--chip-gradient);
-    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.25);
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.25), 0 0 10px var(--chip-glow, transparent);
     flex-shrink: 0;
 }
 
@@ -304,8 +359,10 @@ header .app-logo svg {
 }
 
 .tool-btn {
-    width: 42px;
-    height: 42px;
+    width: 44px;
+    height: 44px;
+    min-width: 44px;
+    min-height: 44px;
     border-radius: 14px;
     border: 1px solid transparent;
     background: rgba(255, 255, 255, 0.04);
@@ -351,6 +408,8 @@ header .app-logo svg {
     grid-template-columns: 1fr 1fr;
     gap: 12px 16px;
     padding: 14px 16px;
+    max-height: min(42dvh, 280px);
+    overflow-y: auto;
     border-radius: 18px;
     border: 1px solid var(--border);
     background: var(--panel-solid);
@@ -397,8 +456,8 @@ input[type="range"] {
 
 input[type="range"]::-webkit-slider-thumb {
     -webkit-appearance: none;
-    width: 14px;
-    height: 14px;
+    width: 16px;
+    height: 16px;
     border-radius: 50%;
     border: 2px solid rgba(255, 255, 255, 0.9);
     background: var(--accent);
@@ -407,8 +466,8 @@ input[type="range"]::-webkit-slider-thumb {
 }
 
 input[type="range"]::-moz-range-thumb {
-    width: 14px;
-    height: 14px;
+    width: 16px;
+    height: 16px;
     border-radius: 50%;
     border: 2px solid rgba(255, 255, 255, 0.9);
     background: var(--a1);
@@ -418,9 +477,10 @@ input[type="range"]::-moz-range-thumb {
 .toast {
     position: fixed;
     left: 50%;
-    bottom: 148px;
+    bottom: 156px;
     transform: translate(-50%, 10px);
     z-index: 30;
+    max-width: calc(100% - 32px);
     padding: 10px 16px;
     border-radius: 999px;
     border: 1px solid var(--border);
@@ -432,7 +492,6 @@ input[type="range"]::-moz-range-thumb {
     opacity: 0;
     pointer-events: none;
     transition: opacity 0.25s, transform 0.25s;
-    white-space: nowrap;
     box-shadow: 0 8px 28px rgba(0, 0, 0, 0.35);
 }
 
@@ -441,8 +500,20 @@ input[type="range"]::-moz-range-thumb {
     transform: translate(-50%, 0);
 }
 
+footer[data-lab-footer] {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
 @keyframes hudIn {
-    from { opacity: 0; transform: translate(-50%, -8px); }
+    from { opacity: 0; transform: translate(-50%, -10px); }
     to { opacity: 1; transform: translate(-50%, 0); }
 }
 
@@ -452,7 +523,7 @@ input[type="range"]::-moz-range-thumb {
 }
 
 @keyframes hintOut {
-    0%, 65% { opacity: 1; }
+    0%, 62% { opacity: 1; }
     100% { opacity: 0; visibility: hidden; }
 }
 
@@ -461,10 +532,11 @@ input[type="range"]::-moz-range-thumb {
     to { opacity: 1; transform: translateY(0); }
 }
 
-@media (max-width: 720px) {
+@media (max-width: 768px) {
     .dock {
-        bottom: 14px;
-        width: calc(100% - 20px);
+        width: calc(100% - 16px);
+        bottom: max(12px, var(--safe-bottom));
+        gap: 8px;
     }
 
     .dock-tools {
@@ -473,31 +545,17 @@ input[type="range"]::-moz-range-thumb {
         border-radius: 18px;
     }
 
-    .tool-btn {
-        width: 40px;
-        height: 40px;
-        border-radius: 12px;
-    }
-
     .tune-panel {
         grid-template-columns: 1fr;
+        max-height: min(38dvh, 240px);
     }
 
     .hud {
-        top: 72px;
-    }
-
-    .hint p {
-        font-size: 0.82rem;
-        padding: 0 18px;
+        top: calc(68px + var(--safe-top));
     }
 
     .toast {
-        bottom: 168px;
-    }
-
-    header .app-logo {
-        font-size: 1.05rem;
+        bottom: 172px;
     }
 }
 
@@ -508,10 +566,91 @@ input[type="range"]::-moz-range-thumb {
         text-overflow: ellipsis;
         white-space: nowrap;
     }
+
+    .hud-scene {
+        max-width: 90vw;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
 }
-/* --- lab-responsive-pass --- */
-@media (max-width: 720px) {
-    .dock { bottom: max(22px, env(safe-area-inset-bottom, 0px)); }
+
+@media (max-height: 520px) and (orientation: landscape) {
+    header {
+        padding: max(0.35rem, var(--safe-top)) max(0.8rem, var(--safe-right)) 0.4rem max(0.8rem, var(--safe-left)) !important;
+    }
+
+    .hud {
+        display: none;
+    }
+
+    .hud-kicker,
+    .hud-meta {
+        font-size: 0.55rem;
+    }
+
+    .hint {
+        display: none;
+    }
+
+    .dock {
+        bottom: max(8px, var(--safe-bottom));
+        width: min(640px, calc(100% - 16px));
+        gap: 6px;
+    }
+
+    .scene-chip {
+        min-height: 36px;
+        padding: 4px 10px 4px 8px;
+        font-size: 0.64rem;
+    }
+
+    .dock-tools {
+        padding: 4px;
+    }
+
+    .tool-btn {
+        width: 40px;
+        height: 40px;
+        min-width: 40px;
+        min-height: 40px;
+        border-radius: 12px;
+    }
+
+    .tune-panel {
+        max-height: min(46dvh, 180px);
+        grid-template-columns: 1fr 1fr 1fr;
+        padding: 10px 12px;
+        gap: 8px 12px;
+    }
+
+    .toast {
+        bottom: 96px;
+    }
+
+    .vignette {
+        background: radial-gradient(ellipse at 50% 40%, transparent 55%, rgba(0, 0, 0, 0.28) 100%);
+    }
+}
+
+@media (pointer: coarse) {
+    .tool-btn,
     .icon-btn,
-    .tool-btn { min-width: 44px; min-height: 44px; }
+    .scene-chip {
+        min-width: 44px;
+        min-height: 44px;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .hud,
+    .dock,
+    .hint,
+    .tune-panel {
+        animation: none;
+    }
+
+    .hint {
+        opacity: 0.7;
+    }
 }

--- a/labs/index.html
+++ b/labs/index.html
@@ -1558,7 +1558,7 @@
         </div>
         <div class="project-content">
           <h2>Aurora Flow</h2>
-          <p>Cortinas, vórtices e tempestades de luz — cenas com física distinta e interação em tempo real</p>
+          <p>Noite polar: cortinas de oxigênio, fitas de plasma e um fiorde que reflete o céu</p>
           <div class="project-tags">
             <span class="tag">Canvas</span>
             <span class="tag">Física</span>


### PR DESCRIPTION
## 🎯 Objetivo

Refazer o Aurora Flow como uma noite polar cinematográfica — cortinas de oxigênio, fitas de plasma e um fiorde que reflete o céu — em vez de um flow field genérico.

## ✨ O que mudou

- Céu em camadas: via láctea, estrelas, lua, cortinas verticais (OI 557.7 nm / N2+) e fitas de plasma com rastro
- Terreno ártico com montanhas, pinheiros e reflexo no fiorde (cenas Boreal, Tempestade, Fjord, Alvorada)
- Seis cenas com física distinta: Boreal, Tempestade, Coroa, Fjord, Plasma, Alvorada
- Interação: atrair / repelir / vórtice / pintar fluxo, flare no toque, meteoros (M)
- Ajustes de altitude e brilho, índice Kp ao vivo, HUD e dock compactos no landscape
- SEO e textos da galeria/README alinhados à nova experiência

## 🧪 Como testar

1. Na raiz do repo: `python3 -m http.server 8000`
2. Abrir [http://localhost:8000/](http://localhost:8000/) (home) e [http://localhost:8000/labs/](http://localhost:8000/labs/) (galeria)
3. Abrir [http://localhost:8000/labs/aurora-flow/](http://localhost:8000/labs/aurora-flow/)
4. Arrastar o campo, toque para flare, `1`–`6` para cenas, `M` para meteoro, `C` para ajustes
5. Responsivo: DevTools em **375×667**, **390×844** e landscape curto (~667×375) — sem overflow horizontal, HUD/controles utilizáveis, alvos ≥ 44px

## ✅ Checklist

- [x] Links conferidos: pasta do lab ↔ card da galeria ↔ README ↔ sitemap (e corrigidos se quebravam)
- [x] README atualizado (linha na tabela + URL + contagem no badge/texto) — obrigatório em lab novo, renomeado ou removido
- [x] SEO consistente: title, description, canonical, author, robots, OG, Twitter, JSON-LD (e contagem nos metas da galeria)
- [x] Testado via HTTP na raiz, não via `file://`
- [x] Responsivo: 375px / 390px / landscape — overflow, HUD, toque, safe-area (`viewport-fit=cover`)
- [x] Nada fora do escopo foi quebrado

Made with [Cursor](https://cursor.com)