### PR TITLE
🧪 lab: Gravity vira sandbox orbital com mundos, zoom e dobra do tempo

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Cada pasta em `/labs/<slug>/` é o mesmo slug do card da galeria, da linha abaix
 | 🟢 **[Matrix](https://diogopaulino.com.br/labs/matrix/)** | Chuva Katakana com glow CRT |
 | 🌌 **[Aurora Flow](https://diogopaulino.com.br/labs/aurora-flow/)** | Aurora boreal em flow fields |
 | 🎨 **[Paint Lab](https://diogopaulino.com.br/labs/paint/)** | Editor de arte digital na web |
-| 🪐 **[Gravity](https://diogopaulino.com.br/labs/gravity/)** | Sandbox gravitacional e física |
+| 🪐 **[Gravity](https://diogopaulino.com.br/labs/gravity/)** | Sandbox orbital — planetas, anéis, binárias e o horizonte de eventos |
 
 ### 🛠️ Ferramentas & Utilidades
 

--- a/labs/gravity/index.html
+++ b/labs/gravity/index.html
@@ -3,12 +3,13 @@
 
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
-    <title>Gravity | Diogo Paulino</title>
-    <meta name="description" content="Simulação gravitacional interativa: sistemas solares, estrelas binárias, buracos negros e colisões galácticas em tempo real.">
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover, maximum-scale=1, user-scalable=no">
+    <title>Gravity — órbitas, buracos negros e colisões | Diogo Paulino</title>
+    <meta name="description" content="Sandbox gravitacional de Diogo Paulino: sistema solar, estrelas binárias, anéis, três corpos e o horizonte de eventos — tudo no canvas.">
     <link rel="canonical" href="https://diogopaulino.com.br/labs/gravity/">
     <meta name="author" content="Diogo Paulino">
     <meta name="robots" content="index, follow">
+    <meta name="theme-color" content="#04040c">
     <link rel="icon" href="/favicon.ico" sizes="any">
     <meta property="og:image" content="https://diogopaulino.com.br/assets/img/diogo.jpeg">
     <meta property="og:image:alt" content="Diogo Paulino">
@@ -17,11 +18,11 @@
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="Diogo Paulino · Labs">
     <meta property="og:url" content="https://diogopaulino.com.br/labs/gravity/">
-    <meta property="og:title" content="Gravity | Diogo Paulino">
-    <meta property="og:description" content="Simulação gravitacional interativa: sistemas solares, estrelas binárias, buracos negros e colisões galácticas em tempo real.">
+    <meta property="og:title" content="Gravity — órbitas, buracos negros e colisões | Diogo Paulino">
+    <meta property="og:description" content="Sandbox gravitacional de Diogo Paulino: sistema solar, estrelas binárias, anéis, três corpos e o horizonte de eventos — tudo no canvas.">
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Gravity | Diogo Paulino">
-    <meta name="twitter:description" content="Simulação gravitacional interativa: sistemas solares, estrelas binárias, buracos negros e colisões galácticas em tempo real.">
+    <meta name="twitter:title" content="Gravity — órbitas, buracos negros e colisões | Diogo Paulino">
+    <meta name="twitter:description" content="Sandbox gravitacional de Diogo Paulino: sistema solar, estrelas binárias, anéis, três corpos e o horizonte de eventos — tudo no canvas.">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
@@ -35,7 +36,7 @@
           "@type": "WebApplication",
           "name": "Gravity",
           "url": "https://diogopaulino.com.br/labs/gravity/",
-          "description": "Simulação gravitacional interativa: sistemas solares, estrelas binárias, buracos negros e colisões galácticas em tempo real.",
+          "description": "Sandbox gravitacional de Diogo Paulino: sistema solar, estrelas binárias, anéis, três corpos e o horizonte de eventos — tudo no canvas.",
           "applicationCategory": "WebApplication",
           "operatingSystem": "Any",
           "inLanguage": "pt-BR",
@@ -80,265 +81,194 @@
         <header data-lab-header data-title="Gravity">
             <template data-slot="logo">
                 <div class="app-logo">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                        <circle cx="12" cy="12" r="4" />
-                        <ellipse cx="12" cy="12" rx="10" ry="4" transform="rotate(-20 12 12)" />
+                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                        <circle cx="12" cy="12" r="3.2" />
+                        <ellipse cx="12" cy="12" rx="10" ry="4.2" transform="rotate(-18 12 12)" />
+                        <ellipse cx="12" cy="12" rx="10" ry="4.2" transform="rotate(28 12 12)" />
                     </svg>
                     Gravity
                 </div>
             </template>
             <template data-slot="actions">
-                <button id="playPauseBtn" class="icon-btn" aria-label="Pausar" title="Pausar (Espaço)">
-                    <svg class="icon-pause" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                        <rect x="6" y="4" width="4" height="16" rx="1"/>
-                        <rect x="14" y="4" width="4" height="16" rx="1"/>
-                    </svg>
-                    <svg class="icon-play" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="display:none">
-                        <polygon points="6 3 20 12 6 21 6 3" />
-                    </svg>
-                </button>
                 <button id="fullscreen-btn" class="icon-btn" aria-label="Tela cheia" title="Tela cheia (F)">
                     <svg class="fullscreen-enter" width="20" height="20" viewBox="0 0 24 24" fill="none"
                         stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                        <path
-                            d="M8 3H5a2 2 0 0 0-2 2v3m18 0V5a2 2 0 0 0-2-2h-3m0 18h3a2 2 0 0 0 2-2v-3M3 16v3a2 2 0 0 0 2 2h3" />
+                        <path d="M8 3H5a2 2 0 0 0-2 2v3m18 0V5a2 2 0 0 0-2-2h-3m0 18h3a2 2 0 0 0 2-2v-3M3 16v3a2 2 0 0 0 2 2h3" />
                     </svg>
                     <svg class="fullscreen-exit" width="20" height="20" viewBox="0 0 24 24" fill="none"
                         stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
                         style="display: none;">
-                        <path
-                            d="M8 3v3a2 2 0 0 1-2 2H3m18 0h-3a2 2 0 0 1-2-2V3m0 18v-3a2 2 0 0 1 2-2h3M3 16h3a2 2 0 0 1 2 2v3" />
+                        <path d="M8 3v3a2 2 0 0 1-2 2H3m18 0h-3a2 2 0 0 1-2-2V3m0 18v-3a2 2 0 0 1 2-2h3M3 16h3a2 2 0 0 1 2 2v3" />
                     </svg>
                 </button>
             </template>
         </header>
 
-        <canvas id="canvas"></canvas>
+        <canvas id="canvas" aria-label="Simulação gravitacional"></canvas>
+
+        <div class="hud" aria-live="polite">
+            <span class="hud-scene" id="hudScene">Sistema Solar</span>
+            <span class="hud-meta">
+                <span id="fps">60</span> fps ·
+                <span id="count">0</span> poeira ·
+                <span id="bodyCount">0</span> corpos
+            </span>
+            <div class="warp" role="group" aria-label="Dobra temporal">
+                <button type="button" class="warp-btn" data-warp="0.5">½×</button>
+                <button type="button" class="warp-btn active" data-warp="1">1×</button>
+                <button type="button" class="warp-btn" data-warp="2">2×</button>
+                <button type="button" class="warp-btn" data-warp="4">4×</button>
+            </div>
+        </div>
+
+        <div class="hint" id="hint">
+            <p>Pinça para zoom · arraste dois dedos para panorâmica · toque num planeta para seguir</p>
+        </div>
 
         <div class="slingshot-hint" id="slingshotHint"></div>
 
-        <button id="toggleControls" class="toggle-controls-btn" aria-label="Mostrar/esconder controles" title="Controles">
-            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                <path
-                    d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z" />
-                <circle cx="12" cy="12" r="3" />
-            </svg>
-        </button>
-
-        <div class="controls" id="controlsPanel">
-            <div class="controls-header">
-                <span>Controles</span>
-                <button id="closeControls" class="close-btn" aria-label="Fechar">
-                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                        <path d="M18 6L6 18M6 6l12 12" />
-                    </svg>
-                </button>
+        <aside class="inspect" id="inspect" hidden>
+            <span class="inspect-swatch" id="inspectSwatch"></span>
+            <div class="inspect-copy">
+                <strong id="inspectName">—</strong>
+                <span id="inspectMeta"></span>
             </div>
+            <button type="button" id="followBtn" class="inspect-follow" aria-pressed="false">Seguir</button>
+        </aside>
 
-            <div class="controls-scroll">
-                <div class="control-section">
-                    <div class="section-title">Cenários</div>
-                    <div class="scenario-grid">
-                        <button class="scenario-btn active" data-scenario="solar" title="Sistema Solar">
-                            <span class="scenario-icon">☀️</span><small>Sistema Solar</small>
-                        </button>
-                        <button class="scenario-btn" data-scenario="binary" title="Estrelas Binárias">
-                            <span class="scenario-icon">💫</span><small>Binárias</small>
-                        </button>
-                        <button class="scenario-btn" data-scenario="blackhole" title="Buraco Negro">
-                            <span class="scenario-icon">🕳️</span><small>Buraco Negro</small>
-                        </button>
-                        <button class="scenario-btn" data-scenario="galaxy" title="Colisão Galáctica">
-                            <span class="scenario-icon">🌌</span><small>Colisão</small>
-                        </button>
-                        <button class="scenario-btn" data-scenario="chaos" title="Caos">
-                            <span class="scenario-icon">⚡</span><small>Caos</small>
-                        </button>
-                        <button class="scenario-btn" data-scenario="classic" title="Chuva Clássica">
-                            <span class="scenario-icon">🌧️</span><small>Clássico</small>
-                        </button>
-                    </div>
+        <div class="dock">
+            <div class="scene-rail" id="sceneRail" role="listbox" aria-label="Cenários"></div>
+
+            <div class="dock-tools">
+                <div class="tool-group" role="group" aria-label="Ferramenta">
+                    <button class="tool-btn active" data-mode="spawn" title="Criar poeira (Q)" aria-label="Criar poeira">
+                        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <path d="M12 3v18M3 12h18" />
+                            <circle cx="12" cy="12" r="3" />
+                        </svg>
+                    </button>
+                    <button class="tool-btn" data-mode="body" title="Lançar planeta (W)" aria-label="Lançar planeta">
+                        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <circle cx="12" cy="12" r="4" />
+                            <ellipse cx="12" cy="12" rx="10" ry="4" />
+                        </svg>
+                    </button>
+                    <button class="tool-btn" data-mode="attract" title="Atrair (A)" aria-label="Atrair">
+                        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <circle cx="12" cy="12" r="3" />
+                            <path d="M12 2v3m0 14v3M2 12h3m14 0h3" />
+                        </svg>
+                    </button>
+                    <button class="tool-btn" data-mode="repel" title="Repelir (E)" aria-label="Repelir">
+                        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <circle cx="12" cy="12" r="3" />
+                            <path d="M5 5l3 3m8 8l3 3M5 19l3-3m8-8l3-3" />
+                        </svg>
+                    </button>
+                    <button class="tool-btn" data-mode="blackhole" title="Horizonte (H)" aria-label="Sugar">
+                        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <circle cx="12" cy="12" r="9" />
+                            <circle cx="12" cy="12" r="3" fill="currentColor" />
+                        </svg>
+                    </button>
+                    <button class="tool-btn" data-mode="erase" title="Apagar (X)" aria-label="Apagar">
+                        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <path d="M4 7h16M9 7V5a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2v2m3 0v12a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2V7h12z" />
+                        </svg>
+                    </button>
                 </div>
 
-                <div class="control-section">
-                    <div class="section-title">Modo do Mouse</div>
-                    <div class="mode-grid">
-                        <button class="mode-btn active" data-mode="spawn" title="Criar Partículas">
-                            <span>✨</span><small>Criar</small>
-                        </button>
-                        <button class="mode-btn" data-mode="body" title="Lançar corpo com estilingue">
-                            <span>🪐</span><small>Corpo</small>
-                        </button>
-                        <button class="mode-btn" data-mode="attract" title="Atrair partículas">
-                            <span>🧲</span><small>Atrair</small>
-                        </button>
-                        <button class="mode-btn" data-mode="repel" title="Repelir partículas">
-                            <span>💨</span><small>Repelir</small>
-                        </button>
-                        <button class="mode-btn" data-mode="blackhole" title="Sugar partículas">
-                            <span>🕳️</span><small>Sugar</small>
-                        </button>
-                        <button class="mode-btn" data-mode="erase" title="Apagar">
-                            <span>🧹</span><small>Apagar</small>
-                        </button>
-                    </div>
-                </div>
-
-                <div class="control-section">
-                    <div class="section-title">Física</div>
-                    <div class="sliders-grid">
-                        <div class="slider-group">
-                            <div class="slider-header">
-                                <label>Gravidade Vertical</label>
-                                <span class="slider-value" id="gravityValue">0.00</span>
-                            </div>
-                            <input type="range" id="gravity" min="-0.5" max="1" step="0.01" value="0">
-                        </div>
-                        <div class="slider-group">
-                            <div class="slider-header">
-                                <label>Força Gravitacional</label>
-                                <span class="slider-value" id="gStrengthValue">1.0</span>
-                            </div>
-                            <input type="range" id="gStrength" min="0.2" max="3" step="0.1" value="1">
-                        </div>
-                        <div class="slider-group">
-                            <div class="slider-header">
-                                <label>Fricção</label>
-                                <span class="slider-value" id="frictionValue">1.000</span>
-                            </div>
-                            <input type="range" id="friction" min="0.95" max="1" step="0.001" value="1">
-                        </div>
-                        <div class="slider-group">
-                            <div class="slider-header">
-                                <label>Tamanho do Corpo</label>
-                                <span class="slider-value" id="bodySizeValue">18</span>
-                            </div>
-                            <input type="range" id="bodySize" min="6" max="45" step="1" value="18">
-                        </div>
-                    </div>
-                    <div class="toggle-row">
-                        <label class="checkbox-label">
-                            <input type="checkbox" id="bodiesAttract">
-                            <span>Corpos se atraem</span>
-                        </label>
-                        <label class="checkbox-label">
-                            <input type="checkbox" id="absorb" checked>
-                            <span>Corpos absorvem partículas</span>
-                        </label>
-                    </div>
-                </div>
-
-                <div class="control-section">
-                    <div class="section-title">Partículas</div>
-                    <div class="sliders-grid">
-                        <div class="slider-group">
-                            <div class="slider-header">
-                                <label>Tamanho</label>
-                                <span class="slider-value" id="sizeValue">3</span>
-                            </div>
-                            <input type="range" id="size" min="1" max="15" step="1" value="3">
-                        </div>
-                        <div class="slider-group">
-                            <div class="slider-header">
-                                <label>Velocidade Inicial</label>
-                                <span class="slider-value" id="velocityValue">10</span>
-                            </div>
-                            <input type="range" id="velocity" min="1" max="30" step="1" value="10">
-                        </div>
-                    </div>
-                </div>
-
-                <div class="control-section">
-                    <div class="section-title">Visual</div>
-                    <div class="select-group">
-                        <label>Tema de Cor</label>
-                        <select id="theme-select">
-                            <option value="neon">Neon</option>
-                            <option value="fire">Fogo</option>
-                            <option value="ice">Gelo</option>
-                            <option value="matrix">Matrix</option>
-                            <option value="rainbow">Rainbow</option>
-                            <option value="sunset">Pôr do Sol</option>
-                            <option value="ocean">Oceano</option>
-                            <option value="galaxy">Galáxia</option>
-                            <option value="aurora">Aurora</option>
-                            <option value="candy">Candy</option>
-                        </select>
-                    </div>
-                    <div class="checkbox-grid">
-                        <label class="checkbox-label">
-                            <input type="checkbox" id="trails" checked>
-                            <span>Rastros</span>
-                        </label>
-                        <label class="checkbox-label">
-                            <input type="checkbox" id="glow" checked>
-                            <span>Brilho</span>
-                        </label>
-                        <label class="checkbox-label">
-                            <input type="checkbox" id="bounce" checked>
-                            <span>Quicar nas bordas</span>
-                        </label>
-                        <label class="checkbox-label">
-                            <input type="checkbox" id="stars" checked>
-                            <span>Estrelas de fundo</span>
-                        </label>
-                        <label class="checkbox-label">
-                            <input type="checkbox" id="velocityColor">
-                            <span>Cor por velocidade</span>
-                        </label>
-                        <label class="checkbox-label">
-                            <input type="checkbox" id="additive">
-                            <span>Mistura aditiva</span>
-                        </label>
-                    </div>
-                </div>
-            </div>
-
-            <div class="control-footer">
-                <div class="action-buttons">
-                    <button id="random" class="action-btn random-btn" title="Cenário aleatório">
-                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <div class="tool-group">
+                    <button id="random" class="tool-btn accent" title="Cenário aleatório (R)" aria-label="Aleatório">
+                        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                             <path d="M2 18h1.4c1.3 0 2.5-.6 3.3-1.7l6.1-8.6c.7-1.1 2-1.7 3.3-1.7H22" />
                             <path d="m18 2 4 4-4 4" />
                             <path d="M2 6h1.9c1.5 0 2.9.9 3.6 2.2" />
                             <path d="M22 18h-5.9c-1.3 0-2.6-.7-3.3-1.8l-.5-.8" />
                             <path d="m18 14 4 4-4 4" />
                         </svg>
-                        Random
                     </button>
-                    <button id="clear" class="action-btn clear-btn" title="Limpar tudo">
-                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <button id="playPauseBtn" class="tool-btn" title="Pausar (Espaço)" aria-label="Pausar">
+                        <svg class="icon-pause" width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
+                            <rect x="6" y="4" width="4" height="16" rx="1" />
+                            <rect x="14" y="4" width="4" height="16" rx="1" />
+                        </svg>
+                        <svg class="icon-play" width="18" height="18" viewBox="0 0 24 24" fill="currentColor" style="display:none">
+                            <path d="M7 4l13 8-13 8V4z" />
+                        </svg>
+                    </button>
+                    <button id="clear" class="tool-btn" title="Limpar (C)" aria-label="Limpar">
+                        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                             <path d="M3 6h18M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2m3 0v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6h14z" />
                         </svg>
-                        Limpar
+                    </button>
+                    <button id="toggleTune" class="tool-btn" title="Ajustes" aria-label="Ajustes"
+                        aria-expanded="false" aria-controls="tunePanel">
+                        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <path d="M4 21v-7M4 10V3M12 21v-9M12 8V3M20 21v-5M20 12V3" />
+                            <path d="M2 14h4M10 8h4M18 16h4" />
+                        </svg>
                     </button>
                 </div>
-                <div class="stats-bar">
-                    <div class="stat">
-                        <span class="stat-value" id="count">0</span>
-                        <span class="stat-label">partículas</span>
-                    </div>
-                    <div class="stat-divider"></div>
-                    <div class="stat">
-                        <span class="stat-value" id="bodyCount">0</span>
-                        <span class="stat-label">corpos</span>
-                    </div>
-                    <div class="stat-divider"></div>
-                    <div class="stat">
-                        <span class="stat-value" id="fps">60</span>
-                        <span class="stat-label">fps</span>
-                    </div>
+            </div>
+
+            <div class="tune-panel" id="tunePanel" hidden>
+                <div class="slider-row">
+                    <label for="gStrength">Força G <span id="gStrengthValue">1.0</span></label>
+                    <input type="range" id="gStrength" min="0.2" max="3" step="0.1" value="1">
                 </div>
-                <div class="shortcuts-hint">Espaço pausa · C limpa · F tela cheia · 1–6 cenários</div>
+                <div class="slider-row">
+                    <label for="gravity">Gravidade Y <span id="gravityValue">0.00</span></label>
+                    <input type="range" id="gravity" min="-0.5" max="1" step="0.01" value="0">
+                </div>
+                <div class="slider-row">
+                    <label for="friction">Fricção <span id="frictionValue">1.000</span></label>
+                    <input type="range" id="friction" min="0.95" max="1" step="0.001" value="1">
+                </div>
+                <div class="slider-row">
+                    <label for="bodySize">Planeta <span id="bodySizeValue">18</span></label>
+                    <input type="range" id="bodySize" min="6" max="45" step="1" value="18">
+                </div>
+                <div class="slider-row">
+                    <label for="size">Poeira <span id="sizeValue">3</span></label>
+                    <input type="range" id="size" min="1" max="12" step="1" value="3">
+                </div>
+                <div class="slider-row">
+                    <label for="velocity">Impulso <span id="velocityValue">10</span></label>
+                    <input type="range" id="velocity" min="1" max="30" step="1" value="10">
+                </div>
+                <div class="select-group">
+                    <label for="theme-select">Paleta</label>
+                    <select id="theme-select">
+                        <option value="nebula">Nébula</option>
+                        <option value="neon">Neon</option>
+                        <option value="fire">Fogo</option>
+                        <option value="ice">Gelo</option>
+                        <option value="sunset">Pôr do Sol</option>
+                        <option value="ocean">Oceano</option>
+                        <option value="galaxy">Galáxia</option>
+                        <option value="aurora">Aurora</option>
+                    </select>
+                </div>
+                <div class="checkbox-grid">
+                    <label class="checkbox-label"><input type="checkbox" id="orbits" checked><span>Órbitas</span></label>
+                    <label class="checkbox-label"><input type="checkbox" id="labels" checked><span>Nomes</span></label>
+                    <label class="checkbox-label"><input type="checkbox" id="trails" checked><span>Rastros</span></label>
+                    <label class="checkbox-label"><input type="checkbox" id="glow" checked><span>Brilho</span></label>
+                    <label class="checkbox-label"><input type="checkbox" id="stars" checked><span>Estrelas</span></label>
+                    <label class="checkbox-label"><input type="checkbox" id="bounce"><span>Quicar</span></label>
+                    <label class="checkbox-label"><input type="checkbox" id="bodiesAttract"><span>N-corpos</span></label>
+                    <label class="checkbox-label"><input type="checkbox" id="absorb" checked><span>Absorver</span></label>
+                    <label class="checkbox-label"><input type="checkbox" id="velocityColor"><span>Cor = velocidade</span></label>
+                    <label class="checkbox-label"><input type="checkbox" id="additive"><span>Aditivo</span></label>
+                </div>
             </div>
         </div>
-
-        <div class="instructions">
-            <p>Arraste para criar partículas · Modo <strong>Corpo</strong>: arraste e solte para lançar um planeta</p>
-        </div>
-
-        <footer data-lab-footer data-home-href="/"></footer>
     </div>
+
+    <div class="toast" id="toast" role="status"></div>
+
+    <footer data-lab-footer data-home-href="/"></footer>
 
     <script src="/labs/shared.js?v=8" defer></script>
     <script src="script.js" defer></script>

--- a/labs/gravity/script.js
+++ b/labs/gravity/script.js
@@ -1,26 +1,41 @@
 (function () {
     'use strict';
 
-    const canvas = document.getElementById('canvas');
-    const ctx = canvas.getContext('2d', {
-        alpha: false,
-        desynchronized: true
-    });
-
-    let width, height;
-
-    // ---- Physics constants ----
+    /**
+     * Gravity — sandbox orbital 2D.
+     *
+     * Newton (Plummer):  a = G M / (r² + ε),  ε = SOFTEN
+     * Órbita circular:   v = √(a r) = √(G M r / (r² + ε))
+     * Massa:             m = r² · MASS_K · (8 se buraco negro)
+     * Binária igual:     v = √(G (m1+m2) / (4 · sep))
+     * Três corpos L4:    v⊥ = √(G · 3m / (R √3))
+     * Fusão:             p conservado; r = √(r1² + r2²)
+     * Estilingue:        v = Δarrasto · SLING_K
+     * Dobra temporal:    n subpassos de Euler com k = scale / n
+     */
+    const TAU = Math.PI * 2;
     const G_BASE = 0.05;
     const MASS_K = 8;
     const SOFTEN = 80;
-    const SLING_K = 0.02;
-    const MAX_PARTICLES = 500;
-    const MAX_BODIES = 40;
+    const SLING_K = 0.018;
+    const MAX_PARTICLES = 720;
+    const MAX_BODIES = 48;
+    const TRAIL_MAX = 140;
 
-    // ---- State ----
+    const canvas = document.getElementById('canvas');
+    const ctx = canvas.getContext('2d', { alpha: false, desynchronized: true });
+
+    let width = 0;
+    let height = 0;
+    let boundW = 0;
+    let boundH = 0;
+    let dpr = 1;
+
     let particles = [];
     let bodies = [];
+    let shockwaves = [];
     let running = true;
+    let timeScale = 1;
 
     let ambientGravity = 0;
     let gStrength = 1;
@@ -28,99 +43,202 @@
     let particleSize = 3;
     let initialVelocity = 10;
     let bodySizeSetting = 18;
-    let bodiesAttract = false;
+    let bodiesAttract = true;
     let absorbEnabled = true;
 
     let mouseMode = 'spawn';
-    let currentTheme = 'neon';
+    let currentTheme = 'nebula';
     let enableTrails = true;
     let enableGlow = true;
-    let enableBounce = true;
+    let enableBounce = false;
     let enableStars = true;
+    let enableOrbits = true;
+    let enableLabels = true;
     let velocityColorMode = false;
     let additiveBlend = false;
     let currentScenario = 'solar';
 
+    const cam = { x: 0, y: 0, zoom: 1, follow: false };
+    let selected = null;
+
     const themes = {
+        nebula: ['#c4b5fd', '#67e8f9', '#fde68a', '#f9a8d4', '#93c5fd'],
         neon: ['#3b82f6', '#8b5cf6', '#ec4899', '#10b981', '#f59e0b'],
-        fire: ['#ff0000', '#ff4d00', '#ff9900', '#ffcc00', '#ffff00'],
-        ice: ['#00ffff', '#00ccff', '#0099ff', '#0066ff', '#0033ff'],
-        matrix: ['#00ff00', '#00cc00', '#009900', '#006600', '#003300'],
-        rainbow: ['#ff0000', '#ff7f00', '#ffff00', '#00ff00', '#0000ff', '#4b0082', '#9400d3'],
+        fire: ['#ff4d00', '#ff9900', '#ffcc00', '#ff6b6b', '#fff3bf'],
+        ice: ['#67e8f9', '#38bdf8', '#818cf8', '#e0f2fe', '#a5f3fc'],
         sunset: ['#ff6b6b', '#feca57', '#ff9ff3', '#54a0ff', '#5f27cd'],
-        ocean: ['#0077b6', '#00b4d8', '#90e0ef', '#caf0f8', '#03045e'],
-        galaxy: ['#9d4edd', '#c77dff', '#e0aaff', '#3c096c', '#240046'],
-        aurora: ['#00f5d4', '#00bbf9', '#9b5de5', '#f15bb5', '#fee440'],
-        candy: ['#ff6b9d', '#c44569', '#f8b500', '#00d4aa', '#7c3aed']
+        ocean: ['#00b4d8', '#90e0ef', '#0077b6', '#caf0f8', '#48bfe3'],
+        galaxy: ['#c77dff', '#e0aaff', '#9d4edd', '#7b2cbf', '#ffd6ff'],
+        aurora: ['#00f5d4', '#00bbf9', '#9b5de5', '#f15bb5', '#fee440']
     };
+
+    const SCENES = [
+        { id: 'solar', name: 'Sistema Solar', chip: '#ffd35c', toast: 'Oito mundos, a Lua, um cinturão e dois cometas.' },
+        { id: 'binary', name: 'Binárias', chip: '#60a5fa', toast: 'Duas estrelas dançam; a poeira segue o baricentro.' },
+        { id: 'blackhole', name: 'Buraco Negro', chip: '#fb923c', toast: 'Um horizonte, um disco e uma estrela a se desfazer.' },
+        { id: 'galaxy', name: 'Colisão', chip: '#e879f9', toast: 'Dois braços espirais em rumo de encontro.' },
+        { id: 'threebody', name: 'Três Corpos', chip: '#34d399', toast: 'Três sóis iguais — o problema que não tem retrato.' },
+        { id: 'rings', name: 'Anéis', chip: '#fbbf24', toast: 'Um gigante, pastores e um disco de gelo.' },
+        { id: 'chaos', name: 'Caos', chip: '#f472b6', toast: 'Massas à deriva. Fusão, rasgo, luz.' },
+        { id: 'classic', name: 'Clássico', chip: '#94a3b8', toast: 'Chuva newtoniana — o sandbox original.' }
+    ];
 
     function hexToRgb(hex) {
         const m = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
         return m ? { r: parseInt(m[1], 16), g: parseInt(m[2], 16), b: parseInt(m[3], 16) } : { r: 255, g: 255, b: 255 };
     }
 
+    function toScreen(x, y) {
+        return {
+            x: (x - cam.x) * cam.zoom + width / 2,
+            y: (y - cam.y) * cam.zoom + height / 2
+        };
+    }
+
+    function toWorld(sx, sy) {
+        return {
+            x: cam.x + (sx - width / 2) / cam.zoom,
+            y: cam.y + (sy - height / 2) / cam.zoom
+        };
+    }
+
+    function clampZoom(z) {
+        return Math.max(0.22, Math.min(4.2, z));
+    }
+
+    function zoomAt(sx, sy, factor) {
+        const before = toWorld(sx, sy);
+        cam.zoom = clampZoom(cam.zoom * factor);
+        const after = toWorld(sx, sy);
+        cam.x += before.x - after.x;
+        cam.y += before.y - after.y;
+        cam.follow = false;
+        syncFollowBtn();
+    }
+
+    function resetCamera() {
+        cam.x = boundW / 2;
+        cam.y = boundH / 2;
+        cam.zoom = 1;
+        cam.follow = false;
+        selected = null;
+        syncInspect();
+    }
+
     function resize() {
-        const newWidth = window.innerWidth;
-        const newHeight = window.innerHeight;
-        if (newWidth === 0 || newHeight === 0) return;
+        const cssW = window.innerWidth;
+        const cssH = window.innerHeight;
+        if (cssW === 0 || cssH === 0) return;
 
-        const oldWidth = width;
-        const oldHeight = height;
-        width = canvas.width = newWidth;
-        height = canvas.height = newHeight;
+        dpr = Math.min(window.devicePixelRatio || 1, 2);
+        const oldW = width;
+        const oldH = height;
+
+        width = cssW;
+        height = cssH;
+        canvas.width = Math.floor(cssW * dpr);
+        canvas.height = Math.floor(cssH * dpr);
+        canvas.style.width = cssW + 'px';
+        canvas.style.height = cssH + 'px';
+        ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+
         generateStars();
+        generateNebula();
 
-        if (oldWidth > 0 && oldHeight > 0 && (oldWidth !== width || oldHeight !== height)) {
-            // Uniform scale around the new center keeps orbits circular instead of
-            // stretching them into ellipses when the aspect ratio changes.
-            const scale = Math.min(width / oldWidth, height / oldHeight);
-            const oldCx = oldWidth / 2;
-            const oldCy = oldHeight / 2;
-            const newCx = width / 2;
-            const newCy = height / 2;
-            for (let i = 0; i < particles.length; i++) {
-                const p = particles[i];
-                p.x = newCx + (p.x - oldCx) * scale;
-                p.y = newCy + (p.y - oldCy) * scale;
-                p.vx *= scale;
-                p.vy *= scale;
-            }
-            for (let i = 0; i < bodies.length; i++) {
-                const b = bodies[i];
-                b.x = newCx + (b.x - oldCx) * scale;
-                b.y = newCy + (b.y - oldCy) * scale;
+        if (oldW > 0 && oldH > 0 && (oldW !== width || oldH !== height)) {
+            const scale = Math.min(width / oldW, height / oldH);
+            const ox = oldW / 2;
+            const oy = oldH / 2;
+            const nx = width / 2;
+            const ny = height / 2;
+            const scaleBody = (b) => {
+                b.x = nx + (b.x - ox) * scale;
+                b.y = ny + (b.y - oy) * scale;
                 b.vx *= scale;
                 b.vy *= scale;
-            }
-        } else if (!oldWidth) {
+            };
+            particles.forEach(scaleBody);
+            bodies.forEach(scaleBody);
+            cam.x = nx + (cam.x - ox) * scale;
+            cam.y = ny + (cam.y - oy) * scale;
+            boundW = width;
+            boundH = height;
+        } else if (!oldW) {
+            boundW = width;
+            boundH = height;
+            cam.x = boundW / 2;
+            cam.y = boundH / 2;
             loadScenario(currentScenario);
+        } else {
+            boundW = width;
+            boundH = height;
         }
     }
 
-    // ---- Starfield ----
+    // ---- Starfield + nebula ----
     let stars = [];
+    let nebula = [];
+
     function generateStars() {
         stars = [];
-        const count = Math.floor((width * height) / 9000);
+        const count = Math.min(280, Math.floor((width * height) / 7000));
         for (let i = 0; i < count; i++) {
             stars.push({
                 x: Math.random() * width,
                 y: Math.random() * height,
-                r: Math.random() * 1.3 + 0.3,
-                phase: Math.random() * Math.PI * 2,
-                speed: 0.4 + Math.random() * 1.4
+                r: Math.random() * 1.4 + 0.2,
+                phase: Math.random() * TAU,
+                speed: 0.4 + Math.random() * 1.6,
+                par: 0.15 + Math.random() * 0.55,
+                tint: Math.random() < 0.12 ? '#c4b5fd' : Math.random() < 0.08 ? '#fde68a' : '#ffffff'
             });
         }
     }
 
-    function drawStars(t) {
+    function generateNebula() {
+        nebula = [
+            { x: 0.18, y: 0.28, r: 0.42, c: 'rgba(88, 40, 160, 0.16)' },
+            { x: 0.78, y: 0.22, r: 0.38, c: 'rgba(20, 80, 160, 0.14)' },
+            { x: 0.62, y: 0.78, r: 0.44, c: 'rgba(160, 40, 90, 0.1)' },
+            { x: 0.28, y: 0.72, r: 0.32, c: 'rgba(20, 140, 150, 0.1)' }
+        ];
+    }
+
+    function drawBackdrop(t) {
+        ctx.globalCompositeOperation = 'source-over';
+        ctx.fillStyle = enableTrails ? 'rgba(4, 4, 12, 0.2)' : '#04040c';
+        ctx.fillRect(0, 0, width, height);
+
+        const ox = (boundW / 2 - cam.x) * 0.04;
+        const oy = (boundH / 2 - cam.y) * 0.04;
+        for (let i = 0; i < nebula.length; i++) {
+            const n = nebula[i];
+            const x = n.x * width + ox;
+            const y = n.y * height + oy;
+            const rad = n.r * Math.max(width, height);
+            const g = ctx.createRadialGradient(x, y, 0, x, y, rad);
+            g.addColorStop(0, n.c);
+            g.addColorStop(1, 'rgba(0,0,0,0)');
+            ctx.fillStyle = g;
+            ctx.beginPath();
+            ctx.arc(x, y, rad, 0, TAU);
+            ctx.fill();
+        }
+
+        if (!enableStars) return;
+        const panX = (cam.x - boundW / 2);
+        const panY = (cam.y - boundH / 2);
         for (let i = 0; i < stars.length; i++) {
             const s = stars[i];
-            const tw = 0.3 + 0.7 * (0.5 + 0.5 * Math.sin(t * 0.0008 * s.speed + s.phase));
-            ctx.globalAlpha = tw * 0.85;
-            ctx.fillStyle = '#ffffff';
+            let sx = s.x - panX * s.par * cam.zoom * 0.15;
+            let sy = s.y - panY * s.par * cam.zoom * 0.15;
+            sx = ((sx % width) + width) % width;
+            sy = ((sy % height) + height) % height;
+            const tw = 0.28 + 0.72 * (0.5 + 0.5 * Math.sin(t * 0.0007 * s.speed + s.phase));
+            ctx.globalAlpha = tw * 0.9;
+            ctx.fillStyle = s.tint;
             ctx.beginPath();
-            ctx.arc(s.x, s.y, s.r, 0, Math.PI * 2);
+            ctx.arc(sx, sy, s.r * (0.7 + cam.zoom * 0.15), 0, TAU);
             ctx.fill();
         }
         ctx.globalAlpha = 1;
@@ -128,148 +246,163 @@
 
     // ---- Particle ----
     class Particle {
-        constructor(x, y, vx, vy, radius, color) {
+        constructor(x, y, vx, vy, radius, color, kind) {
             this.x = x;
             this.y = y;
             this.vx = vx;
             this.vy = vy;
             this.radius = radius;
             this.color = color;
+            this.kind = kind || 'dust';
             this.absorbed = false;
+            this.stretch = 0;
+            this.stretchA = 0;
         }
 
-        update() {
-            this.vy += ambientGravity;
+        step(k) {
+            this.vy += ambientGravity * k;
+            this.stretch = 0;
 
             for (let i = 0; i < bodies.length; i++) {
                 const b = bodies[i];
                 const dx = b.x - this.x;
                 const dy = b.y - this.y;
                 const distSq = dx * dx + dy * dy + SOFTEN;
+                const dist = Math.sqrt(distSq);
 
                 if (absorbEnabled) {
                     const rSum = b.radius + this.radius;
-                    if (distSq < rSum * rSum) {
+                    if (dx * dx + dy * dy < rSum * rSum * 0.85) {
                         this.absorbed = true;
                         b.grow(this.radius);
                         continue;
                     }
                 }
 
-                const dist = Math.sqrt(distSq);
                 const g = (G_BASE * gStrength * b.mass) / distSq;
-                this.vx += (g * dx) / dist;
-                this.vy += (g * dy) / dist;
+                this.vx += ((g * dx) / dist) * k;
+                this.vy += ((g * dy) / dist) * k;
+
+                if (b.kind === 'blackhole') {
+                    const roche = b.radius * 3.4;
+                    const raw = Math.sqrt(dx * dx + dy * dy);
+                    if (raw < roche) {
+                        this.stretch = Math.min(1.8, (roche - raw) / roche * 2.2);
+                        this.stretchA = Math.atan2(dy, dx);
+                    }
+                }
             }
 
             if (this.absorbed) return;
 
-            this.vx *= friction;
-            this.vy *= friction;
-
             if (isPointerDown && mouseMode !== 'spawn' && mouseMode !== 'body' && mouseMode !== 'erase') {
-                const dx = pointerX - this.x;
-                const dy = pointerY - this.y;
+                const dx = pointerW.x - this.x;
+                const dy = pointerW.y - this.y;
                 const distSq = dx * dx + dy * dy;
                 const distance = Math.sqrt(distSq);
-
                 if (mouseMode === 'blackhole') {
-                    const force = 2000 / (distSq + 100);
-                    this.vx += dx * force;
-                    this.vy += dy * force;
-                    if (distance < 20) {
-                        this.x = pointerX + (Math.random() - 0.5) * 10;
-                        this.y = pointerY + (Math.random() - 0.5) * 10;
-                        this.vx = (Math.random() - 0.5) * 20;
-                        this.vy = (Math.random() - 0.5) * 20;
+                    const force = 1800 / (distSq + 120);
+                    this.vx += dx * force * k;
+                    this.vy += dy * force * k;
+                    if (distance < 18) {
+                        this.absorbed = true;
                     }
                 } else {
-                    const force = 500 / (distSq + 100);
-                    if (mouseMode === 'attract') {
-                        this.vx += dx * force * 0.5;
-                        this.vy += dy * force * 0.5;
-                    } else if (mouseMode === 'repel') {
-                        this.vx -= dx * force * 2;
-                        this.vy -= dy * force * 2;
-                    }
+                    const force = 480 / (distSq + 120);
+                    const sign = mouseMode === 'attract' ? 0.5 : -2;
+                    this.vx += dx * force * sign * k;
+                    this.vy += dy * force * sign * k;
                 }
             }
 
-            this.x += this.vx;
-            this.y += this.vy;
+            this.vx *= Math.pow(friction, k);
+            this.vy *= Math.pow(friction, k);
+            this.x += this.vx * k;
+            this.y += this.vy * k;
 
             if (enableBounce) {
-                if (this.y + this.radius > height) {
-                    this.y = height - this.radius;
-                    this.vy = -this.vy * 0.7;
-                }
-                if (this.x + this.radius > width || this.x - this.radius < 0) {
-                    this.vx = -this.vx * 0.7;
-                    if (this.x + this.radius > width) this.x = width - this.radius;
-                    if (this.x - this.radius < 0) this.x = this.radius;
-                }
-                if (this.y - this.radius < 0) {
-                    this.y = this.radius;
-                    this.vy = -this.vy * 0.7;
-                }
+                if (this.x < this.radius) { this.x = this.radius; this.vx = Math.abs(this.vx) * 0.7; }
+                if (this.x > boundW - this.radius) { this.x = boundW - this.radius; this.vx = -Math.abs(this.vx) * 0.7; }
+                if (this.y < this.radius) { this.y = this.radius; this.vy = Math.abs(this.vy) * 0.7; }
+                if (this.y > boundH - this.radius) { this.y = boundH - this.radius; this.vy = -Math.abs(this.vy) * 0.7; }
             } else {
-                if (this.x < -this.radius) this.x = width + this.radius;
-                if (this.x > width + this.radius) this.x = -this.radius;
-                if (this.y < -this.radius) this.y = height + this.radius;
-                if (this.y > height + this.radius) this.y = -this.radius;
+                if (this.x < -40) this.x = boundW + 40;
+                if (this.x > boundW + 40) this.x = -40;
+                if (this.y < -40) this.y = boundH + 40;
+                if (this.y > boundH + 40) this.y = -40;
             }
-
-            this.draw();
         }
 
         draw() {
+            const s = toScreen(this.x, this.y);
+            const pr = Math.max(0.55, this.radius * cam.zoom);
+            if (s.x < -20 || s.x > width + 20 || s.y < -20 || s.y > height + 20) return;
+
             let color = this.color;
             if (velocityColorMode) {
                 const speed = Math.hypot(this.vx, this.vy);
-                const hue = Math.max(0, 265 - speed * 20);
-                color = `hsl(${hue}, 92%, 62%)`;
+                color = `hsl(${Math.max(0, 268 - speed * 18)}, 92%, 62%)`;
             }
 
-            ctx.beginPath();
-            ctx.arc(this.x, this.y, this.radius, 0, Math.PI * 2);
             ctx.fillStyle = color;
-
-            if (enableGlow && this.radius > 2.5 && particles.length < 260) {
-                ctx.shadowBlur = 9;
-                ctx.shadowColor = color;
+            ctx.beginPath();
+            if (this.stretch > 0.08) {
+                ctx.save();
+                ctx.translate(s.x, s.y);
+                ctx.rotate(this.stretchA);
+                ctx.scale(1 + this.stretch, 1 - this.stretch * 0.42);
+                ctx.arc(0, 0, pr, 0, TAU);
+                ctx.fill();
+                ctx.restore();
             } else {
-                ctx.shadowBlur = 0;
+                ctx.arc(s.x, s.y, pr, 0, TAU);
+                ctx.fill();
             }
 
-            ctx.fill();
-            ctx.shadowBlur = 0;
+            if (this.kind === 'comet') {
+                const mag = Math.hypot(this.vx, this.vy) || 1;
+                const tx = s.x - (this.vx / mag) * pr * 7;
+                const ty = s.y - (this.vy / mag) * pr * 7;
+                const tg = ctx.createLinearGradient(s.x, s.y, tx, ty);
+                tg.addColorStop(0, color);
+                tg.addColorStop(1, 'rgba(0,0,0,0)');
+                ctx.strokeStyle = tg;
+                ctx.lineWidth = pr * 1.6;
+                ctx.beginPath();
+                ctx.moveTo(s.x, s.y);
+                ctx.lineTo(tx, ty);
+                ctx.stroke();
+            }
         }
     }
 
-    // ---- Body (gravity attractor) ----
+    // ---- Body ----
     class Body {
-        constructor(x, y, vx, vy, radius, color, type) {
+        constructor(x, y, vx, vy, radius, color, kind, name) {
             this.x = x;
             this.y = y;
             this.vx = vx;
             this.vy = vy;
             this.radius = radius;
-            this.maxRadius = Math.min(95, radius * 2.6);
+            this.maxRadius = Math.min(110, radius * 2.8);
             this.color = color;
             this.rgb = hexToRgb(color);
-            this.type = type || 'star';
+            this.kind = kind || 'planet';
+            this.name = name || '';
             this.pulse = 0;
-            this.ringAngle = Math.random() * Math.PI * 2;
+            this.spin = Math.random() * TAU;
+            this.trail = [];
+            this.pinned = false;
             this.updateMass();
         }
 
         updateMass() {
-            this.mass = this.radius * this.radius * MASS_K * (this.type === 'blackhole' ? 8 : 1);
+            this.mass = this.radius * this.radius * MASS_K * (this.kind === 'blackhole' ? 8 : this.kind === 'sun' ? 1.6 : 1);
         }
 
         grow(amount) {
             if (this.radius < this.maxRadius) {
-                this.radius = Math.min(this.maxRadius, this.radius + amount * 0.035);
+                this.radius = Math.min(this.maxRadius, this.radius + amount * 0.03);
                 this.updateMass();
             }
             this.pulse = 1;
@@ -279,66 +412,325 @@
             return `rgba(${this.rgb.r}, ${this.rgb.g}, ${this.rgb.b}, ${a})`;
         }
 
-        integrate() {
-            this.x += this.vx;
-            this.y += this.vy;
+        integrate(k) {
+            if (this.pinned) {
+                this.vx = 0;
+                this.vy = 0;
+            } else {
+                this.x += this.vx * k;
+                this.y += this.vy * k;
+            }
+            this.spin += 0.01 * k;
+            if (this.pulse > 0) this.pulse -= 0.03 * k;
 
-            if (this.x < -this.radius * 2) this.x = width + this.radius * 2;
-            if (this.x > width + this.radius * 2) this.x = -this.radius * 2;
-            if (this.y < -this.radius * 2) this.y = height + this.radius * 2;
-            if (this.y > height + this.radius * 2) this.y = -this.radius * 2;
+            if (enableOrbits) {
+                this.trail.push(this.x, this.y);
+                if (this.trail.length > TRAIL_MAX * 2) this.trail.splice(0, this.trail.length - TRAIL_MAX * 2);
+            }
+        }
 
-            if (this.pulse > 0) this.pulse -= 0.03;
+        drawTrail() {
+            if (!enableOrbits || this.trail.length < 4) return;
+            const n = this.trail.length / 2;
+            ctx.beginPath();
+            let prev = null;
+            for (let i = 0; i < n; i++) {
+                const s = toScreen(this.trail[i * 2], this.trail[i * 2 + 1]);
+                if (!prev || Math.hypot(s.x - prev.x, s.y - prev.y) > 48) ctx.moveTo(s.x, s.y);
+                else ctx.lineTo(s.x, s.y);
+                prev = s;
+            }
+            ctx.strokeStyle = this.colorAlpha(0.28);
+            ctx.lineWidth = Math.max(0.8, 1.2 * cam.zoom);
+            ctx.stroke();
         }
 
         draw() {
-            if (this.type === 'blackhole') {
-                const grad = ctx.createRadialGradient(this.x, this.y, this.radius * 0.15, this.x, this.y, this.radius * 2.4);
-                grad.addColorStop(0, 'rgba(255, 205, 130, 0.9)');
-                grad.addColorStop(0.18, 'rgba(255, 140, 60, 0.5)');
-                grad.addColorStop(0.45, 'rgba(130, 50, 190, 0.22)');
-                grad.addColorStop(1, 'rgba(0, 0, 0, 0)');
-                ctx.fillStyle = grad;
-                ctx.beginPath();
-                ctx.arc(this.x, this.y, this.radius * 2.4, 0, Math.PI * 2);
-                ctx.fill();
+            const s = toScreen(this.x, this.y);
+            const r = Math.max(1.2, this.radius * cam.zoom);
+            if (s.x < -r * 5 || s.x > width + r * 5 || s.y < -r * 5 || s.y > height + r * 5) return;
 
-                this.ringAngle += 0.015;
-                ctx.strokeStyle = 'rgba(255, 214, 160, 0.9)';
-                ctx.lineWidth = Math.max(2, this.radius * 0.12);
+            switch (this.kind) {
+                case 'blackhole': drawBlackHole(s, r, this); break;
+                case 'sun':
+                case 'star': drawSun(s, r, this); break;
+                case 'saturn': drawSaturn(s, r, this); break;
+                case 'jupiter': drawJupiter(s, r, this); break;
+                case 'earth': drawEarth(s, r, this); break;
+                case 'comet': drawCometBody(s, r, this); break;
+                default: drawPlanet(s, r, this); break;
+            }
+
+            if (selected === this) {
+                ctx.strokeStyle = 'rgba(253, 230, 138, 0.85)';
+                ctx.lineWidth = 1.4;
+                ctx.setLineDash([4, 4]);
                 ctx.beginPath();
-                ctx.ellipse(this.x, this.y, this.radius * 1.7, this.radius * 0.5, this.ringAngle, 0, Math.PI * 2);
+                ctx.arc(s.x, s.y, r + 7, 0, TAU);
                 ctx.stroke();
+                ctx.setLineDash([]);
+            }
 
-                ctx.fillStyle = '#050208';
-                ctx.beginPath();
-                ctx.arc(this.x, this.y, this.radius, 0, Math.PI * 2);
-                ctx.fill();
-            } else {
-                const glowR = this.radius * (2.2 + this.pulse * 0.6);
-                const grad = ctx.createRadialGradient(this.x, this.y, 0, this.x, this.y, glowR);
-                grad.addColorStop(0, this.colorAlpha(0.95));
-                grad.addColorStop(0.35, this.colorAlpha(0.45));
-                grad.addColorStop(1, this.colorAlpha(0));
-                ctx.fillStyle = grad;
-                ctx.beginPath();
-                ctx.arc(this.x, this.y, glowR, 0, Math.PI * 2);
-                ctx.fill();
-
-                ctx.fillStyle = this.color;
-                ctx.beginPath();
-                ctx.arc(this.x, this.y, this.radius, 0, Math.PI * 2);
-                ctx.fill();
-
-                ctx.fillStyle = 'rgba(255, 255, 255, 0.35)';
-                ctx.beginPath();
-                ctx.arc(this.x - this.radius * 0.3, this.y - this.radius * 0.3, this.radius * 0.35, 0, Math.PI * 2);
-                ctx.fill();
+            if (enableLabels && this.name && r > 5 && s.y > 86 && s.y < height - 150) {
+                ctx.font = `600 ${Math.max(10, Math.min(13, r * 0.55))}px Space Grotesk, sans-serif`;
+                ctx.fillStyle = 'rgba(255,255,255,0.72)';
+                ctx.textAlign = 'center';
+                ctx.fillText(this.name, s.x, s.y + r + 14);
             }
         }
     }
 
-    function updateBodies() {
+    function drawGlow(s, r, color, mul) {
+        if (!enableGlow) return;
+        const g = ctx.createRadialGradient(s.x, s.y, r * 0.2, s.x, s.y, r * mul);
+        g.addColorStop(0, color);
+        g.addColorStop(1, 'rgba(0,0,0,0)');
+        ctx.fillStyle = g;
+        ctx.beginPath();
+        ctx.arc(s.x, s.y, r * mul, 0, TAU);
+        ctx.fill();
+    }
+
+    function drawSun(s, r, b) {
+        const t = b.spin;
+        const glowR = r * (2.6 + Math.sin(t * 2) * 0.12 + b.pulse * 0.4);
+        const g = ctx.createRadialGradient(s.x, s.y, 0, s.x, s.y, glowR);
+        g.addColorStop(0, 'rgba(255,255,230,1)');
+        g.addColorStop(0.12, b.colorAlpha(0.95));
+        g.addColorStop(0.38, b.colorAlpha(0.4));
+        g.addColorStop(1, 'rgba(0,0,0,0)');
+        ctx.fillStyle = g;
+        ctx.beginPath();
+        ctx.arc(s.x, s.y, glowR, 0, TAU);
+        ctx.fill();
+
+        ctx.save();
+        ctx.translate(s.x, s.y);
+        ctx.rotate(t * 0.4);
+        ctx.strokeStyle = b.colorAlpha(0.22);
+        ctx.lineCap = 'round';
+        for (let i = 0; i < 10; i++) {
+            const a = i * TAU / 10;
+            const len = r * (1.55 + 0.35 * Math.sin(t * 3 + i));
+            ctx.lineWidth = Math.max(1.2, r * 0.12);
+            ctx.beginPath();
+            ctx.moveTo(Math.cos(a) * r * 0.85, Math.sin(a) * r * 0.85);
+            ctx.lineTo(Math.cos(a) * len, Math.sin(a) * len);
+            ctx.stroke();
+        }
+        ctx.restore();
+
+        const core = ctx.createRadialGradient(s.x - r * 0.2, s.y - r * 0.2, r * 0.1, s.x, s.y, r);
+        core.addColorStop(0, '#fff7d1');
+        core.addColorStop(0.45, b.color);
+        core.addColorStop(1, '#ea580c');
+        ctx.fillStyle = core;
+        ctx.beginPath();
+        ctx.arc(s.x, s.y, r, 0, TAU);
+        ctx.fill();
+    }
+
+    function drawBlackHole(s, r, b) {
+        const glow = ctx.createRadialGradient(s.x, s.y, r * 0.2, s.x, s.y, r * 3.1);
+        glow.addColorStop(0, 'rgba(255, 214, 140, 0.9)');
+        glow.addColorStop(0.16, 'rgba(255, 120, 50, 0.45)');
+        glow.addColorStop(0.42, 'rgba(90, 40, 170, 0.22)');
+        glow.addColorStop(1, 'rgba(0,0,0,0)');
+        ctx.fillStyle = glow;
+        ctx.beginPath();
+        ctx.arc(s.x, s.y, r * 3.1, 0, TAU);
+        ctx.fill();
+
+        ctx.save();
+        ctx.translate(s.x, s.y);
+        ctx.rotate(b.spin * 0.7);
+        ctx.scale(1, 0.34);
+        const disk = ctx.createRadialGradient(0, 0, r * 0.85, 0, 0, r * 2.7);
+        disk.addColorStop(0, 'rgba(0,0,0,0)');
+        disk.addColorStop(0.22, 'rgba(255, 244, 200, 0.95)');
+        disk.addColorStop(0.42, 'rgba(255, 140, 50, 0.7)');
+        disk.addColorStop(0.7, 'rgba(90, 120, 255, 0.32)');
+        disk.addColorStop(1, 'rgba(0,0,0,0)');
+        ctx.fillStyle = disk;
+        ctx.beginPath();
+        ctx.arc(0, 0, r * 2.7, 0, TAU);
+        ctx.fill();
+        ctx.restore();
+
+        ctx.strokeStyle = 'rgba(160, 190, 255, 0.28)';
+        ctx.lineWidth = Math.max(1.5, r * 0.1);
+        ctx.beginPath();
+        ctx.moveTo(s.x, s.y - r * 3.6);
+        ctx.lineTo(s.x, s.y - r * 1.15);
+        ctx.moveTo(s.x, s.y + r * 1.15);
+        ctx.lineTo(s.x, s.y + r * 3.6);
+        ctx.stroke();
+
+        ctx.strokeStyle = 'rgba(255, 220, 170, 0.9)';
+        ctx.lineWidth = Math.max(1.4, r * 0.08);
+        ctx.beginPath();
+        ctx.arc(s.x, s.y, r * 1.18, 0, TAU);
+        ctx.stroke();
+
+        ctx.fillStyle = '#010104';
+        ctx.beginPath();
+        ctx.arc(s.x, s.y, r, 0, TAU);
+        ctx.fill();
+    }
+
+    function drawPlanet(s, r, b) {
+        drawGlow(s, r, b.colorAlpha(0.55), 2.1 + b.pulse * 0.4);
+        const g = ctx.createRadialGradient(s.x - r * 0.3, s.y - r * 0.35, r * 0.1, s.x, s.y, r);
+        g.addColorStop(0, 'rgba(255,255,255,0.55)');
+        g.addColorStop(0.35, b.color);
+        g.addColorStop(1, 'rgba(0,0,0,0.55)');
+        ctx.fillStyle = g;
+        ctx.beginPath();
+        ctx.arc(s.x, s.y, r, 0, TAU);
+        ctx.fill();
+    }
+
+    function drawEarth(s, r, b) {
+        const atmo = ctx.createRadialGradient(s.x, s.y, r * 0.8, s.x, s.y, r * 1.32);
+        atmo.addColorStop(0, 'rgba(80,170,255,0)');
+        atmo.addColorStop(0.72, 'rgba(80,170,255,0.18)');
+        atmo.addColorStop(1, 'rgba(80,170,255,0)');
+        ctx.fillStyle = atmo;
+        ctx.beginPath();
+        ctx.arc(s.x, s.y, r * 1.32, 0, TAU);
+        ctx.fill();
+
+        ctx.save();
+        ctx.beginPath();
+        ctx.arc(s.x, s.y, r, 0, TAU);
+        ctx.clip();
+        ctx.fillStyle = '#1d4ed8';
+        ctx.fillRect(s.x - r, s.y - r, r * 2, r * 2);
+        ctx.fillStyle = '#3d9a4a';
+        blob(s.x + Math.cos(b.spin) * r * 0.15, s.y + Math.sin(b.spin * 0.7) * r * 0.1, r * 0.42);
+        blob(s.x - r * 0.32, s.y + r * 0.22, r * 0.26);
+        blob(s.x + r * 0.28, s.y + r * 0.3, r * 0.18);
+        ctx.fillStyle = '#e8f4ff';
+        ctx.beginPath();
+        ctx.ellipse(s.x, s.y - r * 0.82, r * 0.42, r * 0.16, 0, 0, TAU);
+        ctx.fill();
+        ctx.beginPath();
+        ctx.ellipse(s.x, s.y + r * 0.86, r * 0.36, r * 0.13, 0, 0, TAU);
+        ctx.fill();
+        ctx.fillStyle = 'rgba(255,255,255,0.28)';
+        blob(s.x + r * 0.1, s.y - r * 0.15, r * 0.2);
+        ctx.restore();
+
+        ctx.fillStyle = 'rgba(255,255,255,0.32)';
+        ctx.beginPath();
+        ctx.arc(s.x - r * 0.28, s.y - r * 0.28, r * 0.2, 0, TAU);
+        ctx.fill();
+    }
+
+    function drawJupiter(s, r, b) {
+        drawGlow(s, r, b.colorAlpha(0.4), 1.9);
+        ctx.save();
+        ctx.beginPath();
+        ctx.arc(s.x, s.y, r, 0, TAU);
+        ctx.clip();
+        ctx.fillStyle = '#e8b86a';
+        ctx.fillRect(s.x - r, s.y - r, r * 2, r * 2);
+        const bands = ['#d4924a', '#f0d0a0', '#c47a38', '#ead8b0', '#d9a056', '#b86a32'];
+        for (let i = 0; i < 7; i++) {
+            ctx.fillStyle = bands[i % bands.length];
+            ctx.globalAlpha = 0.75;
+            ctx.fillRect(s.x - r, s.y - r + (i + 0.15 + Math.sin(b.spin + i) * 0.04) * r * 0.28, r * 2, r * 0.16);
+        }
+        ctx.globalAlpha = 1;
+        ctx.fillStyle = '#c4452d';
+        ctx.beginPath();
+        ctx.ellipse(s.x + r * 0.32, s.y + r * 0.18, r * 0.28, r * 0.15, -0.3, 0, TAU);
+        ctx.fill();
+        ctx.restore();
+        ctx.fillStyle = 'rgba(255,255,255,0.22)';
+        ctx.beginPath();
+        ctx.arc(s.x - r * 0.3, s.y - r * 0.3, r * 0.18, 0, TAU);
+        ctx.fill();
+    }
+
+    function drawSaturn(s, r, b) {
+        drawRings(s, r, b, 'back');
+        drawPlanet(s, r, b);
+        drawRings(s, r, b, 'front');
+    }
+
+    function drawRings(s, r, b, pass) {
+        ctx.save();
+        ctx.translate(s.x, s.y);
+        ctx.rotate(-0.35);
+        ctx.beginPath();
+        if (pass === 'back') ctx.rect(-r * 4, -r * 4, r * 8, r * 4);
+        else ctx.rect(-r * 4, 0, r * 8, r * 4);
+        ctx.clip();
+        ctx.scale(1, 0.32);
+        const rings = [
+            [r * 1.45, r * 1.7, 'rgba(232, 201, 148, 0.55)'],
+            [r * 1.78, r * 2.05, 'rgba(210, 180, 130, 0.28)'],
+            [r * 2.12, r * 2.45, 'rgba(245, 230, 190, 0.4)']
+        ];
+        for (let i = 0; i < rings.length; i++) {
+            ctx.beginPath();
+            ctx.arc(0, 0, rings[i][1], 0, TAU);
+            ctx.arc(0, 0, rings[i][0], 0, TAU, true);
+            ctx.fillStyle = rings[i][2];
+            ctx.fill();
+        }
+        ctx.restore();
+    }
+
+    function drawCometBody(s, r, b) {
+        const mag = Math.hypot(b.vx, b.vy) || 1;
+        const tx = s.x - (b.vx / mag) * Math.min(70, r * 8);
+        const ty = s.y - (b.vy / mag) * Math.min(70, r * 8);
+        const g = ctx.createLinearGradient(s.x, s.y, tx, ty);
+        g.addColorStop(0, 'rgba(186, 230, 253, 0.9)');
+        g.addColorStop(1, 'rgba(0,0,0,0)');
+        ctx.strokeStyle = g;
+        ctx.lineWidth = Math.max(1.5, r * 1.1);
+        ctx.lineCap = 'round';
+        ctx.beginPath();
+        ctx.moveTo(s.x, s.y);
+        ctx.lineTo(tx, ty);
+        ctx.stroke();
+        drawPlanet(s, r, b);
+    }
+
+    function blob(x, y, r) {
+        ctx.beginPath();
+        ctx.ellipse(x, y, r, r * 0.72, 0.4, 0, TAU);
+        ctx.fill();
+    }
+
+    function spawnShock(x, y, color, maxR) {
+        shockwaves.push({ x, y, r: 4, max: maxR, color, life: 1 });
+    }
+
+    function drawShocks() {
+        for (let i = shockwaves.length - 1; i >= 0; i--) {
+            const w = shockwaves[i];
+            w.r += 2.8 * timeScale;
+            w.life -= 0.018 * timeScale;
+            if (w.life <= 0 || w.r > w.max) {
+                shockwaves.splice(i, 1);
+                continue;
+            }
+            const s = toScreen(w.x, w.y);
+            ctx.strokeStyle = w.color;
+            ctx.globalAlpha = w.life * 0.7;
+            ctx.lineWidth = 2;
+            ctx.beginPath();
+            ctx.arc(s.x, s.y, w.r * cam.zoom, 0, TAU);
+            ctx.stroke();
+            ctx.globalAlpha = 1;
+        }
+    }
+
+    function updateBodies(k) {
         if (bodiesAttract) {
             for (let i = 0; i < bodies.length; i++) {
                 const a = bodies[i];
@@ -348,22 +740,20 @@
                     const dy = b.y - a.y;
                     const distSq = dx * dx + dy * dy + SOFTEN;
                     const dist = Math.sqrt(distSq);
-
                     const aAcc = (G_BASE * gStrength * b.mass) / distSq;
-                    a.vx += (aAcc * dx) / dist;
-                    a.vy += (aAcc * dy) / dist;
-
+                    if (!a.pinned) {
+                        a.vx += ((aAcc * dx) / dist) * k;
+                        a.vy += ((aAcc * dy) / dist) * k;
+                    }
                     const bAcc = (G_BASE * gStrength * a.mass) / distSq;
-                    b.vx -= (bAcc * dx) / dist;
-                    b.vy -= (bAcc * dy) / dist;
+                    if (!b.pinned) {
+                        b.vx -= ((bAcc * dx) / dist) * k;
+                        b.vy -= ((bAcc * dy) / dist) * k;
+                    }
                 }
             }
         }
-
-        for (let i = 0; i < bodies.length; i++) {
-            bodies[i].integrate();
-        }
-
+        for (let i = 0; i < bodies.length; i++) bodies[i].integrate(k);
         if (bodiesAttract) mergeBodies();
     }
 
@@ -372,38 +762,45 @@
             for (let j = i - 1; j >= 0; j--) {
                 const a = bodies[i];
                 const b = bodies[j];
-                const dx = a.x - b.x;
-                const dy = a.y - b.y;
-                const dist = Math.hypot(dx, dy);
-
-                if (dist < (a.radius + b.radius) * 0.55) {
-                    const totalMass = a.mass + b.mass;
-                    b.x = (a.x * a.mass + b.x * b.mass) / totalMass;
-                    b.y = (a.y * a.mass + b.y * b.mass) / totalMass;
-                    b.vx = (a.vx * a.mass + b.vx * b.mass) / totalMass;
-                    b.vy = (a.vy * a.mass + b.vy * b.mass) / totalMass;
-                    if (a.type === 'blackhole' || b.type === 'blackhole') b.type = 'blackhole';
-                    if (a.radius > b.radius) {
-                        b.color = a.color;
-                        b.rgb = a.rgb;
-                    }
-                    b.radius = Math.min(95, Math.sqrt(a.radius * a.radius + b.radius * b.radius));
-                    b.maxRadius = Math.max(b.maxRadius, a.maxRadius, b.radius * 1.4);
-                    b.updateMass();
-                    b.pulse = 1;
-                    bodies.splice(i, 1);
+                const dist = Math.hypot(a.x - b.x, a.y - b.y);
+                if (dist < (a.radius + b.radius) * 0.5) {
+                    const total = a.mass + b.mass;
+                    const keep = a.mass > b.mass ? a : b;
+                    const eat = keep === a ? b : a;
+                    keep.x = (a.x * a.mass + b.x * b.mass) / total;
+                    keep.y = (a.y * a.mass + b.y * b.mass) / total;
+                    keep.vx = (a.vx * a.mass + b.vx * b.mass) / total;
+                    keep.vy = (a.vy * a.mass + b.vy * b.mass) / total;
+                    if (a.kind === 'blackhole' || b.kind === 'blackhole') keep.kind = 'blackhole';
+                    if (a.pinned || b.pinned) keep.pinned = true;
+                    keep.radius = Math.min(110, Math.sqrt(a.radius * a.radius + b.radius * b.radius));
+                    keep.maxRadius = Math.max(keep.maxRadius, eat.maxRadius, keep.radius * 1.3);
+                    keep.updateMass();
+                    keep.pulse = 1;
+                    if (!keep.name) keep.name = eat.name;
+                    spawnShock(keep.x, keep.y, keep.colorAlpha(0.8), keep.radius * 6);
+                    burst(keep.x, keep.y, 14, keep.color);
+                    if (selected === eat) selected = keep;
+                    bodies.splice(eat === a ? i : j, 1);
                     break;
                 }
             }
         }
     }
 
-    // ---- Spawning ----
+    function burst(x, y, n, color) {
+        const colors = themes[currentTheme];
+        for (let i = 0; i < n && particles.length < MAX_PARTICLES; i++) {
+            const a = Math.random() * TAU;
+            const sp = 1.5 + Math.random() * 4;
+            particles.push(new Particle(x, y, Math.cos(a) * sp, Math.sin(a) * sp, 1.2 + Math.random() * 2, color || colors[i % colors.length]));
+        }
+    }
+
     function spawnParticles(x, y, count) {
-        if (particles.length >= MAX_PARTICLES) return;
         const colors = themes[currentTheme];
         for (let i = 0; i < count && particles.length < MAX_PARTICLES; i++) {
-            const radius = Math.random() * particleSize + 2;
+            const radius = Math.random() * particleSize + 1.4;
             const color = colors[Math.floor(Math.random() * colors.length)];
             const vx = (Math.random() - 0.5) * initialVelocity;
             const vy = (Math.random() - 0.5) * initialVelocity;
@@ -415,74 +812,110 @@
         if (bodies.length >= MAX_BODIES) return;
         const colors = themes[currentTheme];
         const color = colors[Math.floor(Math.random() * colors.length)];
-        bodies.push(new Body(x, y, vx, vy, radius, color, 'star'));
+        const kinds = ['planet', 'ice', 'star', 'mars'];
+        bodies.push(new Body(x, y, vx, vy, radius, color, kinds[Math.floor(Math.random() * kinds.length)], 'Mundo'));
     }
 
     function eraseAt(x, y) {
         for (let i = bodies.length - 1; i >= 0; i--) {
-            if (Math.hypot(bodies[i].x - x, bodies[i].y - y) < bodies[i].radius + 18) {
+            if (Math.hypot(bodies[i].x - x, bodies[i].y - y) < bodies[i].radius + 16 / cam.zoom) {
+                if (selected === bodies[i]) selected = null;
+                spawnShock(bodies[i].x, bodies[i].y, bodies[i].colorAlpha(0.6), 40);
                 bodies.splice(i, 1);
             }
         }
         for (let i = particles.length - 1; i >= 0; i--) {
-            if (Math.hypot(particles[i].x - x, particles[i].y - y) < 34) {
+            if (Math.hypot(particles[i].x - x, particles[i].y - y) < 32 / cam.zoom) {
                 particles.splice(i, 1);
             }
         }
+        syncInspect();
     }
 
     function orbitVelocity(mass, r) {
         const distSq = r * r + SOFTEN;
         const a = (G_BASE * gStrength * mass) / distSq;
-        return Math.sqrt(a * r);
+        return Math.sqrt(Math.max(0.0001, a * r));
+    }
+
+    function placeOrbit(host, radiusOrbit, size, color, kind, name, extraVx, extraVy) {
+        const angle = Math.random() * TAU;
+        const x = host.x + Math.cos(angle) * radiusOrbit;
+        const y = host.y + Math.sin(angle) * radiusOrbit;
+        const v = orbitVelocity(host.mass, radiusOrbit);
+        const vx = host.vx + -Math.sin(angle) * v + (extraVx || 0);
+        const vy = host.vy + Math.cos(angle) * v + (extraVy || 0);
+        const body = new Body(x, y, vx, vy, size, color, kind, name);
+        bodies.push(body);
+        return body;
+    }
+
+    function ringDust(host, r0, r1, n, colors) {
+        for (let i = 0; i < n && particles.length < MAX_PARTICLES; i++) {
+            const r = r0 + Math.random() * (r1 - r0);
+            const angle = Math.random() * TAU;
+            const x = host.x + Math.cos(angle) * r;
+            const y = host.y + Math.sin(angle) * r * 0.98;
+            const v = orbitVelocity(host.mass, r);
+            particles.push(new Particle(
+                x, y,
+                host.vx + -Math.sin(angle) * v,
+                host.vy + Math.cos(angle) * v,
+                1 + Math.random() * 1.6,
+                colors[i % colors.length]
+            ));
+        }
     }
 
     function clearAll() {
         particles = [];
         bodies = [];
+        shockwaves = [];
+        selected = null;
+        cam.follow = false;
+        syncInspect();
     }
 
-    // ---- Scenarios ----
+    function unit() {
+        return Math.min(boundW, boundH);
+    }
+
     function scenarioSolar() {
         clearAll();
         ambientGravity = 0;
         friction = 1;
-        bodiesAttract = false;
+        bodiesAttract = true;
         absorbEnabled = true;
         gStrength = 1;
+        enableBounce = false;
 
-        const cx = width / 2;
-        const cy = height / 2;
-        const sun = new Body(cx, cy, 0, 0, 34, '#ffd35c', 'star');
+        const cx = boundW / 2;
+        const cy = boundH / 2;
+        const u = unit();
+        const sun = new Body(cx, cy, 0, 0, Math.max(22, u * 0.038), '#ffd35c', 'sun', 'Sol');
+        sun.pinned = true;
         bodies.push(sun);
 
-        const planetDefs = [
-            { r: 70, radius: 6, color: '#9ca3af' },
-            { r: 105, radius: 8, color: '#f59e0b' },
-            { r: 145, radius: 9, color: '#3b82f6' },
-            { r: 190, radius: 7, color: '#ef4444' },
-            { r: 250, radius: 15, color: '#d97706' }
-        ];
+        const earth = placeOrbit(sun, u * 0.16, Math.max(10, u * 0.016), '#3b82f6', 'earth', 'Terra');
+        placeOrbit(earth, Math.max(14, earth.radius * 1.85), Math.max(2.6, u * 0.005), '#cbd5e1', 'moon', 'Lua');
+        placeOrbit(sun, u * 0.08, Math.max(3.5, u * 0.006), '#9ca3af', 'planet', 'Mercúrio');
+        placeOrbit(sun, u * 0.12, Math.max(6.5, u * 0.01), '#f59e0b', 'planet', 'Vênus');
+        placeOrbit(sun, u * 0.2, Math.max(5.5, u * 0.009), '#ef4444', 'mars', 'Marte');
+        ringDust(sun, u * 0.225, u * 0.255, 70, ['#c4b5fd', '#a8a29e', '#fde68a']);
+        placeOrbit(sun, u * 0.31, Math.max(14, u * 0.022), '#e8b86a', 'jupiter', 'Júpiter');
+        const saturn = placeOrbit(sun, u * 0.39, Math.max(12, u * 0.018), '#f5d0a6', 'saturn', 'Saturno');
+        ringDust(saturn, saturn.radius * 1.6, saturn.radius * 2.5, 40, ['#fde68a', '#e7e5e4']);
+        placeOrbit(sun, u * 0.45, Math.max(8, u * 0.013), '#7dd3fc', 'ice', 'Urano');
+        placeOrbit(sun, u * 0.51, Math.max(8, u * 0.013), '#2563eb', 'ice', 'Netuno');
 
-        planetDefs.forEach((def) => {
-            const angle = Math.random() * Math.PI * 2;
-            const px = cx + Math.cos(angle) * def.r;
-            const py = cy + Math.sin(angle) * def.r;
-            const v = orbitVelocity(sun.mass, def.r);
-            const vx = -Math.sin(angle) * v;
-            const vy = Math.cos(angle) * v;
-            bodies.push(new Body(px, py, vx, vy, def.radius, def.color, 'planet'));
-        });
-
-        for (let i = 0; i < 60; i++) {
-            const r = 215 + Math.random() * 20;
-            const angle = Math.random() * Math.PI * 2;
+        for (let i = 0; i < 2; i++) {
+            const r = u * (0.34 + i * 0.12);
+            const angle = 1.2 + i * 2.1;
             const x = cx + Math.cos(angle) * r;
             const y = cy + Math.sin(angle) * r;
-            const v = orbitVelocity(sun.mass, r);
-            const vx = -Math.sin(angle) * v;
-            const vy = Math.cos(angle) * v;
-            particles.push(new Particle(x, y, vx, vy, 1 + Math.random() * 1.5, '#c4b5fd'));
+            const v = orbitVelocity(sun.mass, r) * 0.92;
+            const comet = new Body(x, y, -Math.sin(angle) * v, Math.cos(angle) * v, 4, '#e0f2fe', 'comet', i ? 'Halley' : 'Encke');
+            bodies.push(comet);
         }
     }
 
@@ -493,71 +926,62 @@
         bodiesAttract = true;
         absorbEnabled = true;
         gStrength = 1;
+        enableBounce = false;
 
-        const cx = width / 2;
-        const cy = height / 2;
-        const sep = 160;
-        const radius = 24;
-        const starA = new Body(cx - sep / 2, cy, 0, 0, radius, '#60a5fa', 'star');
-        const starB = new Body(cx + sep / 2, cy, 0, 0, radius, '#f472b6', 'star');
-        const v = Math.sqrt((G_BASE * gStrength * (starA.mass + starB.mass)) / (4 * sep));
-        starA.vy = -v;
-        starB.vy = v;
-        bodies.push(starA, starB);
-
-        const comboMass = starA.mass + starB.mass;
-        const colors = themes[currentTheme];
-        for (let i = 0; i < 90; i++) {
-            const r = 240 + Math.random() * 140;
-            const angle = Math.random() * Math.PI * 2;
-            const x = cx + Math.cos(angle) * r;
-            const y = cy + Math.sin(angle) * r;
-            const vOrb = orbitVelocity(comboMass, r);
-            const vx = -Math.sin(angle) * vOrb;
-            const vy = Math.cos(angle) * vOrb;
-            particles.push(new Particle(x, y, vx, vy, 1 + Math.random() * 2, colors[i % colors.length]));
-        }
+        const cx = boundW / 2;
+        const cy = boundH / 2;
+        const sep = unit() * 0.16;
+        const radius = Math.max(16, unit() * 0.028);
+        const a = new Body(cx - sep / 2, cy, 0, 0, radius, '#60a5fa', 'star', 'Azura');
+        const b = new Body(cx + sep / 2, cy, 0, 0, radius, '#f472b6', 'star', 'Rosa');
+        const v = Math.sqrt((G_BASE * gStrength * (a.mass + b.mass)) / (4 * sep));
+        a.vy = -v;
+        b.vy = v;
+        bodies.push(a, b);
+        ringDust({ x: cx, y: cy, vx: 0, vy: 0, mass: a.mass + b.mass }, sep * 1.6, sep * 2.8, 110, themes[currentTheme]);
     }
 
     function scenarioBlackhole() {
         clearAll();
         ambientGravity = 0;
         friction = 1;
-        bodiesAttract = false;
+        bodiesAttract = true;
         absorbEnabled = true;
-        gStrength = 1.3;
+        gStrength = 1.25;
+        enableBounce = false;
 
-        const cx = width / 2;
-        const cy = height / 2;
-        const bh = new Body(cx, cy, 0, 0, 26, '#1a1a2e', 'blackhole');
+        const cx = boundW / 2;
+        const cy = boundH / 2;
+        const bh = new Body(cx, cy, 0, 0, Math.max(18, unit() * 0.03), '#1a1a2e', 'blackhole', 'Horizonte');
+        bh.pinned = true;
         bodies.push(bh);
+        ringDust(bh, bh.radius * 3.2, bh.radius * 9, 160, ['#fde68a', '#fb923c', '#a78bfa', '#f97316']);
 
-        for (let i = 0; i < 140; i++) {
-            const r = 70 + Math.random() * 220;
-            const angle = Math.random() * Math.PI * 2;
-            const x = cx + Math.cos(angle) * r;
-            const y = cy + Math.sin(angle) * r;
-            const v = orbitVelocity(bh.mass, r) * (0.85 + Math.random() * 0.3);
-            const vx = -Math.sin(angle) * v;
-            const vy = Math.cos(angle) * v;
-            const heatColor = r < 130 ? '#fde68a' : r < 200 ? '#fb923c' : '#a78bfa';
-            particles.push(new Particle(x, y, vx, vy, 1 + Math.random() * 2.2, heatColor));
-        }
+        const r = unit() * 0.28;
+        const star = new Body(cx + r, cy, 0, orbitVelocity(bh.mass, r) * 0.55, Math.max(14, unit() * 0.022), '#fde68a', 'star', 'Vítima');
+        bodies.push(star);
     }
 
-    function makeMiniGalaxy(cx, cy, color, driftVx, driftVy) {
-        const core = new Body(cx, cy, driftVx, driftVy, 22, color, 'star');
+    function spawnSpiral(cx, cy, color, name, driftVx, driftVy) {
+        const core = new Body(cx, cy, driftVx, driftVy, Math.max(14, unit() * 0.022), color, 'star', name);
         bodies.push(core);
         const colors = themes[currentTheme];
-        for (let i = 0; i < 70; i++) {
-            const r = 40 + Math.random() * 130;
-            const angle = Math.random() * Math.PI * 2;
-            const x = cx + Math.cos(angle) * r;
-            const y = cy + Math.sin(angle) * r;
-            const v = orbitVelocity(core.mass, r);
-            const vx = -Math.sin(angle) * v + driftVx;
-            const vy = Math.cos(angle) * v + driftVy;
-            particles.push(new Particle(x, y, vx, vy, 1 + Math.random() * 2, colors[i % colors.length]));
+        const arms = 2;
+        for (let i = 0; i < 90 && particles.length < MAX_PARTICLES; i++) {
+            const arm = i % arms;
+            const t = i / 90;
+            const rad = unit() * (0.04 + t * 0.16);
+            const angle = arm * Math.PI + t * 3.1 + Math.random() * 0.18;
+            const x = cx + Math.cos(angle) * rad;
+            const y = cy + Math.sin(angle) * rad * 0.72;
+            const v = orbitVelocity(core.mass, rad);
+            particles.push(new Particle(
+                x, y,
+                -Math.sin(angle) * v + driftVx,
+                Math.cos(angle) * v + driftVy,
+                1 + Math.random() * 1.8,
+                colors[i % colors.length]
+            ));
         }
     }
 
@@ -568,10 +992,76 @@
         bodiesAttract = true;
         absorbEnabled = true;
         gStrength = 1;
+        enableBounce = false;
+        const cy = boundH / 2;
+        spawnSpiral(boundW * 0.3, cy, '#60a5fa', 'Azul', 0.85, 0.15);
+        spawnSpiral(boundW * 0.7, cy, '#f472b6', 'Magenta', -0.85, -0.15);
+    }
 
-        const cy = height / 2;
-        makeMiniGalaxy(width * 0.28, cy, '#60a5fa', 1.1, 0);
-        makeMiniGalaxy(width * 0.72, cy, '#f472b6', -1.1, 0);
+    function scenarioThreeBody() {
+        clearAll();
+        ambientGravity = 0;
+        friction = 1;
+        bodiesAttract = true;
+        absorbEnabled = false;
+        gStrength = 1;
+        enableBounce = false;
+
+        const cx = boundW / 2;
+        const cy = boundH / 2;
+        const R = unit() * 0.16;
+        const radius = Math.max(14, unit() * 0.024);
+        const colors = ['#fde68a', '#67e8f9', '#f9a8d4'];
+        const names = ['Alfa', 'Beta', 'Gama'];
+        const probe = new Body(0, 0, 0, 0, radius, colors[0], 'sun', names[0]);
+        const v = Math.sqrt((G_BASE * gStrength * 3 * probe.mass) / (R * Math.sqrt(3)));
+        for (let i = 0; i < 3; i++) {
+            const a = i * TAU / 3;
+            const star = new Body(
+                cx + Math.cos(a) * R,
+                cy + Math.sin(a) * R,
+                -Math.sin(a) * v,
+                Math.cos(a) * v,
+                radius,
+                colors[i],
+                'sun',
+                names[i]
+            );
+            bodies.push(star);
+        }
+        const colorsDust = themes[currentTheme];
+        for (let i = 0; i < 80; i++) {
+            const a = Math.random() * TAU;
+            const rad = R * (1.6 + Math.random() * 1.4);
+            particles.push(new Particle(
+                cx + Math.cos(a) * rad,
+                cy + Math.sin(a) * rad,
+                (Math.random() - 0.5) * 0.6,
+                (Math.random() - 0.5) * 0.6,
+                1.2 + Math.random() * 1.8,
+                colorsDust[i % colorsDust.length]
+            ));
+        }
+    }
+
+    function scenarioRings() {
+        clearAll();
+        ambientGravity = 0;
+        friction = 1;
+        bodiesAttract = true;
+        absorbEnabled = true;
+        gStrength = 1;
+        enableBounce = false;
+
+        const cx = boundW / 2;
+        const cy = boundH / 2;
+        const planet = new Body(cx, cy, 0, 0, Math.max(26, unit() * 0.045), '#f5d0a6', 'saturn', 'Cronos');
+        planet.pinned = true;
+        bodies.push(planet);
+        ringDust(planet, planet.radius * 1.55, planet.radius * 2.15, 90, ['#fde68a', '#e7e5e4', '#fcd34d']);
+        ringDust(planet, planet.radius * 2.3, planet.radius * 3.1, 120, ['#e0f2fe', '#cbd5e1', '#fef3c7']);
+        placeOrbit(planet, planet.radius * 3.6, 6, '#cbd5e1', 'moon', 'Pastor A');
+        placeOrbit(planet, planet.radius * 4.4, 5, '#94a3b8', 'moon', 'Pastor B');
     }
 
     function scenarioChaos() {
@@ -580,31 +1070,36 @@
         friction = 0.999;
         bodiesAttract = true;
         absorbEnabled = true;
-        gStrength = 1.5;
-
-        const n = 4 + Math.floor(Math.random() * 3);
+        gStrength = 1.45;
+        enableBounce = false;
         const colors = themes[currentTheme];
+        const n = 4 + Math.floor(Math.random() * 3);
         for (let i = 0; i < n; i++) {
-            const radius = 10 + Math.random() * 22;
-            const x = Math.random() * width;
-            const y = Math.random() * height;
-            const vx = (Math.random() - 0.5) * 3;
-            const vy = (Math.random() - 0.5) * 3;
-            bodies.push(new Body(x, y, vx, vy, radius, colors[i % colors.length], 'star'));
+            const radius = 10 + Math.random() * 18;
+            const kind = i === 0 && Math.random() > 0.5 ? 'blackhole' : 'star';
+            bodies.push(new Body(
+                boundW * (0.2 + Math.random() * 0.6),
+                boundH * (0.2 + Math.random() * 0.6),
+                (Math.random() - 0.5) * 2.4,
+                (Math.random() - 0.5) * 2.4,
+                radius,
+                colors[i % colors.length],
+                kind,
+                kind === 'blackhole' ? 'Poço' : 'Astro ' + (i + 1)
+            ));
         }
-        for (let i = 0; i < 120; i++) {
-            spawnParticles(Math.random() * width, Math.random() * height, 1);
-        }
+        for (let i = 0; i < 130; i++) spawnParticles(Math.random() * boundW, Math.random() * boundH, 1);
     }
 
     function scenarioClassic() {
         clearAll();
-        ambientGravity = 0.5;
-        friction = 0.98;
+        ambientGravity = 0.45;
+        friction = 0.985;
         bodiesAttract = false;
         absorbEnabled = false;
         gStrength = 1;
-        spawnParticles(width / 2, height / 2, 30);
+        enableBounce = true;
+        spawnParticles(boundW / 2, boundH * 0.28, 40);
     }
 
     const scenarios = {
@@ -612,31 +1107,40 @@
         binary: scenarioBinary,
         blackhole: scenarioBlackhole,
         galaxy: scenarioGalaxy,
+        threebody: scenarioThreeBody,
+        rings: scenarioRings,
         chaos: scenarioChaos,
         classic: scenarioClassic
     };
 
     function loadScenario(name) {
         if (!scenarios[name]) return;
-        if (width && height) {
-            ctx.globalCompositeOperation = 'source-over';
-            ctx.fillStyle = '#06060e';
-            ctx.fillRect(0, 0, width, height);
-        }
         scenarios[name]();
         currentScenario = name;
+        if (history.replaceState) history.replaceState(null, '', '#' + name);
+        resetCamera();
+        bounceCheckbox.checked = enableBounce;
         syncUIFromState();
-        document.querySelectorAll('.scenario-btn').forEach((btn) => {
+        document.querySelectorAll('.scene-chip').forEach((btn) => {
             btn.classList.toggle('active', btn.dataset.scenario === name);
         });
+        const meta = SCENES.find((s) => s.id === name);
+        hudScene.textContent = meta ? meta.name : name;
+        if (meta) toast(meta.toast);
     }
 
-    // ---- Input handling ----
+    // ---- Input ----
     let isPointerDown = false;
     let pointerX = 0;
     let pointerY = 0;
+    let pointerW = { x: 0, y: 0 };
     let slingActive = false;
     let slingStart = null;
+    let panning = false;
+    let panLast = null;
+    let spawnArmed = false;
+    let downOnBody = null;
+    let pinchStart = null;
 
     const slingshotHint = document.getElementById('slingshotHint');
 
@@ -645,121 +1149,238 @@
         return { x: clientX - rect.left, y: clientY - rect.top };
     }
 
-    function pointerDown(x, y) {
+    function hitBody(wx, wy) {
+        let best = null;
+        let bestD = Infinity;
+        for (let i = 0; i < bodies.length; i++) {
+            const b = bodies[i];
+            const d = Math.hypot(b.x - wx, b.y - wy);
+            const pad = Math.max(10 / cam.zoom, b.radius * 1.15);
+            if (d < pad && d < bestD) {
+                best = b;
+                bestD = d;
+            }
+        }
+        return best;
+    }
+
+    function pointerDown(x, y, pan) {
         pointerX = x;
         pointerY = y;
+        pointerW = toWorld(x, y);
+        downOnBody = hitBody(pointerW.x, pointerW.y);
+
+        if (pan) {
+            panning = true;
+            panLast = { x, y };
+            cam.follow = false;
+            syncFollowBtn();
+            return;
+        }
 
         if (mouseMode === 'body') {
             slingActive = true;
-            slingStart = { x, y };
+            slingStart = { x: pointerW.x, y: pointerW.y, sx: x, sy: y };
             showSlingshotHint(x, y);
-        } else if (mouseMode === 'spawn') {
-            isPointerDown = true;
-            spawnParticles(x, y, 10);
-        } else if (mouseMode === 'erase') {
-            isPointerDown = true;
-            eraseAt(x, y);
-        } else {
-            isPointerDown = true;
+            return;
         }
+
+        if (downOnBody && mouseMode === 'spawn') {
+            selected = downOnBody;
+            spawnArmed = false;
+            syncInspect();
+            return;
+        }
+
+        spawnArmed = mouseMode === 'spawn';
+        isPointerDown = true;
+        if (mouseMode === 'spawn') spawnParticles(pointerW.x, pointerW.y, 8);
+        if (mouseMode === 'erase') eraseAt(pointerW.x, pointerW.y);
     }
 
     function pointerMove(x, y) {
         pointerX = x;
         pointerY = y;
+        pointerW = toWorld(x, y);
+
+        if (panning && panLast) {
+            cam.x -= (x - panLast.x) / cam.zoom;
+            cam.y -= (y - panLast.y) / cam.zoom;
+            panLast = { x, y };
+            cam.follow = false;
+            syncFollowBtn();
+            return;
+        }
 
         if (slingActive) {
             showSlingshotHint(x, y);
-        } else if (isPointerDown && mouseMode === 'spawn') {
-            spawnParticles(x, y, 2);
-        } else if (isPointerDown && mouseMode === 'erase') {
-            eraseAt(x, y);
+            return;
         }
+
+        if (downOnBody && mouseMode === 'spawn' && !isPointerDown) {
+            const dx = x - (toScreen(downOnBody.x, downOnBody.y).x);
+            const dy = y - (toScreen(downOnBody.x, downOnBody.y).y);
+            if (Math.hypot(dx, dy) > 12) {
+                isPointerDown = true;
+                spawnArmed = true;
+                spawnParticles(pointerW.x, pointerW.y, 4);
+            }
+            return;
+        }
+
+        if (isPointerDown && mouseMode === 'spawn') spawnParticles(pointerW.x, pointerW.y, 2);
+        if (isPointerDown && mouseMode === 'erase') eraseAt(pointerW.x, pointerW.y);
     }
 
     function pointerUp() {
-        if (slingActive) {
-            const dx = slingStart.x - pointerX;
-            const dy = slingStart.y - pointerY;
+        if (slingActive && slingStart) {
+            const dx = slingStart.x - pointerW.x;
+            const dy = slingStart.y - pointerW.y;
             addBody(slingStart.x, slingStart.y, dx * SLING_K, dy * SLING_K, bodySizeSetting);
             slingActive = false;
             slingshotHint.classList.remove('visible');
         }
         isPointerDown = false;
+        panning = false;
+        panLast = null;
+        spawnArmed = false;
+        downOnBody = null;
     }
 
     function showSlingshotHint(x, y) {
         if (!slingStart) return;
-        const dx = slingStart.x - x;
-        const dy = slingStart.y - y;
-        const speed = Math.hypot(dx, dy) * SLING_K;
-        slingshotHint.style.left = slingStart.x + 'px';
-        slingshotHint.style.top = slingStart.y + 'px';
-        slingshotHint.textContent = speed > 0.15 ? `lançar ${speed.toFixed(1)}` : 'solte para criar';
+        const world = toWorld(x, y);
+        const speed = Math.hypot(slingStart.x - world.x, slingStart.y - world.y) * SLING_K;
+        const scr = toScreen(slingStart.x, slingStart.y);
+        slingshotHint.style.left = scr.x + 'px';
+        slingshotHint.style.top = scr.y + 'px';
+        slingshotHint.textContent = speed > 0.12 ? `lançar ${speed.toFixed(1)}` : 'solte para criar';
         slingshotHint.classList.add('visible');
     }
 
     function drawSlingshotPreview() {
         if (!slingActive || !slingStart) return;
+        const a = toScreen(slingStart.x, slingStart.y);
+        const b = { x: pointerX, y: pointerY };
         ctx.save();
         ctx.setLineDash([6, 6]);
-        ctx.strokeStyle = 'rgba(251, 191, 36, 0.85)';
+        ctx.strokeStyle = 'rgba(253, 230, 138, 0.9)';
         ctx.lineWidth = 2;
         ctx.beginPath();
-        ctx.moveTo(slingStart.x, slingStart.y);
-        ctx.lineTo(pointerX, pointerY);
+        ctx.moveTo(a.x, a.y);
+        ctx.lineTo(b.x, b.y);
         ctx.stroke();
         ctx.setLineDash([]);
-
-        ctx.fillStyle = 'rgba(251, 191, 36, 0.25)';
-        ctx.strokeStyle = 'rgba(251, 191, 36, 0.8)';
-        ctx.lineWidth = 1.5;
+        ctx.fillStyle = 'rgba(253, 230, 138, 0.2)';
+        ctx.strokeStyle = 'rgba(253, 230, 138, 0.85)';
         ctx.beginPath();
-        ctx.arc(slingStart.x, slingStart.y, bodySizeSetting, 0, Math.PI * 2);
+        ctx.arc(a.x, a.y, bodySizeSetting * cam.zoom, 0, TAU);
         ctx.fill();
         ctx.stroke();
         ctx.restore();
     }
 
+    function drawPointerField() {
+        if (!isPointerDown || (mouseMode !== 'attract' && mouseMode !== 'repel' && mouseMode !== 'blackhole')) return;
+        const s = { x: pointerX, y: pointerY };
+        const g = ctx.createRadialGradient(s.x, s.y, 8, s.x, s.y, 90);
+        if (mouseMode === 'attract') {
+            g.addColorStop(0, 'rgba(103, 232, 249, 0.28)');
+            g.addColorStop(1, 'rgba(0,0,0,0)');
+        } else if (mouseMode === 'repel') {
+            g.addColorStop(0, 'rgba(249, 168, 212, 0.28)');
+            g.addColorStop(1, 'rgba(0,0,0,0)');
+        } else {
+            g.addColorStop(0, 'rgba(251, 146, 60, 0.35)');
+            g.addColorStop(1, 'rgba(0,0,0,0)');
+        }
+        ctx.fillStyle = g;
+        ctx.beginPath();
+        ctx.arc(s.x, s.y, 90, 0, TAU);
+        ctx.fill();
+    }
+
     canvas.addEventListener('mousedown', (e) => {
         const p = canvasPoint(e.clientX, e.clientY);
-        pointerDown(p.x, p.y);
+        pointerDown(p.x, p.y, e.button === 1 || e.button === 2 || e.shiftKey);
     });
     canvas.addEventListener('mousemove', (e) => {
         const p = canvasPoint(e.clientX, e.clientY);
         pointerMove(p.x, p.y);
     });
     window.addEventListener('mouseup', pointerUp);
+    canvas.addEventListener('contextmenu', (e) => e.preventDefault());
+    canvas.addEventListener('wheel', (e) => {
+        e.preventDefault();
+        const p = canvasPoint(e.clientX, e.clientY);
+        zoomAt(p.x, p.y, e.deltaY > 0 ? 0.9 : 1.11);
+    }, { passive: false });
 
     canvas.addEventListener('touchstart', (e) => {
         e.preventDefault();
-        const touch = e.touches[0];
-        const p = canvasPoint(touch.clientX, touch.clientY);
-        pointerDown(p.x, p.y);
+        if (e.touches.length === 2) {
+            slingActive = false;
+            isPointerDown = false;
+            const a = canvasPoint(e.touches[0].clientX, e.touches[0].clientY);
+            const b = canvasPoint(e.touches[1].clientX, e.touches[1].clientY);
+            pinchStart = {
+                dist: Math.hypot(a.x - b.x, a.y - b.y),
+                midX: (a.x + b.x) / 2,
+                midY: (a.y + b.y) / 2,
+                zoom: cam.zoom
+            };
+            return;
+        }
+        const t = e.touches[0];
+        const p = canvasPoint(t.clientX, t.clientY);
+        pointerDown(p.x, p.y, false);
     }, { passive: false });
 
     canvas.addEventListener('touchmove', (e) => {
         e.preventDefault();
-        const touch = e.touches[0];
-        const p = canvasPoint(touch.clientX, touch.clientY);
+        if (e.touches.length === 2 && pinchStart) {
+            const a = canvasPoint(e.touches[0].clientX, e.touches[0].clientY);
+            const b = canvasPoint(e.touches[1].clientX, e.touches[1].clientY);
+            const dist = Math.hypot(a.x - b.x, a.y - b.y);
+            const midX = (a.x + b.x) / 2;
+            const midY = (a.y + b.y) / 2;
+            const factor = dist / Math.max(1, pinchStart.dist);
+            const before = toWorld(midX, midY);
+            cam.zoom = clampZoom(pinchStart.zoom * factor);
+            const after = toWorld(midX, midY);
+            cam.x += before.x - after.x;
+            cam.y += before.y - after.y;
+            cam.x -= (midX - pinchStart.midX) / cam.zoom;
+            cam.y -= (midY - pinchStart.midY) / cam.zoom;
+            pinchStart.midX = midX;
+            pinchStart.midY = midY;
+            cam.follow = false;
+            syncFollowBtn();
+            return;
+        }
+        const t = e.touches[0];
+        const p = canvasPoint(t.clientX, t.clientY);
         pointerMove(p.x, p.y);
     }, { passive: false });
 
     canvas.addEventListener('touchend', (e) => {
         e.preventDefault();
-        pointerUp();
+        if (e.touches.length < 2) pinchStart = null;
+        if (e.touches.length === 0) pointerUp();
     }, { passive: false });
 
-    // ---- Animation loop ----
+    // ---- Loop ----
     let lastFpsUpdate = 0;
     let frameCount = 0;
+    const fpsEl = document.getElementById('fps');
+    const countEl = document.getElementById('count');
+    const bodyCountEl = document.getElementById('bodyCount');
+    const hudScene = document.getElementById('hudScene');
 
     function updateFps(now) {
         frameCount++;
         if (now - lastFpsUpdate > 500) {
-            const fps = Math.round((frameCount * 1000) / (now - lastFpsUpdate));
-            const el = document.getElementById('fps');
-            if (el) el.innerText = fps;
+            fpsEl.textContent = String(Math.round((frameCount * 1000) / (now - lastFpsUpdate)));
             frameCount = 0;
             lastFpsUpdate = now;
         }
@@ -767,39 +1388,46 @@
 
     function animate(now) {
         requestAnimationFrame(animate);
-        if (!running) return;
         now = now || performance.now();
         updateFps(now);
 
-        ctx.globalCompositeOperation = 'source-over';
-        ctx.fillStyle = enableTrails ? 'rgba(6, 6, 14, 0.22)' : '#06060e';
-        ctx.fillRect(0, 0, width, height);
+        if (running) {
+            const steps = Math.max(1, Math.round(timeScale));
+            const k = timeScale / steps;
+            for (let s = 0; s < steps; s++) {
+                for (let i = particles.length - 1; i >= 0; i--) {
+                    particles[i].step(k);
+                    if (particles[i].absorbed) particles.splice(i, 1);
+                }
+                updateBodies(k);
+            }
+        }
 
-        if (enableStars) drawStars(now);
+        if (cam.follow && selected) {
+            cam.x += (selected.x - cam.x) * 0.08;
+            cam.y += (selected.y - cam.y) * 0.08;
+        }
 
+        drawBackdrop(now);
         ctx.globalCompositeOperation = additiveBlend ? 'lighter' : 'source-over';
-        for (let i = particles.length - 1; i >= 0; i--) {
-            particles[i].update();
-            if (particles[i].absorbed) particles.splice(i, 1);
-        }
+        for (let i = 0; i < particles.length; i++) particles[i].draw();
         ctx.globalCompositeOperation = 'source-over';
 
-        updateBodies();
-        for (let i = 0; i < bodies.length; i++) bodies[i].draw();
-
-        if (particles.length > MAX_PARTICLES) {
-            particles.splice(0, particles.length - MAX_PARTICLES);
+        if (enableOrbits) {
+            for (let i = 0; i < bodies.length; i++) bodies[i].drawTrail();
         }
-
+        for (let i = 0; i < bodies.length; i++) bodies[i].draw();
+        drawShocks();
+        drawPointerField();
         drawSlingshotPreview();
 
-        const countEl = document.getElementById('count');
-        const bodyCountEl = document.getElementById('bodyCount');
-        if (countEl) countEl.innerText = particles.length;
-        if (bodyCountEl) bodyCountEl.innerText = bodies.length;
+        if (particles.length > MAX_PARTICLES) particles.splice(0, particles.length - MAX_PARTICLES);
+        countEl.textContent = String(particles.length);
+        bodyCountEl.textContent = String(bodies.length);
+        if (selected) updateInspectMeta();
     }
 
-    // ---- UI wiring ----
+    // ---- UI ----
     const gravityInput = document.getElementById('gravity');
     const gStrengthInput = document.getElementById('gStrength');
     const frictionInput = document.getElementById('friction');
@@ -811,152 +1439,182 @@
     const clearBtn = document.getElementById('clear');
     const randomBtn = document.getElementById('random');
     const themeSelect = document.getElementById('theme-select');
-    const modeBtns = document.querySelectorAll('.mode-btn');
-    const scenarioBtns = document.querySelectorAll('.scenario-btn');
     const trailsCheckbox = document.getElementById('trails');
     const glowCheckbox = document.getElementById('glow');
     const bounceCheckbox = document.getElementById('bounce');
     const starsCheckbox = document.getElementById('stars');
+    const orbitsCheckbox = document.getElementById('orbits');
+    const labelsCheckbox = document.getElementById('labels');
     const velocityColorCheckbox = document.getElementById('velocityColor');
     const additiveCheckbox = document.getElementById('additive');
     const fullscreenBtn = document.getElementById('fullscreen-btn');
     const playPauseBtn = document.getElementById('playPauseBtn');
+    const toggleTune = document.getElementById('toggleTune');
+    const tunePanel = document.getElementById('tunePanel');
+    const inspectEl = document.getElementById('inspect');
+    const inspectName = document.getElementById('inspectName');
+    const inspectMeta = document.getElementById('inspectMeta');
+    const inspectSwatch = document.getElementById('inspectSwatch');
+    const followBtn = document.getElementById('followBtn');
+    const toastEl = document.getElementById('toast');
+    const sceneRail = document.getElementById('sceneRail');
+
+    let toastTimer = 0;
+    function toast(msg) {
+        toastEl.textContent = msg;
+        toastEl.classList.add('show');
+        clearTimeout(toastTimer);
+        toastTimer = setTimeout(() => toastEl.classList.remove('show'), 2400);
+    }
 
     function syncUIFromState() {
         gravityInput.value = ambientGravity;
         document.getElementById('gravityValue').textContent = ambientGravity.toFixed(2);
-
         gStrengthInput.value = gStrength;
         document.getElementById('gStrengthValue').textContent = gStrength.toFixed(1);
-
         frictionInput.value = friction;
         document.getElementById('frictionValue').textContent = friction.toFixed(3);
-
         bodiesAttractInput.checked = bodiesAttract;
         absorbInput.checked = absorbEnabled;
+        bounceCheckbox.checked = enableBounce;
     }
+
+    function updateInspectMeta() {
+        if (!selected) return;
+        const speed = Math.hypot(selected.vx, selected.vy);
+        inspectMeta.textContent = `${selected.kind} · r ${selected.radius.toFixed(0)} · v ${speed.toFixed(2)}`;
+    }
+
+    function syncInspect() {
+        if (!selected || bodies.indexOf(selected) === -1) {
+            selected = null;
+            inspectEl.hidden = true;
+            cam.follow = false;
+            syncFollowBtn();
+            return;
+        }
+        inspectEl.hidden = false;
+        inspectName.textContent = selected.name || 'Corpo';
+        inspectSwatch.style.background = selected.color;
+        updateInspectMeta();
+        syncFollowBtn();
+    }
+
+    function syncFollowBtn() {
+        followBtn.setAttribute('aria-pressed', cam.follow && selected ? 'true' : 'false');
+        followBtn.textContent = cam.follow && selected ? 'Seguindo' : 'Seguir';
+    }
+
+    followBtn.addEventListener('click', () => {
+        if (!selected) return;
+        cam.follow = !cam.follow;
+        syncFollowBtn();
+    });
+
+    SCENES.forEach((scene) => {
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className = 'scene-chip' + (scene.id === 'solar' ? ' active' : '');
+        btn.dataset.scenario = scene.id;
+        btn.setAttribute('role', 'option');
+        btn.innerHTML = `<span class="scene-swatch" style="--chip:${scene.chip};background:${scene.chip}"></span><span>${scene.name}</span>`;
+        btn.addEventListener('click', () => loadScenario(scene.id));
+        sceneRail.appendChild(btn);
+    });
 
     gravityInput.addEventListener('input', (e) => {
         ambientGravity = parseFloat(e.target.value);
         document.getElementById('gravityValue').textContent = ambientGravity.toFixed(2);
     });
-
     gStrengthInput.addEventListener('input', (e) => {
         gStrength = parseFloat(e.target.value);
         document.getElementById('gStrengthValue').textContent = gStrength.toFixed(1);
     });
-
     frictionInput.addEventListener('input', (e) => {
         friction = parseFloat(e.target.value);
         document.getElementById('frictionValue').textContent = friction.toFixed(3);
     });
-
     bodySizeInput.addEventListener('input', (e) => {
         bodySizeSetting = parseFloat(e.target.value);
         document.getElementById('bodySizeValue').textContent = bodySizeSetting;
     });
-
     sizeInput.addEventListener('input', (e) => {
         particleSize = parseFloat(e.target.value);
         document.getElementById('sizeValue').textContent = particleSize;
     });
-
     velocityInput.addEventListener('input', (e) => {
         initialVelocity = parseFloat(e.target.value);
         document.getElementById('velocityValue').textContent = initialVelocity;
     });
+    bodiesAttractInput.addEventListener('change', (e) => { bodiesAttract = e.target.checked; });
+    absorbInput.addEventListener('change', (e) => { absorbEnabled = e.target.checked; });
+    trailsCheckbox.addEventListener('change', (e) => { enableTrails = e.target.checked; });
+    glowCheckbox.addEventListener('change', (e) => { enableGlow = e.target.checked; });
+    bounceCheckbox.addEventListener('change', (e) => { enableBounce = e.target.checked; });
+    starsCheckbox.addEventListener('change', (e) => { enableStars = e.target.checked; });
+    orbitsCheckbox.addEventListener('change', (e) => { enableOrbits = e.target.checked; });
+    labelsCheckbox.addEventListener('change', (e) => { enableLabels = e.target.checked; });
+    velocityColorCheckbox.addEventListener('change', (e) => { velocityColorMode = e.target.checked; });
+    additiveCheckbox.addEventListener('change', (e) => { additiveBlend = e.target.checked; });
+    themeSelect.addEventListener('change', (e) => { currentTheme = e.target.value; });
 
-    bodiesAttractInput.addEventListener('change', (e) => {
-        bodiesAttract = e.target.checked;
+    document.querySelectorAll('.tool-btn[data-mode]').forEach((btn) => {
+        btn.addEventListener('click', () => {
+            document.querySelectorAll('.tool-btn[data-mode]').forEach((b) => b.classList.remove('active'));
+            btn.classList.add('active');
+            mouseMode = btn.dataset.mode;
+            slingActive = false;
+            slingshotHint.classList.remove('visible');
+            isPointerDown = false;
+        });
     });
 
-    absorbInput.addEventListener('change', (e) => {
-        absorbEnabled = e.target.checked;
+    document.querySelectorAll('.warp-btn').forEach((btn) => {
+        btn.addEventListener('click', () => {
+            document.querySelectorAll('.warp-btn').forEach((b) => b.classList.remove('active'));
+            btn.classList.add('active');
+            timeScale = parseFloat(btn.dataset.warp);
+        });
     });
 
     clearBtn.addEventListener('click', () => {
         particles = [];
         bodies = [];
+        shockwaves = [];
+        selected = null;
+        syncInspect();
     });
-
-    themeSelect.addEventListener('change', (e) => {
-        currentTheme = e.target.value;
-    });
-
-    modeBtns.forEach((btn) => {
-        btn.addEventListener('click', () => {
-            modeBtns.forEach((b) => b.classList.remove('active'));
-            btn.classList.add('active');
-            if (slingActive) {
-                slingActive = false;
-                slingshotHint.classList.remove('visible');
-            }
-            isPointerDown = false;
-            mouseMode = btn.dataset.mode;
-        });
-    });
-
-    scenarioBtns.forEach((btn) => {
-        btn.addEventListener('click', () => {
-            loadScenario(btn.dataset.scenario);
-        });
-    });
-
-    trailsCheckbox.addEventListener('change', (e) => { enableTrails = e.target.checked; });
-    glowCheckbox.addEventListener('change', (e) => { enableGlow = e.target.checked; });
-    bounceCheckbox.addEventListener('change', (e) => { enableBounce = e.target.checked; });
-    starsCheckbox.addEventListener('change', (e) => { enableStars = e.target.checked; });
-    velocityColorCheckbox.addEventListener('change', (e) => { velocityColorMode = e.target.checked; });
-    additiveCheckbox.addEventListener('change', (e) => { additiveBlend = e.target.checked; });
 
     randomBtn.addEventListener('click', () => {
-        const scenarioKeys = Object.keys(scenarios);
-        const randomScenario = scenarioKeys[Math.floor(Math.random() * scenarioKeys.length)];
-
-        const themeKeys = Object.keys(themes);
-        currentTheme = themeKeys[Math.floor(Math.random() * themeKeys.length)];
+        const keys = Object.keys(scenarios);
+        currentTheme = Object.keys(themes)[Math.floor(Math.random() * Object.keys(themes).length)];
         themeSelect.value = currentTheme;
-
-        loadScenario(randomScenario);
-
-        gStrength = 0.6 + Math.random() * 1.8;
-        gStrengthInput.value = gStrength;
-        document.getElementById('gStrengthValue').textContent = gStrength.toFixed(1);
-
-        particleSize = 1 + Math.floor(Math.random() * 10);
-        sizeInput.value = particleSize;
-        document.getElementById('sizeValue').textContent = particleSize;
-
-        initialVelocity = 4 + Math.floor(Math.random() * 20);
-        velocityInput.value = initialVelocity;
-        document.getElementById('velocityValue').textContent = initialVelocity;
-
-        enableGlow = Math.random() > 0.2;
-        glowCheckbox.checked = enableGlow;
-
-        velocityColorMode = Math.random() > 0.6;
-        velocityColorCheckbox.checked = velocityColorMode;
-
-        additiveBlend = Math.random() > 0.6;
+        loadScenario(keys[Math.floor(Math.random() * keys.length)]);
+        additiveBlend = Math.random() > 0.55;
         additiveCheckbox.checked = additiveBlend;
+        velocityColorMode = Math.random() > 0.65;
+        velocityColorCheckbox.checked = velocityColorMode;
+    });
+
+    toggleTune.addEventListener('click', () => {
+        const open = tunePanel.hidden;
+        tunePanel.hidden = !open;
+        toggleTune.setAttribute('aria-expanded', open ? 'true' : 'false');
     });
 
     fullscreenBtn.addEventListener('click', () => {
         if (!document.fullscreenElement) {
             document.documentElement.requestFullscreen().then(() => {
                 document.body.classList.add('fullscreen');
-            }).catch(() => { });
+            }).catch(() => {});
         } else {
             document.exitFullscreen().then(() => {
                 document.body.classList.remove('fullscreen');
-            }).catch(() => { });
+            }).catch(() => {});
         }
     });
-
     document.addEventListener('fullscreenchange', () => {
-        if (!document.fullscreenElement) {
-            document.body.classList.remove('fullscreen');
-        }
+        if (!document.fullscreenElement) document.body.classList.remove('fullscreen');
     });
 
     function setRunning(next) {
@@ -966,47 +1624,36 @@
         playPauseBtn.setAttribute('aria-label', running ? 'Pausar' : 'Retomar');
         playPauseBtn.title = running ? 'Pausar (Espaço)' : 'Retomar (Espaço)';
     }
-
     playPauseBtn.addEventListener('click', () => setRunning(!running));
 
-    const controlsPanel = document.getElementById('controlsPanel');
-    const toggleControlsBtn = document.getElementById('toggleControls');
-    const closeControlsBtn = document.getElementById('closeControls');
-
-    toggleControlsBtn.addEventListener('click', () => {
-        controlsPanel.classList.add('visible');
-        toggleControlsBtn.classList.add('hidden');
-    });
-
-    closeControlsBtn.addEventListener('click', () => {
-        controlsPanel.classList.remove('visible');
-        toggleControlsBtn.classList.remove('hidden');
-    });
+    const modeKeys = { q: 'spawn', w: 'body', a: 'attract', e: 'repel', h: 'blackhole', x: 'erase' };
 
     document.addEventListener('keydown', (e) => {
         if (e.target && (e.target.tagName === 'INPUT' || e.target.tagName === 'SELECT')) return;
-
         if (e.code === 'Space') {
             e.preventDefault();
             setRunning(!running);
         } else if (e.key === 'c' || e.key === 'C') {
-            particles = [];
-            bodies = [];
+            clearBtn.click();
         } else if (e.key === 'f' || e.key === 'F') {
             fullscreenBtn.click();
-        } else if (e.key >= '1' && e.key <= '6') {
-            const keys = Object.keys(scenarios);
+        } else if (e.key === 'r' || e.key === 'R') {
+            randomBtn.click();
+        } else if (e.key >= '1' && e.key <= '8') {
             const idx = parseInt(e.key, 10) - 1;
-            if (keys[idx]) loadScenario(keys[idx]);
+            if (SCENES[idx]) loadScenario(SCENES[idx].id);
+        } else if (modeKeys[e.key.toLowerCase()]) {
+            const mode = modeKeys[e.key.toLowerCase()];
+            const btn = document.querySelector(`.tool-btn[data-mode="${mode}"]`);
+            if (btn) btn.click();
         }
     });
 
     window.addEventListener('resize', resize);
 
-    // ---- Init ----
+    const hashScene = (location.hash || '').replace('#', '');
+    if (scenarios[hashScene]) currentScenario = hashScene;
+
     resize();
-    if (width && height && bodies.length === 0 && particles.length === 0) {
-        loadScenario('solar');
-    }
     requestAnimationFrame(animate);
 })();

--- a/labs/gravity/style.css
+++ b/labs/gravity/style.css
@@ -1,24 +1,26 @@
 :root {
-    --g1: #6366f1;
-    --g2: #8b5cf6;
-    --g3: #ec4899;
-    --panel-bg: rgba(10, 10, 20, 0.92);
-    --panel-border: rgba(255, 255, 255, 0.08);
-    --glow-color: rgba(99, 102, 241, 0.35);
-    --text-primary: rgba(255, 255, 255, 0.95);
-    --text-secondary: rgba(255, 255, 255, 0.55);
-    --accent-gradient: linear-gradient(135deg, var(--g1), var(--g2));
-    /* O palco é sempre escuro (#05050b), inclusive no tema claro: o header
-       que flutua sobre ele precisa de cor própria, senão some no fundo. */
-    --on-canvas: rgba(255, 255, 255, 0.78);
+    --g1: #7c5cff;
+    --g2: #3ee0ff;
+    --g3: #ffb347;
+    --panel: rgba(8, 8, 20, 0.78);
+    --panel-solid: rgba(8, 8, 18, 0.94);
+    --border: rgba(255, 255, 255, 0.1);
+    --text: rgba(255, 255, 255, 0.94);
+    --muted: rgba(255, 255, 255, 0.5);
+    --glow: rgba(124, 92, 255, 0.4);
+    --accent: linear-gradient(135deg, var(--g1), var(--g2));
+    --on-canvas: rgba(255, 255, 255, 0.82);
     --on-canvas-border: rgba(255, 255, 255, 0.16);
+    --dock-radius: 22px;
 }
 
 [data-theme="light"] {
-    --panel-bg: rgba(255, 255, 255, 0.92);
-    --panel-border: rgba(0, 0, 0, 0.08);
-    --text-primary: rgba(15, 15, 25, 0.95);
-    --text-secondary: rgba(15, 15, 25, 0.5);
+    --panel: rgba(255, 255, 255, 0.82);
+    --panel-solid: rgba(255, 255, 255, 0.94);
+    --border: rgba(0, 0, 0, 0.1);
+    --text: rgba(12, 12, 24, 0.92);
+    --muted: rgba(12, 12, 24, 0.5);
+    --glow: rgba(99, 70, 220, 0.28);
 }
 
 * {
@@ -27,14 +29,22 @@
     box-sizing: border-box;
 }
 
+html,
 body {
-    font-family: 'Space Grotesk', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    overflow: hidden;
+    overflow-x: clip;
+    width: 100%;
+    height: 100%;
+    height: 100dvh;
+}
+
+body {
+    font-family: 'Space Grotesk', -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
     padding: 0 !important;
     display: block !important;
-    overflow: hidden;
-    width: 100vw;
-    height: 100vh;
-    background: #05050b;
+    background: #04040c;
+    color: var(--text);
+    touch-action: none;
 }
 
 .container {
@@ -53,9 +63,9 @@ body {
     height: 100%;
     display: block;
     cursor: crosshair;
+    touch-action: none;
 }
 
-/* Header */
 header {
     position: absolute;
     top: 0;
@@ -64,24 +74,24 @@ header {
     width: auto !important;
     max-width: none !important;
     z-index: 20;
-    padding: max(1.1rem, env(safe-area-inset-top)) max(1.35rem, env(safe-area-inset-right)) 1.1rem max(1.35rem, env(safe-area-inset-left)) !important;
-    background: linear-gradient(to bottom, rgba(0, 0, 0, 0.55), transparent);
+    padding: max(0.85rem, env(safe-area-inset-top)) max(1.1rem, env(safe-area-inset-right)) 0.85rem max(1.1rem, env(safe-area-inset-left)) !important;
+    background: linear-gradient(to bottom, rgba(0, 0, 0, 0.62), transparent);
     margin: 0 !important;
     display: grid !important;
     grid-template-columns: auto 1fr auto !important;
     align-items: center !important;
-    gap: 1rem !important;
+    gap: 0.75rem !important;
     pointer-events: none;
 }
 
-header>* {
+header > * {
     pointer-events: auto;
 }
 
 header .back-link {
     grid-column: 1;
     justify-self: start;
-    background: rgba(255, 255, 255, 0.06);
+    background: rgba(255, 255, 255, 0.07);
     border: 1px solid var(--on-canvas-border);
     color: var(--on-canvas);
     min-height: 44px;
@@ -89,9 +99,9 @@ header .back-link {
 }
 
 header .back-link:hover {
-    background: rgba(99, 102, 241, 0.18);
-    border-color: rgba(99, 102, 241, 0.4);
-    color: #c7d2fe;
+    background: rgba(124, 92, 255, 0.2);
+    border-color: rgba(124, 92, 255, 0.45);
+    color: #ddd6ff;
 }
 
 header .app-logo {
@@ -99,48 +109,56 @@ header .app-logo {
     justify-self: center;
     display: flex;
     align-items: center;
-    gap: 0.5rem;
-    font-size: 1.3rem;
+    gap: 0.45rem;
+    font-size: 1.22rem;
     font-weight: 700;
-    background: linear-gradient(135deg, #667eea 0%, #8b5cf6 50%, #ec4899 100%) !important;
+    letter-spacing: 0.02em;
+    background: linear-gradient(135deg, #c4b5fd 0%, #67e8f9 50%, #fde68a 100%) !important;
     -webkit-background-clip: text !important;
     -webkit-text-fill-color: transparent !important;
     background-clip: text !important;
-    filter: drop-shadow(0 0 20px var(--glow-color));
-    letter-spacing: 0.01em;
+    filter: drop-shadow(0 0 18px var(--glow));
+    min-width: 0;
+    max-width: min(100%, calc(100vw - 10rem));
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 header .app-logo svg {
     stroke: #a5b4fc;
-    filter: drop-shadow(0 0 8px rgba(165, 180, 252, 0.6));
+    filter: drop-shadow(0 0 8px rgba(165, 180, 252, 0.7));
+    flex-shrink: 0;
 }
 
 .header-actions {
     grid-column: 3;
     justify-self: end;
     display: flex;
-    gap: 0.5rem;
+    gap: 0.4rem;
     align-items: center;
 }
 
 .icon-btn {
-    background: rgba(255, 255, 255, 0.06);
+    background: rgba(255, 255, 255, 0.07);
     border: 1px solid var(--on-canvas-border);
     border-radius: 10px;
-    padding: 0.55rem;
+    padding: 0.5rem;
     cursor: pointer;
     color: var(--on-canvas);
-    transition: all 0.2s ease;
     display: flex;
     align-items: center;
     justify-content: center;
+    min-width: 44px;
+    min-height: 44px;
+    transition: background 0.2s, border-color 0.2s, color 0.2s, transform 0.2s;
 }
 
 .icon-btn:hover {
-    background: rgba(99, 102, 241, 0.2);
-    border-color: rgba(99, 102, 241, 0.4);
-    color: #c7d2fe;
-    transform: scale(1.05);
+    background: rgba(124, 92, 255, 0.22);
+    border-color: rgba(124, 92, 255, 0.45);
+    color: #ddd6ff;
+    transform: scale(1.04);
 }
 
 .fullscreen .icon-btn .fullscreen-enter,
@@ -152,275 +170,343 @@ header .app-logo svg {
     display: block;
 }
 
-/* Toggle controls floating button */
-.toggle-controls-btn {
-    position: fixed;
-    bottom: 24px;
-    right: 24px;
-    z-index: 15;
-    background: var(--panel-bg);
-    backdrop-filter: blur(20px);
-    -webkit-backdrop-filter: blur(20px);
-    border: 1px solid var(--panel-border);
-    color: #a5b4fc;
-    padding: 14px;
-    border-radius: 14px;
-    cursor: pointer;
-    transition: all 0.3s cubic-bezier(0.16, 1, 0.3, 1);
-    box-shadow: 0 4px 24px rgba(0, 0, 0, 0.4), 0 0 40px rgba(99, 102, 241, 0.12);
-}
-
-.toggle-controls-btn:hover {
-    transform: scale(1.08);
-    box-shadow: 0 6px 32px rgba(0, 0, 0, 0.5), 0 0 60px rgba(99, 102, 241, 0.2);
-}
-
-.toggle-controls-btn.hidden {
-    opacity: 0;
+.hud {
+    position: absolute;
+    top: 72px;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 8;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 6px;
     pointer-events: none;
-    transform: scale(0.8) translateY(20px);
-}
-
-.toggle-controls-btn svg {
-    display: block;
-}
-
-/* Controls panel (slide-out drawer) */
-.controls {
-    position: fixed;
-    top: 88px;
-    right: 20px;
-    bottom: 20px;
-    width: 320px;
-    display: flex;
-    flex-direction: column;
-    background: var(--panel-bg);
-    backdrop-filter: blur(24px) saturate(180%);
-    -webkit-backdrop-filter: blur(24px) saturate(180%);
-    border-radius: 20px;
-    border: 1px solid var(--panel-border);
-    box-shadow: 0 8px 40px rgba(0, 0, 0, 0.5), 0 0 80px rgba(99, 102, 241, 0.06);
-    z-index: 10;
-    transition: all 0.4s cubic-bezier(0.16, 1, 0.3, 1);
-    transform: translateX(calc(100% + 40px));
-    opacity: 0;
-    overflow: hidden;
-}
-
-.controls.visible {
-    transform: translateX(0);
-    opacity: 1;
-}
-
-.controls-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 16px 18px;
-    border-bottom: 1px solid var(--panel-border);
-    background: rgba(0, 0, 0, 0.2);
-    flex-shrink: 0;
-}
-
-.controls-header span {
-    font-size: 0.72rem;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 2px;
-    color: #a5b4fc;
-}
-
-.close-btn {
-    background: transparent;
-    border: none;
-    color: var(--text-secondary);
-    cursor: pointer;
-    padding: 4px;
-    border-radius: 6px;
-    transition: all 0.2s ease;
-    display: flex;
-}
-
-.close-btn:hover {
-    color: #c7d2fe;
-    background: rgba(255, 255, 255, 0.1);
-}
-
-.controls-scroll {
-    flex: 1;
-    overflow-y: auto;
-    overflow-x: hidden;
-    padding: 16px;
-    display: flex;
-    flex-direction: column;
-    gap: 20px;
-}
-
-.controls-scroll::-webkit-scrollbar {
-    width: 4px;
-}
-
-.controls-scroll::-webkit-scrollbar-track {
-    background: transparent;
-}
-
-.controls-scroll::-webkit-scrollbar-thumb {
-    background: rgba(255, 255, 255, 0.15);
-    border-radius: 2px;
-}
-
-.control-section {
-    display: flex;
-    flex-direction: column;
-    gap: 10px;
-}
-
-.section-title {
-    font-size: 0.65rem;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 1.5px;
-    color: var(--text-secondary);
-}
-
-/* Scenario grid */
-.scenario-grid {
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    gap: 8px;
-}
-
-.scenario-btn {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 4px;
-    padding: 10px 4px 8px;
-    background: rgba(255, 255, 255, 0.03);
-    border: 1px solid transparent;
-    border-radius: 12px;
-    cursor: pointer;
-    transition: all 0.25s ease;
-    color: var(--text-secondary);
-}
-
-.scenario-icon {
-    font-size: 1.3rem;
-    line-height: 1;
-    transition: transform 0.2s ease;
-}
-
-.scenario-btn small {
-    font-size: 0.55rem;
-    text-transform: uppercase;
-    letter-spacing: 0.3px;
-    font-weight: 600;
     text-align: center;
+    max-width: min(92vw, 420px);
+    padding-top: env(safe-area-inset-top, 0px);
 }
 
-.scenario-btn:hover {
-    background: rgba(255, 255, 255, 0.08);
-    color: var(--text-primary);
+.hud-scene {
+    font-size: 0.7rem;
+    font-weight: 700;
+    letter-spacing: 0.22em;
+    text-transform: uppercase;
+    color: #c4b5fd;
+    text-shadow: 0 0 22px var(--glow);
 }
 
-.scenario-btn:hover .scenario-icon {
-    transform: scale(1.15);
+.hud-meta {
+    font-size: 0.62rem;
+    letter-spacing: 0.06em;
+    color: var(--muted);
+    font-variant-numeric: tabular-nums;
 }
 
-.scenario-btn.active {
-    background: var(--accent-gradient);
-    border-color: transparent;
-    color: #fff;
-    box-shadow: 0 4px 16px rgba(99, 102, 241, 0.35);
-}
-
-/* Mode grid */
-.mode-grid {
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    gap: 8px;
-}
-
-.mode-btn {
+.warp {
+    pointer-events: auto;
     display: flex;
-    flex-direction: column;
-    align-items: center;
     gap: 4px;
-    padding: 10px 4px 8px;
-    background: rgba(255, 255, 255, 0.03);
-    border: 1px solid transparent;
-    border-radius: 12px;
+    margin-top: 2px;
+    padding: 3px;
+    border-radius: 999px;
+    border: 1px solid var(--border);
+    background: var(--panel);
+    backdrop-filter: blur(16px) saturate(160%);
+    -webkit-backdrop-filter: blur(16px) saturate(160%);
+}
+
+.warp-btn {
+    min-width: 44px;
+    min-height: 32px;
+    padding: 0 10px;
+    border: none;
+    border-radius: 999px;
+    background: transparent;
+    color: var(--muted);
+    font-family: inherit;
+    font-size: 0.68rem;
+    font-weight: 700;
     cursor: pointer;
-    transition: all 0.25s ease;
-    color: var(--text-secondary);
+    transition: background 0.2s, color 0.2s;
 }
 
-.mode-btn span {
-    font-size: 1.15rem;
-    line-height: 1;
-    transition: transform 0.2s ease;
+.warp-btn:hover {
+    color: var(--text);
 }
 
-.mode-btn small {
-    font-size: 0.55rem;
-    text-transform: uppercase;
-    letter-spacing: 0.3px;
-    font-weight: 600;
+.warp-btn.active {
+    background: var(--accent);
+    color: #061018;
 }
 
-.mode-btn:hover {
-    background: rgba(255, 255, 255, 0.08);
-    color: var(--text-primary);
+.hint {
+    position: absolute;
+    top: 42%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    z-index: 6;
+    pointer-events: none;
+    text-align: center;
+    max-width: min(90vw, 440px);
+    animation: hintOut 4.5s ease forwards;
 }
 
-.mode-btn:hover span {
-    transform: scale(1.15);
+.hint p {
+    margin: 0;
+    font-size: 0.9rem;
+    font-weight: 500;
+    color: rgba(255, 255, 255, 0.62);
+    text-shadow: 0 0 24px rgba(124, 92, 255, 0.45);
 }
 
-.mode-btn.active {
-    background: var(--accent-gradient);
-    border-color: transparent;
-    color: #fff;
-    box-shadow: 0 4px 16px rgba(99, 102, 241, 0.35);
+.inspect {
+    position: absolute;
+    left: 50%;
+    bottom: 168px;
+    transform: translateX(-50%);
+    z-index: 16;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    width: min(360px, calc(100% - 28px));
+    padding: 10px 10px 10px 12px;
+    border-radius: 16px;
+    border: 1px solid var(--border);
+    background: var(--panel-solid);
+    backdrop-filter: blur(20px) saturate(170%);
+    -webkit-backdrop-filter: blur(20px) saturate(170%);
+    box-shadow: 0 10px 36px rgba(0, 0, 0, 0.4);
 }
 
-/* Sliders */
-.sliders-grid {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 14px 12px;
+.inspect[hidden] {
+    display: none;
 }
 
-.slider-group {
+.inspect-swatch {
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    flex-shrink: 0;
+    box-shadow: 0 0 16px color-mix(in srgb, var(--g3) 40%, transparent);
+}
+
+.inspect-copy {
+    flex: 1;
+    min-width: 0;
     display: flex;
     flex-direction: column;
-    gap: 6px;
+    gap: 1px;
 }
 
-.slider-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    gap: 6px;
-}
-
-.slider-header label {
-    font-size: 0.55rem;
-    text-transform: uppercase;
-    letter-spacing: 0.6px;
-    color: var(--text-secondary);
-    font-weight: 600;
+.inspect-copy strong {
+    font-size: 0.88rem;
+    font-weight: 700;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
 }
 
-.slider-value {
-    font-size: 0.65rem;
-    font-weight: 700;
-    color: #a5b4fc;
-    font-variant-numeric: tabular-nums;
+.inspect-copy span {
+    font-size: 0.62rem;
+    letter-spacing: 0.04em;
+    color: var(--muted);
+    text-transform: uppercase;
+}
+
+.inspect-follow {
     flex-shrink: 0;
+    min-height: 44px;
+    padding: 0 14px;
+    border-radius: 12px;
+    border: 1px solid rgba(124, 92, 255, 0.35);
+    background: rgba(124, 92, 255, 0.16);
+    color: #ddd6ff;
+    font-family: inherit;
+    font-size: 0.72rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    cursor: pointer;
+}
+
+.inspect-follow[aria-pressed="true"] {
+    background: var(--accent);
+    color: #061018;
+    border-color: transparent;
+}
+
+.dock {
+    position: absolute;
+    left: 50%;
+    bottom: max(18px, env(safe-area-inset-bottom, 0px));
+    transform: translateX(-50%);
+    z-index: 15;
+    width: min(760px, calc(100% - 20px));
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.scene-rail {
+    display: flex;
+    gap: 8px;
+    overflow-x: auto;
+    padding: 2px;
+    scrollbar-width: none;
+    scroll-snap-type: x proximity;
+    -webkit-overflow-scrolling: touch;
+}
+
+.scene-rail::-webkit-scrollbar {
+    display: none;
+}
+
+.scene-chip {
+    flex: 0 0 auto;
+    scroll-snap-align: start;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-height: 44px;
+    padding: 8px 14px 8px 10px;
+    border-radius: 999px;
+    border: 1px solid var(--border);
+    background: var(--panel);
+    backdrop-filter: blur(18px) saturate(160%);
+    -webkit-backdrop-filter: blur(18px) saturate(160%);
+    color: var(--muted);
+    cursor: pointer;
+    font-family: inherit;
+    font-size: 0.7rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    transition: transform 0.2s, border-color 0.2s, color 0.2s, background 0.2s, box-shadow 0.2s;
+}
+
+.scene-chip:hover {
+    color: var(--text);
+    transform: translateY(-1px);
+}
+
+.scene-chip.active {
+    color: #061018;
+    border-color: transparent;
+    background: var(--accent);
+    box-shadow: 0 6px 22px rgba(124, 92, 255, 0.28);
+}
+
+.scene-swatch {
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    background: var(--chip);
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.28);
+    flex-shrink: 0;
+}
+
+.dock-tools {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    padding: 8px;
+    border-radius: var(--dock-radius);
+    border: 1px solid var(--border);
+    background: var(--panel);
+    backdrop-filter: blur(22px) saturate(170%);
+    -webkit-backdrop-filter: blur(22px) saturate(170%);
+    box-shadow: 0 12px 40px rgba(0, 0, 0, 0.38);
+}
+
+.tool-group {
+    display: flex;
+    gap: 5px;
+    flex-wrap: nowrap;
+}
+
+.tool-group:last-child {
+    margin-left: auto;
+}
+
+.tool-btn {
+    width: 44px;
+    height: 44px;
+    min-width: 44px;
+    min-height: 44px;
+    border-radius: 14px;
+    border: 1px solid transparent;
+    background: rgba(255, 255, 255, 0.04);
+    color: var(--muted);
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    transition: transform 0.2s, background 0.2s, color 0.2s, box-shadow 0.2s;
+}
+
+.tool-btn:hover {
+    color: var(--text);
+    background: rgba(255, 255, 255, 0.1);
+}
+
+.tool-btn.active {
+    color: #061018;
+    background: var(--accent);
+    box-shadow: 0 4px 16px rgba(124, 92, 255, 0.3);
+}
+
+.tool-btn.accent {
+    color: #f0abfc;
+    background: rgba(192, 38, 211, 0.14);
+    border-color: rgba(192, 38, 211, 0.28);
+}
+
+.tool-btn[aria-expanded="true"] {
+    color: #c4b5fd;
+    border-color: rgba(124, 92, 255, 0.4);
+    background: rgba(124, 92, 255, 0.14);
+}
+
+.tune-panel {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 12px 16px;
+    padding: 14px 16px;
+    max-height: min(46dvh, 360px);
+    overflow-y: auto;
+    border-radius: 18px;
+    border: 1px solid var(--border);
+    background: var(--panel-solid);
+    backdrop-filter: blur(22px);
+    -webkit-backdrop-filter: blur(22px);
+}
+
+.tune-panel[hidden] {
+    display: none;
+}
+
+.slider-row,
+.select-group {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.slider-row label,
+.select-group label {
+    display: flex;
+    justify-content: space-between;
+    font-size: 0.62rem;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--muted);
+}
+
+.slider-row label span {
+    color: #c4b5fd;
+    font-variant-numeric: tabular-nums;
 }
 
 input[type="range"] {
@@ -428,136 +514,45 @@ input[type="range"] {
     appearance: none;
     width: 100%;
     height: 4px;
-    background: rgba(255, 255, 255, 0.1);
-    border-radius: 2px;
-    outline: none;
     border: none;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.12);
+    outline: none;
 }
 
 input[type="range"]::-webkit-slider-thumb {
     -webkit-appearance: none;
-    width: 14px;
-    height: 14px;
-    background: var(--accent-gradient);
+    width: 16px;
+    height: 16px;
     border-radius: 50%;
-    cursor: pointer;
-    transition: all 0.2s ease;
     border: 2px solid rgba(255, 255, 255, 0.9);
-    box-shadow: 0 2px 8px rgba(99, 102, 241, 0.4);
-}
-
-input[type="range"]::-webkit-slider-thumb:hover {
-    transform: scale(1.25);
-    box-shadow: 0 2px 12px rgba(99, 102, 241, 0.6);
+    background: var(--accent);
+    cursor: pointer;
 }
 
 input[type="range"]::-moz-range-thumb {
-    width: 14px;
-    height: 14px;
-    background: var(--accent-gradient);
+    width: 16px;
+    height: 16px;
     border-radius: 50%;
-    cursor: pointer;
     border: 2px solid rgba(255, 255, 255, 0.9);
-    box-shadow: 0 2px 8px rgba(99, 102, 241, 0.4);
-}
-
-/* Toggles */
-.toggle-row,
-.checkbox-grid {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 8px 10px;
-}
-
-.checkbox-label {
-    display: flex;
-    align-items: center;
-    gap: 8px;
+    background: var(--g1);
     cursor: pointer;
-    font-size: 0.72rem;
-    color: var(--text-secondary);
-    transition: color 0.2s ease;
-    font-weight: 500;
-}
-
-.checkbox-label:hover {
-    color: var(--text-primary);
-}
-
-.checkbox-label input[type="checkbox"] {
-    appearance: none;
-    -webkit-appearance: none;
-    width: 17px;
-    height: 17px;
-    background: rgba(255, 255, 255, 0.06);
-    border: 1.5px solid var(--panel-border);
-    border-radius: 5px;
-    cursor: pointer;
-    transition: all 0.2s ease;
-    position: relative;
-    flex-shrink: 0;
-}
-
-.checkbox-label input[type="checkbox"]:hover {
-    border-color: rgba(99, 102, 241, 0.6);
-}
-
-.checkbox-label input[type="checkbox"]:checked {
-    background: var(--accent-gradient);
-    border-color: transparent;
-    box-shadow: 0 0 10px rgba(99, 102, 241, 0.4);
-}
-
-.checkbox-label input[type="checkbox"]:checked::after {
-    content: '✓';
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    color: white;
-    font-size: 11px;
-    font-weight: bold;
-}
-
-/* Select */
-.select-group {
-    display: flex;
-    flex-direction: column;
-    gap: 6px;
-}
-
-.select-group label {
-    font-size: 0.55rem;
-    text-transform: uppercase;
-    letter-spacing: 1px;
-    color: var(--text-secondary);
-    font-weight: 600;
 }
 
 select {
-    background: rgba(255, 255, 255, 0.05);
-    border: 1px solid var(--panel-border);
-    color: var(--text-primary);
+    background: rgba(255, 255, 255, 0.06);
+    border: 1px solid var(--border);
+    color: var(--text);
     padding: 10px 28px 10px 12px;
     border-radius: 10px;
     font-size: 0.8rem;
     font-family: inherit;
     font-weight: 600;
     cursor: pointer;
-    transition: all 0.2s ease;
     appearance: none;
-    -webkit-appearance: none;
-    width: 100%;
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 24 24' fill='none' stroke='%23a5b4fc' stroke-width='2.5'%3E%3Cpath d='M6 9l6 6 6-6'/%3E%3C/svg%3E");
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 24 24' fill='none' stroke='%23c4b5fd' stroke-width='2.5'%3E%3Cpath d='M6 9l6 6 6-6'/%3E%3C/svg%3E");
     background-repeat: no-repeat;
     background-position: right 12px center;
-}
-
-select:hover,
-select:focus {
-    border-color: rgba(99, 102, 241, 0.4);
-    outline: none;
-    background-color: rgba(255, 255, 255, 0.08);
 }
 
 select option {
@@ -565,180 +560,63 @@ select option {
     color: #fff;
 }
 
-/* Footer */
-.control-footer {
-    padding: 14px 16px;
-    border-top: 1px solid var(--panel-border);
-    background: rgba(0, 0, 0, 0.2);
-    display: flex;
-    flex-direction: column;
-    gap: 10px;
-    flex-shrink: 0;
-}
-
-.action-buttons {
+.checkbox-grid {
+    grid-column: 1 / -1;
     display: grid;
     grid-template-columns: 1fr 1fr;
+    gap: 8px 12px;
+}
+
+.checkbox-label {
+    display: flex;
+    align-items: center;
     gap: 8px;
-}
-
-.action-btn {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 6px;
-    padding: 10px 12px;
-    border-radius: 10px;
+    min-height: 44px;
     cursor: pointer;
-    font-size: 0.7rem;
-    font-weight: 700;
-    font-family: inherit;
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    transition: all 0.25s ease;
-    border: 1px solid;
-}
-
-.action-btn svg {
-    transition: transform 0.3s ease;
-}
-
-.random-btn {
-    background: linear-gradient(135deg, rgba(168, 85, 247, 0.15), rgba(236, 72, 153, 0.15));
-    border-color: rgba(168, 85, 247, 0.3);
-    color: #d8b4fe;
-}
-
-.random-btn:hover {
-    background: linear-gradient(135deg, rgba(168, 85, 247, 0.28), rgba(236, 72, 153, 0.28));
-    border-color: rgba(168, 85, 247, 0.5);
-    box-shadow: 0 4px 20px rgba(168, 85, 247, 0.2);
-    transform: translateY(-1px);
-}
-
-.random-btn:hover svg {
-    transform: rotate(180deg);
-}
-
-.clear-btn {
-    background: rgba(255, 255, 255, 0.05);
-    border-color: rgba(248, 113, 113, 0.25);
-    color: #fca5a5;
-}
-
-.clear-btn:hover {
-    background: rgba(239, 68, 68, 0.15);
-    border-color: rgba(248, 113, 113, 0.5);
-    color: #fff;
-    transform: translateY(-1px);
-    box-shadow: 0 4px 20px rgba(239, 68, 68, 0.2);
-}
-
-.clear-btn:hover svg {
-    transform: rotate(-8deg);
-}
-
-.stats-bar {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 14px;
-    padding: 8px;
-    background: rgba(0, 0, 0, 0.3);
-    border-radius: 8px;
-}
-
-.stat {
-    display: flex;
-    align-items: baseline;
-    gap: 4px;
-}
-
-.stat-value {
-    font-size: 0.85rem;
-    font-weight: 700;
-    color: #a5b4fc;
-    font-variant-numeric: tabular-nums;
-}
-
-.stat-label {
-    font-size: 0.52rem;
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    color: var(--text-secondary);
-}
-
-.stat-divider {
-    width: 1px;
-    height: 14px;
-    background: var(--panel-border);
-}
-
-.shortcuts-hint {
-    text-align: center;
-    font-size: 0.6rem;
-    color: var(--text-secondary);
-    letter-spacing: 0.3px;
-}
-
-/* Instructions */
-.instructions {
-    position: absolute;
-    top: 100px;
-    left: 50%;
-    transform: translateX(-50%);
-    text-align: center;
-    pointer-events: none;
-    font-size: 0.9rem;
-    color: #ffffff;
-    background: rgba(0, 0, 0, 0.8);
-    padding: 12px 24px;
-    border-radius: 30px;
-    border: 1px solid rgba(165, 180, 252, 0.4);
-    backdrop-filter: blur(10px);
-    z-index: 8;
-    max-width: 90%;
-    animation: instructionsFade 7s forwards 2s;
-}
-
-.instructions p {
-    margin: 0;
+    font-size: 0.75rem;
+    color: var(--muted);
     font-weight: 500;
 }
 
-.instructions strong {
-    color: #c4b5fd;
+.checkbox-label input {
+    appearance: none;
+    width: 18px;
+    height: 18px;
+    border: 1.5px solid var(--border);
+    border-radius: 5px;
+    background: rgba(255, 255, 255, 0.05);
+    flex-shrink: 0;
+    position: relative;
 }
 
-@keyframes instructionsFade {
-    0% {
-        opacity: 1;
-    }
-
-    85% {
-        opacity: 1;
-    }
-
-    100% {
-        opacity: 0;
-        visibility: hidden;
-    }
+.checkbox-label input:checked {
+    background: var(--accent);
+    border-color: transparent;
 }
 
-/* Slingshot drag hint */
+.checkbox-label input:checked::after {
+    content: '✓';
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #fff;
+    font-size: 11px;
+    font-weight: 700;
+}
+
 .slingshot-hint {
     position: fixed;
     pointer-events: none;
     z-index: 12;
-    font-size: 0.7rem;
+    font-size: 0.68rem;
     font-weight: 700;
-    color: #fbbf24;
+    color: #fde68a;
     text-shadow: 0 0 8px rgba(0, 0, 0, 0.8);
-    letter-spacing: 0.5px;
+    letter-spacing: 0.08em;
     text-transform: uppercase;
     opacity: 0;
-    transition: opacity 0.15s ease;
-    white-space: nowrap;
     transform: translate(-50%, -140%);
 }
 
@@ -746,31 +624,54 @@ select option {
     opacity: 1;
 }
 
+.toast {
+    position: fixed;
+    left: 50%;
+    bottom: 196px;
+    transform: translate(-50%, 8px);
+    z-index: 30;
+    padding: 10px 16px;
+    border-radius: 999px;
+    border: 1px solid var(--border);
+    background: var(--panel-solid);
+    color: var(--text);
+    font-size: 0.75rem;
+    font-weight: 600;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.25s, transform 0.25s;
+    max-width: min(90vw, 360px);
+    text-align: center;
+}
+
+.toast.show {
+    opacity: 1;
+    transform: translate(-50%, 0);
+}
+
 footer {
     position: absolute;
-    bottom: 24px;
-    left: 50%;
-    transform: translateX(-50%);
-    color: var(--text-secondary);
-    font-size: 0.7rem;
+    left: max(14px, env(safe-area-inset-left));
+    bottom: max(14px, env(safe-area-inset-bottom));
     z-index: 5;
+    width: auto;
+    max-width: none;
+    margin: 0;
+    padding: 0;
+    border: none;
+    color: var(--muted);
+    font-size: 0.68rem;
 }
 
 footer a {
-    color: #a5b4fc;
-    opacity: 0.7;
-    transition: opacity 0.2s ease;
-}
-
-footer a:hover {
-    opacity: 1;
+    color: #c4b5fd;
+    opacity: 0.65;
 }
 
 body.fullscreen header,
 body.fullscreen footer,
-body.fullscreen .instructions {
+body.fullscreen .hint {
     opacity: 0;
-    transition: opacity 0.3s ease;
     pointer-events: none;
 }
 
@@ -779,91 +680,153 @@ body.fullscreen:hover header {
     pointer-events: auto;
 }
 
-@media (max-width: 900px) {
-    .controls {
-        width: calc(100% - 32px);
-        max-width: 360px;
-        top: auto;
-        bottom: 88px;
-        right: 16px;
-        max-height: 70vh;
-    }
+@keyframes hintOut {
+    0%, 70% { opacity: 1; }
+    100% { opacity: 0; visibility: hidden; }
+}
 
-    .toggle-controls-btn {
-        bottom: 20px;
-        right: 20px;
-    }
-
+@media (max-width: 768px) {
     header .app-logo {
-        font-size: 1.1rem;
+        font-size: clamp(0.95rem, 4.2vw, 1.15rem);
     }
 
-    .instructions {
-        top: 90px;
-        font-size: 0.78rem;
-        padding: 10px 18px;
+    .hud {
+        top: 64px;
+    }
+
+    .dock-tools {
+        justify-content: flex-start;
+        flex-wrap: nowrap;
+        overflow: hidden;
+        border-radius: 18px;
+    }
+
+    .tool-group {
+        flex-wrap: nowrap;
+    }
+
+    .tool-group:first-child {
+        flex: 1;
+        min-width: 0;
+        overflow-x: auto;
+        scrollbar-width: none;
+        -webkit-overflow-scrolling: touch;
+    }
+
+    .tool-group:first-child::-webkit-scrollbar {
+        display: none;
+    }
+
+    .tool-group:last-child {
+        flex-shrink: 0;
+        margin-left: 6px;
+    }
+
+    .tune-panel {
+        grid-template-columns: 1fr;
+        max-height: min(42dvh, 320px);
+    }
+
+    .inspect {
+        bottom: 178px;
     }
 
     footer {
-        bottom: 16px;
-        font-size: 0.65rem;
+        display: none;
     }
 
-    .sliders-grid,
-    .checkbox-grid,
-    .toggle-row {
-        grid-template-columns: 1fr 1fr;
-    }
-
-    .scenario-grid,
-    .mode-grid {
-        grid-template-columns: repeat(3, 1fr);
+    .toast {
+        bottom: 210px;
     }
 }
 
 @media (max-width: 420px) {
+    .scene-chip span:not(.scene-swatch) {
+        max-width: 78px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    .hint p {
+        font-size: 0.8rem;
+        padding: 0 14px;
+    }
+
+    .warp-btn {
+        min-width: 40px;
+        padding: 0 8px;
+    }
+}
+
+@media (max-height: 520px) and (orientation: landscape) {
     header {
-        padding: max(1rem, env(safe-area-inset-top)) max(1rem, env(safe-area-inset-right)) 1rem max(1rem, env(safe-area-inset-left)) !important;
+        padding: max(0.4rem, env(safe-area-inset-top)) max(0.8rem, env(safe-area-inset-right)) 0.4rem max(0.8rem, env(safe-area-inset-left)) !important;
     }
 
-    .header-actions {
-        gap: 0.35rem;
+    .hud {
+        top: 48px;
+        gap: 3px;
     }
 
-    .controls {
-        width: calc(100% - 24px);
-        right: 12px;
-        bottom: 78px;
-        max-height: 65vh;
+    .hud-meta {
+        display: none;
     }
 
-    .controls-scroll {
-        padding: 12px;
-        gap: 16px;
+    .hint {
+        display: none;
     }
 
-    .toggle-controls-btn {
-        bottom: 16px;
-        right: 16px;
-        padding: 12px;
+    .inspect {
+        bottom: 92px;
+        width: min(300px, calc(100% - 120px));
+        padding: 6px 8px;
+    }
+
+    .scene-rail {
+        max-width: calc(100vw - 24px);
+    }
+
+    .scene-chip {
+        min-height: 36px;
+        padding: 4px 10px 4px 8px;
+        font-size: 0.62rem;
+    }
+
+    .dock {
+        bottom: max(8px, env(safe-area-inset-bottom));
+        width: min(640px, calc(100% - 16px));
+        gap: 6px;
+    }
+
+    .dock-tools {
+        padding: 4px;
+        gap: 4px;
+    }
+
+    .tool-btn {
+        width: 40px;
+        height: 40px;
+        border-radius: 12px;
+    }
+
+    .tune-panel {
+        max-height: min(38dvh, 200px);
+        grid-template-columns: 1fr 1fr;
+        padding: 10px 12px;
+    }
+
+    footer {
+        display: none;
     }
 }
 
 @media (prefers-reduced-motion: reduce) {
-
-    .controls,
-    .toggle-controls-btn,
-    .action-btn,
-    .scenario-btn,
-    .mode-btn {
+    .hint,
+    .toast,
+    .scene-chip,
+    .tool-btn {
+        animation: none;
         transition: none;
     }
-}
-/* --- lab-responsive-pass --- */
-.icon-btn,
-.toggle-controls-btn,
-.close-btn { min-width: 44px; min-height: 44px; }
-
-@media (max-width: 900px) {
-    footer { bottom: max(16px, env(safe-area-inset-bottom, 0px)); }
 }

--- a/labs/index.html
+++ b/labs/index.html
@@ -1596,7 +1596,7 @@
         </div>
         <div class="project-content">
           <h2>Gravity</h2>
-          <p>Simulação de partículas com física, gravidade e colisões interativas</p>
+          <p>Órbitas, colisões e buracos negros — um universo de brinquedo no canvas</p>
           <div class="project-tags">
             <span class="tag">Canvas</span>
             <span class="tag">Física</span>


### PR DESCRIPTION
## 🎯 Objetivo

Reconstruir o lab Gravity para parecer um universo de brinquedo — não um sandbox de círculos — com planetas reconhecíveis, câmera, dobra temporal e cenários novos.

## ✨ O que mudou

- Sistema solar com Sol, mundos nomeados, Lua, cinturão, Saturno com anéis e cometas
- Cenários novos: três corpos, anéis com pastores, disruptura de maré no buraco negro; binárias, colisão espiral e caos refeitos
- Câmera com zoom (roda/pinça), panorâmica (dois dedos / shift) e seguir planeta
- Dobra temporal ½×–4×, rastros de órbita, fusões com onda de choque
- Dock de cenários sempre visível, HUD e ajustes; SEO e textos da galeria/README atualizados

## 🧪 Como testar

1. Na raiz do repo: `python3 -m http.server 8000`
2. Abrir [http://localhost:8000/](http://localhost:8000/) (home) e [http://localhost:8000/labs/](http://localhost:8000/labs/) (galeria)
3. Abrir [http://localhost:8000/labs/gravity/](http://localhost:8000/labs/gravity/) — conferir CSS, JS e o voltar
4. Responsivo: DevTools em **375×667**, **390×844** e landscape curto (~667×375) — sem overflow horizontal, HUD/controles utilizáveis, alvos ≥ 44px
5. Trocar cenários na trilha (1–8), lançar um planeta no modo corpo, pinçar/zoom, tocar um mundo e seguir
6. Pasta `labs/gravity/` ↔ card da galeria ↔ README ↔ `sitemap.xml` ↔ canonical/OG (slug inalterado)

## ✅ Checklist

- [x] Links conferidos: pasta do lab ↔ card da galeria ↔ README ↔ sitemap (e corrigidos se quebravam)
- [x] README atualizado (linha na tabela + URL + contagem no badge/texto) — obrigatório em lab novo, renomeado ou removido
- [x] SEO consistente: title, description, canonical, author, robots, OG, Twitter, JSON-LD (e contagem nos metas da galeria)
- [x] Testado via HTTP na raiz, não via `file://`
- [x] Responsivo: 375px / 390px / landscape — overflow, HUD, toque, safe-area (`viewport-fit=cover`)
- [x] Nada fora do escopo foi quebrado


Made with [Cursor](https://cursor.com)