### PR TITLE
🧪 lab: reescreve o Pulsar com pulso no BPM e visual de constelação

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Cada pasta em `/labs/<slug>/` é o mesmo slug do card da galeria, da linha abaix
 | 🎼 **[Partitura: Maestro Quest](https://diogopaulino.com.br/labs/partitura/)** | Aprendizado gamificado de partituras |
 | 🎹 **[Piano](https://diogopaulino.com.br/labs/piano/)** | Sintetizador de 4 oitavas no navegador |
 | 📻 **[Winamp JS](https://diogopaulino.com.br/labs/winamp/)** | Nostalgia pura: player estilo Winamp 2.x |
-| ✨ **[Pulsar](https://diogopaulino.com.br/labs/pulsar/)** | Instrumento musical generativo |
+| ✨ **[Pulsar](https://diogopaulino.com.br/labs/pulsar/)** | Constelação musical — orbes pulsam no BPM, altura é nota, posição é o tempo |
 
 ---
 

--- a/labs/index.html
+++ b/labs/index.html
@@ -1480,7 +1480,7 @@
         </div>
         <div class="project-content">
           <h2>Pulsar</h2>
-          <p>Instrumento generativo: toque para criar orbes que pulsam, se conectam e compõem música sozinhos</p>
+          <p>Constelação musical: plante orbes — altura é nota, posição é tempo, pulso no BPM</p>
           <div class="project-tags">
             <span class="tag">Generative</span>
             <span class="tag">Ambient</span>

--- a/labs/pulsar/index.html
+++ b/labs/pulsar/index.html
@@ -1,12 +1,13 @@
 <!DOCTYPE html>
-<html lang="pt-br">
+<html lang="pt-br" data-theme="dark">
 
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
-    <title>Pulsar | Diogo Paulino</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+    <meta name="theme-color" content="#05060d">
+    <title>Pulsar — instrumento generativo | Diogo Paulino</title>
     <meta name="description"
-        content="Instrumento musical generativo: toque na tela para criar orbes que pulsam, se conectam e compõem música ambiente sozinhos.">
+        content="Constelação musical de Diogo Paulino: plante orbes — a altura é a nota, a posição o tempo, e eles pulsam no BPM e se respondem em cânone.">
     <link rel="canonical" href="https://diogopaulino.com.br/labs/pulsar/">
     <meta name="author" content="Diogo Paulino">
     <meta name="robots" content="index, follow">
@@ -18,14 +19,16 @@
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="Diogo Paulino · Labs">
     <meta property="og:url" content="https://diogopaulino.com.br/labs/pulsar/">
-    <meta property="og:title" content="Pulsar | Diogo Paulino">
-    <meta property="og:description" content="Instrumento musical generativo: toque na tela para criar orbes que pulsam, se conectam e compõem música ambiente sozinhos.">
+    <meta property="og:title" content="Pulsar — instrumento generativo | Diogo Paulino">
+    <meta property="og:description"
+        content="Constelação musical de Diogo Paulino: plante orbes — a altura é a nota, a posição o tempo, e eles pulsam no BPM e se respondem em cânone.">
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Pulsar | Diogo Paulino">
-    <meta name="twitter:description" content="Instrumento musical generativo: toque na tela para criar orbes que pulsam, se conectam e compõem música ambiente sozinhos.">
+    <meta name="twitter:title" content="Pulsar — instrumento generativo | Diogo Paulino">
+    <meta name="twitter:description"
+        content="Constelação musical de Diogo Paulino: plante orbes — a altura é a nota, a posição o tempo, e eles pulsam no BPM e se respondem em cânone.">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Oxanium:wght@400;600;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Oxanium:wght@400;600;700;800&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/labs/shared.css?v=9">
     <link rel="stylesheet" href="style.css">
     <script type="application/ld+json">
@@ -36,7 +39,7 @@
           "@type": "WebApplication",
           "name": "Pulsar",
           "url": "https://diogopaulino.com.br/labs/pulsar/",
-          "description": "Instrumento musical generativo: toque na tela para criar orbes que pulsam, se conectam e compõem música ambiente sozinhos.",
+          "description": "Constelação musical de Diogo Paulino: plante orbes — a altura é a nota, a posição o tempo, e eles pulsam no BPM e se respondem em cânone.",
           "applicationCategory": "MultimediaApplication",
           "operatingSystem": "Any",
           "inLanguage": "pt-BR",
@@ -82,7 +85,7 @@
             <template data-slot="logo">
                 <div class="app-logo">
                     <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
-                        stroke-linecap="round" stroke-linejoin="round">
+                        stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                         <circle cx="12" cy="12" r="2.2" />
                         <path d="M12 5.5a6.5 6.5 0 0 1 6.5 6.5" opacity="0.85" />
                         <path d="M12 2a10 10 0 0 1 10 10" opacity="0.5" />
@@ -93,7 +96,7 @@
                 </div>
             </template>
             <template data-slot="actions">
-                <button id="muteBtn" class="icon-btn" aria-label="Mudo" title="Mudo">
+                <button id="muteBtn" class="icon-btn" aria-label="Mudo" title="Mudo (M)">
                     <svg class="icon-sound" width="20" height="20" viewBox="0 0 24 24" fill="none"
                         stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                         <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5" />
@@ -101,21 +104,20 @@
                         <path d="M19.07 4.93a10 10 0 0 1 0 14.14" opacity="0.6" />
                     </svg>
                     <svg class="icon-mute" width="20" height="20" viewBox="0 0 24 24" fill="none"
-                        stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
-                        style="display:none">
+                        stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" hidden>
                         <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5" />
                         <line x1="23" y1="9" x2="17" y2="15" />
                         <line x1="17" y1="9" x2="23" y2="15" />
                     </svg>
                 </button>
-                <button id="fullscreen" class="icon-btn" aria-label="Tela cheia" title="Tela cheia">
+                <button id="fullscreen" class="icon-btn" aria-label="Tela cheia" title="Tela cheia (F)">
                     <svg class="fullscreen-enter" width="20" height="20" viewBox="0 0 24 24" fill="none"
                         stroke="currentColor" stroke-width="2">
                         <path
                             d="M8 3H5a2 2 0 0 0-2 2v3m18 0V5a2 2 0 0 0-2-2h-3m0 18h3a2 2 0 0 0 2-2v-3M3 16v3a2 2 0 0 0 2 2h3" />
                     </svg>
                     <svg class="fullscreen-exit" width="20" height="20" viewBox="0 0 24 24" fill="none"
-                        stroke="currentColor" stroke-width="2" style="display:none">
+                        stroke="currentColor" stroke-width="2" hidden>
                         <path
                             d="M8 3v3a2 2 0 0 1-2 2H3m18 0h-3a2 2 0 0 1-2-2V3m0 18v-3a2 2 0 0 1 2-2h3M3 16h3a2 2 0 0 1 2 2v3" />
                     </svg>
@@ -123,41 +125,58 @@
             </template>
         </header>
 
-        <div class="css-bg">
-            <div class="blob blob-1"></div>
-            <div class="blob blob-2"></div>
-            <div class="blob blob-3"></div>
+        <main class="stage">
+            <canvas id="canvas" aria-label="Campo de orbes do Pulsar"></canvas>
+        </main>
+
+        <div class="hud" aria-live="polite">
+            <span id="hudPreset">Nebula</span>
+            <span class="hud-dot" aria-hidden="true"></span>
+            <span id="hudMeta">72 BPM · 0 orbes</span>
         </div>
 
-        <canvas id="canvas"></canvas>
+        <div class="instructions" id="hint">
+            <p>Toque para plantar um orbe. Alto é agudo, baixo é grave — a esquerda começa o compasso.</p>
+            <p class="sub">Arraste para afinar · toque duplo para apagar · <kbd>1</kbd>–<kbd>4</kbd> modos</p>
+        </div>
 
         <div class="floating-toolbar">
-            <button id="cyclePreset" class="tool-btn" aria-label="Mudar Modo" title="Mudar Modo (Mood)">
-                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                    <path d="M12 2v4M12 18v4M4.93 4.93l2.83 2.83M16.24 16.24l2.83 2.83M2 12h4M18 12h4M4.93 19.07l2.83-2.83M16.24 7.76l2.83-2.83"/>
+            <button id="cyclePreset" class="tool-btn preset-btn" aria-label="Mudar modo" title="Mudar modo (1–4)">
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                    aria-hidden="true">
+                    <path
+                        d="M12 2v4M12 18v4M4.93 4.93l2.83 2.83M16.24 16.24l2.83 2.83M2 12h4M18 12h4M4.93 19.07l2.83-2.83M16.24 7.76l2.83-2.83" />
                 </svg>
                 <span class="preset-name" id="presetName">Nebula</span>
             </button>
-            <div class="divider"></div>
-            <button id="droneToggle" class="tool-btn drone-toggle" aria-label="Fundo Ambiente" aria-pressed="false" title="Fundo Ambiente">
-                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <div class="divider" aria-hidden="true"></div>
+            <button id="playPause" class="tool-btn" aria-label="Pausar" title="Pausar (Espaço)" aria-pressed="true">
+                <svg class="icon-pause" width="20" height="20" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                    <rect x="6" y="4" width="4" height="16" rx="1" />
+                    <rect x="14" y="4" width="4" height="16" rx="1" />
+                </svg>
+                <svg class="icon-play" width="20" height="20" viewBox="0 0 24 24" fill="currentColor" hidden
+                    aria-hidden="true">
+                    <path d="M7 4l13 8-13 8V4z" />
+                </svg>
+            </button>
+            <button id="droneToggle" class="tool-btn" aria-label="Fundo ambiente" aria-pressed="false"
+                title="Fundo ambiente (D)">
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                    aria-hidden="true">
                     <path d="M9 18V5l12-2v13" />
                     <circle cx="6" cy="18" r="3" />
                     <circle cx="18" cy="16" r="3" />
                 </svg>
             </button>
-            <button id="clear" class="tool-btn" aria-label="Limpar Orbes" title="Limpar Orbes">
-                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <button id="clear" class="tool-btn" aria-label="Limpar orbes" title="Limpar orbes (C)">
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                    aria-hidden="true">
                     <path d="M3 6h18" />
                     <path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
                     <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
                 </svg>
             </button>
-        </div>
-
-        <div class="instructions">
-            <p>Toque na tela para criar orbes. Eles pulsam sozinhos e ativam vizinhos próximos.</p>
-            <p class="sub">Arraste para mover · toque duplo para apagar</p>
         </div>
 
         <footer data-lab-footer data-home-href="/"></footer>

--- a/labs/pulsar/script.js
+++ b/labs/pulsar/script.js
@@ -1,327 +1,402 @@
 (function () {
     'use strict';
 
+    /**
+     * Pulsar — instrumento generativo espacial.
+     *
+     * Composição pelo lugar:
+     *   Y → grau da escala (topo = agudo). midi = root + oitava*12 + scale[i]
+     *   X → pan estéreo e fase no compasso (esquerda = beat 0)
+     *   Y em terços → período em beats: alto=2, meio=4, baixo=8
+     *
+     * Relógio:
+     *   beat = t * BPM / 60
+     *   o orbe dispara no flanco em que floor(beat) % period === phase
+     *
+     * Cânone:
+     *   vizinho a ≤ alcance recebe um eco após delay = quantize(dist / 280px/s, ½ beat)
+     *   velocity *= 0.58^hops, no máximo 3 hops
+     */
+
     const canvas = document.getElementById('canvas');
-    const ctx2d = canvas.getContext('2d');
+    const ctx = canvas.getContext('2d', { alpha: false });
 
     const NOTE_MIDI = { C: 48, D: 50, E: 52, F: 53, G: 55, A: 57, B: 59 };
     const SCALES = {
         pentatonic: [0, 2, 4, 7, 9],
         major: [0, 2, 4, 5, 7, 9, 11],
         minor: [0, 2, 3, 5, 7, 8, 10],
-        dorian: [0, 2, 3, 5, 7, 9, 10],
-        wholetone: [0, 2, 4, 6, 8, 10]
+        dorian: [0, 2, 3, 5, 7, 9, 10]
     };
-    const OCTAVE_SPAN = 2.4;
-    const RIPPLE_SPEED = 260; // px/s
-    const ORB_COOLDOWN = 0.28; // s
-    const MAX_HOPS = 4;
-    const HOP_DECAY = 0.72;
-    const MAX_ORBS = 60;
-    const STORAGE_KEY = 'pulsar-state-v1';
+    const OCTAVES = 2.2;
+    const RIPPLE_SPEED = 280;
+    const MAX_HOPS = 3;
+    const HOP_DECAY = 0.58;
+    const MAX_ORBS = 40;
+    const MAX_VOICES = 16;
+    const MAX_STARS = 160;
+    const STORAGE_KEY = 'pulsar-state-v3';
+    const DPR_CAP = 2;
 
     const THEMES = {
         nebula: ['#22d3ee', '#a855f7', '#f472b6'],
-        aurora: ['#00ff88', '#00d4ff', '#8b5cf6'],
-        sunset: ['#ff6b6b', '#feca57', '#ff9ff3'],
-        deep: ['#0066ff', '#6366f1', '#22d3ee']
+        aurora: ['#34d399', '#22d3ee', '#818cf8'],
+        sunset: ['#fb7185', '#fbbf24', '#f472b6'],
+        deep: ['#60a5fa', '#818cf8', '#22d3ee']
     };
 
     const PRESETS = [
-        { name: 'Nebula', themeKey: 'nebula', scale: 'pentatonic', root: 'E', waveform: 'sine', tempo: 1, reachPercent: 100, reverbMix: 0.45 },
-        { name: 'Aurora', themeKey: 'aurora', scale: 'major', root: 'C', waveform: 'triangle', tempo: 1.2, reachPercent: 110, reverbMix: 0.5 },
-        { name: 'Sunset', themeKey: 'sunset', scale: 'dorian', root: 'D', waveform: 'soft-saw', tempo: 0.8, reachPercent: 90, reverbMix: 0.6 },
-        { name: 'Deep', themeKey: 'deep', scale: 'minor', root: 'A', waveform: 'sine', tempo: 0.6, reachPercent: 130, reverbMix: 0.75 }
+        { name: 'Nebula', themeKey: 'nebula', scale: 'pentatonic', root: 'E', waveform: 'sine', bpm: 72, reachPercent: 100, reverbMix: 0.42 },
+        { name: 'Aurora', themeKey: 'aurora', scale: 'major', root: 'C', waveform: 'triangle', bpm: 88, reachPercent: 108, reverbMix: 0.38 },
+        { name: 'Sunset', themeKey: 'sunset', scale: 'dorian', root: 'D', waveform: 'warm', bpm: 64, reachPercent: 92, reverbMix: 0.5 },
+        { name: 'Deep', themeKey: 'deep', scale: 'minor', root: 'A', waveform: 'sine', bpm: 52, reachPercent: 124, reverbMix: 0.58 }
     ];
 
     const state = {
         presetIndex: 0,
-        volume: 0.8,
-        droneOn: false
+        volume: 0.82,
+        droneOn: false,
+        playing: true
     };
 
-    function getPreset() { return PRESETS[state.presetIndex]; }
-
-    let width = 0, height = 0, reachBase = 0;
+    let width = 0;
+    let height = 0;
+    let reachBase = 0;
     let orbs = [];
     const orbsById = new Map();
     let idCounter = 1;
-    let pendingTriggers = [];
+    let pending = [];
     let ripples = [];
+    let sparks = [];
     let stars = [];
-    let noteCount = 0;
-    let saveTimer = null;
+    let nebula = [];
+    let connectionsDirty = true;
+    let cachedReach = 140;
+    let lastBeat = -1;
+    let downbeatFlash = 0;
+    let ghost = null;
+    let dragState = null;
+    let lastTap = { id: null, time: 0 };
+    let saveTimer = 0;
+    let raf = 0;
+    let running = true;
+    let finePointer = true;
 
-    // ---------- helpers ----------
-    function clamp(v, min, max) { return Math.max(min, Math.min(max, v)); }
+    const hudPreset = document.getElementById('hudPreset');
+    const hudMeta = document.getElementById('hudMeta');
+    const presetNameEl = document.getElementById('presetName');
+
+    function clamp(v, min, max) { return v < min ? min : v > max ? max : v; }
     function dist(a, b) { return Math.hypot(a.x - b.x, a.y - b.y); }
-    function clock() { return performance.now() / 1000; }
+    function now() { return performance.now() * 0.001; }
     function midiToFreq(m) { return 440 * Math.pow(2, (m - 69) / 12); }
+    function getPreset() { return PRESETS[state.presetIndex]; }
+    function isDark() { return document.documentElement.getAttribute('data-theme') !== 'light'; }
+    function beatDuration() { return 60 / getPreset().bpm; }
 
     function hexToRgb(hex) {
-        const n = parseInt(hex.replace('#', ''), 16);
+        const n = parseInt(hex.slice(1), 16);
         return { r: (n >> 16) & 255, g: (n >> 8) & 255, b: n & 255 };
     }
 
-    function lerpColor(hexA, hexB, t) {
-        const a = hexToRgb(hexA), b = hexToRgb(hexB);
+    function lerpColor(a, b, t) {
         return {
-            r: Math.round(a.r + (b.r - a.r) * t),
-            g: Math.round(a.g + (b.g - a.g) * t),
-            b: Math.round(a.b + (b.b - a.b) * t)
+            r: (a.r + (b.r - a.r) * t + 0.5) | 0,
+            g: (a.g + (b.g - a.g) * t + 0.5) | 0,
+            b: (a.b + (b.b - a.b) * t + 0.5) | 0
         };
     }
 
-    function rgbStr(c) { return `rgb(${c.r}, ${c.g}, ${c.b})`; }
-    function rgbaStr(c, a) { return `rgba(${c.r}, ${c.g}, ${c.b}, ${a})`; }
+    function rgba(c, a) { return 'rgba(' + c.r + ',' + c.g + ',' + c.b + ',' + a + ')'; }
 
     function colorForT(t) {
-        const stops = THEMES[getPreset().themeKey] || THEMES.nebula;
-        if (t <= 0.5) return lerpColor(stops[0], stops[1], t / 0.5);
-        return lerpColor(stops[1], stops[2], (t - 0.5) / 0.5);
+        const stops = THEMES[getPreset().themeKey];
+        const a = hexToRgb(stops[0]);
+        const b = hexToRgb(stops[1]);
+        const c = hexToRgb(stops[2]);
+        return t <= 0.5 ? lerpColor(a, b, t * 2) : lerpColor(b, c, (t - 0.5) * 2);
     }
 
     function tForY(y) { return 1 - clamp(y / Math.max(1, height), 0, 1); }
-    function colorForY(y) { return colorForT(tForY(y)); }
 
     function freqForY(y) {
         const preset = getPreset();
-        const scaleArr = SCALES[preset.scale] || SCALES.pentatonic;
+        const scale = SCALES[preset.scale];
         const t = tForY(y);
-        const totalSteps = Math.max(1, Math.floor(scaleArr.length * OCTAVE_SPAN));
-        const idx = Math.min(totalSteps - 1, Math.floor(t * totalSteps));
-        const octave = Math.floor(idx / scaleArr.length);
-        const semi = scaleArr[idx % scaleArr.length];
-        const midi = (NOTE_MIDI[preset.root] || 52) + octave * 12 + semi;
+        const steps = Math.max(1, (scale.length * OCTAVES) | 0);
+        const idx = Math.min(steps - 1, (t * steps) | 0);
+        const midi = (NOTE_MIDI[preset.root] || 52) + ((idx / scale.length) | 0) * 12 + scale[idx % scale.length];
         return midiToFreq(midi);
     }
 
+    function periodForY(y) {
+        const t = clamp(y / Math.max(1, height), 0, 1);
+        return t < 0.34 ? 2 : t < 0.67 ? 4 : 8;
+    }
+
+    function phaseForX(x, period) {
+        return (clamp(x / Math.max(1, width), 0, 0.999) * period) | 0;
+    }
+
+    function radiusForPeriod(period) {
+        return period === 8 ? 13 : period === 4 ? 10.5 : 8;
+    }
+
     function applyThemeVars() {
-        const stops = THEMES[getPreset().themeKey] || THEMES.nebula;
-        document.documentElement.style.setProperty('--p-1', stops[0]);
-        document.documentElement.style.setProperty('--p-2', stops[1]);
-        document.documentElement.style.setProperty('--p-3', stops[2]);
-        document.documentElement.style.setProperty('--glow-color', rgbaStr(hexToRgb(stops[1]), 0.32));
+        const stops = THEMES[getPreset().themeKey];
+        const root = document.documentElement.style;
+        root.setProperty('--p-1', stops[0]);
+        root.setProperty('--p-2', stops[1]);
+        root.setProperty('--p-3', stops[2]);
+        const mid = hexToRgb(stops[1]);
+        root.setProperty('--glow-color', rgba(mid, 0.36));
+        const dark = isDark();
+        const themeMeta = document.querySelector('meta[name="theme-color"]');
+        if (themeMeta) themeMeta.setAttribute('content', dark ? '#05060d' : '#e7ebf8');
+    }
+
+    function retuneOrb(o) {
+        o.freq = freqForY(o.y);
+        o.color = colorForT(tForY(o.y));
+        o.period = periodForY(o.y);
+        o.phase = phaseForX(o.x, o.period);
+        o.r = radiusForPeriod(o.period);
     }
 
     function retuneAll() {
-        orbs.forEach((o) => {
-            o.freq = freqForY(o.y);
-            o.color = colorForY(o.y);
-        });
+        for (let i = 0; i < orbs.length; i++) retuneOrb(orbs[i]);
+        connectionsDirty = true;
     }
 
-    // ---------- audio engine ----------
     const AudioEngine = (function () {
-        let ctx = null, masterGain = null, dryGain = null, wetGain = null, convolver = null, compressor = null;
-        let droneNodes = null;
+        let actx = null;
+        let master = null;
+        let wet = null;
         let muted = false;
+        let activeVoices = 0;
+        let drone = null;
 
-        function buildImpulse(audioCtx, duration, decay) {
-            const rate = audioCtx.sampleRate;
-            const length = Math.max(1, Math.floor(rate * duration));
-            const impulse = audioCtx.createBuffer(2, length, rate);
+        function impulse(seconds, decay) {
+            const rate = actx.sampleRate;
+            const len = Math.max(1, (rate * seconds) | 0);
+            const buf = actx.createBuffer(2, len, rate);
             for (let ch = 0; ch < 2; ch++) {
-                const data = impulse.getChannelData(ch);
-                for (let i = 0; i < length; i++) {
-                    data[i] = (Math.random() * 2 - 1) * Math.pow(1 - i / length, decay);
+                const data = buf.getChannelData(ch);
+                for (let i = 0; i < len; i++) {
+                    data[i] = (Math.random() * 2 - 1) * Math.pow(1 - i / len, decay);
                 }
             }
-            return impulse;
+            return buf;
         }
 
-        function ensureContext() {
-            if (ctx) return ctx;
+        function ensure() {
+            if (actx) return actx;
             const AC = window.AudioContext || window.webkitAudioContext;
             if (!AC) return null;
-            ctx = new AC();
-            masterGain = ctx.createGain();
-            masterGain.gain.value = muted ? 0 : state.volume;
-            dryGain = ctx.createGain();
-            dryGain.gain.value = 1;
-            wetGain = ctx.createGain();
-            wetGain.gain.value = getPreset().reverbMix;
-            convolver = ctx.createConvolver();
-            convolver.buffer = buildImpulse(ctx, 3.2, 3.2);
-            compressor = ctx.createDynamicsCompressor();
-
-            masterGain.connect(dryGain);
-            dryGain.connect(compressor);
-            masterGain.connect(wetGain);
-            wetGain.connect(convolver);
-            convolver.connect(compressor);
-            compressor.connect(ctx.destination);
-            return ctx;
+            actx = new AC();
+            master = actx.createGain();
+            master.gain.value = muted ? 0 : state.volume;
+            const dry = actx.createGain();
+            dry.gain.value = 1;
+            wet = actx.createGain();
+            wet.gain.value = getPreset().reverbMix;
+            const conv = actx.createConvolver();
+            conv.buffer = impulse(1.7, 2.6);
+            const comp = actx.createDynamicsCompressor();
+            comp.threshold.value = -18;
+            comp.knee.value = 10;
+            comp.ratio.value = 5;
+            comp.attack.value = 0.004;
+            comp.release.value = 0.16;
+            master.connect(dry);
+            dry.connect(comp);
+            master.connect(wet);
+            wet.connect(conv);
+            conv.connect(comp);
+            comp.connect(actx.destination);
+            return actx;
         }
 
         function resume() {
-            ensureContext();
-            if (ctx && ctx.state === 'suspended') ctx.resume();
-        }
-
-        function setVolume(v) {
-            state.volume = v;
-            if (masterGain) masterGain.gain.setTargetAtTime(muted ? 0 : v, ctx.currentTime, 0.05);
+            ensure();
+            if (actx && actx.state === 'suspended') actx.resume();
         }
 
         function setMute(m) {
             muted = m;
-            if (masterGain) masterGain.gain.setTargetAtTime(m ? 0 : state.volume, ctx.currentTime, 0.05);
+            if (master && actx) master.gain.setTargetAtTime(m ? 0 : state.volume, actx.currentTime, 0.05);
         }
 
-        function isMuted() { return muted; }
-
-        function setReverbMix(v) {
-            state.reverbMix = v;
-            if (wetGain) wetGain.gain.setTargetAtTime(v, ctx.currentTime, 0.1);
+        function setReverb(v) {
+            if (wet && actx) wet.gain.setTargetAtTime(v, actx.currentTime, 0.12);
         }
 
         function playNote(freq, opts) {
             opts = opts || {};
-            if (!ctx) return;
-            const velocity = clamp(opts.velocity != null ? opts.velocity : 1, 0, 1.4);
-            const pan = clamp(opts.pan || 0, -1, 1);
+            if (!actx) return;
+            const hops = opts.hops || 0;
+            if (activeVoices >= MAX_VOICES && hops > 0) return;
+            if (activeVoices >= MAX_VOICES + 4) return;
+
+            const t0 = actx.currentTime;
+            const vel = clamp(opts.velocity != null ? opts.velocity : 1, 0, 1.2);
             const waveform = opts.waveform || 'sine';
-            const t0 = ctx.currentTime;
+            const osc1 = actx.createOscillator();
+            const osc2 = actx.createOscillator();
+            const g = actx.createGain();
+            const filter = actx.createBiquadFilter();
+            const panner = actx.createStereoPanner ? actx.createStereoPanner() : null;
 
-            const osc = ctx.createOscillator();
-            const gain = ctx.createGain();
-            const filter = ctx.createBiquadFilter();
-            const panner = ctx.createStereoPanner ? ctx.createStereoPanner() : null;
-
-            osc.type = waveform === 'soft-saw' ? 'sawtooth' : (waveform === 'triangle' ? 'triangle' : 'sine');
-            osc.frequency.value = freq;
-            osc.detune.value = Math.random() * 10 - 5;
+            osc1.type = waveform === 'triangle' ? 'triangle' : 'sine';
+            osc2.type = waveform === 'warm' ? 'sawtooth' : 'triangle';
+            osc1.frequency.value = freq;
+            osc2.frequency.value = freq;
+            osc1.detune.value = Math.random() * 8 - 4;
+            osc2.detune.value = (waveform === 'warm' ? 7 : 5) + Math.random() * 4;
 
             filter.type = 'lowpass';
-            filter.Q.value = 0.6;
-            if (waveform === 'soft-saw') {
-                filter.frequency.setValueAtTime(freq * 5, t0);
-                filter.frequency.exponentialRampToValueAtTime(Math.max(200, freq * 1.4), t0 + 0.6);
-            } else {
-                filter.frequency.value = freq * 8;
-            }
+            filter.Q.value = waveform === 'warm' ? 1.1 : 0.55;
+            const cutoff = waveform === 'warm' ? freq * 4.2 : freq * 7.5;
+            filter.frequency.setValueAtTime(cutoff, t0);
+            filter.frequency.exponentialRampToValueAtTime(Math.max(180, freq * 1.35), t0 + 0.7);
 
-            const peak = 0.26 * velocity;
-            gain.gain.setValueAtTime(0.0001, t0);
-            gain.gain.linearRampToValueAtTime(peak, t0 + 0.02);
-            gain.gain.exponentialRampToValueAtTime(Math.max(0.0002, peak * 0.35), t0 + 0.5);
-            gain.gain.exponentialRampToValueAtTime(0.0001, t0 + 2.0);
+            const peak = (hops ? 0.16 : 0.22) * vel;
+            g.gain.setValueAtTime(0.0001, t0);
+            g.gain.exponentialRampToValueAtTime(peak, t0 + 0.012);
+            g.gain.exponentialRampToValueAtTime(Math.max(0.0002, peak * 0.32), t0 + 0.42);
+            g.gain.exponentialRampToValueAtTime(0.0001, t0 + 1.65);
 
-            osc.connect(filter);
+            const mix2 = actx.createGain();
+            mix2.gain.value = waveform === 'warm' ? 0.18 : 0.28;
+            osc1.connect(filter);
+            osc2.connect(mix2);
+            mix2.connect(filter);
             if (panner) {
                 filter.connect(panner);
-                panner.pan.value = pan;
-                panner.connect(gain);
+                panner.pan.value = clamp(opts.pan || 0, -1, 1);
+                panner.connect(g);
             } else {
-                filter.connect(gain);
+                filter.connect(g);
             }
-            gain.connect(masterGain);
+            g.connect(master);
 
-            osc.start(t0);
-            osc.stop(t0 + 2.1);
-            osc.onended = function () {
-                try { osc.disconnect(); gain.disconnect(); filter.disconnect(); if (panner) panner.disconnect(); } catch (e) { /* noop */ }
+            activeVoices++;
+            osc1.start(t0);
+            osc2.start(t0);
+            osc1.stop(t0 + 1.75);
+            osc2.stop(t0 + 1.75);
+            osc1.onended = function () {
+                activeVoices = Math.max(0, activeVoices - 1);
+                try {
+                    osc1.disconnect();
+                    osc2.disconnect();
+                    mix2.disconnect();
+                    filter.disconnect();
+                    g.disconnect();
+                    if (panner) panner.disconnect();
+                } catch (err) { /* already gone */ }
             };
         }
 
         function startDrone() {
-            ensureContext();
-            if (!ctx || droneNodes) return;
-            const t0 = ctx.currentTime;
-            const g = ctx.createGain();
+            ensure();
+            if (!actx || drone) return;
+            const t0 = actx.currentTime;
+            const g = actx.createGain();
             g.gain.value = 0.0001;
-            g.connect(masterGain);
-
+            g.connect(master);
             const rootFreq = midiToFreq((NOTE_MIDI[getPreset().root] || 52) - 12);
-            const oscs = [];
-            [0, 7, 12].forEach((semi, i) => {
-                const o = ctx.createOscillator();
+            const oscs = [0, 7, 12].map(function (semi, i) {
+                const o = actx.createOscillator();
+                const og = actx.createGain();
+                const f = actx.createBiquadFilter();
                 o.type = 'sine';
                 o.frequency.value = rootFreq * Math.pow(2, semi / 12);
-                o.detune.value = Math.random() * 6 - 3;
-                const og = ctx.createGain();
-                og.gain.value = i === 0 ? 0.5 : 0.28;
-                const filt = ctx.createBiquadFilter();
-                filt.type = 'lowpass';
-                filt.frequency.value = 700;
-                o.connect(filt);
-                filt.connect(og);
+                o.detune.value = Math.random() * 5 - 2.5;
+                og.gain.value = i === 0 ? 0.46 : 0.24;
+                f.type = 'lowpass';
+                f.frequency.value = 640;
+                o.connect(f);
+                f.connect(og);
                 og.connect(g);
                 o.start(t0);
-                oscs.push({ o: o, filt: filt });
+                return { o: o, f: f };
             });
-
-            const lfo = ctx.createOscillator();
-            lfo.frequency.value = 0.045;
-            const lfoGain = ctx.createGain();
-            lfoGain.gain.value = 260;
-            lfo.connect(lfoGain);
-            oscs.forEach(function (n) { lfoGain.connect(n.filt.frequency); });
+            const lfo = actx.createOscillator();
+            const lfoG = actx.createGain();
+            lfo.frequency.value = 0.04;
+            lfoG.gain.value = 220;
+            lfo.connect(lfoG);
+            oscs.forEach(function (n) { lfoG.connect(n.f.frequency); });
             lfo.start(t0);
-
-            g.gain.linearRampToValueAtTime(0.16, t0 + 2.5);
-            droneNodes = { g: g, oscs: oscs, lfo: lfo };
+            g.gain.linearRampToValueAtTime(0.13, t0 + 2.2);
+            drone = { g: g, oscs: oscs, lfo: lfo };
         }
 
         function stopDrone() {
-            if (!ctx || !droneNodes) return;
-            const t0 = ctx.currentTime;
-            const nodes = droneNodes;
-            droneNodes = null;
+            if (!actx || !drone) return;
+            const t0 = actx.currentTime;
+            const nodes = drone;
+            drone = null;
             nodes.g.gain.cancelScheduledValues(t0);
-            nodes.g.gain.setValueAtTime(nodes.g.gain.value, t0);
-            nodes.g.gain.linearRampToValueAtTime(0.0001, t0 + 1.2);
+            nodes.g.gain.setValueAtTime(Math.max(0.0001, nodes.g.gain.value), t0);
+            nodes.g.gain.linearRampToValueAtTime(0.0001, t0 + 1.1);
             setTimeout(function () {
-                nodes.oscs.forEach(function (n) { try { n.o.stop(); } catch (e) { /* noop */ } });
-                try { nodes.lfo.stop(); } catch (e) { /* noop */ }
-            }, 1400);
+                nodes.oscs.forEach(function (n) { try { n.o.stop(); } catch (err) { /* noop */ } });
+                try { nodes.lfo.stop(); } catch (err) { /* noop */ }
+            }, 1200);
         }
 
-        function refreshDroneTuning() {
-            if (!droneNodes) return;
+        function refreshDrone() {
+            if (!drone || !actx) return;
             const rootFreq = midiToFreq((NOTE_MIDI[getPreset().root] || 52) - 12);
-            [0, 7, 12].forEach((semi, i) => {
-                if (droneNodes.oscs[i]) droneNodes.oscs[i].o.frequency.setTargetAtTime(rootFreq * Math.pow(2, semi / 12), ctx.currentTime, 0.4);
+            [0, 7, 12].forEach(function (semi, i) {
+                if (drone.oscs[i]) {
+                    drone.oscs[i].o.frequency.setTargetAtTime(rootFreq * Math.pow(2, semi / 12), actx.currentTime, 0.35);
+                }
             });
         }
 
         return {
             resume: resume,
-            setVolume: setVolume,
             setMute: setMute,
-            isMuted: isMuted,
-            setReverbMix: setReverbMix,
+            isMuted: function () { return muted; },
+            setReverb: setReverb,
             playNote: playNote,
             startDrone: startDrone,
             stopDrone: stopDrone,
-            refreshDroneTuning: refreshDroneTuning,
-            hasContext: function () { return !!ctx; }
+            refreshDrone: refreshDrone
         };
     })();
 
-    // ---------- orbs ----------
-    function addOrb(x, y, skipTrigger) {
+    function markConnectionsDirty() { connectionsDirty = true; }
+
+    function addOrb(x, y, opts) {
+        opts = opts || {};
         if (orbs.length >= MAX_ORBS) removeOrb(orbs[0]);
         const orb = {
             id: idCounter++,
-            x: x, y: y,
-            rx: x / width, ry: y / height,
-            r: 9 + Math.random() * 3,
-            freq: freqForY(y),
-            color: colorForY(y),
-            baseInterval: 3.5 + Math.random() * 4.5,
-            nextPulseTime: clock() + Math.random() * 3 + 1.2,
-            cooldownUntil: 0,
-            lastTriggerTime: -10,
+            x: x,
+            y: y,
+            rx: x / Math.max(1, width),
+            ry: y / Math.max(1, height),
+            r: 10,
+            freq: 440,
+            color: { r: 168, g: 85, b: 247 },
+            period: 4,
+            phase: 0,
+            lastTrigger: -10,
             connections: []
         };
+        retuneOrb(orb);
         orbs.push(orb);
         orbsById.set(orb.id, orb);
-        updateOrbCountUI();
-        if (!skipTrigger) {
+        markConnectionsDirty();
+        if (!opts.silent) {
             AudioEngine.resume();
+            triggerOrb(orb, { hops: 0, fromClock: false });
         }
+        updateHud();
         return orb;
     }
 
@@ -331,31 +406,40 @@
         if (idx === -1) return;
         orbs.splice(idx, 1);
         orbsById.delete(orb.id);
-        pendingTriggers = pendingTriggers.filter(function (p) { return p.id !== orb.id; });
-        updateOrbCountUI();
+        pending = pending.filter(function (p) { return p.id !== orb.id; });
+        markConnectionsDirty();
+        updateHud();
     }
 
     function clearOrbs() {
         orbs = [];
         orbsById.clear();
-        pendingTriggers = [];
+        pending = [];
         ripples = [];
-        updateOrbCountUI();
+        sparks = [];
+        markConnectionsDirty();
+        updateHud();
     }
 
     function findOrbAt(x, y) {
-        let best = null, bestDist = Infinity;
-        for (const o of orbs) {
+        const hitPad = finePointer ? 18 : 26;
+        let best = null;
+        let bestD = Infinity;
+        for (let i = 0; i < orbs.length; i++) {
+            const o = orbs[i];
             const d = Math.hypot(o.x - x, o.y - y);
-            const hitR = Math.max(o.r + 14, 22);
-            if (d <= hitR && d < bestDist) { best = o; bestDist = d; }
+            if (d <= o.r + hitPad && d < bestD) {
+                best = o;
+                bestD = d;
+            }
         }
         return best;
     }
 
     function computeConnections() {
         const reach = reachBase * (getPreset().reachPercent / 100);
-        for (const o of orbs) o.connections.length = 0;
+        cachedReach = reach;
+        for (let i = 0; i < orbs.length; i++) orbs[i].connections.length = 0;
         for (let i = 0; i < orbs.length; i++) {
             for (let j = i + 1; j < orbs.length; j++) {
                 if (dist(orbs[i], orbs[j]) <= reach) {
@@ -364,259 +448,371 @@
                 }
             }
         }
+        connectionsDirty = false;
         return reach;
     }
 
     function triggerOrb(orb, opts) {
         opts = opts || {};
         const hops = opts.hops || 0;
-        const now = clock();
-        if (now < orb.cooldownUntil) return false;
-        orb.cooldownUntil = now + ORB_COOLDOWN;
-        orb.lastTriggerTime = now;
-        orb.nextPulseTime = now + orb.baseInterval / getPreset().tempo;
+        const t = now();
+        if (t - orb.lastTrigger < 0.08) return false;
+        orb.lastTrigger = t;
 
-        const velocity = Math.pow(HOP_DECAY, hops);
         AudioEngine.playNote(orb.freq, {
-            velocity: velocity,
+            velocity: Math.pow(HOP_DECAY, hops),
             pan: (orb.x / Math.max(1, width)) * 2 - 1,
-            waveform: getPreset().waveform
+            waveform: getPreset().waveform,
+            hops: hops
         });
 
         ripples.push({
-            x: orb.x, y: orb.y,
-            born: now,
+            x: orb.x,
+            y: orb.y,
+            born: t,
             color: orb.color,
-            maxR: (reachBase * (getPreset().reachPercent / 100)) * 1.05 || 140
+            maxR: cachedReach * 0.95 || 120
         });
 
-        noteCount++;
-        updateNoteCountUI();
-
         if (hops < MAX_HOPS) {
-            for (const nb of orb.connections) {
-                if (now >= nb.cooldownUntil) {
-                    const d = dist(orb, nb);
-                    const delay = d / RIPPLE_SPEED;
-                    pendingTriggers.push({ id: nb.id, fireAt: now + delay, hops: hops + 1 });
-                }
+            const beatHalf = beatDuration() * 0.5;
+            for (let i = 0; i < orb.connections.length; i++) {
+                const nb = orb.connections[i];
+                if (t - nb.lastTrigger < 0.12) continue;
+                if (opts.fromClock && (lastBeat % nb.period === nb.phase)) continue;
+                const d = dist(orb, nb);
+                const delay = Math.max(beatHalf, Math.round(d / RIPPLE_SPEED / beatHalf) * beatHalf);
+                pending.push({ id: nb.id, fireAt: t + delay, hops: hops + 1 });
+                sparks.push({
+                    ax: orb.x, ay: orb.y,
+                    bx: nb.x, by: nb.y,
+                    born: t, dur: delay,
+                    color: orb.color
+                });
             }
         }
         return true;
     }
 
-    // ---------- starfield ----------
-    function initStars() {
-        stars = [];
-        const count = Math.floor((width * height) / 9000);
+    function initField() {
+        const count = Math.min(MAX_STARS, Math.max(48, ((width * height) / 14000) | 0));
+        stars = new Array(count);
         for (let i = 0; i < count; i++) {
-            stars.push({
+            stars[i] = {
                 x: Math.random() * width,
                 y: Math.random() * height,
-                r: Math.random() * 1.3 + 0.3,
-                speed: 0.4 + Math.random() * 1.2,
-                phase: Math.random() * Math.PI * 2
-            });
+                r: Math.random() * 1.25 + 0.25,
+                a: 0.25 + Math.random() * 0.55,
+                s: 0.35 + Math.random() * 1.4,
+                p: Math.random() * Math.PI * 2
+            };
         }
+        nebula = [
+            { x: width * 0.22, y: height * 0.28, r: Math.min(width, height) * 0.55 },
+            { x: width * 0.78, y: height * 0.62, r: Math.min(width, height) * 0.6 },
+            { x: width * 0.5, y: height * 0.42, r: Math.min(width, height) * 0.42 }
+        ];
     }
 
-    // ---------- render ----------
-    function isDark() {
-        return document.documentElement.getAttribute('data-theme') !== 'light';
+    function drawBackground(t) {
+        const dark = isDark();
+        ctx.fillStyle = dark ? '#05060d' : '#e7ebf8';
+        ctx.fillRect(0, 0, width, height);
+
+        const stops = THEMES[getPreset().themeKey];
+        const cols = [hexToRgb(stops[0]), hexToRgb(stops[1]), hexToRgb(stops[2])];
+        const pulse = 0.85 + downbeatFlash * 0.2;
+        ctx.globalCompositeOperation = dark ? 'screen' : 'multiply';
+        for (let i = 0; i < nebula.length; i++) {
+            const n = nebula[i];
+            const wobble = Math.sin(t * 0.12 + i * 1.7) * 18;
+            const g = ctx.createRadialGradient(n.x + wobble, n.y, 0, n.x, n.y, n.r);
+            g.addColorStop(0, rgba(cols[i], (dark ? 0.22 : 0.16) * pulse));
+            g.addColorStop(1, rgba(cols[i], 0));
+            ctx.fillStyle = g;
+            ctx.beginPath();
+            ctx.arc(n.x, n.y, n.r, 0, Math.PI * 2);
+            ctx.fill();
+        }
+
+        ctx.globalCompositeOperation = dark ? 'screen' : 'source-over';
+        for (let i = 0; i < stars.length; i++) {
+            const s = stars[i];
+            const tw = 0.45 + 0.55 * Math.sin(t * s.s + s.p);
+            ctx.fillStyle = dark
+                ? 'rgba(255,255,255,' + (s.a * tw * 0.7).toFixed(3) + ')'
+                : 'rgba(40,50,90,' + (s.a * tw * 0.35).toFixed(3) + ')';
+            ctx.beginPath();
+            ctx.arc(s.x, s.y, s.r, 0, Math.PI * 2);
+            ctx.fill();
+        }
+        ctx.globalCompositeOperation = 'source-over';
     }
 
-    function drawBackground(now) {
-        ctx2d.fillStyle = isDark() ? '#05060d' : '#eef1fb';
-        ctx2d.fillRect(0, 0, width, height);
-    }
-
-    function drawConnections(reach) {
-        const now = clock();
-        ctx2d.globalCompositeOperation = isDark() ? 'screen' : 'multiply';
-        
+    function drawConnections(t) {
+        const dark = isDark();
+        ctx.globalCompositeOperation = dark ? 'screen' : 'multiply';
         for (let i = 0; i < orbs.length; i++) {
             const a = orbs[i];
-            const burstA = clamp(1 - (now - a.lastTriggerTime) / 0.45, 0, 1);
-            
-            for (const b of a.connections) {
+            const burstA = clamp(1 - (t - a.lastTrigger) / 0.4, 0, 1);
+            for (let k = 0; k < a.connections.length; k++) {
+                const b = a.connections[k];
                 if (b.id < a.id) continue;
                 const d = dist(a, b);
-                const baseAlpha = clamp(1 - d / reach, 0, 1) * 0.28;
-                if (baseAlpha <= 0.01) continue;
-                
-                const burstB = clamp(1 - (now - b.lastTriggerTime) / 0.45, 0, 1);
-                const activeFactor = Math.max(burstA, burstB);
-                const finalAlpha = baseAlpha + (activeFactor * 0.4);
-                
-                ctx2d.strokeStyle = rgbaStr(a.color, finalAlpha);
-                ctx2d.lineWidth = 1 + activeFactor * 1.5;
-                
-                ctx2d.beginPath();
-                ctx2d.moveTo(a.x, a.y);
-                ctx2d.lineTo(b.x, b.y);
-                ctx2d.stroke();
+                const base = clamp(1 - d / cachedReach, 0, 1) * (dark ? 0.46 : 0.3);
+                if (base < 0.02) continue;
+                const burstB = clamp(1 - (t - b.lastTrigger) / 0.4, 0, 1);
+                const live = Math.max(burstA, burstB);
+                ctx.strokeStyle = rgba(a.color, base + live * 0.45);
+                ctx.lineWidth = 1 + live * 1.8;
+                ctx.beginPath();
+                ctx.moveTo(a.x, a.y);
+                ctx.lineTo(b.x, b.y);
+                ctx.stroke();
             }
         }
-        ctx2d.globalCompositeOperation = 'source-over';
+        ctx.globalCompositeOperation = 'source-over';
     }
 
-    function drawOrbs(now) {
-        const dark = isDark();
-        ctx2d.globalCompositeOperation = dark ? 'screen' : 'source-over';
-        
-        for (const o of orbs) {
-            const progress = clamp(1 - (o.nextPulseTime - now) / Math.max(0.1, o.baseInterval / state.tempo), 0, 1);
-            const burst = clamp(1 - (now - o.lastTriggerTime) / 0.45, 0, 1);
-            const r = o.r + progress * 2.5 + burst * 8;
-            const glowR = r + 16 + burst * 28;
-
-            // Outer Bloom
-            ctx2d.beginPath();
-            ctx2d.arc(o.x, o.y, glowR * 0.8, 0, Math.PI * 2);
-            ctx2d.fillStyle = rgbaStr(o.color, 0.18 + burst * 0.22);
-            ctx2d.fill();
-
-            // Inner solid orb
-            ctx2d.beginPath();
-            ctx2d.arc(o.x, o.y, r, 0, Math.PI * 2);
-            ctx2d.fillStyle = rgbStr(o.color);
-            ctx2d.fill();
-            
-            // Orb border
-            ctx2d.lineWidth = 1.5 + burst;
-            ctx2d.strokeStyle = dark ? 'rgba(255,255,255,0.85)' : 'rgba(255,255,255,0.9)';
-            ctx2d.stroke();
-            
-            // Orb Core (Energy center)
-            ctx2d.beginPath();
-            ctx2d.arc(o.x, o.y, Math.max(1.5, r * 0.25), 0, Math.PI * 2);
-            ctx2d.fillStyle = dark ? '#fff' : 'rgba(255,255,255,0.9)';
-            ctx2d.fill();
+    function drawSparks(t) {
+        ctx.globalCompositeOperation = isDark() ? 'screen' : 'source-over';
+        for (let i = sparks.length - 1; i >= 0; i--) {
+            const s = sparks[i];
+            const u = (t - s.born) / s.dur;
+            if (u >= 1) {
+                sparks.splice(i, 1);
+                continue;
+            }
+            const x = s.ax + (s.bx - s.ax) * u;
+            const y = s.ay + (s.by - s.ay) * u;
+            const g = ctx.createRadialGradient(x, y, 0, x, y, 9);
+            g.addColorStop(0, rgba(s.color, 0.95));
+            g.addColorStop(1, rgba(s.color, 0));
+            ctx.fillStyle = g;
+            ctx.beginPath();
+            ctx.arc(x, y, 9, 0, Math.PI * 2);
+            ctx.fill();
         }
-        ctx2d.globalCompositeOperation = 'source-over';
+        ctx.globalCompositeOperation = 'source-over';
     }
 
-    function drawRipples(now) {
-        ctx2d.globalCompositeOperation = isDark() ? 'screen' : 'source-over';
+    function drawRipples(t) {
+        ctx.globalCompositeOperation = isDark() ? 'screen' : 'source-over';
         for (let i = ripples.length - 1; i >= 0; i--) {
             const rp = ripples[i];
-            const age = Math.max(0, now - rp.born);
-            const r = age * RIPPLE_SPEED;
-            const alpha = clamp(1 - r / rp.maxR, 0, 1) * 0.65;
-            if (alpha <= 0.01 || r > rp.maxR) { ripples.splice(i, 1); continue; }
-            
-            ctx2d.beginPath();
-            ctx2d.arc(rp.x, rp.y, r, 0, Math.PI * 2);
-            ctx2d.lineWidth = 2.5 - (r / rp.maxR) * 1.5;
-            ctx2d.strokeStyle = rgbaStr(rp.color, alpha);
-            ctx2d.stroke();
-        }
-        ctx2d.globalCompositeOperation = 'source-over';
-    }
-
-    // ---------- main loop ----------
-    function update(now) {
-        const reach = computeConnections();
-
-        for (const o of orbs) {
-            if (now >= o.nextPulseTime) triggerOrb(o, { hops: 0 });
-        }
-
-        if (pendingTriggers.length) {
-            const remaining = [];
-            for (const p of pendingTriggers) {
-                if (now >= p.fireAt) {
-                    const orb = orbsById.get(p.id);
-                    if (orb) triggerOrb(orb, { hops: p.hops });
-                } else {
-                    remaining.push(p);
-                }
+            const r = Math.max(0, t - rp.born) * RIPPLE_SPEED;
+            const alpha = clamp(1 - r / rp.maxR, 0, 1) * 0.55;
+            if (alpha < 0.02 || r > rp.maxR) {
+                ripples.splice(i, 1);
+                continue;
             }
-            pendingTriggers = remaining;
+            ctx.beginPath();
+            ctx.arc(rp.x, rp.y, r, 0, Math.PI * 2);
+            ctx.lineWidth = 2.2 - (r / rp.maxR) * 1.4;
+            ctx.strokeStyle = rgba(rp.color, alpha);
+            ctx.stroke();
         }
-
-        drawBackground(now);
-        drawConnections(reach);
-        drawRipples(now);
-        drawOrbs(now);
+        ctx.globalCompositeOperation = 'source-over';
     }
 
-    function loop() {
-        update(clock());
-        requestAnimationFrame(loop);
+    function drawOrb(o, t, ghosted) {
+        const dark = isDark();
+        const bpm = getPreset().bpm;
+        const beats = t * bpm / 60;
+        const local = ((beats % o.period) + o.period) % o.period;
+        const until = (o.phase - local + o.period) % o.period;
+        const approach = until < 0.55 ? 1 - until / 0.55 : 0;
+        const burst = clamp(1 - (t - o.lastTrigger) / 0.42, 0, 1);
+        const r = o.r + approach * 2.2 + burst * 6;
+        const glowR = r + 14 + burst * 22;
+        ctx.globalAlpha = ghosted ? 0.38 : 1;
+
+        const bloom = ctx.createRadialGradient(o.x, o.y, r * 0.2, o.x, o.y, glowR);
+        bloom.addColorStop(0, rgba(o.color, (dark ? 0.55 : 0.4) + burst * 0.3));
+        bloom.addColorStop(1, rgba(o.color, 0));
+        ctx.fillStyle = bloom;
+        ctx.beginPath();
+        ctx.arc(o.x, o.y, glowR, 0, Math.PI * 2);
+        ctx.fill();
+
+        const body = ctx.createRadialGradient(o.x - r * 0.25, o.y - r * 0.3, r * 0.1, o.x, o.y, r);
+        body.addColorStop(0, dark ? '#fff' : 'rgba(255,255,255,0.95)');
+        body.addColorStop(0.35, rgba(o.color, 1));
+        body.addColorStop(1, rgba(o.color, 0.75));
+        ctx.fillStyle = body;
+        ctx.beginPath();
+        ctx.arc(o.x, o.y, r, 0, Math.PI * 2);
+        ctx.fill();
+
+        if (approach > 0.05 && !ghosted) {
+            ctx.strokeStyle = rgba(o.color, approach * 0.55);
+            ctx.lineWidth = 1.5;
+            ctx.beginPath();
+            ctx.arc(o.x, o.y, r + 6 + (1 - approach) * 8, 0, Math.PI * 2);
+            ctx.stroke();
+        }
+        ctx.globalAlpha = 1;
     }
 
-    // ---------- resize ----------
+    function drawOrbs(t) {
+        ctx.globalCompositeOperation = isDark() ? 'screen' : 'source-over';
+        for (let i = 0; i < orbs.length; i++) drawOrb(orbs[i], t, false);
+        if (ghost) drawOrb(ghost, t, true);
+        ctx.globalCompositeOperation = 'source-over';
+    }
+
+    function tickClock(t) {
+        if (!state.playing) return;
+        const bpm = getPreset().bpm;
+        const beat = (t * bpm / 60) | 0;
+        if (beat === lastBeat) return;
+        lastBeat = beat;
+        if (beat % 4 === 0) downbeatFlash = 1;
+        for (let i = 0; i < orbs.length; i++) {
+            const o = orbs[i];
+            if (beat % o.period === o.phase) triggerOrb(o, { hops: 0, fromClock: true });
+        }
+    }
+
+    function flushPending(t) {
+        if (!pending.length) return;
+        const keep = [];
+        for (let i = 0; i < pending.length; i++) {
+            const p = pending[i];
+            if (t >= p.fireAt) {
+                const orb = orbsById.get(p.id);
+                if (orb) triggerOrb(orb, { hops: p.hops });
+            } else {
+                keep.push(p);
+            }
+        }
+        pending = keep;
+    }
+
+    function updateHud() {
+        const p = getPreset();
+        const count = orbs.length;
+        const label = count === 1 ? '1 orbe' : count + ' orbes';
+        if (hudPreset) hudPreset.textContent = p.name;
+        if (hudMeta) hudMeta.textContent = p.bpm + ' BPM · ' + label;
+        if (presetNameEl) presetNameEl.textContent = p.name;
+    }
+
+    function frame() {
+        const t = now();
+        downbeatFlash *= 0.9;
+        if (connectionsDirty) computeConnections();
+        tickClock(t);
+        flushPending(t);
+        drawBackground(t);
+        drawConnections(t);
+        drawRipples(t);
+        drawSparks(t);
+        drawOrbs(t);
+        raf = requestAnimationFrame(frame);
+    }
+
+    function startLoop() {
+        if (running) return;
+        running = true;
+        raf = requestAnimationFrame(frame);
+    }
+
+    function stopLoop() {
+        running = false;
+        cancelAnimationFrame(raf);
+    }
+
     function resize() {
-        width = canvas.width = window.innerWidth;
-        height = canvas.height = window.innerHeight;
+        const dpr = Math.min(DPR_CAP, window.devicePixelRatio || 1);
+        const cssW = window.innerWidth;
+        const cssH = window.innerHeight;
+        canvas.width = Math.max(1, (cssW * dpr) | 0);
+        canvas.height = Math.max(1, (cssH * dpr) | 0);
+        canvas.style.width = cssW + 'px';
+        canvas.style.height = cssH + 'px';
+        ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+        width = cssW;
+        height = cssH;
         reachBase = Math.min(width, height) * 0.22;
-        for (const o of orbs) {
+        for (let i = 0; i < orbs.length; i++) {
+            const o = orbs[i];
             o.x = o.rx * width;
             o.y = o.ry * height;
         }
         retuneAll();
-        initStars();
+        initField();
     }
-
-    // ---------- UI: stats ----------
-    const orbCountEl = document.getElementById('orbCount');
-    const noteCountEl = document.getElementById('noteCount');
-    function updateOrbCountUI() { if (orbCountEl) orbCountEl.textContent = String(orbs.length); }
-    function updateNoteCountUI() { if (noteCountEl) noteCountEl.textContent = String(noteCount); }
-
-    // ---------- pointer interaction ----------
-    let dragState = null;
-    let lastTap = { id: null, time: 0 };
 
     function getPos(e) {
         const rect = canvas.getBoundingClientRect();
-        return { x: clamp(e.clientX - rect.left, 0, width), y: clamp(e.clientY - rect.top, 0, height) };
+        return {
+            x: clamp(e.clientX - rect.left, 0, width),
+            y: clamp(e.clientY - rect.top, 0, height)
+        };
+    }
+
+    function makeGhost(x, y) {
+        const period = periodForY(y);
+        return {
+            x: x, y: y,
+            r: radiusForPeriod(period),
+            color: colorForT(tForY(y)),
+            period: period,
+            phase: phaseForX(x, period),
+            lastTrigger: -10
+        };
     }
 
     canvas.addEventListener('pointerdown', function (e) {
         AudioEngine.resume();
         const pos = getPos(e);
+        ghost = null;
         const hit = findOrbAt(pos.x, pos.y);
         if (hit) {
             dragState = { orb: hit, isNew: false, moved: false, startX: pos.x, startY: pos.y };
         } else {
-            const orb = addOrb(pos.x, pos.y, true);
+            const orb = addOrb(pos.x, pos.y);
             dragState = { orb: orb, isNew: true, moved: false, startX: pos.x, startY: pos.y };
         }
-        // Best-effort: lança InvalidStateError se o ponteiro já terminou.
-        try {
-            canvas.setPointerCapture(e.pointerId);
-        } catch (err) {
-            /* segue sem captura */
-        }
+        try { canvas.setPointerCapture(e.pointerId); } catch (err) { /* pointer already up */ }
     });
 
     canvas.addEventListener('pointermove', function (e) {
-        if (!dragState) return;
         const pos = getPos(e);
-        if (Math.hypot(pos.x - dragState.startX, pos.y - dragState.startY) > 6) dragState.moved = true;
-        dragState.orb.x = pos.x;
-        dragState.orb.y = pos.y;
-        dragState.orb.rx = pos.x / width;
-        dragState.orb.ry = pos.y / height;
-        dragState.orb.freq = freqForY(pos.y);
-        dragState.orb.color = colorForY(pos.y);
+        if (dragState) {
+            if (Math.hypot(pos.x - dragState.startX, pos.y - dragState.startY) > 6) dragState.moved = true;
+            const o = dragState.orb;
+            o.x = pos.x;
+            o.y = pos.y;
+            o.rx = pos.x / Math.max(1, width);
+            o.ry = pos.y / Math.max(1, height);
+            retuneOrb(o);
+            markConnectionsDirty();
+            return;
+        }
+        if (!finePointer) return;
+        ghost = findOrbAt(pos.x, pos.y) ? null : makeGhost(pos.x, pos.y);
     });
 
-    function endDrag(e) {
-        if (!dragState) return;
-        const orb = dragState.orb, isNew = dragState.isNew, moved = dragState.moved;
-        dragState = null;
+    canvas.addEventListener('pointerleave', function () {
+        if (!dragState) ghost = null;
+    });
 
+    function endDrag() {
+        if (!dragState) return;
+        const orb = dragState.orb;
+        const isNew = dragState.isNew;
+        const moved = dragState.moved;
+        dragState = null;
         if (!isNew && !moved) {
-            const now = clock();
-            if (lastTap.id === orb.id && (now - lastTap.time) < 0.35) {
+            const t = now();
+            if (lastTap.id === orb.id && (t - lastTap.time) < 0.42) {
                 removeOrb(orb);
                 lastTap = { id: null, time: 0 };
             } else {
                 triggerOrb(orb, { hops: 0 });
-                lastTap = { id: orb.id, time: now };
+                lastTap = { id: orb.id, time: t };
             }
         }
         scheduleSave();
@@ -625,74 +821,110 @@
     canvas.addEventListener('pointerup', endDrag);
     canvas.addEventListener('pointercancel', function () { dragState = null; });
 
-    // ---------- persistence ----------
     function scheduleSave() {
         clearTimeout(saveTimer);
-        saveTimer = setTimeout(saveState, 700);
+        saveTimer = setTimeout(saveState, 500);
     }
 
     function saveState() {
         try {
-            const data = {
-                v: 2,
+            localStorage.setItem(STORAGE_KEY, JSON.stringify({
+                v: 3,
                 presetIndex: state.presetIndex,
-                volume: state.volume,
                 orbs: orbs.map(function (o) { return { rx: o.rx, ry: o.ry }; })
-            };
-            localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
-        } catch (e) { /* private mode or storage disabled */ }
+            }));
+        } catch (err) { /* private mode */ }
     }
 
     function loadState() {
         try {
-            const raw = localStorage.getItem(STORAGE_KEY);
-            if (!raw) return false;
-            const data = JSON.parse(raw);
+            const data = JSON.parse(localStorage.getItem(STORAGE_KEY) || 'null');
             if (!data || !Array.isArray(data.orbs)) return false;
-
-            if (data.v === 2 && typeof data.presetIndex === 'number') {
-                state.presetIndex = Math.min(Math.max(0, data.presetIndex), PRESETS.length - 1);
+            if (typeof data.presetIndex === 'number') {
+                state.presetIndex = clamp(data.presetIndex, 0, PRESETS.length - 1) | 0;
             }
-            state.volume = typeof data.volume === 'number' ? data.volume : state.volume;
-
             data.orbs.forEach(function (o) {
                 if (typeof o.rx === 'number' && typeof o.ry === 'number') {
-                    addOrb(o.rx * width, o.ry * height, true);
+                    addOrb(o.rx * width, o.ry * height, { silent: true });
                 }
             });
             return orbs.length > 0;
-        } catch (e) {
+        } catch (err) {
             return false;
         }
     }
 
-    function seedDefaultConstellation() {
+    function seedDefault() {
         const pts = [
-            [0.28, 0.35], [0.4, 0.55], [0.55, 0.32], [0.68, 0.5], [0.5, 0.68]
+            [0.24, 0.70],
+            [0.38, 0.52],
+            [0.50, 0.34],
+            [0.64, 0.48],
+            [0.78, 0.28]
         ];
-        pts.forEach(function (p, i) {
-            const orb = addOrb(p[0] * width, p[1] * height, true);
-            orb.nextPulseTime = clock() + 1 + i * 0.6;
+        pts.forEach(function (p) {
+            addOrb(p[0] * width, p[1] * height, { silent: true });
         });
     }
 
-    // ---------- controls wiring ----------
-    const presetNameEl = document.getElementById('presetName');
-    
-    function updatePresetUI() {
-        if (presetNameEl) presetNameEl.textContent = getPreset().name;
+    function applyPreset(index, fromKey) {
+        AudioEngine.resume();
+        state.presetIndex = ((index % PRESETS.length) + PRESETS.length) % PRESETS.length;
         applyThemeVars();
         retuneAll();
-        AudioEngine.refreshDroneTuning();
-        scheduleSave();
+        AudioEngine.setReverb(getPreset().reverbMix);
+        AudioEngine.refreshDrone();
+        lastBeat = -1;
+        updateHud();
+        if (!fromKey) scheduleSave();
+        else scheduleSave();
     }
 
-    const cyclePresetBtn = document.getElementById('cyclePreset');
-    if (cyclePresetBtn) {
-        cyclePresetBtn.addEventListener('click', function () {
+    function setPlaying(on) {
+        state.playing = on;
+        const btn = document.getElementById('playPause');
+        if (!btn) return;
+        btn.setAttribute('aria-pressed', String(on));
+        btn.setAttribute('aria-label', on ? 'Pausar' : 'Tocar');
+        btn.setAttribute('title', on ? 'Pausar (Espaço)' : 'Tocar (Espaço)');
+        const pauseIcon = btn.querySelector('.icon-pause');
+        const playIcon = btn.querySelector('.icon-play');
+        if (pauseIcon) pauseIcon.hidden = !on;
+        if (playIcon) playIcon.hidden = on;
+        if (on) lastBeat = -1;
+    }
+
+    function setDrone(on) {
+        state.droneOn = on;
+        const btn = document.getElementById('droneToggle');
+        if (btn) btn.setAttribute('aria-pressed', String(on));
+        if (on) AudioEngine.startDrone();
+        else AudioEngine.stopDrone();
+    }
+
+    function setMuted(on) {
+        AudioEngine.setMute(on);
+        const btn = document.getElementById('muteBtn');
+        if (!btn) return;
+        btn.classList.toggle('muted', on);
+        const sound = btn.querySelector('.icon-sound');
+        const mute = btn.querySelector('.icon-mute');
+        if (sound) sound.hidden = on;
+        if (mute) mute.hidden = !on;
+    }
+
+    const cycleBtn = document.getElementById('cyclePreset');
+    if (cycleBtn) {
+        cycleBtn.addEventListener('click', function () {
+            applyPreset(state.presetIndex + 1);
+        });
+    }
+
+    const playBtn = document.getElementById('playPause');
+    if (playBtn) {
+        playBtn.addEventListener('click', function () {
             AudioEngine.resume();
-            state.presetIndex = (state.presetIndex + 1) % PRESETS.length;
-            updatePresetUI();
+            setPlaying(!state.playing);
         });
     }
 
@@ -700,10 +932,7 @@
     if (droneBtn) {
         droneBtn.addEventListener('click', function () {
             AudioEngine.resume();
-            state.droneOn = !state.droneOn;
-            droneBtn.setAttribute('aria-pressed', String(state.droneOn));
-            if (state.droneOn) AudioEngine.startDrone(); else AudioEngine.stopDrone();
-            scheduleSave();
+            setDrone(!state.droneOn);
         });
     }
 
@@ -719,15 +948,10 @@
     if (muteBtn) {
         muteBtn.addEventListener('click', function () {
             AudioEngine.resume();
-            const next = !AudioEngine.isMuted();
-            AudioEngine.setMute(next);
-            muteBtn.classList.toggle('muted', next);
-            const soundIcon = muteBtn.querySelector('.icon-sound');
-            const muteIcon = muteBtn.querySelector('.icon-mute');
-            if (soundIcon) soundIcon.style.display = next ? 'none' : 'block';
-            if (muteIcon) muteIcon.style.display = next ? 'block' : 'none';
+            setMuted(!AudioEngine.isMuted());
         });
     }
+
     const fullscreenBtn = document.getElementById('fullscreen');
     if (fullscreenBtn) {
         fullscreenBtn.addEventListener('click', function () {
@@ -738,28 +962,62 @@
             }
         });
         document.addEventListener('fullscreenchange', function () {
-            const enter = document.querySelector('.fullscreen-enter');
-            const exit = document.querySelector('.fullscreen-exit');
-            const active = !!document.fullscreenElement;
-            if (enter) enter.style.display = active ? 'none' : 'block';
-            if (exit) exit.style.display = active ? 'block' : 'none';
+            const on = !!document.fullscreenElement;
+            const enter = fullscreenBtn.querySelector('.fullscreen-enter');
+            const exit = fullscreenBtn.querySelector('.fullscreen-exit');
+            if (enter) enter.hidden = on;
+            if (exit) exit.hidden = !on;
         });
     }
 
-    // ---------- init ----------
+    window.addEventListener('keydown', function (e) {
+        if (e.metaKey || e.ctrlKey || e.altKey) return;
+        const tag = (e.target && e.target.tagName) || '';
+        if (tag === 'INPUT' || tag === 'TEXTAREA') return;
+        if (e.code === 'Space') {
+            e.preventDefault();
+            AudioEngine.resume();
+            setPlaying(!state.playing);
+        } else if (e.key === '1' || e.key === '2' || e.key === '3' || e.key === '4') {
+            applyPreset(Number(e.key) - 1, true);
+        } else if (e.key === 'd' || e.key === 'D') {
+            AudioEngine.resume();
+            setDrone(!state.droneOn);
+        } else if (e.key === 'c' || e.key === 'C') {
+            clearOrbs();
+            scheduleSave();
+        } else if (e.key === 'm' || e.key === 'M') {
+            AudioEngine.resume();
+            setMuted(!AudioEngine.isMuted());
+        } else if (e.key === 'f' || e.key === 'F') {
+            if (fullscreenBtn) fullscreenBtn.click();
+        } else if (e.key === 'Backspace' || e.key === 'Delete') {
+            if (orbs.length) {
+                removeOrb(orbs[orbs.length - 1]);
+                scheduleSave();
+            }
+        }
+    });
+
+    document.addEventListener('visibilitychange', function () {
+        if (document.hidden) stopLoop();
+        else startLoop();
+    });
+
+    const themeObs = new MutationObserver(function () {
+        applyThemeVars();
+    });
+    themeObs.observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme'] });
+
+    finePointer = window.matchMedia('(pointer: fine)').matches;
     applyThemeVars();
     resize();
     window.addEventListener('resize', resize);
 
-    const hadSaved = loadState();
-    if (!hadSaved) seedDefaultConstellation();
-
-    // sync initial control UI
-    if (presetNameEl) presetNameEl.textContent = getPreset().name;
-    if (droneBtn) droneBtn.setAttribute('aria-pressed', String(state.droneOn));
-    
+    if (!loadState()) seedDefault();
     applyThemeVars();
     retuneAll();
-
-    requestAnimationFrame(loop);
+    updateHud();
+    running = true;
+    raf = requestAnimationFrame(frame);
 })();

--- a/labs/pulsar/style.css
+++ b/labs/pulsar/style.css
@@ -2,55 +2,67 @@
     --p-1: #22d3ee;
     --p-2: #a855f7;
     --p-3: #f472b6;
-    --panel-bg: rgba(8, 10, 20, 0.92);
-    --panel-border: rgba(255, 255, 255, 0.08);
-    --glow-color: rgba(168, 85, 247, 0.32);
+    --panel-bg: rgba(8, 10, 20, 0.86);
+    --panel-border: rgba(255, 255, 255, 0.1);
+    --glow-color: rgba(168, 85, 247, 0.38);
     --text-primary: rgba(255, 255, 255, 0.95);
-    --text-secondary: rgba(255, 255, 255, 0.5);
+    --text-secondary: rgba(255, 255, 255, 0.52);
     --accent-gradient: linear-gradient(135deg, var(--p-1), var(--p-2));
     --bg-deep: #05060d;
+    --header-fade: linear-gradient(to bottom, rgba(5, 6, 13, 0.78), transparent);
+    --chrome: rgba(255, 255, 255, 0.1);
+    --chrome-border: rgba(255, 255, 255, 0.14);
 }
 
 [data-theme="dark"] {
     --p-1: #22d3ee;
     --p-2: #a855f7;
     --p-3: #f472b6;
-    --panel-bg: rgba(8, 10, 20, 0.92);
-    --panel-border: rgba(255, 255, 255, 0.08);
-    --glow-color: rgba(168, 85, 247, 0.32);
+    --panel-bg: rgba(8, 10, 20, 0.86);
+    --panel-border: rgba(255, 255, 255, 0.1);
+    --glow-color: rgba(168, 85, 247, 0.38);
     --text-primary: rgba(255, 255, 255, 0.95);
-    --text-secondary: rgba(255, 255, 255, 0.5);
+    --text-secondary: rgba(255, 255, 255, 0.52);
     --accent-gradient: linear-gradient(135deg, var(--p-1), var(--p-2));
     --bg-deep: #05060d;
+    --header-fade: linear-gradient(to bottom, rgba(5, 6, 13, 0.78), transparent);
+    --chrome: rgba(255, 255, 255, 0.1);
+    --chrome-border: rgba(255, 255, 255, 0.14);
 }
 
 [data-theme="light"] {
     --p-1: #0891b2;
     --p-2: #7c3aed;
     --p-3: #db2777;
-    --panel-bg: rgba(255, 255, 255, 0.92);
-    --panel-border: rgba(0, 0, 0, 0.08);
+    --panel-bg: rgba(255, 255, 255, 0.88);
+    --panel-border: rgba(15, 18, 40, 0.1);
     --glow-color: rgba(124, 58, 237, 0.28);
-    --text-primary: rgba(0, 0, 0, 0.95);
-    --text-secondary: rgba(0, 0, 0, 0.5);
+    --text-primary: rgba(12, 16, 32, 0.94);
+    --text-secondary: rgba(12, 16, 32, 0.5);
     --accent-gradient: linear-gradient(135deg, var(--p-1), var(--p-2));
-    --bg-deep: #eef1fb;
+    --bg-deep: #e7ebf8;
+    --header-fade: linear-gradient(to bottom, rgba(231, 235, 248, 0.88), transparent);
+    --chrome: rgba(255, 255, 255, 0.72);
+    --chrome-border: rgba(15, 18, 40, 0.1);
 }
 
-* {
-    margin: 0;
-    padding: 0;
-    box-sizing: border-box;
+html {
+    overflow-x: clip;
 }
 
 body {
-    font-family: 'Oxanium', -apple-system, BlinkMacSystemFont, sans-serif;
+    font-family: 'Oxanium', Outfit, -apple-system, BlinkMacSystemFont, sans-serif;
     padding: 0 !important;
     display: block !important;
     overflow: hidden;
-    width: 100vw;
+    overflow-x: clip;
+    width: 100%;
     height: 100vh;
+    height: 100dvh;
     background: var(--bg-deep);
+    color: var(--text-primary);
+    user-select: none;
+    -webkit-user-select: none;
 }
 
 .container {
@@ -62,6 +74,12 @@ body {
     padding: 0 !important;
 }
 
+.stage {
+    position: absolute;
+    inset: 0;
+    z-index: 1;
+}
+
 #canvas {
     position: absolute;
     inset: 0;
@@ -70,6 +88,7 @@ body {
     display: block;
     cursor: crosshair;
     touch-action: none;
+    z-index: 2;
 }
 
 header {
@@ -78,33 +97,36 @@ header {
     left: 0;
     right: 0;
     z-index: 20;
-    padding: max(1.1rem, env(safe-area-inset-top)) max(1.35rem, env(safe-area-inset-right)) 1.1rem max(1.35rem, env(safe-area-inset-left)) !important;
-    background: linear-gradient(to bottom, rgba(0, 0, 0, 0.7), transparent);
+    padding: max(0.85rem, env(safe-area-inset-top, 0px))
+        max(1.1rem, env(safe-area-inset-right, 0px))
+        0.85rem
+        max(1.1rem, env(safe-area-inset-left, 0px)) !important;
+    background: var(--header-fade);
     margin: 0 !important;
     display: grid !important;
-    grid-template-columns: auto 1fr auto !important;
+    grid-template-columns: auto minmax(0, 1fr) auto !important;
     align-items: center !important;
-    gap: 1rem !important;
+    gap: 0.75rem !important;
     max-width: none !important;
     width: auto !important;
+    pointer-events: none;
 }
 
-header>* {
+header > * {
     pointer-events: auto;
 }
 
 header .back-link {
-    background: rgba(255, 255, 255, 0.1);
-    border: 1px solid rgba(255, 255, 255, 0.14);
-    color: rgba(255, 255, 255, 0.85);
-    transition: all 0.2s ease;
+    background: var(--chrome);
+    border: 1px solid var(--chrome-border);
+    color: var(--text-primary);
     min-height: 44px;
     min-width: 44px;
 }
 
 header .back-link:hover {
-    background: rgba(168, 85, 247, 0.15);
-    border-color: rgba(168, 85, 247, 0.3);
+    background: color-mix(in srgb, var(--p-2) 22%, transparent);
+    border-color: color-mix(in srgb, var(--p-2) 45%, transparent);
     color: var(--p-2);
 }
 
@@ -112,277 +134,394 @@ header .app-logo {
     justify-self: center;
     display: flex;
     align-items: center;
-    gap: 0.5rem;
-    font-size: 1.4rem;
+    gap: 0.45rem;
+    font-size: clamp(1rem, 2.6vw, 1.35rem);
     font-weight: 700;
     background: var(--accent-gradient) !important;
     -webkit-background-clip: text !important;
     -webkit-text-fill-color: transparent !important;
     background-clip: text !important;
-    filter: drop-shadow(0 0 20px var(--glow-color));
+    filter: drop-shadow(0 0 18px var(--glow-color));
     letter-spacing: 0.02em;
+    max-width: min(100%, calc(100vw - 11rem));
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 header .app-logo svg {
     stroke: var(--p-1);
+    flex-shrink: 0;
     filter: drop-shadow(0 0 8px var(--p-1));
+    -webkit-text-fill-color: initial;
 }
 
 .header-actions {
     display: flex;
-    gap: 0.5rem;
+    gap: 0.45rem;
+    align-items: center;
 }
 
 .icon-btn {
-    background: rgba(255, 255, 255, 0.1);
-    border: 1px solid rgba(255, 255, 255, 0.14);
-    color: rgba(255, 255, 255, 0.85);
-    padding: 0.55rem;
-    border-radius: 10px;
+    background: var(--chrome);
+    border: 1px solid var(--chrome-border);
+    color: var(--text-primary);
+    padding: 0;
+    width: 44px;
+    height: 44px;
+    min-width: 44px;
+    min-height: 44px;
+    border-radius: 12px;
     cursor: pointer;
-    transition: all 0.2s ease;
-    display: flex;
+    transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease, transform 0.2s ease;
+    display: inline-flex;
     align-items: center;
     justify-content: center;
 }
 
 .icon-btn:hover {
-    background: rgba(168, 85, 247, 0.15);
-    border-color: rgba(168, 85, 247, 0.3);
+    background: color-mix(in srgb, var(--p-2) 22%, transparent);
+    border-color: color-mix(in srgb, var(--p-2) 45%, transparent);
     color: var(--p-2);
 }
 
 .icon-btn.muted {
     color: var(--p-3);
-    border-color: rgba(244, 114, 182, 0.35);
+    border-color: color-mix(in srgb, var(--p-3) 45%, transparent);
 }
 
-.css-bg {
+.hud {
     position: absolute;
-    inset: 0;
-    width: 100%;
-    height: 100%;
-    z-index: 1;
-    overflow: hidden;
+    top: max(4.6rem, calc(env(safe-area-inset-top, 0px) + 3.6rem));
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 12;
+    display: flex;
+    align-items: center;
+    gap: 0.55rem;
+    padding: 0.35rem 0.85rem;
+    border-radius: 999px;
+    background: var(--panel-bg);
+    border: 1px solid var(--panel-border);
+    backdrop-filter: blur(18px) saturate(160%);
+    -webkit-backdrop-filter: blur(18px) saturate(160%);
+    font-size: 0.72rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--text-secondary);
     pointer-events: none;
-    mix-blend-mode: screen;
+    white-space: nowrap;
+    max-width: calc(100% - 1.5rem);
 }
 
-[data-theme="light"] .css-bg {
-    mix-blend-mode: multiply;
+#hudPreset {
+    color: var(--p-1);
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
-.css-bg .blob {
-    position: absolute;
+.hud-dot {
+    width: 5px;
+    height: 5px;
     border-radius: 50%;
-    filter: blur(90px);
-    opacity: 0.45;
-    animation: blobFloat 20s infinite alternate ease-in-out;
-}
-
-.css-bg .blob-1 {
-    top: 10%; left: 15%;
-    width: 55vw; height: 55vw;
-    background: var(--p-1);
-    animation-delay: 0s;
-}
-
-.css-bg .blob-2 {
-    bottom: 5%; right: 10%;
-    width: 60vw; height: 60vw;
     background: var(--p-2);
-    animation-delay: -5s;
-    animation-duration: 25s;
+    box-shadow: 0 0 8px var(--p-2);
+    flex-shrink: 0;
 }
 
-.css-bg .blob-3 {
-    top: 35%; left: 45%;
-    width: 45vw; height: 45vw;
-    background: var(--p-3);
-    animation-delay: -10s;
-    animation-duration: 22s;
-}
-
-@keyframes blobFloat {
-    0% { transform: translate(0, 0) scale(1); }
-    50% { transform: translate(5vw, 10vh) scale(1.1); }
-    100% { transform: translate(-8vw, -5vh) scale(0.95); }
-}
-
-#canvas {
-    z-index: 2;
+#hudMeta {
+    font-variant-numeric: tabular-nums;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .floating-toolbar {
     position: fixed;
-    bottom: 32px;
+    bottom: max(1.25rem, calc(env(safe-area-inset-bottom, 0px) + 0.75rem));
     left: 50%;
     transform: translateX(-50%);
     z-index: 15;
     background: var(--panel-bg);
     backdrop-filter: blur(24px) saturate(180%);
     -webkit-backdrop-filter: blur(24px) saturate(180%);
-    border: 1px solid rgba(255, 255, 255, 0.12);
-    padding: 8px 12px;
+    border: 1px solid var(--panel-border);
+    padding: 8px 10px;
     border-radius: 999px;
     display: flex;
     align-items: center;
-    gap: 8px;
-    box-shadow: 0 16px 40px rgba(0, 0, 0, 0.4), inset 0 1px 0 rgba(255, 255, 255, 0.2), 0 0 20px var(--glow-color);
-    animation: toolbarEnter 0.6s cubic-bezier(0.16, 1, 0.3, 1) backwards;
-    animation-delay: 0.2s;
-}
-
-@keyframes toolbarEnter {
-    from { opacity: 0; transform: translate(-50%, 40px) scale(0.9); }
-    to { opacity: 1; transform: translate(-50%, 0) scale(1); }
+    gap: 6px;
+    max-width: calc(100% - 1.5rem);
+    box-shadow: 0 16px 40px rgba(0, 0, 0, 0.28), 0 0 24px var(--glow-color);
 }
 
 .tool-btn {
     background: transparent;
     border: none;
     color: var(--text-secondary);
-    padding: 10px;
+    width: 44px;
+    height: 44px;
+    min-width: 44px;
+    min-height: 44px;
+    padding: 0;
     border-radius: 50%;
     cursor: pointer;
-    transition: all 0.3s cubic-bezier(0.16, 1, 0.3, 1);
-    display: flex;
+    transition: color 0.2s ease, background 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+    display: inline-flex;
     align-items: center;
     justify-content: center;
     gap: 8px;
-    position: relative;
-    overflow: hidden;
-}
-
-.tool-btn::after {
-    content: '';
-    position: absolute;
-    inset: 0;
-    background: var(--accent-gradient);
-    opacity: 0;
-    transition: opacity 0.3s ease;
-    z-index: -1;
-    border-radius: inherit;
 }
 
 .tool-btn:hover {
     color: var(--text-primary);
-    transform: translateY(-2px);
-}
-
-.tool-btn:hover::after {
-    opacity: 0.15;
+    background: color-mix(in srgb, var(--p-1) 14%, transparent);
+    transform: translateY(-1px);
 }
 
 .tool-btn[aria-pressed="true"] {
     color: #fff;
-    box-shadow: 0 4px 12px var(--glow-color);
+    background: var(--accent-gradient);
+    box-shadow: 0 4px 14px var(--glow-color);
 }
 
-.tool-btn[aria-pressed="true"]::after {
-    opacity: 1;
+[data-theme="light"] .tool-btn[aria-pressed="true"] {
+    color: #fff;
 }
 
 .tool-btn svg {
     display: block;
     width: 20px;
     height: 20px;
+    flex-shrink: 0;
 }
 
-.tool-btn .preset-name {
-    font-family: 'Oxanium', sans-serif;
-    font-size: 0.85rem;
-    font-weight: 700;
-    padding-right: 6px;
-    letter-spacing: 0.5px;
+.tool-btn svg[hidden],
+.icon-btn svg[hidden] {
+    display: none !important;
 }
 
-#cyclePreset {
+.preset-btn {
+    width: auto;
     border-radius: 999px;
-    padding: 10px 18px 10px 14px;
+    padding: 0 16px 0 12px;
     color: var(--p-1);
-    background: rgba(255, 255, 255, 0.05);
-    border: 1px solid rgba(255, 255, 255, 0.08);
+    background: color-mix(in srgb, var(--p-1) 10%, transparent);
+    border: 1px solid color-mix(in srgb, var(--p-1) 22%, transparent);
 }
 
-#cyclePreset:hover {
-    border-color: rgba(255, 255, 255, 0.2);
+.preset-btn:hover {
+    border-color: color-mix(in srgb, var(--p-1) 45%, transparent);
     box-shadow: 0 4px 16px var(--glow-color);
+}
+
+.preset-name {
+    font-size: 0.82rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    max-width: 7.5rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .divider {
     width: 1px;
-    height: 24px;
+    height: 22px;
     background: var(--panel-border);
-    margin: 0 4px;
+    margin: 0 2px;
+    flex-shrink: 0;
 }
 
 .instructions {
     position: absolute;
-    top: 50%;
+    top: 46%;
     left: 50%;
     transform: translate(-50%, -50%);
     text-align: center;
     pointer-events: none;
     z-index: 5;
-    animation: instructionsFade 6s forwards;
-    padding: 0 24px;
+    animation: instructionsFade 7s forwards;
+    padding: 0 1.25rem;
+    max-width: min(34rem, calc(100% - 2rem));
 }
 
 .instructions p {
-    font-size: 1.1rem;
+    font-size: clamp(0.92rem, 2.6vw, 1.12rem);
     color: var(--text-primary);
-    opacity: 0.85;
-    text-shadow: 0 0 30px var(--glow-color);
-    letter-spacing: 0.04em;
+    text-shadow: 0 0 28px var(--glow-color);
+    letter-spacing: 0.02em;
     font-weight: 600;
 }
 
 .instructions p.sub {
-    margin-top: 8px;
-    font-size: 0.85rem;
+    margin-top: 0.45rem;
+    font-size: 0.82rem;
     font-weight: 500;
     color: var(--text-secondary);
+    text-shadow: none;
+}
+
+kbd {
+    display: inline-block;
+    padding: 0.05rem 0.35rem;
+    border-radius: 5px;
+    border: 1px solid var(--panel-border);
+    background: var(--panel-bg);
+    font-family: inherit;
+    font-size: 0.72em;
+    font-weight: 700;
 }
 
 @keyframes instructionsFade {
-    0%, 70% { opacity: 1; transform: translate(-50%, -50%) scale(1); }
-    100% { opacity: 0; transform: translate(-50%, -60%) scale(0.95); visibility: hidden; }
+    0%, 72% { opacity: 1; }
+    100% { opacity: 0; visibility: hidden; }
 }
 
 footer {
     position: absolute;
-    bottom: 24px;
-    left: 50%;
-    transform: translateX(-50%);
+    left: max(1rem, env(safe-area-inset-left, 0px));
+    bottom: max(1rem, env(safe-area-inset-bottom, 0px));
+    z-index: 8;
+    margin: 0 !important;
+    padding: 0 !important;
+    width: auto !important;
+    max-width: none !important;
+    border: none !important;
+    font-size: 0.68rem;
     color: var(--text-secondary);
-    font-size: 0.7rem;
-    z-index: 5;
-    display: none; /* Hide footer to keep it fully minimal, or move it elsewhere if needed */
 }
 
 @media (max-width: 768px) {
-    header .app-logo { font-size: 1.2rem; }
-    .instructions { top: 38%; }
-    .instructions p { font-size: 0.95rem; }
-    .floating-toolbar { bottom: 24px; padding: 6px 10px; gap: 6px; }
-    .tool-btn { padding: 8px; }
-    #cyclePreset { padding: 8px 14px 8px 10px; }
-    .tool-btn .preset-name { font-size: 0.75rem; }
+    header .app-logo {
+        font-size: 1.05rem;
+    }
+
+    .hud {
+        top: max(4.15rem, calc(env(safe-area-inset-top, 0px) + 3.25rem));
+        font-size: 0.64rem;
+        gap: 0.4rem;
+        padding: 0.3rem 0.7rem;
+    }
+
+    .instructions {
+        top: 40%;
+    }
+
+    .preset-name {
+        font-size: 0.75rem;
+        max-width: 5.5rem;
+    }
+
+    footer {
+        display: none;
+    }
 }
 
 @media (max-width: 420px) {
-    header { padding: max(1rem, env(safe-area-inset-top)) max(1rem, env(safe-area-inset-right)) 1rem max(1rem, env(safe-area-inset-left)) !important; }
-    header .app-logo { font-size: 1rem; }
-    .floating-toolbar { bottom: 20px; width: calc(100% - 32px); justify-content: space-between; }
-    .tool-btn .preset-name { max-width: 80px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-}
-/* --- lab-responsive-pass --- */
-@media (max-width: 768px) {
-    .floating-toolbar {
-        bottom: max(24px, calc(env(safe-area-inset-bottom, 0px) + 12px));
-        max-width: calc(100% - 1.5rem);
+    header {
+        padding: max(0.7rem, env(safe-area-inset-top, 0px))
+            max(0.55rem, env(safe-area-inset-right, 0px))
+            0.7rem
+            max(0.55rem, env(safe-area-inset-left, 0px)) !important;
+        gap: 0.35rem !important;
     }
+
+    header .app-logo {
+        font-size: 0.95rem;
+        gap: 0.3rem;
+    }
+
+    .header-actions {
+        gap: 0.25rem;
+    }
+
+    .icon-btn {
+        width: 40px;
+        height: 40px;
+        min-width: 40px;
+        min-height: 40px;
+        border-radius: 10px;
+    }
+
+    header .theme-toggle {
+        width: 48px;
+        min-width: 48px;
+        height: 28px;
+    }
+
+    header .theme-toggle-thumb {
+        width: 22px;
+        height: 22px;
+    }
+
+    [data-theme="dark"] header .theme-toggle-thumb {
+        transform: translateX(20px);
+    }
+
+    #fullscreen {
+        display: none;
+    }
+
+    .floating-toolbar {
+        width: calc(100% - 1.25rem);
+        justify-content: space-between;
+        padding: 6px 8px;
+    }
+}
+
+@media (max-height: 520px) and (orientation: landscape) {
+    header {
+        padding: max(0.4rem, env(safe-area-inset-top, 0px))
+            max(0.8rem, env(safe-area-inset-right, 0px))
+            0.4rem
+            max(0.8rem, env(safe-area-inset-left, 0px)) !important;
+    }
+
+    header .app-logo {
+        font-size: 0.95rem;
+    }
+
+    .hud {
+        display: none;
+    }
+
+    .floating-toolbar {
+        bottom: max(0.5rem, env(safe-area-inset-bottom, 0px));
+        padding: 4px 8px;
+        gap: 4px;
+    }
+
+    .preset-name {
+        display: inline;
+        max-width: 5.5rem;
+    }
+
     .tool-btn,
-    #cyclePreset { min-height: 44px; min-width: 44px; padding: 12px; }
+    .icon-btn {
+        width: 40px;
+        height: 40px;
+        min-width: 40px;
+        min-height: 40px;
+    }
+
+    .instructions {
+        display: none;
+    }
+
+    footer {
+        display: none;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .instructions {
+        animation: none;
+        opacity: 0.85;
+    }
+
+    .tool-btn,
+    .icon-btn,
+    header .back-link {
+        transition: none;
+    }
 }


### PR DESCRIPTION
## 🎯 Objetivo

O Pulsar estava estranho: orbes disparando em intervalos aleatórios, canvas borrado, tema claro lavado e pouca leitura de que o espaço *é* a música. Esta PR reescreve o lab como constelação no tempo — ainda o mesmo slug, agora com groove.

## ✨ O que mudou

- Relógio musical compartilhado (BPM do preset): altura = nota, X = fase no compasso, terço vertical = período 2/4/8 beats
- Canvas em DPR (teto 2×), starfield de verdade, nebulosa no canvas (sem blobs CSS pesados) e orbes com glow em vez de bolinha de borda branca
- Primeiro toque já soa; ecos entre vizinhos quantizados em ½ beat, com teto de vozes
- Tema escuro de primeira pintura; claro deixa de parecer página em branco; HUD com BPM e contagem
- Pause, atalhos (1–4, Espaço, D, C, M) e layout que cabe em 375px / landscape curto
- Copy da galeria e do README alinhada ao instrumento novo (slug e sitemap intactos)

## 🧪 Como testar

1. Na raiz do repo: `python3 -m http.server 8000`
2. Abrir [http://localhost:8000/](http://localhost:8000/) (home) e [http://localhost:8000/labs/](http://localhost:8000/labs/) (galeria)
3. Abrir [http://localhost:8000/labs/pulsar/](http://localhost:8000/labs/pulsar/) — a constelação padrão deve pulsar no tempo; toque para plantar, arraste para afinar, toque duplo para apagar
4. Clicar na tela uma vez para o áudio (gesture do browser); ciclar Nebula/Aurora/Sunset/Deep; drone; mute; pause
5. Responsivo: DevTools em **375×667**, **390×844** e landscape curto (~667×375) — sem overflow horizontal, HUD/controles utilizáveis, alvos ≥ 44px
6. Conferir pasta ↔ card da galeria ↔ README ↔ `sitemap.xml` ↔ canonical/OG (slug `pulsar` inalterado)

## ✅ Checklist

- [x] Links conferidos: pasta do lab ↔ card da galeria ↔ README ↔ sitemap (e corrigidos se quebravam)
- [x] README atualizado (linha na tabela + URL + contagem no badge/texto) — obrigatório em lab novo, renomeado ou removido
- [x] SEO consistente: title, description, canonical, author, robots, OG, Twitter, JSON-LD (e contagem nos metas da galeria)
- [x] Testado via HTTP na raiz, não via `file://`
- [x] Responsivo: 375px / 390px / landscape — overflow, HUD, toque, safe-area (`viewport-fit=cover`)
- [x] Nada fora do escopo foi quebrado


Made with [Cursor](https://cursor.com)