### PR TITLE
🐛 fix: corrige proporções e UI de O Último Bastião

### DIFF
--- a/labs/ultimo-bastiao/ASSETS.md
+++ b/labs/ultimo-bastiao/ASSETS.md
@@ -2,7 +2,7 @@
 
 ## Personagem
 
-- `HVGirl.glb`: Personagem carregada do repositório oficial de modelos do [Babylon.js](https://models.babylonjs.com/), substituindo os formatos geométricos anteriores para otimização e realismo.
+- `KnightCharacter.gltf` e `KnightCharacter.bin`: Knight Character carregado em tempo de execução do repositório [three.js](https://github.com/mrdoob/three.js/tree/master/manual/examples/resources/models/knight), distribuído com o projeto sob licença MIT.
 
 ## Poly Haven — CC0
 

--- a/labs/ultimo-bastiao/index.html
+++ b/labs/ultimo-bastiao/index.html
@@ -27,7 +27,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="preconnect" href="https://cdn.babylonjs.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;600;700;800&family=Manrope:wght@400;500;600;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="style.css?v=1">
+  <link rel="stylesheet" href="style.css?v=2">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -203,7 +203,7 @@
 
   <script src="https://cdn.babylonjs.com/babylon.js"></script>
   <script src="https://cdn.babylonjs.com/loaders/babylonjs.loaders.min.js"></script>
-  <script type="module" src="src/game.js?v=2"></script>
+  <script type="module" src="src/game.js?v=3"></script>
 </body>
 
 </html>

--- a/labs/ultimo-bastiao/src/characters.js
+++ b/labs/ultimo-bastiao/src/characters.js
@@ -5,14 +5,44 @@ const damp = (current, target, smoothing, dt) => B.Scalar.Lerp(current, target, 
 
 let knightContainer = null;
 let instanceId = 0;
+let textureCache = null;
 
-const CHARACTER_ROOT = 'https://models.babylonjs.com/';
+const CHARACTER_ROOT = 'https://raw.githubusercontent.com/mrdoob/three.js/master/manual/examples/resources/models/knight/';
+const CHARACTER_TEXTURES = {
+  armor: 'https://dl.polyhaven.org/file/ph-assets/Textures/jpg/1k/metal_plate/metal_plate_diff_1k.jpg',
+  armorNormal: 'https://dl.polyhaven.org/file/ph-assets/Textures/jpg/1k/metal_plate/metal_plate_nor_gl_1k.jpg',
+  armorRoughness: 'https://dl.polyhaven.org/file/ph-assets/Textures/jpg/1k/metal_plate/metal_plate_rough_1k.jpg',
+  leather: 'https://dl.polyhaven.org/file/ph-assets/Textures/jpg/1k/brown_leather/brown_leather_albedo_1k.jpg',
+  leatherNormal: 'https://dl.polyhaven.org/file/ph-assets/Textures/jpg/1k/brown_leather/brown_leather_nor_gl_1k.jpg',
+  leatherRoughness: 'https://dl.polyhaven.org/file/ph-assets/Textures/jpg/1k/brown_leather/brown_leather_rough_1k.jpg'
+};
+
+function characterTextures(scene) {
+  if (textureCache) return textureCache;
+  const load = (path, gammaSpace = true) => {
+    const image = new B.Texture(path, scene, true, false, B.Texture.TRILINEAR_SAMPLINGMODE);
+    image.wrapU = B.Texture.WRAP_ADDRESSMODE;
+    image.wrapV = B.Texture.WRAP_ADDRESSMODE;
+    image.uScale = image.vScale = 3.4;
+    image.gammaSpace = gammaSpace;
+    return image;
+  };
+  textureCache = {
+    armor: load(CHARACTER_TEXTURES.armor),
+    armorNormal: load(CHARACTER_TEXTURES.armorNormal, false),
+    armorRoughness: load(CHARACTER_TEXTURES.armorRoughness, false),
+    leather: load(CHARACTER_TEXTURES.leather),
+    leatherNormal: load(CHARACTER_TEXTURES.leatherNormal, false),
+    leatherRoughness: load(CHARACTER_TEXTURES.leatherRoughness, false)
+  };
+  return textureCache;
+}
 
 /** Carrega uma única malha humana esquelética; cada combatente recebe sua própria instância e animações. */
 export async function loadCharacterAssets(scene, onProgress) {
   knightContainer = await B.SceneLoader.LoadAssetContainerAsync(
     CHARACTER_ROOT,
-    'HVGirl.glb',
+    'KnightCharacter.gltf',
     scene,
     event => {
       if (!event.lengthComputable || !onProgress) return;
@@ -22,29 +52,53 @@ export async function loadCharacterAssets(scene, onProgress) {
   knightContainer.animationGroups.forEach(group => group.stop());
 }
 
-function tuneMaterial(material, enemy, boss, kind) {
+function tuneMaterial(material, enemy, boss, kind, textures) {
   if (!material) return;
   if (material.subMaterials) {
-    material.subMaterials.forEach(subMaterial => tuneMaterial(subMaterial, enemy, boss, kind));
+    material.subMaterials.forEach(subMaterial => tuneMaterial(subMaterial, enemy, boss, kind, textures));
     return;
   }
-  
-  // Apenas ajustamos cores simples para otimização extrema e identificação
-  if (material.albedoColor) {
-    if (boss) {
-      material.albedoColor = new B.Color3(0.8, 0.1, 0.1);
-      material.emissiveColor = new B.Color3(0.2, 0.0, 0.0);
-    } else if (enemy) {
-      material.albedoColor = new B.Color3(0.2, 0.2, 0.25);
-    } else {
-      material.albedoColor = new B.Color3(0.1, 0.3, 0.8);
+
+  const name = material.name.toLowerCase();
+  if (name.includes('armor')) {
+    material.albedoColor = boss
+      ? new B.Color3(.23, .13, .065)
+      : enemy ? new B.Color3(.055, .06, .065) : new B.Color3(.27, .30, .31);
+    material.metallic = boss ? .82 : .94;
+    material.roughness = boss ? .31 : enemy ? .42 : .27;
+    material.environmentIntensity = 1.05;
+    material.albedoTexture = textures.armor;
+    material.bumpTexture = textures.armorNormal;
+    material.bumpTexture.level = .22;
+    material.metallicTexture = textures.armorRoughness;
+    material.useRoughnessFromMetallicTextureAlpha = false;
+    material.useRoughnessFromMetallicTextureGreen = true;
+    material.useMetallnessFromMetallicTextureBlue = false;
+    if (material.clearCoat) {
+      material.clearCoat.isEnabled = true;
+      material.clearCoat.intensity = enemy ? .18 : .34;
+      material.clearCoat.roughness = enemy ? .52 : .35;
     }
+  } else if (name.includes('skin')) {
+    material.albedoColor = enemy ? new B.Color3(.34, .22, .16) : new B.Color3(.55, .34, .23);
+    material.metallic = 0;
+    material.roughness = .76;
+    if (material.subSurface) {
+      material.subSurface.isTranslucencyEnabled = true;
+      material.subSurface.translucencyIntensity = .12;
+    }
+  } else if (name.includes('boot')) {
+    material.albedoColor = kind === 'player' ? new B.Color3(.095, .047, .025) : new B.Color3(.045, .028, .019);
+    material.metallic = .02;
+    material.roughness = .9;
+    material.albedoTexture = textures.leather;
+    material.bumpTexture = textures.leatherNormal;
+    material.bumpTexture.level = .32;
+    material.metallicTexture = textures.leatherRoughness;
+    material.useRoughnessFromMetallicTextureAlpha = false;
+    material.useRoughnessFromMetallicTextureGreen = true;
+    material.useMetallnessFromMetallicTextureBlue = false;
   }
-  
-  // Simplificação do PBR
-  material.metallic = 0.1;
-  material.roughness = 0.8;
-  material.environmentIntensity = 0.5;
 }
 
 function findAnimation(groups, names) {
@@ -60,11 +114,11 @@ function buildAnimationSet(groups) {
     group.blendingSpeed = .08;
   });
   return {
-    idle: findAnimation(groups, ['Idle']),
-    run: findAnimation(groups, ['Walking']),
-    attack: findAnimation(groups, ['Samba']),
-    block: findAnimation(groups, ['Idle']),
-    dodge: findAnimation(groups, ['WalkingBack'])
+    idle: findAnimation(groups, ['Idle_swordLeft', 'Idle']),
+    run: findAnimation(groups, ['Run_swordRight', 'Run']),
+    attack: findAnimation(groups, ['Run_swordAttack', 'Attack']),
+    block: findAnimation(groups, ['Idle_swordLeft', 'Idle']),
+    dodge: findAnimation(groups, ['Roll_sword', 'Roll'])
   };
 }
 
@@ -75,14 +129,13 @@ function startAction(rig, action) {
   const group = rig.animations[action];
   if (!group) return;
   const loop = action === 'idle' || action === 'run' || action === 'block';
-  // Acelera a animação de Samba para parecer um golpe rápido e fluído
-  const speed = action === 'run' ? 1.5 : action === 'attack' ? 3.0 : action === 'dodge' ? 2.5 : 1.0;
+  const speed = action === 'run' ? 1.08 : action === 'attack' ? 1.25 : action === 'dodge' ? 1.16 : .88;
   group.start(loop, speed, group.from, group.to, false);
 }
 
-/** Cria um lutador esquelético completo. */
+/** Cria um cavaleiro esquelético completo, em vez de montar um corpo com formas geométricas. */
 export function createKnight(scene, world, options = {}) {
-  if (!knightContainer) throw new Error('O modelo realista não foi carregado.');
+  if (!knightContainer) throw new Error('O modelo realista do cavaleiro não foi carregado.');
 
   const enemy = Boolean(options.enemy);
   const kind = options.kind || (enemy ? 'raider' : 'player');
@@ -107,7 +160,8 @@ export function createKnight(scene, world, options = {}) {
     world.addShadow(mesh);
     if (mesh.material) materials.add(mesh.material);
   });
-  materials.forEach(material => tuneMaterial(material, enemy, boss, kind));
+  const textures = characterTextures(scene);
+  materials.forEach(material => tuneMaterial(material, enemy, boss, kind, textures));
 
   const rig = {
     root,

--- a/labs/ultimo-bastiao/style.css
+++ b/labs/ultimo-bastiao/style.css
@@ -153,7 +153,7 @@ kbd { display: inline-block; min-width: 26px; margin-right: 5px; padding: 4px 6p
   .portrait { width: 36px; height: 36px; font-size: 16px; }
   .bars { gap: 6px; }
   .bar-line { grid-template-columns: 42px 1fr 22px; gap: 5px; font-size: 7px; }
-  .battle-status { top: auto; bottom: max(14px, calc(env(safe-area-inset-bottom) + 8px)); min-width: 155px; padding: 8px 13px; }
+  .battle-status { top: auto; bottom: max(190px, calc(env(safe-area-inset-bottom) + 180px)); min-width: 155px; padding: 8px 13px; }
   .battle-status strong { font-size: 10px; }
   .battle-status > span:last-child { font-size: 8px; }
   .combo { top: max(60px, calc(env(safe-area-inset-top) + 50px)); right: max(10px, env(safe-area-inset-right)); padding: 7px 9px; }
@@ -180,7 +180,7 @@ kbd { display: inline-block; min-width: 26px; margin-right: 5px; padding: 4px 6p
   .vitals { top: max(46px, calc(env(safe-area-inset-top) + 40px)); left: max(10px, env(safe-area-inset-left)); width: 245px; padding-block: 6px; }
   .portrait { width: 32px; height: 32px; }
   .combo { top: max(46px, calc(env(safe-area-inset-top) + 40px)); }
-  .battle-status { bottom: max(5px, env(safe-area-inset-bottom)); padding: 5px 11px; }
+  .battle-status { top: max(46px, calc(env(safe-area-inset-top) + 40px)); bottom: auto; min-width: 150px; padding: 5px 14px; }
   .move-stick { width: 96px; height: 96px; bottom: max(8px, env(safe-area-inset-bottom)); }
   .move-stick i { width: 42px; height: 42px; }
   .combat-buttons { width: 176px; height: 124px; bottom: max(6px, env(safe-area-inset-bottom)); }


### PR DESCRIPTION
## 🎯 Objetivo

Corrigir as proporções quebradas e a UI estranha reportadas em `/labs/ultimo-bastiao/`.

## ✨ O que mudou

- **Personagem restaurado.** O commit de perf mais recente (`⚡️ Otimizar personagem...`) trocou o modelo `KnightCharacter.gltf` (cavaleiro com armadura, calibrado com a escala do mundo, distância de câmera e alcance de ataque) pelo `HVGirl.glb` — um modelo de dança do Mixamo, sem armadura, reaproveitando a animação **"Samba"** como golpe de espada e **"WalkingBack"** como rolamento de esquiva. O resultado era uma personagem fora de tema e de proporção com o castelo/HUD ao redor. Revertido para o cavaleiro original (`labs/ultimo-bastiao/src/characters.js`, `ASSETS.md`), que já tinha materiais de armadura/couro e animações de combate corretas (`Idle_swordLeft`, `Run_swordAttack`, `Roll_sword`).
- **HUD sobreposto aos controles de toque.** Em telas estreitas (`≤768px`) o painel de onda/objetivo ("ONDA I · Segure o pátio") ficava ancorado no rodapé central e sobrepunha os botões de ataque/esquiva/defesa, tornando ambos parcialmente ilegíveis e intocáveis. Corrigido para ficar acima da faixa de controles. Em landscape curto o mesmo painel também colidia com o botão de esquiva; passou a ocupar a linha superior (onde o título da marca já é ocultado), alinhado com vida/abates — espelhando o layout do desktop.
- Bump de cache-busting em `style.css` e `src/game.js`.

## 🧪 Como testar

1. Na raiz do repo: `python3 -m http.server 8000`
2. Abrir `http://localhost:8000/labs/ultimo-bastiao/`
3. Responsivo: DevTools em **375×667**, **390×844** e landscape curto (~667×375) — o painel "ONDA I" não deve mais cobrir os botões de ataque/esquiva/defesa
4. Iniciar uma batalha e conferir que o cavaleiro aparece com armadura (não a personagem de dança) e que o golpe de espada não usa mais a animação de samba

**Nota de ambiente:** este sandbox bloqueia por política de proxy os hosts externos usados pelo jogo (`cdn.babylonjs.com`, `models.babylonjs.com` via `raw.githubusercontent.com`, `dl.polyhaven.org`), então não consegui renderizar a cena 3D aqui para tirar print do resultado final. A correção do modelo foi validada por arqueologia do git (comparando com a versão anterior ao commit que trocou o personagem, que funcionava) e a correção do HUD foi validada com screenshots reais via Playwright forçando os overlays a aparecer sem depender do carregamento do WebGL. Vale um teste manual no ambiente real antes de mergear.

## ✅ Checklist

- [x] Links conferidos: pasta do lab ↔ card da galeria ↔ README ↔ sitemap (nada mudou de slug, não se aplica)
- [x] README atualizado — não se aplica (nenhum lab novo, renomeado ou removido)
- [x] SEO consistente — não alterado, nenhuma mudança de título/slug
- [x] Testado via HTTP na raiz, não via `file://`
- [x] Responsivo: 375px / 390px / landscape — overflow, HUD, toque, safe-area (validado via screenshot; overflow horizontal = 0px nos quatro viewports)
- [x] Nada fora do escopo foi quebrado


---
_Generated by [Claude Code](https://claude.ai/code/session_013JxvDuovjtdhbmmG3fp8hc)_