### PR TITLE
🐛 Corrige proporções, iluminação e o giro do tabuleiro no lab Xadrez

### DIFF
--- a/labs/xadrez/src/main.js
+++ b/labs/xadrez/src/main.js
@@ -9,7 +9,7 @@ import { LESSONS, PUZZLES, commentOnMove, loadProgress, saveProgress } from './c
 import { createTextures } from './textures.js';
 import { PieceFactory } from './pieces.js';
 import {
-    buildWorld, setupLights, setupPostProcess, squareToWorld, worldToSquare, placeMark
+    buildWorld, setupLights, setupEnvironment, setupPostProcess, squareToWorld, worldToSquare, placeMark
 } from './world.js';
 import { SalonAudio } from './audio.js';
 
@@ -182,12 +182,15 @@ class Atelier {
 
         this.quality = pickQuality(this.settings.quality);
 
-        // Câmera orbital elegante
-        this.camera = new BABYLON.ArcRotateCamera('camera', -Math.PI / 2, Math.PI / 3.4, 13.5, new BABYLON.Vector3(0, 0.3, 0), this.scene);
-        this.camera.lowerRadiusLimit = 6;
-        this.camera.upperRadiusLimit = 20;
-        this.camera.lowerBetaLimit = 0.25;
-        this.camera.upperBetaLimit = Math.PI / 2.2;
+        // Câmera orbital elegante. Radius maior + FOV mais fechado do que o
+        // padrão do Babylon (0.8) achatam a perspectiva: sem isso, a casa mais
+        // próxima da câmera aparecia enorme e a última fileira, minúscula.
+        this.camera = new BABYLON.ArcRotateCamera('camera', -Math.PI / 2, Math.PI / 3.9, 16.5, new BABYLON.Vector3(0, 0.35, 0), this.scene);
+        this.camera.fov = 0.62;
+        this.camera.lowerRadiusLimit = 9;
+        this.camera.upperRadiusLimit = 24;
+        this.camera.lowerBetaLimit = 0.35;
+        this.camera.upperBetaLimit = Math.PI / 2.4;
         this.camera.wheelDeltaPercentage = 0.015;
         this.camera.pinchDeltaPercentage = 0.015;
         this.camera.inertia = 0.85;
@@ -197,11 +200,13 @@ class Atelier {
             this.camera.autoRotationBehavior.idleRotationWaitTime = 2000;
         }
         this.camera.attachControl(this.canvas, true);
+        this.fitCameraFov();
 
         this.setLoad(0.2, 'Talhando o marfim em Babylon.js…');
         const tex = createTextures(this.scene);
 
         this.setLoad(0.45, 'Montando o atelier…');
+        setupEnvironment(BABYLON, this.scene);
         this.world = buildWorld(BABYLON, this.scene, tex, this.quality);
         this.lights = setupLights(BABYLON, this.scene, this.quality);
         this.postProcess = setupPostProcess(BABYLON, this.scene, this.quality);
@@ -226,8 +231,25 @@ class Atelier {
             this.scene.render();
         });
 
-        window.addEventListener('resize', () => this.engine.resize());
-        window.visualViewport?.addEventListener('resize', () => this.engine.resize());
+        window.addEventListener('resize', () => {
+            this.engine.resize();
+            this.fitCameraFov();
+        });
+        window.visualViewport?.addEventListener('resize', () => {
+            this.engine.resize();
+            this.fitCameraFov();
+        });
+    }
+
+    // Em telas estreitas (retrato), FOV vertical fixo faz o campo de visão
+    // horizontal encolher com o aspect ratio e corta as laterais do tabuleiro.
+    // Travar o FOV horizontal garante a largura do tabuleiro em qualquer tela.
+    fitCameraFov() {
+        if (!this.camera || !this.engine) return;
+        const aspect = this.engine.getRenderWidth() / this.engine.getRenderHeight();
+        this.camera.fovMode = aspect < 1
+            ? window.BABYLON.Camera.FOVMODE_HORIZONTAL_FIXED
+            : window.BABYLON.Camera.FOVMODE_VERTICAL_FIXED;
     }
 
     start() {
@@ -251,6 +273,7 @@ class Atelier {
             this.camera.autoRotationBehavior.idleRotationSpeed = 0;
         }
         this.engine.resize();
+        this.fitCameraFov();
         const mode = document.getElementById('modeSelect')?.value || 'cpu';
         this.setMode(mode);
     }
@@ -374,7 +397,7 @@ class Atelier {
             if (!p) continue;
             const mesh = this.factory.spawn(p.t, p.c);
             if (mesh) {
-                const pos = squareToWorld(i, this.flip);
+                const pos = squareToWorld(i);
                 mesh.position.set(pos.x, 0.07, pos.z);
                 mesh.metadata = { kind: p.t, color: p.c, index: i };
                 if (this.lights?.shadowGen) {
@@ -478,7 +501,7 @@ class Atelier {
         const hit = ray.intersectsPlane(new window.BABYLON.Plane(0, 1, 0, 0));
         if (hit !== null && hit !== undefined) {
             const pt = ray.origin.add(ray.direction.scale(hit));
-            return worldToSquare(pt.x, pt.z, this.flip);
+            return worldToSquare(pt.x, pt.z);
         }
         return -1;
     }
@@ -597,8 +620,8 @@ class Atelier {
     }
 
     hop(mesh, from, to) {
-        const a = squareToWorld(from, this.flip);
-        const b = squareToWorld(to, this.flip);
+        const a = squareToWorld(from);
+        const b = squareToWorld(to);
         const dist = Math.hypot(b.x - a.x, b.z - a.z);
         const h = mesh.metadata?.kind === 'n' ? Math.max(0.6, dist * 0.2) : Math.min(1.2, Math.max(0.2, dist * 0.15));
         return this.tween(0.38, (t) => {
@@ -696,7 +719,7 @@ class Atelier {
         this.selected = mv.from;
         this.legal = this.game.legalMovesFrom(mv.from);
         this.refreshMarks();
-        placeMark(this.world.marks.hint, mv.to, this.flip);
+        placeMark(this.world.marks.hint, mv.to);
         const p = this.game.board[mv.from];
         this.coach('Dica', `Considere ${this.game.san(mv)}. ${p ? PIECE_HOW[p.t] : ''}`, 'Toque a peça destacada e a casa verde.');
     }
@@ -708,7 +731,7 @@ class Atelier {
         this.selected = from;
         this.legal = this.game.legalMovesFrom(from);
         this.refreshMarks();
-        placeMark(this.world.marks.hint, to, this.flip);
+        placeMark(this.world.marks.hint, to);
     }
 
     undo() {
@@ -726,10 +749,17 @@ class Atelier {
     }
 
     toggleFlip() {
+        // O tabuleiro e as peças ficam parados — só a câmera anda até o outro
+        // lado da mesa, como alguém dando a volta para ver da perspectiva das
+        // pretas. Gira sempre por um delta relativo (nunca um alvo absoluto),
+        // senão o sentido do giro depende de onde a órbita livre deixou a
+        // câmera e o resultado parece errático.
         this.flip = !this.flip;
-        this.rebuildPieces();
-        const targetAlpha = this.flip ? Math.PI / 2 : -Math.PI / 2;
-        window.BABYLON.Animation.CreateAndStartAnimation('flipCam', this.camera, 'alpha', 60, 30, this.camera.alpha, targetAlpha, window.BABYLON.Animation.ANIMATIONLOOPMODE_CONSTANT);
+        const targetAlpha = this.camera.alpha + Math.PI;
+        window.BABYLON.Animation.CreateAndStartAnimation(
+            'flipCam', this.camera, 'alpha', 60, 36,
+            this.camera.alpha, targetAlpha, window.BABYLON.Animation.ANIMATIONLOOPMODE_CONSTANT
+        );
     }
 
     fresh() {
@@ -769,24 +799,24 @@ class Atelier {
     refreshMarks() {
         this.clearMarks();
         const m = this.world.marks;
-        if (this.selected >= 0) placeMark(m.select, this.selected, this.flip);
+        if (this.selected >= 0) placeMark(m.select, this.selected);
         let di = 0;
         let ci = 0;
         for (const mv of this.legal) {
             if (mv.captured || mv.flag === 'e') {
-                if (ci < m.caps.length) placeMark(m.caps[ci++], mv.to, this.flip);
+                if (ci < m.caps.length) placeMark(m.caps[ci++], mv.to);
             } else if (di < m.dots.length) {
-                placeMark(m.dots[di++], mv.to, this.flip);
+                placeMark(m.dots[di++], mv.to);
             }
         }
         const last = this.game.stack[this.game.stack.length - 1];
         if (last) {
-            placeMark(m.lastFrom, last.from, this.flip);
-            placeMark(m.lastTo, last.to, this.flip);
+            placeMark(m.lastFrom, last.from);
+            placeMark(m.lastTo, last.to);
         }
         if (this.game.inCheck()) {
             const k = this.game.kingIndex(this.game.side);
-            if (k >= 0) placeMark(m.check, k, this.flip);
+            if (k >= 0) placeMark(m.check, k);
         }
     }
 

--- a/labs/xadrez/src/pieces.js
+++ b/labs/xadrez/src/pieces.js
@@ -63,12 +63,18 @@ export function buildPieceGeometries(BABYLON, scene, seg = 48) {
         [0, 0.88]
     ], seg, scene);
     const rookCollar = collar(BABYLON, 'rook_col', 0.22, 0.74, 0.03, seg, scene);
+    // Ameias: 8 blocos assentados exatamente na borda do copo do torno (raio
+    // e altura do próprio perfil), em vez de flutuar acima dele.
     const merlons = [];
-    const rookR = 0.20;
-    const rookY = 1.04;
-    for (let i = 0; i < 4; i++) {
-        const a = (i / 4) * Math.PI * 2 + Math.PI / 4;
-        merlons.push(box(BABYLON, `rook_m_${i}`, 0.15, 0.15, 0.13, Math.cos(a) * rookR, rookY, Math.sin(a) * rookR, scene));
+    const rookR = 0.225;
+    const rookY = 0.955;
+    const merlonCount = 8;
+    for (let i = 0; i < merlonCount; i++) {
+        const a = (i / merlonCount) * Math.PI * 2;
+        const m = BABYLON.MeshBuilder.CreateBox(`rook_m_${i}`, { width: 0.075, height: 0.10, depth: 0.11 }, scene);
+        m.position.set(Math.cos(a) * rookR, rookY, Math.sin(a) * rookR);
+        m.rotation.y = -a;
+        merlons.push(m);
     }
     const rook = merge(BABYLON, 'geo_rook', [rookLathe, rookCollar, ...merlons], scene);
 
@@ -116,40 +122,73 @@ export function buildPieceGeometries(BABYLON, scene, seg = 48) {
     const crossH = box(BABYLON, 'cross_h', 0.17, 0.045, 0.045, 0, 1.70, 0, scene);
     const king = merge(BABYLON, 'geo_king', [kingLathe, kingCollar, crossV, crossH], scene);
 
-    // 6. CAVALO (Knight)
+    // 6. CAVALO (Knight) — todo o pescoço/cabeça compartilha um único ângulo de
+    // inclinação (A) para que as caixas fiquem alinhadas ao mesmo eixo, em vez
+    // de se cruzarem em ângulos diferentes (o que produzia um bloco quebrado).
     const knightBase = lathe(BABYLON, 'knight_base', [
-        [0, 0], [0.36, 0], [0.38, 0.045], [0.31, 0.10],
-        [0.28, 0.18], [0.22, 0.26], [0.20, 0.42],
-        [0.22, 0.50], [0.18, 0.54]
+        [0, 0], [0.34, 0], [0.36, 0.045], [0.30, 0.10],
+        [0.27, 0.18], [0.21, 0.26], [0.19, 0.40],
+        [0.20, 0.48], [0.17, 0.52]
     ], seg, scene);
-    const knightRing = collar(BABYLON, 'knight_ring', 0.20, 0.50, 0.03, seg, scene);
-    const neck = BABYLON.MeshBuilder.CreateCylinder('knight_neck', { height: 0.52, diameterTop: 0.24, diameterBottom: 0.32, tessellation: 16 }, scene);
-    neck.position.set(0.04, 0.70, 0);
-    neck.rotation.z = -0.22;
+    const knightRing = collar(BABYLON, 'knight_ring', 0.19, 0.485, 0.028, seg, scene);
 
-    const headMuzzle = box(BABYLON, 'knight_head', 0.38, 0.24, 0.22, 0.18, 0.95, 0, scene);
-    headMuzzle.rotation.z = -0.32;
-    const snout = box(BABYLON, 'knight_snout', 0.22, 0.18, 0.18, 0.34, 0.84, 0, scene);
-    snout.rotation.z = -0.15;
-    const earL = BABYLON.MeshBuilder.CreateCylinder('knight_ear_l', { height: 0.16, diameterTop: 0, diameterBottom: 0.09, tessellation: 8 }, scene);
-    earL.position.set(0.04, 1.15, 0.07);
-    earL.rotation.z = -0.35;
-    earL.rotation.x = 0.25;
-    const earR = BABYLON.MeshBuilder.CreateCylinder('knight_ear_r', { height: 0.16, diameterTop: 0, diameterBottom: 0.09, tessellation: 8 }, scene);
-    earR.position.set(0.04, 1.15, -0.07);
-    earR.rotation.z = -0.35;
-    earR.rotation.x = -0.25;
+    // Pescoço em cilindros afunilados (superfície lisa, sem quinas) e cabeça
+    // em elipsoides (esferas escaladas) — o mesmo bloco boxy de antes ficava
+    // com as arestas soltas, destoando do acabamento torneado do resto do jogo.
+    const A = -0.34;
+    const up = [-Math.sin(A), Math.cos(A)];
+    const fwd = [Math.cos(A), Math.sin(A)];
+    const P0 = [0.02, 0.49];
+    const at = (u, f = 0, z = 0) => [P0[0] + up[0] * u + fwd[0] * f, P0[1] + up[1] * u + fwd[1] * f, z];
 
-    const mane = box(BABYLON, 'knight_mane', 0.10, 0.45, 0.08, -0.08, 0.88, 0, scene);
-    mane.rotation.z = 0.25;
+    const neckCyl = (name, u, h, dBottom, dTop) => {
+        const [x, y, z] = at(u);
+        const c = BABYLON.MeshBuilder.CreateCylinder(name, { height: h, diameterBottom: dBottom, diameterTop: dTop, tessellation: Math.max(14, Math.round(seg / 2)) }, scene);
+        c.position.set(x, y, z);
+        c.rotation.z = A;
+        return c;
+    };
+    const headBlob = (name, diam, sx, sy, sz, u, f, z = 0) => {
+        const [x, y, zz] = at(u, f, z);
+        const s = BABYLON.MeshBuilder.CreateSphere(name, { diameter: diam, segments: 14 }, scene);
+        s.scaling.set(sx, sy, sz);
+        s.rotation.z = A;
+        s.position.set(x, y, zz);
+        return s;
+    };
 
-    const eyeL = BABYLON.MeshBuilder.CreateSphere('knight_eye_l', { diameter: 0.05, segments: 8 }, scene);
-    eyeL.position.set(0.20, 1.00, 0.10);
-    const eyeR = BABYLON.MeshBuilder.CreateSphere('knight_eye_r', { diameter: 0.05, segments: 8 }, scene);
-    eyeR.position.set(0.20, 1.00, -0.10);
+    const neckLower = neckCyl('knight_neck_lo', 0.16, 0.32, 0.34, 0.30);
+    const neckUpper = neckCyl('knight_neck_hi', 0.46, 0.28, 0.30, 0.26);
+    const poll = headBlob('knight_poll', 0.30, 1.0, 0.85, 0.92, 0.60, 0);
+    const muzzle = headBlob('knight_muzzle', 0.22, 1.3, 0.85, 0.85, 0.56, 0.20);
+    const jaw = headBlob('knight_jaw', 0.15, 1.1, 0.8, 0.85, 0.48, 0.24);
+
+    const mane = BABYLON.MeshBuilder.CreateCylinder('knight_mane', { height: 0.46, diameterBottom: 0.15, diameterTop: 0.10, tessellation: 10 }, scene);
+    {
+        const [x, y, z] = at(0.40, -0.15);
+        mane.position.set(x, y, z);
+        mane.rotation.z = A;
+        mane.scaling.z = 0.45;
+    }
+
+    const [earBx, earBy] = at(0.70, -0.02, 0);
+    const earL = BABYLON.MeshBuilder.CreateCylinder('knight_ear_l', { height: 0.15, diameterTop: 0, diameterBottom: 0.085, tessellation: 10 }, scene);
+    earL.position.set(earBx, earBy, 0.075);
+    earL.rotation.z = A;
+    earL.rotation.x = 0.28;
+    const earR = BABYLON.MeshBuilder.CreateCylinder('knight_ear_r', { height: 0.15, diameterTop: 0, diameterBottom: 0.085, tessellation: 10 }, scene);
+    earR.position.set(earBx, earBy, -0.075);
+    earR.rotation.z = A;
+    earR.rotation.x = -0.28;
+
+    const [eyeX, eyeY] = at(0.50, 0.15, 0);
+    const eyeL = BABYLON.MeshBuilder.CreateSphere('knight_eye_l', { diameter: 0.045, segments: 8 }, scene);
+    eyeL.position.set(eyeX, eyeY, 0.085);
+    const eyeR = BABYLON.MeshBuilder.CreateSphere('knight_eye_r', { diameter: 0.045, segments: 8 }, scene);
+    eyeR.position.set(eyeX, eyeY, -0.085);
 
     const knight = merge(BABYLON, 'geo_knight', [
-        knightBase, knightRing, neck, headMuzzle, snout, earL, earR, mane, eyeL, eyeR
+        knightBase, knightRing, neckLower, neckUpper, poll, jaw, muzzle, mane, earL, earR, eyeL, eyeR
     ], scene);
 
     return { p: pawn, r: rook, n: knight, b: bishop, q: queen, k: king };
@@ -177,11 +216,11 @@ export function makeMaterials(BABYLON, scene, tex, theme = 'classic') {
         ebony.albedoTexture = tex.ebony.map;
         ebony.bumpTexture = tex.ebony.normalMap;
     }
-    ebony.metallic = 0.08;
-    ebony.roughness = 0.22;
+    ebony.metallic = 0.05;
+    ebony.roughness = 0.32;
     ebony.clearCoat.isEnabled = true;
-    ebony.clearCoat.intensity = 0.9;
-    ebony.clearCoat.roughness = 0.12;
+    ebony.clearCoat.intensity = 0.75;
+    ebony.clearCoat.roughness = 0.22;
     ebony.sheen.isEnabled = true;
     ebony.sheen.intensity = 0.3;
     ebony.sheen.color = new BABYLON.Color3(0.25, 0.14, 0.09);

--- a/labs/xadrez/src/world.js
+++ b/labs/xadrez/src/world.js
@@ -271,17 +271,18 @@ export function placeMark(mesh, index, flip = false) {
 }
 
 export function setupLights(BABYLON, scene, quality) {
-    // Luz ambiente suave
+    // Luz ambiente suave — intensidade mais alta e chão mais claro para que o
+    // ébano (muito escuro) não vire silhueta pura nas áreas de sombra.
     const hemi = new BABYLON.HemisphericLight('hemi_light', new BABYLON.Vector3(0, 1, 0), scene);
-    hemi.diffuse = new BABYLON.Color3(0.7, 0.65, 0.58);
-    hemi.groundColor = new BABYLON.Color3(0.25, 0.20, 0.15);
-    hemi.intensity = 0.85;
+    hemi.diffuse = new BABYLON.Color3(0.78, 0.73, 0.66);
+    hemi.groundColor = new BABYLON.Color3(0.38, 0.32, 0.26);
+    hemi.intensity = 1.05;
 
     // Sol / Luz direcionada com sombras
     const sun = new BABYLON.DirectionalLight('sun_light', new BABYLON.Vector3(-4, -10, 6).normalize(), scene);
     sun.position = new BABYLON.Vector3(8, 18, -12);
     sun.diffuse = new BABYLON.Color3(1.0, 0.95, 0.88);
-    sun.intensity = 1.6;
+    sun.intensity = 1.5;
 
     let shadowGen = null;
     if (quality.shadows) {
@@ -289,15 +290,51 @@ export function setupLights(BABYLON, scene, quality) {
         shadowGen.usePoissonSampling = true;
         shadowGen.bias = 0.001;
         shadowGen.normalBias = 0.002;
+        shadowGen.darkness = 0.35;
     }
+
+    // Luz de preenchimento fria, do lado oposto ao sol — sem ela o lado
+    // sombreado das peças (sobretudo as de ébano) desaparecia em preto puro.
+    const fill = new BABYLON.DirectionalLight('fill_light', new BABYLON.Vector3(5, -6, -8).normalize(), scene);
+    fill.diffuse = new BABYLON.Color3(0.55, 0.60, 0.68);
+    fill.specular = new BABYLON.Color3(0.2, 0.2, 0.24);
+    fill.intensity = 0.55;
 
     // Ponto de luz quente sobre a mesa
     const warmLamp = new BABYLON.PointLight('warm_lamp', new BABYLON.Vector3(0, 5, 0), scene);
     warmLamp.diffuse = new BABYLON.Color3(1.0, 0.85, 0.65);
-    warmLamp.intensity = 0.6;
+    warmLamp.intensity = 0.7;
     warmLamp.range = 14;
 
-    return { hemi, sun, shadowGen, warmLamp };
+    return { hemi, sun, fill, shadowGen, warmLamp };
+}
+
+/**
+ * Ambiente de reflexo procedural (sem HDR externo): um "cubemap" simples,
+ * claro em cima e escuro embaixo, só para o PBR (clearcoat/sheen) ter algo
+ * para refletir. Sem isso, materiais escuros como o ébano ficam achatados.
+ */
+export function setupEnvironment(BABYLON, scene) {
+    const size = 64;
+    const face = (top, bottom) => {
+        const el = document.createElement('canvas');
+        el.width = size;
+        el.height = size;
+        const ctx = el.getContext('2d');
+        const g = ctx.createLinearGradient(0, 0, 0, size);
+        g.addColorStop(0, top);
+        g.addColorStop(1, bottom);
+        ctx.fillStyle = g;
+        ctx.fillRect(0, 0, size, size);
+        return el.toDataURL('image/png');
+    };
+    const side = face('#8c7c68', '#171310');
+    const top = face('#e4d3ac', '#8c7c68');
+    const bottom = face('#171310', '#050403');
+    const env = BABYLON.CubeTexture.CreateFromImages([side, side, top, bottom, side, side], scene);
+    scene.environmentTexture = env;
+    scene.environmentIntensity = 0.65;
+    return env;
 }
 
 export function setupPostProcess(BABYLON, scene, quality) {

--- a/labs/xadrez/style.css
+++ b/labs/xadrez/style.css
@@ -614,12 +614,15 @@ button {
         margin-bottom: 0.8rem;
     }
     .coach {
+        /* O dock tem 8 botões e quebra para 2 linhas em quase toda largura
+           de celular (flex-wrap acima) — 5.6rem só cobria 1 linha e o dock
+           acabava cobrindo o rodapé do card do mestre. */
         top: auto;
-        bottom: calc(5.6rem + var(--safe-bottom));
+        bottom: calc(7.8rem + var(--safe-bottom));
         left: calc(0.6rem + var(--safe-left));
         right: calc(0.6rem + var(--safe-right));
         width: auto;
-        max-height: min(38dvh, 280px);
+        max-height: min(34dvh, 260px);
     }
 
     .tray {
@@ -664,11 +667,21 @@ button {
 
 @media (max-height: 520px) and (orientation: landscape) {
     .coach {
+        /* "top" + "bottom" juntos com height:auto esticam a caixa para
+           preencher o vão inteiro — mesmo recolhida (is-collapsed), ela
+           virava um painel enorme e vazio cobrindo o tabuleiro. Um celular
+           landscape também casa com a media query de max-width:768px acima
+           (que define "bottom"), então isso precisa ser anulado aqui com
+           "bottom: auto" — senão os dois "top"+"bottom" de regras
+           diferentes se combinam e o esticamento volta. Só "top" +
+           max-height deixa a caixa abraçar o conteúdo e ainda limita o
+           card expandido a não invadir o dock. */
         top: calc(3.6rem + var(--safe-top));
-        bottom: calc(4.6rem + var(--safe-bottom));
+        bottom: auto;
         left: calc(0.5rem + var(--safe-left));
+        right: auto;
         width: min(260px, 38vw);
-        max-height: none;
+        max-height: min(58dvh, 260px);
     }
 
     .tray {


### PR DESCRIPTION
## 🎯 Objetivo

Revisar o lab de Xadrez 3D: proporções da câmera/peças, iluminação, texturas e a jogabilidade estavam estranhas — em especial o botão "Virar tabuleiro", que teleportava as peças para posições espelhadas ao mesmo tempo em que a câmera girava.

## ✨ O que mudou

- **Câmera**: radius maior + FOV mais fechado achatam a perspectiva exagerada (antes a casa mais próxima da câmera aparecia enorme e a última fileira, minúscula); FOV horizontal fixo em telas estreitas evita cortar as laterais do tabuleiro no celular
- **Iluminação**: hemisférica mais forte, luz de preenchimento fria do lado oposto ao sol, e um ambiente de reflexo procedural (sem HDR externo, gerado em canvas) para o PBR ter algo para refletir — as peças de ébano deixam de virar silhuetas pretas chapadas
- **Cavalo**: reconstruído com pescoço em cilindros afunilados e cabeça em elipsoides, tudo no mesmo eixo de inclinação — a versão anterior era uma pilha de caixas em ângulos diferentes que ficava com as arestas soltas e irreconhecível como cavalo
- **Torre**: ameias reconstruídas encostadas na borda real do copo torneado (antes flutuavam soltas acima do topo, formando um blob de cubos)
- **"Virar tabuleiro"**: agora só gira a câmera até o outro lado da mesa (delta relativo, nunca um alvo absoluto) — tabuleiro e peças ficam parados, como alguém dando a volta na mesa, em vez do duplo movimento estranho de antes (peças teleportando + câmera girando ao mesmo tempo)
- **Mobile**: o painel do mestre não fica mais coberto pelo dock de 2 linhas no retrato (375–768px), nem vira um card vazio esticado cobrindo o tabuleiro no landscape curto (bug de CSS: duas media queries definiam `top`+`bottom` ao mesmo tempo e esticavam a caixa mesmo recolhida)

## 🧪 Como testar

1. Na raiz do repo: `python3 -m http.server 8000`
2. Abrir [http://localhost:8000/labs/xadrez/](http://localhost:8000/labs/xadrez/)
3. Entrar no atelier e conferir: peças bem proporcionadas ao tabuleiro, cavalo reconhecível, torre com ameias limpas, peças de ébano com volume visível (não silhueta preta chapada)
4. Clicar "Virar" — a câmera deve orbitar suavemente para o lado oposto da mesa; as peças não devem pular/teleportar
5. Responsivo: DevTools em **375×667**, **390×844** e landscape curto (~667×375) — painel do mestre (recolhido e expandido) não deve sobrepor o dock nem virar um card vazio

Testado localmente com Babylon.js real (via pacote npm, já que o CDN estava bloqueado neste sandbox) nos quatro tamanhos de viewport acima.

## ✅ Checklist

- [x] Links conferidos: nenhuma mudança de catálogo (lab existente, sem mudança de slug)
- [x] README: não aplicável (sem mudança de catálogo)
- [x] SEO: não aplicável (sem mudança de título/slug/descrição)
- [x] Testado via HTTP na raiz, não via `file://`
- [x] Responsivo: 375px / 390px / landscape — sem overflow, HUD utilizável, sem sobreposição
- [x] Nada fora do escopo foi quebrado


---
_Generated by [Claude Code](https://claude.ai/code/session_01N4ruetWqDBKcuxoaFfg49t)_