### PR TITLE
🐛 fix: CyberOS quebra em landscape curto e trunca versão no header mobile

### DIFF
--- a/labs/cyberos/style.css
+++ b/labs/cyberos/style.css
@@ -743,6 +743,7 @@ select {
 /* Status bar */
 .os-statusbar {
   display: flex;
+  flex-direction: row;
   flex-wrap: wrap;
   align-items: center;
   gap: 0.35rem;
@@ -939,4 +940,43 @@ select {
     .dock { bottom: max(2.4rem, env(safe-area-inset-bottom, 0px)); }
     .window { height: 52% !important; top: 10% !important; max-width: calc(100% - 1rem); }
     .phos-btn { min-width: 44px; min-height: 44px; padding: 0.35rem 0.5rem; }
+}
+
+/* Telas estreitas: "v2.7" ao lado de "CyberOS" não cabe e trunca no meio do
+   número (sem reticências, pois é um flex com múltiplos filhos). Esconder o
+   badge de versão evita o corte feio; o app-logo ainda tem overflow/ellipsis
+   como rede de segurança. */
+@media (max-width: 480px), (max-height: 520px) and (orientation: landscape) {
+    .brand-ver { display: none; }
+}
+
+/* Landscape curto (celular deitado): header + status bar já consomem boa
+   parte dos ~375px de altura, sobrando pouco para o .desktop. Como as
+   janelas usam min-height:180px com top+height em %, a % de altura acaba
+   maior que o espaço restante e a janela extrapola para CIMA do container
+   (que tem overflow:hidden) — escondendo a titlebar inteira, incluindo o
+   botão de fechar. Ancorar com top+bottom (height:auto) garante que a
+   titlebar fique sempre visível; o que sobra é o corpo, que já rola. */
+@media (max-height: 520px) and (orientation: landscape) {
+    .crt-bezel { min-height: calc(100dvh - 3rem); padding: 8px; }
+    .crt-screen { min-height: calc(100dvh - 4rem); }
+
+    .crt-screen > header[data-lab-header] { padding: 0.3rem 0.6rem; }
+    .crt-screen .os-brand { font-size: 1.05rem; gap: 0.3rem; }
+
+    .os-statusbar {
+        flex-wrap: nowrap;
+        overflow-x: auto;
+        justify-content: flex-start;
+    }
+    .os-statusbar .status-sep { display: inline; }
+
+    .dock { padding: 0.3rem; gap: 0.3rem; bottom: 0.4rem; }
+
+    .window {
+        top: 4% !important;
+        bottom: 4% !important;
+        height: auto !important;
+        min-height: 130px;
+    }
 }


### PR DESCRIPTION
## 🎯 Objetivo

Revisão de detalhe do lab CyberOS (o "app" desktop-simulator do playground): corrigir bugs de UI, usabilidade e responsividade encontrados ao testar as janelas do app nos breakpoints mobile obrigatórios do AGENTS.md.

## ✨ O que mudou

- **Botão de fechar inacessível em landscape curto (~667×375).** As janelas (`.window`) usavam `top` + `height` em `%` combinados com `min-height: 180px`. Em telas curtas o `.desktop` disponível encolhe tanto que a altura mínima força a janela a extrapolar para **cima** do container (que tem `overflow: hidden`), escondendo a titlebar inteira — incluindo o `×` de fechar. Troquei para `top` + `bottom` (com `height: auto`), que ancora a titlebar sempre dentro da área visível; o que sobra vira scroll no corpo, que já tinha `overflow: auto`. Confirmado via Playwright: antes o botão de fechar tinha `y < 0` (fora do viewport); depois fica clicável normalmente.
- **Status bar empilhando em 3 linhas soltas.** `.os-statusbar` é um `<footer>`, e o `shared.css` tem uma regra genérica `footer { flex-direction: column }` para o rodapé do site em telas ≤768px. Como o CSS do CyberOS nunca declarava `flex-direction`, essa regra vazava e forçava relógio / mensagem / uplink cada um em sua própria linha — desperdiçando altura preciosa justamente em landscape curto. Adicionei `flex-direction: row` explícito no `.os-statusbar`.
- **"CyberOS v2.7" truncando no meio do número.** Em telas estreitas (375–414px) o badge de versão ao lado do título não cabia e cortava para "CyberOS v" ou "CyberOS v2" sem reticências (é um flex com múltiplos filhos, então `text-overflow: ellipsis` do container não se aplica). Escondido o badge `.brand-ver` em `max-width: 480px` e em landscape curto.
- Compactei padding do header/`crt-bezel`/`crt-screen` em landscape curto para sobrar mais espaço útil para o desktop das janelas.

Nenhum touch target foi reduzido abaixo de 44×44px — só espaçamento/paddings não-interativos.

## 🧪 Como testar

1. Na raiz do repo: `python3 -m http.server 8000`
2. Abrir [http://localhost:8000/labs/cyberos/](http://localhost:8000/labs/cyberos/)
3. DevTools em **375×667**, **390×844** e landscape curto **~667×375**:
   - Landscape curto: abrir um app pelo dock (ex. Terminal) e confirmar que a titlebar com o `×` fica visível e clicável.
   - Confirmar status bar em uma linha (não 3 linhas empilhadas) em qualquer largura.
   - Confirmar que "CyberOS" nunca corta no meio de uma palavra/número.
4. Desktop (≥820px): confirmar que nada mudou visualmente ("v2.7" continua aparecendo, janelas arrastáveis).

## ✅ Checklist

- [x] Links conferidos: nenhuma mudança de slug/pasta/catálogo — apenas CSS de um lab existente
- [x] README/sitemap/galeria — não aplicável (sem mudança de catálogo)
- [x] SEO consistente — não aplicável (sem mudança de metadata)
- [x] Testado via HTTP na raiz, não via `file://`
- [x] Responsivo: 375px / 390px / landscape curto — overflow, HUD, toque, safe-area validados com screenshots (Playwright) antes/depois
- [x] Nada fora do escopo foi quebrado (verificado desktop 1280×800 e landscape largo 844×390)


---
_Generated by [Claude Code](https://claude.ai/code/session_01RtCw6fRjc4gBdQ515ojBdo)_