### PR TITLE
🧪 lab: Mimo — pet virtual 3D

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 Mais de 20 anos em tecnologia, entre liderança, código hands-on e design UI/UX.
 
 [![Website](https://img.shields.io/badge/Website-diogopaulino.com.br-3B82F6?style=flat-square&logo=googlechrome&logoColor=white)](https://diogopaulino.com.br/)
-[![Labs](https://img.shields.io/badge/Labs-53_experimentos-8B5CF6?style=flat-square&logo=stackblitz&logoColor=white)](https://diogopaulino.com.br/labs/)
+[![Labs](https://img.shields.io/badge/Labs-54_experimentos-8B5CF6?style=flat-square&logo=stackblitz&logoColor=white)](https://diogopaulino.com.br/labs/)
 [![GitHub](https://img.shields.io/badge/GitHub-diogopaulino-181717?style=flat-square&logo=github&logoColor=white)](https://github.com/diogopaulino)
 [![LinkedIn](https://img.shields.io/badge/LinkedIn-Diogo_Paulino-0A66C2?style=flat-square)](https://br.linkedin.com/in/diogopaulino)
 [![Spotify](https://img.shields.io/badge/Spotify-Artist-1DB954?style=flat-square&logo=spotify&logoColor=white)](https://open.spotify.com/intl-pt/artist/0ue2WfDQ1P4XR2vXdSIrYQ)
@@ -32,7 +32,7 @@ Gosto de construir coisas — de time e produto até interface e código. Nessa 
 
 > *Abre, experimenta, quebra, reconstrói. Esse é o espírito.*
 
-Um laboratório aberto com **53 experimentos** que rodam direto no navegador — HTML, CSS e JavaScript puro, sem instalar nada. Catálogo completo em [diogopaulino.com.br/labs](https://diogopaulino.com.br/labs/).
+Um laboratório aberto com **54 experimentos** que rodam direto no navegador — HTML, CSS e JavaScript puro, sem instalar nada. Catálogo completo em [diogopaulino.com.br/labs](https://diogopaulino.com.br/labs/).
 
 Cada pasta em `/labs/<slug>/` é o mesmo slug do card da galeria, da linha abaixo e da URL `https://diogopaulino.com.br/labs/<slug>/`.
 
@@ -47,6 +47,7 @@ Cada pasta em `/labs/<slug>/` é o mesmo slug do card da galeria, da linha abaix
 | 🏮 **[A Menina da Lanterna](https://diogopaulino.com.br/labs/menina-da-lanterna/)** | Conto 3D — Clara carrega a última chama, acende Vale-da-Bruma e traz o primeiro sol |
 | 🏃 **[Forrest Run](https://diogopaulino.com.br/labs/forrest-run/)** | Endless runner 3D — Forrest corre sem parar pelos EUA, pena branca e o pessoal atrás |
 | 🫐 **[Nina](https://diogopaulino.com.br/labs/nina/)** | Vale 3D toon — a raposinha resgata filhotes, coleta amoras e monta o piquenique no ninho |
+| 🐾 **[Mimo](https://diogopaulino.com.br/labs/mimo/)** | Pet virtual 3D — escolha cão ou gato, dê nome e raça, alimente, dê banho e brinque |
 | 🧩 **[Quimera](https://diogopaulino.com.br/labs/quimera/)** | Ateliê 3D relaxante — misture cabeça, corpo e acessórios de pirata, marinheiro, astronauta, guerreiro e outros |
 | 🏰 **[Castelo Estelar](https://diogopaulino.com.br/labs/castelo-estelar/)** | Abertura cinematográfica em three.js — castelo hiper-realista, lua, lago, fanfarra e fogos |
 | ✧ **[Eyra](https://diogopaulino.com.br/labs/eyra/)** | Voo numa fera alada pelos picos flutuantes — sementes de luz, cachoeiras no céu e a Yva |

--- a/index.html
+++ b/index.html
@@ -157,7 +157,7 @@
       </nav>
       <div class="labs-easter-egg" id="labs-easter-egg">
         <a href="/labs/" class="labs-badge"
-          aria-label="Labs de Diogo Paulino: 53 experimentos de jogos, código, música e IA">
+          aria-label="Labs de Diogo Paulino: 54 experimentos de jogos, código, música e IA">
           <span class="labs-text">labs</span>
           <svg class="labs-sparkles" width="14" height="14" viewBox="0 0 24 24" fill="currentColor" stroke="none">
             <path d="M12 2L14.4 9.6L22 12L14.4 14.4L12 22L9.6 14.4L2 12L9.6 9.6L12 2Z" />

--- a/labs/index.html
+++ b/labs/index.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <title>Labs — Diogo Paulino | Jogos 3D, código, música e IA</title>
-  <meta name="description" content="53 experimentos de Diogo Paulino: jogos 3D, ferramentas, música e inteligência artificial em HTML, CSS e JavaScript puro.">
+  <meta name="description" content="54 experimentos de Diogo Paulino: jogos 3D, ferramentas, música e inteligência artificial em HTML, CSS e JavaScript puro.">
   <meta name="author" content="Diogo Paulino">
   <meta name="robots" content="index, follow">
   <meta name="theme-color" content="#fafbfc">
@@ -16,14 +16,14 @@
   <meta property="og:site_name" content="Diogo Paulino · Labs">
   <meta property="og:title" content="Labs — Diogo Paulino | Jogos 3D, código, música e IA">
   <meta property="og:description"
-    content="53 laboratórios de Diogo Paulino: mundos 3D, jogos, ferramentas, música e IA em HTML, CSS e JavaScript puro.">
+    content="54 laboratórios de Diogo Paulino: mundos 3D, jogos, ferramentas, música e IA em HTML, CSS e JavaScript puro.">
   <meta property="og:url" content="https://diogopaulino.com.br/labs/">
   <meta property="og:image" content="https://diogopaulino.com.br/assets/img/diogo.jpeg">
   <meta property="og:image:alt" content="Diogo Paulino">
   <meta property="og:locale" content="pt_BR">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Labs — Diogo Paulino | Jogos 3D, código, música e IA">
-  <meta name="twitter:description" content="53 experimentos de Diogo Paulino: jogos, código, música e inteligência artificial.">
+  <meta name="twitter:description" content="54 experimentos de Diogo Paulino: jogos, código, música e inteligência artificial.">
   <meta name="twitter:image" content="https://diogopaulino.com.br/assets/img/diogo.jpeg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -39,7 +39,7 @@
         "@id": "https://diogopaulino.com.br/labs/#page",
         "name": "Labs — Diogo Paulino",
         "url": "https://diogopaulino.com.br/labs/",
-        "description": "53 experimentos de Diogo Paulino: jogos 3D, ferramentas, música e inteligência artificial em HTML, CSS e JavaScript puro.",
+        "description": "54 experimentos de Diogo Paulino: jogos 3D, ferramentas, música e inteligência artificial em HTML, CSS e JavaScript puro.",
         "inLanguage": "pt-BR",
         "isPartOf": {
           "@id": "https://diogopaulino.com.br/#website"
@@ -47,7 +47,7 @@
         "creator": {
           "@id": "https://diogopaulino.com.br/#person"
         },
-        "numberOfItems": 53,
+        "numberOfItems": 54,
         "mainEntity": {
           "@id": "https://diogopaulino.com.br/labs/#list"
         }
@@ -56,7 +56,7 @@
         "@type": "ItemList",
         "@id": "https://diogopaulino.com.br/labs/#list",
         "name": "Labs de Diogo Paulino",
-        "numberOfItems": 53,
+        "numberOfItems": 54,
         "itemListElement": [
           {
             "@type": "ListItem",
@@ -369,6 +369,12 @@
             "position": 56,
             "url": "https://diogopaulino.com.br/labs/ultimo-bastiao/",
             "name": "O Último Bastião"
+          },
+          {
+            "@type": "ListItem",
+            "position": 57,
+            "url": "https://diogopaulino.com.br/labs/mimo/",
+            "name": "Mimo"
           }
         ]
       },
@@ -576,6 +582,29 @@
             <span class="tag">three.js</span>
             <span class="tag">Infantil</span>
             <span class="tag">Animais</span>
+          </div>
+        </div>
+      </a>
+      <a href="/labs/mimo/" class="project-card" data-groups="game,creative">
+        <div class="project-icon">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+            stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <circle cx="9.2" cy="13.2" r="5.1" />
+            <path d="M6.4 9.2c-.15-1.8 1-3.4 2.6-3.7 1.6.15 2.9 1.8 2.7 3.6" />
+            <path d="M7.6 12.6h.1M10.8 12.6h.1" />
+            <path d="M7.8 14.8c.6.6 2.4.6 3 0" opacity="0.75" />
+            <path d="M14.2 16.2c1.2.7 2.8.9 4.2.2" opacity="0.55" />
+            <path d="M16.6 11.2c.9-1.6 2.8-1.8 4-.4" />
+            <circle cx="18.2" cy="9.4" r="0.7" />
+          </svg>
+        </div>
+        <div class="project-content">
+          <h2>Mimo</h2>
+          <p>Pet virtual 3D: escolha cão ou gato, dê nome e raça, alimente, dê banho e brinque no lar ao entardecer</p>
+          <div class="project-tags">
+            <span class="tag">three.js</span>
+            <span class="tag">Pet</span>
+            <span class="tag">Cuidado</span>
           </div>
         </div>
       </a>

--- a/labs/mimo/index.html
+++ b/labs/mimo/index.html
@@ -1,0 +1,282 @@
+<!DOCTYPE html>
+<html lang="pt-br" data-theme="dark">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport"
+        content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover">
+    <meta name="theme-color" content="#1c1410">
+    <title>Mimo — pet virtual 3D | Diogo Paulino</title>
+    <meta name="description"
+        content="Pet virtual 3D em three.js: escolha cão ou gato, dê nome e raça, alimente, dê banho, brinque e faça carinho num lar ao entardecer.">
+    <link rel="canonical" href="https://diogopaulino.com.br/labs/mimo/">
+    <meta name="author" content="Diogo Paulino">
+    <meta name="robots" content="index, follow">
+    <link rel="icon" href="/favicon.ico" sizes="any">
+    <meta property="og:image" content="https://diogopaulino.com.br/assets/img/diogo.jpeg">
+    <meta property="og:image:alt" content="Diogo Paulino">
+    <meta property="og:locale" content="pt_BR">
+    <meta name="twitter:image" content="https://diogopaulino.com.br/assets/img/diogo.jpeg">
+
+    <meta property="og:type" content="website">
+    <meta property="og:site_name" content="Diogo Paulino · Labs">
+    <meta property="og:url" content="https://diogopaulino.com.br/labs/mimo/">
+    <meta property="og:title" content="Mimo — pet virtual 3D | Diogo Paulino">
+    <meta property="og:description"
+        content="Um lar 3D para o seu cão ou gato: raça, pelagem, nome, comida, banho e brincadeira. three.js no navegador.">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Mimo — pet virtual 3D | Diogo Paulino">
+    <meta name="twitter:description" content="Escolha cão ou gato, dê um nome e cuide dele em three.js.">
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;600;700&family=Outfit:wght@400;500;600;700&display=swap"
+        rel="stylesheet">
+    <link rel="stylesheet" href="/labs/shared.css?v=9">
+    <link rel="stylesheet" href="style.css">
+
+    <script type="importmap">
+    {
+        "imports": {
+            "three": "https://cdn.jsdelivr.net/npm/three@0.185.1/build/three.module.js",
+            "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.185.1/examples/jsm/"
+        }
+    }
+    </script>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@graph": [
+        {
+          "@type": "WebApplication",
+          "name": "Mimo",
+          "url": "https://diogopaulino.com.br/labs/mimo/",
+          "description": "Pet virtual 3D em three.js: escolha cão ou gato, dê nome e raça, alimente, dê banho, brinque e faça carinho num lar ao entardecer.",
+          "applicationCategory": "GameApplication",
+          "operatingSystem": "Any",
+          "inLanguage": "pt-BR",
+          "isAccessibleForFree": true,
+          "author": {
+            "@type": "Person",
+            "name": "Diogo Paulino",
+            "url": "https://diogopaulino.com.br/"
+          },
+          "image": "https://diogopaulino.com.br/assets/img/diogo.jpeg"
+        },
+        {
+          "@type": "BreadcrumbList",
+          "itemListElement": [
+            {
+              "@type": "ListItem",
+              "position": 1,
+              "name": "Diogo Paulino",
+              "item": "https://diogopaulino.com.br/"
+            },
+            {
+              "@type": "ListItem",
+              "position": 2,
+              "name": "Labs",
+              "item": "https://diogopaulino.com.br/labs/"
+            },
+            {
+              "@type": "ListItem",
+              "position": 3,
+              "name": "Mimo",
+              "item": "https://diogopaulino.com.br/labs/mimo/"
+            }
+          ]
+        }
+      ]
+    }
+    </script>
+</head>
+
+<body>
+    <main class="game-shell">
+        <header data-lab-header data-title="Mimo" data-back-label="Labs">
+            <template data-slot="logo">
+                <div class="app-logo">
+                    <span class="brand-mark" aria-hidden="true">🐾</span>
+                    <span>Mimo</span>
+                </div>
+            </template>
+        </header>
+
+        <canvas id="scene" aria-label="Sala 3D com o pet virtual"></canvas>
+        <div class="vignette" aria-hidden="true"></div>
+
+        <div id="hud" class="hud" hidden>
+            <div class="hud-top">
+                <div class="panel identity-panel">
+                    <span class="hud-label" id="moodLine">Mimo está contente</span>
+                    <strong id="petName">Mel</strong>
+                    <span id="petMeta" class="hud-sub">Golden Retriever</span>
+                </div>
+                <div class="panel needs-panel" aria-label="Necessidades">
+                    <div class="need" data-need-row="hunger">
+                        <span>Fome</span>
+                        <i><b data-need="hunger"></b></i>
+                        <em data-need-val="hunger">72</em>
+                    </div>
+                    <div class="need" data-need-row="joy">
+                        <span>Alegria</span>
+                        <i><b data-need="joy"></b></i>
+                        <em data-need-val="joy">78</em>
+                    </div>
+                    <div class="need" data-need-row="hygiene">
+                        <span>Higiene</span>
+                        <i><b data-need="hygiene"></b></i>
+                        <em data-need-val="hygiene">88</em>
+                    </div>
+                    <div class="need" data-need-row="energy">
+                        <span>Energia</span>
+                        <i><b data-need="energy"></b></i>
+                        <em data-need-val="energy">80</em>
+                    </div>
+                    <div class="need" data-need-row="love">
+                        <span>Carinho</span>
+                        <i><b data-need="love"></b></i>
+                        <em data-need-val="love">70</em>
+                    </div>
+                </div>
+            </div>
+
+            <p id="message" class="message" role="status" aria-live="polite" data-show="false"></p>
+
+            <div class="hud-actions">
+                <button id="soundButton" class="icon-button" type="button" aria-pressed="true"
+                    title="Som (M)" aria-label="Alternar som">♪</button>
+                <button id="pauseButton" class="icon-button" type="button" title="Pausar (P)"
+                    aria-label="Pausar">II</button>
+            </div>
+
+            <nav id="actionDock" class="dock" aria-label="Cuidar do pet">
+                <button type="button" data-action="feed"><span>🍽️</span>Comer</button>
+                <button type="button" data-action="treat"><span>🦴</span>Petisco</button>
+                <button type="button" data-action="play"><span>🎾</span>Brincar</button>
+                <button type="button" data-action="bath"><span>🛁</span>Banho</button>
+                <button type="button" data-action="sleep"><span>🌙</span>Dormir</button>
+                <button type="button" data-action="pet"><span>🤍</span>Carinho</button>
+            </nav>
+        </div>
+
+        <div id="loadingOverlay" class="overlay loading-overlay">
+            <div class="loading-card">
+                <span class="star-loader" aria-hidden="true">🐾</span>
+                <h1>Mimo</h1>
+                <p id="loadingText">Preparando o almofadão…</p>
+                <div class="loading-bar"><i id="loadingFill"></i></div>
+            </div>
+        </div>
+
+        <div id="welcomeOverlay" class="overlay" hidden>
+            <div class="overlay-card compact-card">
+                <p class="eyebrow"><i></i> de volta ao lar</p>
+                <h2><span id="welcomeName">Mel</span> está<br>te esperando.</h2>
+                <p class="lede">A luz da janela ainda está quente. Arraste para orbitar, toque no pet para fazer carinho.</p>
+                <div class="card-actions">
+                    <button id="continueButton" class="primary-button" type="button">
+                        <span>Continuar</span><i aria-hidden="true">→</i>
+                    </button>
+                    <button id="newPetButton" class="ghost-button" type="button">Adotar outro</button>
+                </div>
+            </div>
+        </div>
+
+        <div id="createOverlay" class="overlay create-overlay" hidden>
+            <div class="overlay-card create-card">
+                <header class="menu-head">
+                    <p class="eyebrow"><i></i> three.js · pet virtual</p>
+                    <h1>Mimo</h1>
+                    <p class="lede">Escolha cão ou gato, a raça, a pelagem e um nome. Depois é só cuidar: comida, banho, brincadeira e colo.</p>
+                </header>
+
+                <nav class="create-steps" aria-label="Etapas">
+                    <button type="button" data-create-step="species" aria-current="step">1 Espécie</button>
+                    <button type="button" data-create-step="breed">2 Raça</button>
+                    <button type="button" data-create-step="style">3 Casa</button>
+                </nav>
+
+                <section id="stepSpecies" class="create-step">
+                    <div class="species-grid">
+                        <button type="button" class="species-card is-on" data-species="dog">
+                            <span class="species-art" aria-hidden="true">🐶</span>
+                            <strong>Cão</strong>
+                            <em>rabo, latido e bolinha</em>
+                        </button>
+                        <button type="button" class="species-card" data-species="cat">
+                            <span class="species-art" aria-hidden="true">🐱</span>
+                            <strong>Gato</strong>
+                            <em>ronronar, novelo e colo</em>
+                        </button>
+                    </div>
+                </section>
+
+                <section id="stepBreed" class="create-step" hidden>
+                    <div id="breedGrid" class="breed-grid"></div>
+                </section>
+
+                <section id="stepStyle" class="create-step" hidden>
+                    <label class="field">
+                        <span>Nome</span>
+                        <input id="petNameInput" type="text" maxlength="16" placeholder="Luna, Thor, Mimo…"
+                            autocomplete="off" enterkeyhint="done">
+                    </label>
+                    <p class="field-label">Pelagem</p>
+                    <div id="coatGrid" class="coat-grid"></div>
+                    <p class="section-note">O pet no centro da sala já é o seu — gire a câmera.</p>
+                </section>
+
+                <footer class="menu-foot create-foot">
+                    <div class="settings-inline">
+                        <label class="field field-mini">
+                            <span>Qualidade</span>
+                            <select id="qualitySelect">
+                                <option value="auto">Automática</option>
+                                <option value="low">Leve</option>
+                                <option value="medium">Equilibrada</option>
+                                <option value="high">Cinemática</option>
+                            </select>
+                        </label>
+                        <label class="field field-mini">
+                            <span>Volume <b id="volumeValue">70</b></span>
+                            <input id="volumeSlider" type="range" min="0" max="100" step="1" value="70">
+                        </label>
+                    </div>
+                    <button id="arriveButton" class="primary-button" type="button">
+                        <span>Chegar em casa</span>
+                        <i aria-hidden="true">🏠</i>
+                    </button>
+                </footer>
+            </div>
+        </div>
+
+        <div id="pauseOverlay" class="overlay" hidden>
+            <div class="overlay-card compact-card">
+                <p class="eyebrow"><i></i> o lar espera</p>
+                <h2>Uma pausa<br>no sofá.</h2>
+                <div class="card-actions">
+                    <button id="resumeButton" class="primary-button" type="button">
+                        <span>Voltar</span><i aria-hidden="true">→</i>
+                    </button>
+                    <button id="pauseMenuButton" class="ghost-button" type="button">Tela inicial</button>
+                    <button id="resetPetButton" class="ghost-button danger" type="button">Adotar outro pet</button>
+                </div>
+            </div>
+        </div>
+
+        <div id="errorOverlay" class="overlay" hidden>
+            <div class="overlay-card compact-card">
+                <p class="eyebrow"><i></i> webgl</p>
+                <h2>A sala não abriu.</h2>
+                <p id="errorText" class="lede">Este navegador não conseguiu iniciar o WebGL.</p>
+            </div>
+        </div>
+    </main>
+
+    <script src="/labs/shared.js?v=8"></script>
+    <script type="module" src="src/main.js"></script>
+</body>
+
+</html>

--- a/labs/mimo/src/audio.js
+++ b/labs/mimo/src/audio.js
@@ -1,0 +1,216 @@
+/**
+ * Pad quente, ronronar, latido, miado, água e petiscos — Web Audio puro.
+ */
+
+export class MimoAudio {
+    constructor() {
+        this.ctx = null;
+        this.enabled = true;
+        this.volume = 0.7;
+        this.started = false;
+        this._purr = null;
+    }
+
+    async resume() {
+        if (!this.ctx) this.boot();
+        if (!this.ctx) return;
+        if (this.ctx.state === 'suspended') await this.ctx.resume();
+        this.started = true;
+        if (this.padGain && this.enabled) {
+            this.padGain.gain.setTargetAtTime(0.045, this.ctx.currentTime, 1.6);
+        }
+    }
+
+    boot() {
+        const Ctx = window.AudioContext || window.webkitAudioContext;
+        if (!Ctx) return;
+        const ctx = new Ctx();
+        this.ctx = ctx;
+        this.master = ctx.createGain();
+        this.master.gain.value = this.enabled ? this.volume : 0;
+        this.master.connect(ctx.destination);
+
+        this.sfx = ctx.createGain();
+        this.sfx.gain.value = 0.9;
+        this.sfx.connect(this.master);
+
+        this.padGain = ctx.createGain();
+        this.padGain.gain.value = 0;
+        this.padGain.connect(this.master);
+        this._pad(ctx);
+    }
+
+    setEnabled(on) {
+        this.enabled = on;
+        if (this.master) this.master.gain.value = on ? this.volume : 0;
+        if (on) this.resume();
+        else this.stopPurr();
+    }
+
+    setVolume(v) {
+        this.volume = v;
+        if (this.master) this.master.gain.value = this.enabled ? v : 0;
+    }
+
+    _pad(ctx) {
+        const filter = ctx.createBiquadFilter();
+        filter.type = 'lowpass';
+        filter.frequency.value = 640;
+        filter.Q.value = 0.5;
+        filter.connect(this.padGain);
+        for (const [f, g, type] of [[174.61, 0.07, 'sine'], [220, 0.04, 'triangle'], [261.63, 0.03, 'sine']]) {
+            const o = ctx.createOscillator();
+            o.type = type;
+            o.frequency.value = f;
+            const gain = ctx.createGain();
+            gain.gain.value = g;
+            o.connect(gain);
+            gain.connect(filter);
+            o.start();
+        }
+    }
+
+    _env(dest, t, attack, dur, peak = 0.2) {
+        const g = this.ctx.createGain();
+        g.gain.setValueAtTime(0.0001, t);
+        g.gain.exponentialRampToValueAtTime(peak, t + attack);
+        g.gain.exponentialRampToValueAtTime(0.0001, t + dur);
+        g.connect(dest);
+        return g;
+    }
+
+    bark() {
+        if (!this.ctx || !this.enabled) return;
+        const t = this.ctx.currentTime;
+        for (const [f, d] of [[180, 0.12], [140, 0.18]]) {
+            const o = this.ctx.createOscillator();
+            o.type = 'sawtooth';
+            o.frequency.setValueAtTime(f, t);
+            o.frequency.exponentialRampToValueAtTime(f * 0.6, t + d);
+            const g = this._env(this.sfx, t, 0.01, d, 0.16);
+            const ftr = this.ctx.createBiquadFilter();
+            ftr.type = 'bandpass';
+            ftr.frequency.value = 420;
+            o.connect(ftr);
+            ftr.connect(g);
+            o.start(t);
+            o.stop(t + d + 0.02);
+        }
+    }
+
+    meow() {
+        if (!this.ctx || !this.enabled) return;
+        const t = this.ctx.currentTime;
+        const o = this.ctx.createOscillator();
+        o.type = 'triangle';
+        o.frequency.setValueAtTime(720, t);
+        o.frequency.linearRampToValueAtTime(480, t + 0.12);
+        o.frequency.linearRampToValueAtTime(640, t + 0.28);
+        o.frequency.exponentialRampToValueAtTime(300, t + 0.42);
+        const g = this._env(this.sfx, t, 0.02, 0.45, 0.14);
+        o.connect(g);
+        o.start(t);
+        o.stop(t + 0.46);
+    }
+
+    chirp(species) {
+        if (species === 'cat') this.meow();
+        else this.bark();
+    }
+
+    eat() {
+        if (!this.ctx || !this.enabled) return;
+        const t = this.ctx.currentTime;
+        for (let i = 0; i < 6; i++) {
+            const o = this.ctx.createOscillator();
+            o.type = 'square';
+            o.frequency.value = 180 + Math.random() * 90;
+            const g = this._env(this.sfx, t + i * 0.09, 0.005, 0.08, 0.05);
+            o.connect(g);
+            o.start(t + i * 0.09);
+            o.stop(t + i * 0.09 + 0.09);
+        }
+    }
+
+    water() {
+        if (!this.ctx || !this.enabled) return;
+        const t = this.ctx.currentTime;
+        const buf = this.ctx.createBuffer(1, this.ctx.sampleRate * 0.8, this.ctx.sampleRate);
+        const data = buf.getChannelData(0);
+        for (let i = 0; i < data.length; i++) data[i] = (Math.random() * 2 - 1) * (1 - i / data.length);
+        const src = this.ctx.createBufferSource();
+        src.buffer = buf;
+        const f = this.ctx.createBiquadFilter();
+        f.type = 'highpass';
+        f.frequency.value = 900;
+        const g = this._env(this.sfx, t, 0.05, 0.75, 0.12);
+        src.connect(f);
+        f.connect(g);
+        src.start(t);
+    }
+
+    chime() {
+        if (!this.ctx || !this.enabled) return;
+        const t = this.ctx.currentTime;
+        for (const f of [523.25, 659.25, 783.99]) {
+            const o = this.ctx.createOscillator();
+            o.type = 'sine';
+            o.frequency.value = f;
+            const g = this._env(this.sfx, t, 0.01, 0.5, 0.07);
+            o.connect(g);
+            o.start(t);
+            o.stop(t + 0.52);
+        }
+    }
+
+    shake() {
+        if (!this.ctx || !this.enabled) return;
+        const t = this.ctx.currentTime;
+        const o = this.ctx.createOscillator();
+        o.type = 'sawtooth';
+        o.frequency.setValueAtTime(90, t);
+        o.frequency.linearRampToValueAtTime(40, t + 0.35);
+        const g = this._env(this.sfx, t, 0.01, 0.36, 0.1);
+        o.connect(g);
+        o.start(t);
+        o.stop(t + 0.38);
+    }
+
+    startPurr() {
+        if (!this.ctx || !this.enabled || this._purr) return;
+        const ctx = this.ctx;
+        const noise = ctx.createBufferSource();
+        const buf = ctx.createBuffer(1, ctx.sampleRate, ctx.sampleRate);
+        const d = buf.getChannelData(0);
+        for (let i = 0; i < d.length; i++) d[i] = Math.random() * 2 - 1;
+        noise.buffer = buf;
+        noise.loop = true;
+        const f = ctx.createBiquadFilter();
+        f.type = 'bandpass';
+        f.frequency.value = 80;
+        f.Q.value = 6;
+        const g = ctx.createGain();
+        g.gain.value = 0.05;
+        const lfo = ctx.createOscillator();
+        lfo.frequency.value = 12;
+        const lg = ctx.createGain();
+        lg.gain.value = 0.03;
+        lfo.connect(lg);
+        lg.connect(g.gain);
+        noise.connect(f);
+        f.connect(g);
+        g.connect(this.sfx);
+        noise.start();
+        lfo.start();
+        this._purr = { noise, lfo, g };
+    }
+
+    stopPurr() {
+        if (!this._purr) return;
+        try {
+            this._purr.noise.stop();
+            this._purr.lfo.stop();
+        } catch { /* */ }
+        this._purr = null;
+    }
+}

--- a/labs/mimo/src/config.js
+++ b/labs/mimo/src/config.js
@@ -1,0 +1,225 @@
+/**
+ * Mimo — regras, raças e paleta.
+ *
+ * Necessidades em [0, 100]: fome, alegria, higiene, energia, carinho.
+ *
+ * Decaimento em jogo (por segundo, pet acordado):
+ *   fome 0.12 (~14 min até 0) · alegria 0.08 · higiene 0.06 · energia 0.07 · carinho 0.05
+ * Dormindo: energia sobe 5/s; as outras caem pela metade.
+ *
+ * Ausente (por hora real, aplicado no load):
+ *   fome −8 · alegria −5 · higiene −4 · energia +12 (teto 100) · carinho −6
+ *
+ * Ações (deltas e duração):
+ *   Comer    fome +48  alegria +10              ~4.4 s
+ *   Petisco  fome +14  alegria +22              ~2.1 s
+ *   Brincar  alegria +38 energia −20 fome −8    ~7.2 s
+ *   Banho    higiene = 100 alegria +12 energia −8  ~6.8 s
+ *   Dormir   energia → 100  alegria +8          até encher
+ *   Carinho  carinho +8  alegria +6             por toque (~0.4 s)
+ *
+ * Humor = 0.28·fome + 0.26·alegria + 0.16·higiene + 0.16·energia + 0.14·carinho
+ */
+
+export const STORAGE_KEY = 'mimo-pet-v1';
+
+export const NEED_KEYS = ['hunger', 'joy', 'hygiene', 'energy', 'love'];
+
+export const NEED_LABELS = {
+    hunger: 'Fome',
+    joy: 'Alegria',
+    hygiene: 'Higiene',
+    energy: 'Energia',
+    love: 'Carinho'
+};
+
+export const DECAY_PLAY = {
+    hunger: 0.12,
+    joy: 0.08,
+    hygiene: 0.06,
+    energy: 0.07,
+    love: 0.05
+};
+
+export const DECAY_AWAY_PER_HOUR = {
+    hunger: -8,
+    joy: -5,
+    hygiene: -4,
+    energy: 12,
+    love: -6
+};
+
+export const SLEEP_ENERGY = 5;
+
+export const ACTIONS = {
+    feed: { duration: 4.4, hunger: 48, joy: 10 },
+    treat: { duration: 2.1, hunger: 14, joy: 22 },
+    play: { duration: 7.2, joy: 38, energy: -20, hunger: -8 },
+    bath: { duration: 6.8, hygiene: 100, joy: 12, energy: -8, setHygiene: true },
+    sleep: { duration: 0, energy: 100, joy: 8 },
+    pet: { duration: 0.45, love: 8, joy: 6 }
+};
+
+export const MOOD_WEIGHTS = {
+    hunger: 0.28,
+    joy: 0.26,
+    hygiene: 0.16,
+    energy: 0.16,
+    love: 0.14
+};
+
+export const COATS = [
+    { id: 'cream', name: 'Creme', primary: '#e8d2b0', secondary: '#f4ece0', belly: '#f7efe4', nose: '#3a2420', eyes: '#6b4a2a' },
+    { id: 'gold', name: 'Dourado', primary: '#c9924a', secondary: '#e8c888', belly: '#f0d9b0', nose: '#3a2420', eyes: '#4a6a38' },
+    { id: 'chocolate', name: 'Chocolate', primary: '#6b3d24', secondary: '#c4a07a', belly: '#d4b896', nose: '#1a1010', eyes: '#8a5a28' },
+    { id: 'black', name: 'Preto', primary: '#1c1a1c', secondary: '#3a3438', belly: '#2a2628', nose: '#111010', eyes: '#d4a84a' },
+    { id: 'gray', name: 'Cinza', primary: '#8a8c94', secondary: '#d0d2d8', belly: '#eceef2', nose: '#2a2428', eyes: '#6a8cb0' },
+    { id: 'orange', name: 'Laranja', primary: '#d07838', secondary: '#f0c090', belly: '#f4e0c4', nose: '#3a2018', eyes: '#3d6a38' },
+    { id: 'white', name: 'Branco', primary: '#f2eee8', secondary: '#e8d8c8', belly: '#fffaf4', nose: '#e8a0b0', eyes: '#58a0d0' },
+    { id: 'sable', name: 'Sable', primary: '#8a5a32', secondary: '#f0e4d0', belly: '#f6ead8', nose: '#2a1814', eyes: '#3a5a28' }
+];
+
+export const DOG_BREEDS = [
+    {
+        id: 'golden', name: 'Golden Retriever',
+        bodyLen: 1.18, bodyH: 0.52, bodyW: 0.48, legLen: 0.42, legR: 0.09,
+        head: 0.42, snout: 0.34, ear: 'floppy', earSize: 1.05,
+        tail: 'bushy', fur: 0.85, coat: 'gold', pattern: 'solid',
+        names: ['Mel', 'Thor', 'Lola', 'Sol']
+    },
+    {
+        id: 'labrador', name: 'Labrador',
+        bodyLen: 1.08, bodyH: 0.54, bodyW: 0.5, legLen: 0.4, legR: 0.1,
+        head: 0.44, snout: 0.3, ear: 'floppy', earSize: 0.86,
+        tail: 'otter', fur: 0.35, coat: 'gold', pattern: 'solid',
+        names: ['Max', 'Nina', 'Toby', 'Lua']
+    },
+    {
+        id: 'shiba', name: 'Shiba Inu',
+        bodyLen: 0.92, bodyH: 0.48, bodyW: 0.46, legLen: 0.36, legR: 0.085,
+        head: 0.46, snout: 0.22, ear: 'point', earSize: 0.92,
+        tail: 'curl', fur: 0.7, coat: 'orange', pattern: 'bicolor',
+        names: ['Kiko', 'Hana', 'Mochi', 'Yuki']
+    },
+    {
+        id: 'poodle', name: 'Poodle',
+        bodyLen: 0.95, bodyH: 0.46, bodyW: 0.4, legLen: 0.46, legR: 0.07,
+        head: 0.4, snout: 0.28, ear: 'floppy', earSize: 0.9,
+        tail: 'pompon', fur: 1, coat: 'cream', pattern: 'poodle',
+        names: ['Coco', 'Pierre', 'Bela', 'Nino']
+    },
+    {
+        id: 'bulldog', name: 'Bulldog',
+        bodyLen: 0.88, bodyH: 0.5, bodyW: 0.58, legLen: 0.26, legR: 0.11,
+        head: 0.52, snout: 0.12, ear: 'fold', earSize: 0.7,
+        tail: 'short', fur: 0.15, coat: 'sable', pattern: 'bicolor',
+        names: ['Brutus', 'Daisy', 'Tank', 'Pudim']
+    },
+    {
+        id: 'husky', name: 'Husky',
+        bodyLen: 1.12, bodyH: 0.52, bodyW: 0.46, legLen: 0.44, legR: 0.085,
+        head: 0.42, snout: 0.28, ear: 'point', earSize: 0.95,
+        tail: 'bushy', fur: 0.8, coat: 'gray', pattern: 'mask',
+        names: ['Nieve', 'Koda', 'Storm', 'Alaska']
+    },
+    {
+        id: 'dachshund', name: 'Dachshund',
+        bodyLen: 1.42, bodyH: 0.34, bodyW: 0.36, legLen: 0.18, legR: 0.07,
+        head: 0.36, snout: 0.42, ear: 'floppy', earSize: 1.15,
+        tail: 'whip', fur: 0.25, coat: 'chocolate', pattern: 'solid',
+        names: ['Salsicha', 'Pretzel', 'Lili', 'Otto']
+    },
+    {
+        id: 'collie', name: 'Border Collie',
+        bodyLen: 1.1, bodyH: 0.5, bodyW: 0.42, legLen: 0.44, legR: 0.08,
+        head: 0.4, snout: 0.3, ear: 'semi', earSize: 0.88,
+        tail: 'plume', fur: 0.75, coat: 'black', pattern: 'bicolor',
+        names: ['Sky', 'Bess', 'Ranger', 'Pip']
+    }
+];
+
+export const CAT_BREEDS = [
+    {
+        id: 'siamese', name: 'Siamês',
+        bodyLen: 0.95, bodyH: 0.36, bodyW: 0.32, legLen: 0.34, legR: 0.055,
+        head: 0.34, snout: 0.16, ear: 'point', earSize: 1.25,
+        tail: 'whip', fur: 0.25, coat: 'cream', pattern: 'colorpoint',
+        names: ['Suki', 'Ming', 'Cleo', 'Thai']
+    },
+    {
+        id: 'persian', name: 'Persa',
+        bodyLen: 0.85, bodyH: 0.42, bodyW: 0.48, legLen: 0.22, legR: 0.08,
+        head: 0.46, snout: 0.08, ear: 'small', earSize: 0.62,
+        tail: 'plume', fur: 1, coat: 'cream', pattern: 'solid',
+        names: ['Nuvem', 'Mimi', 'Duque', 'Pompom']
+    },
+    {
+        id: 'mainecoon', name: 'Maine Coon',
+        bodyLen: 1.2, bodyH: 0.44, bodyW: 0.42, legLen: 0.38, legR: 0.07,
+        head: 0.4, snout: 0.18, ear: 'tuft', earSize: 1.15,
+        tail: 'plume', fur: 0.95, coat: 'sable', pattern: 'tabby',
+        names: ['Leon', 'Maple', 'Odin', 'Fera']
+    },
+    {
+        id: 'orange', name: 'Laranja',
+        bodyLen: 0.9, bodyH: 0.38, bodyW: 0.36, legLen: 0.3, legR: 0.06,
+        head: 0.38, snout: 0.14, ear: 'point', earSize: 1,
+        tail: 'whip', fur: 0.4, coat: 'orange', pattern: 'tabby',
+        names: ['Garfield', 'Frajola', 'Tangerina', 'Ginger']
+    },
+    {
+        id: 'black', name: 'Preto',
+        bodyLen: 0.88, bodyH: 0.36, bodyW: 0.34, legLen: 0.3, legR: 0.058,
+        head: 0.36, snout: 0.14, ear: 'point', earSize: 1.05,
+        tail: 'whip', fur: 0.35, coat: 'black', pattern: 'solid',
+        names: ['Shadow', 'Noite', 'Salém', 'Ink']
+    },
+    {
+        id: 'ragdoll', name: 'Ragdoll',
+        bodyLen: 1.05, bodyH: 0.4, bodyW: 0.4, legLen: 0.32, legR: 0.065,
+        head: 0.4, snout: 0.14, ear: 'point', earSize: 0.92,
+        tail: 'plume', fur: 0.9, coat: 'cream', pattern: 'colorpoint',
+        names: ['Doll', 'Azul', 'Momo', 'Luna']
+    },
+    {
+        id: 'british', name: 'British Shorthair',
+        bodyLen: 0.86, bodyH: 0.42, bodyW: 0.46, legLen: 0.24, legR: 0.08,
+        head: 0.46, snout: 0.12, ear: 'small', earSize: 0.72,
+        tail: 'thick', fur: 0.55, coat: 'gray', pattern: 'solid',
+        names: ['Winston', 'Misty', 'Earl', 'Puff']
+    },
+    {
+        id: 'calico', name: 'Calico',
+        bodyLen: 0.9, bodyH: 0.37, bodyW: 0.35, legLen: 0.3, legR: 0.06,
+        head: 0.37, snout: 0.14, ear: 'point', earSize: 1,
+        tail: 'whip', fur: 0.4, coat: 'white', pattern: 'patches',
+        names: ['Pinta', 'Flor', 'Calí', 'Mancha']
+    }
+];
+
+export function breedsOf(species) {
+    return species === 'cat' ? CAT_BREEDS : DOG_BREEDS;
+}
+
+export function breedById(species, id) {
+    return breedsOf(species).find((b) => b.id === id) || breedsOf(species)[0];
+}
+
+export function coatById(id) {
+    return COATS.find((c) => c.id === id) || COATS[0];
+}
+
+export const QUALITY = {
+    low: { id: 'low', pixelRatio: 1, shadows: false, shadowSize: 512, bloom: false, dust: 40, aniso: 2, segs: 12 },
+    medium: { id: 'medium', pixelRatio: 1.5, shadows: true, shadowSize: 1024, bloom: true, dust: 90, aniso: 4, segs: 18 },
+    high: { id: 'high', pixelRatio: 2, shadows: true, shadowSize: 2048, bloom: true, dust: 180, aniso: 8, segs: 28 }
+};
+
+export const LIGHT = {
+    exposure: 1.08,
+    clear: 0x1a1412,
+    fog: 0x2a201c,
+    sun: 0xffd4a0,
+    sky: 0xa8c8e8,
+    ground: 0x4a3024
+};

--- a/labs/mimo/src/effects.js
+++ b/labs/mimo/src/effects.js
@@ -1,0 +1,148 @@
+/**
+ * Partículas: corações, gotas, bolhas e farelo.
+ */
+
+import * as THREE from 'three';
+
+function makeSprite(draw, size = 64) {
+    const el = document.createElement('canvas');
+    el.width = el.height = size;
+    draw(el.getContext('2d'), size);
+    const tex = new THREE.CanvasTexture(el);
+    tex.colorSpace = THREE.SRGBColorSpace;
+    return new THREE.SpriteMaterial({
+        map: tex,
+        transparent: true,
+        depthWrite: false,
+        blending: THREE.AdditiveBlending
+    });
+}
+
+const heartMat = makeSprite((ctx, s) => {
+    ctx.translate(s / 2, s / 2);
+    ctx.scale(s / 28, s / 28);
+    ctx.beginPath();
+    ctx.moveTo(0, 6);
+    ctx.bezierCurveTo(-12, -2, -10, -12, 0, -6);
+    ctx.bezierCurveTo(10, -12, 12, -2, 0, 6);
+    ctx.fillStyle = '#ff6b8a';
+    ctx.fill();
+});
+
+const dropMat = makeSprite((ctx, s) => {
+    ctx.translate(s / 2, s * 0.3);
+    ctx.beginPath();
+    ctx.moveTo(0, 0);
+    ctx.quadraticCurveTo(10, 16, 0, 22);
+    ctx.quadraticCurveTo(-10, 16, 0, 0);
+    ctx.fillStyle = 'rgba(160, 210, 255, 0.95)';
+    ctx.fill();
+});
+
+const bubbleMat = makeSprite((ctx, s) => {
+    ctx.beginPath();
+    ctx.arc(s / 2, s / 2, s * 0.38, 0, Math.PI * 2);
+    ctx.strokeStyle = 'rgba(220, 245, 255, 0.85)';
+    ctx.lineWidth = 3;
+    ctx.stroke();
+    ctx.beginPath();
+    ctx.arc(s * 0.38, s * 0.38, s * 0.1, 0, Math.PI * 2);
+    ctx.fillStyle = 'rgba(255,255,255,0.7)';
+    ctx.fill();
+});
+
+const crumbMat = makeSprite((ctx, s) => {
+    ctx.fillStyle = '#d4a056';
+    ctx.beginPath();
+    ctx.arc(s / 2, s / 2, s * 0.28, 0, Math.PI * 2);
+    ctx.fill();
+});
+
+class Burst {
+    constructor(mat, count) {
+        this.items = [];
+        this.alive = false;
+        for (let i = 0; i < count; i++) {
+            const spr = new THREE.Sprite(mat.clone());
+            spr.visible = false;
+            spr.scale.setScalar(0.12);
+            this.items.push({
+                spr,
+                vel: new THREE.Vector3(),
+                life: 0,
+                max: 1
+            });
+        }
+    }
+
+    addTo(scene) {
+        for (const it of this.items) scene.add(it.spr);
+    }
+
+    spawn(origin, n = this.items.length) {
+        this.alive = true;
+        for (let i = 0; i < this.items.length; i++) {
+            const it = this.items[i];
+            if (i >= n) {
+                it.spr.visible = false;
+                it.life = 0;
+                continue;
+            }
+            it.spr.position.copy(origin);
+            it.spr.position.x += (Math.random() - 0.5) * 0.15;
+            it.spr.position.z += (Math.random() - 0.5) * 0.15;
+            it.vel.set((Math.random() - 0.5) * 0.6, 0.4 + Math.random() * 0.7, (Math.random() - 0.5) * 0.6);
+            it.life = it.max = 0.7 + Math.random() * 0.5;
+            it.spr.visible = true;
+            it.spr.material.opacity = 1;
+        }
+    }
+
+    update(dt) {
+        if (!this.alive) return;
+        let any = false;
+        for (const it of this.items) {
+            if (it.life <= 0) {
+                it.spr.visible = false;
+                continue;
+            }
+            any = true;
+            it.life -= dt;
+            it.vel.y -= 0.55 * dt;
+            it.spr.position.addScaledVector(it.vel, dt);
+            it.spr.material.opacity = Math.max(0, it.life / it.max);
+            it.spr.scale.setScalar(0.08 + 0.1 * (it.life / it.max));
+        }
+        this.alive = any;
+    }
+}
+
+export class Effects {
+    constructor(scene) {
+        this.hearts = new Burst(heartMat, 10);
+        this.drops = new Burst(dropMat, 16);
+        this.bubbles = new Burst(bubbleMat, 14);
+        this.crumbs = new Burst(crumbMat, 8);
+        this.hearts.addTo(scene);
+        this.drops.addTo(scene);
+        this.bubbles.addTo(scene);
+        this.crumbs.addTo(scene);
+    }
+
+    love(pos) { this.hearts.spawn(pos, 8); }
+    splash(pos) { this.drops.spawn(pos, 14); }
+    foam(pos) {
+        this.bubbles.spawn(pos, 12);
+        for (const it of this.bubbles.items) {
+            it.vel.set((Math.random() - 0.5) * 0.2, 0.25 + Math.random() * 0.25, (Math.random() - 0.5) * 0.2);
+        }
+    }
+    eat(pos) { this.crumbs.spawn(pos, 6); }
+
+    update(dt) {
+        this.hearts.update(dt);
+        this.drops.update(dt);
+        this.bubbles.update(dt);
+        this.crumbs.update(dt);
+    }
+}

--- a/labs/mimo/src/hud.js
+++ b/labs/mimo/src/hud.js
@@ -1,0 +1,145 @@
+/**
+ * Ligação HUD ↔ estado: barras, humor, dock de ações e overlays.
+ */
+
+import { NEED_KEYS, breedsOf, COATS } from './config.js';
+import { moodLabel, formatAge } from './utils.js';
+
+const $ = (sel) => document.querySelector(sel);
+
+export class Hud {
+    constructor() {
+        this.els = {
+            loading: $('#loadingOverlay'),
+            loadingText: $('#loadingText'),
+            loadingFill: $('#loadingFill'),
+            welcome: $('#welcomeOverlay'),
+            create: $('#createOverlay'),
+            hud: $('#hud'),
+            pause: $('#pauseOverlay'),
+            error: $('#errorOverlay'),
+            errorText: $('#errorText'),
+            petName: $('#petName'),
+            petMeta: $('#petMeta'),
+            moodLine: $('#moodLine'),
+            message: $('#message'),
+            bars: NEED_KEYS.map((k) => ({
+                key: k,
+                fill: document.querySelector(`[data-need="${k}"]`),
+                val: document.querySelector(`[data-need-val="${k}"]`)
+            })),
+            dock: $('#actionDock'),
+            sound: $('#soundButton'),
+            pauseBtn: $('#pauseButton'),
+            welcomeName: $('#welcomeName'),
+            stepSpecies: $('#stepSpecies'),
+            stepBreed: $('#stepBreed'),
+            stepStyle: $('#stepStyle'),
+            breedGrid: $('#breedGrid'),
+            coatGrid: $('#coatGrid'),
+            nameInput: $('#petNameInput')
+        };
+    }
+
+    setLoading(p, text) {
+        if (this.els.loadingFill) this.els.loadingFill.style.width = `${Math.round(p * 100)}%`;
+        if (text && this.els.loadingText) this.els.loadingText.textContent = text;
+    }
+
+    hideLoading() {
+        if (this.els.loading) this.els.loading.hidden = true;
+    }
+
+    showError(msg) {
+        if (this.els.error) this.els.error.hidden = false;
+        if (this.els.errorText) this.els.errorText.textContent = msg;
+        this.hideLoading();
+    }
+
+    showWelcome(profile) {
+        this.els.welcome.hidden = false;
+        this.els.create.hidden = true;
+        this.els.hud.hidden = true;
+        if (this.els.welcomeName) this.els.welcomeName.textContent = profile.name;
+    }
+
+    showCreate() {
+        this.els.welcome.hidden = true;
+        this.els.create.hidden = false;
+        this.els.hud.hidden = true;
+        this.setCreateStep('species');
+    }
+
+    showCare() {
+        this.els.welcome.hidden = true;
+        this.els.create.hidden = true;
+        this.els.pause.hidden = true;
+        this.els.hud.hidden = false;
+    }
+
+    setPaused(on) {
+        this.els.pause.hidden = !on;
+    }
+
+    setCreateStep(step) {
+        this.els.stepSpecies.hidden = step !== 'species';
+        this.els.stepBreed.hidden = step !== 'breed';
+        this.els.stepStyle.hidden = step !== 'style';
+        document.querySelectorAll('[data-create-step]').forEach((btn) => {
+            btn.setAttribute('aria-current', btn.dataset.createStep === step ? 'step' : 'false');
+        });
+    }
+
+    fillBreeds(species, selected) {
+        const list = breedsOf(species);
+        this.els.breedGrid.innerHTML = list.map((b) => `
+            <button type="button" class="breed-card${b.id === selected ? ' is-on' : ''}" data-breed="${b.id}">
+                <span class="breed-emoji">${species === 'cat' ? '🐱' : '🐶'}</span>
+                <strong>${b.name}</strong>
+            </button>
+        `).join('');
+    }
+
+    fillCoats(selected) {
+        this.els.coatGrid.innerHTML = COATS.map((c) => `
+            <button type="button" class="coat-swatch${c.id === selected ? ' is-on' : ''}"
+                data-coat="${c.id}" title="${c.name}" aria-label="${c.name}"
+                style="--sw: ${c.primary}; --sw2: ${c.secondary}"></button>
+        `).join('');
+    }
+
+    syncProfile(profile) {
+        const mood = moodLabel(profile.needs);
+        this.els.petName.textContent = profile.name;
+        const kind = profile.species === 'cat' ? 'gato' : 'cão';
+        const breed = breedsOf(profile.species).find((b) => b.id === profile.breed);
+        this.els.petMeta.textContent = `${breed?.name || ''} · ${kind} · ${formatAge(Date.now() - profile.bornAt)}`;
+        this.els.moodLine.textContent = `${mood.emoji} ${profile.name} está ${mood.text}`;
+        for (const bar of this.els.bars) {
+            const v = profile.needs[bar.key];
+            if (bar.fill) bar.fill.style.width = `${v}%`;
+            if (bar.val) bar.val.textContent = `${Math.round(v)}`;
+            bar.fill?.parentElement?.classList.toggle('is-low', v < 28);
+        }
+    }
+
+    say(text) {
+        const el = this.els.message;
+        if (!el) return;
+        el.textContent = text;
+        el.dataset.show = 'true';
+        clearTimeout(this._msg);
+        this._msg = setTimeout(() => { el.dataset.show = 'false'; }, 2800);
+    }
+
+    setMuted(on) {
+        this.els.sound?.setAttribute('aria-pressed', on ? 'false' : 'true');
+    }
+
+    setBusy(on) {
+        this.els.dock?.classList.toggle('is-busy', on);
+        document.querySelectorAll('#actionDock button').forEach((b) => {
+            b.disabled = on && b.dataset.action !== 'pet';
+        });
+    }
+}

--- a/labs/mimo/src/main.js
+++ b/labs/mimo/src/main.js
@@ -1,0 +1,579 @@
+/**
+ * Mimo — laço principal: casa, câmera orbital, criação do pet e ações de cuidado.
+ */
+
+import * as THREE from 'three';
+import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+import { RoomEnvironment } from 'three/addons/environments/RoomEnvironment.js';
+import { RectAreaLightUniformsLib } from 'three/addons/lights/RectAreaLightUniformsLib.js';
+
+import { QUALITY, LIGHT, ACTIONS, breedById } from './config.js';
+import { clamp, detectMobile, detectSoftwareGL, rendererIsSoftware } from './utils.js';
+import { Pet } from './pet.js';
+import { buildRoom, updateRoom } from './room.js';
+import { Effects } from './effects.js';
+import { MimoAudio } from './audio.js';
+import { Hud } from './hud.js';
+import {
+    defaultProfile, loadProfile, saveProfile, clearProfile,
+    tickNeeds, applyAction
+} from './state.js';
+
+const $ = (sel) => document.querySelector(sel);
+const HOME_CAM = new THREE.Vector3(1.85, 1.28, 2.35);
+const HOME_TARGET = new THREE.Vector3(0, 0.42, 0.1);
+const TMP = new THREE.Vector3();
+
+function resolveQuality(choice) {
+    if (choice && choice !== 'auto' && QUALITY[choice]) return QUALITY[choice];
+    if (detectMobile() || detectSoftwareGL()) return QUALITY.low;
+    const big = Math.min(window.innerWidth, window.innerHeight) >= 900;
+    return big ? QUALITY.high : QUALITY.medium;
+}
+
+class Mimo {
+    constructor() {
+        this.canvas = $('#scene');
+        this.hud = new Hud();
+        this.audio = new MimoAudio();
+        this.profile = loadProfile() || defaultProfile();
+        this.draft = { ...this.profile };
+        this.mode = 'boot';
+        this.paused = false;
+        this.busy = false;
+        this.time = 0;
+        this.saveAcc = 0;
+        this.hudAcc = 0;
+        this.raycaster = new THREE.Raycaster();
+        this.pointer = new THREE.Vector2();
+        this.settings = this.loadSettings();
+        this._head = new THREE.Vector3();
+    }
+
+    loadSettings() {
+        const fallback = { quality: 'auto', volume: 70, muted: false };
+        try {
+            const raw = localStorage.getItem('mimo-settings');
+            return raw ? { ...fallback, ...JSON.parse(raw) } : fallback;
+        } catch {
+            return fallback;
+        }
+    }
+
+    saveSettings() {
+        try { localStorage.setItem('mimo-settings', JSON.stringify(this.settings)); } catch { /* */ }
+    }
+
+    async init() {
+        window.LabShell?.init();
+        this.hud.setLoading(0.08, 'Abrindo as cortinas…');
+        this.quality = resolveQuality(this.settings.quality);
+        this.mobile = detectMobile();
+
+        try {
+            this.renderer = new THREE.WebGLRenderer({
+                canvas: this.canvas,
+                antialias: this.quality.id !== 'low',
+                powerPreference: 'high-performance',
+                alpha: false
+            });
+        } catch {
+            this.hud.showError('Não foi possível criar o contexto WebGL.');
+            return;
+        }
+
+        this.renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, this.quality.pixelRatio));
+        this.renderer.setSize(window.innerWidth, window.innerHeight, false);
+        this.renderer.outputColorSpace = THREE.SRGBColorSpace;
+        this.renderer.toneMapping = THREE.ACESFilmicToneMapping;
+        this.renderer.toneMappingExposure = LIGHT.exposure;
+        this.renderer.shadowMap.enabled = this.quality.shadows;
+        this.renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+        this.renderer.setClearColor(LIGHT.clear);
+
+        if (rendererIsSoftware(this.renderer) && this.quality.id !== 'low') {
+            this.quality = QUALITY.low;
+            this.renderer.setPixelRatio(1);
+            this.renderer.shadowMap.enabled = false;
+        }
+
+        this.scene = new THREE.Scene();
+        this.scene.background = new THREE.Color(0x241c18);
+        this.scene.fog = new THREE.Fog(0x2a221c, 6.5, 14);
+
+        this.camera = new THREE.PerspectiveCamera(42, window.innerWidth / window.innerHeight, 0.08, 40);
+        this.camera.position.copy(HOME_CAM);
+
+        this.hud.setLoading(0.28, 'Ajeitando o tapete…');
+        const room = buildRoom(this.quality);
+        this.scene.add(room.root);
+        this.refs = room.refs;
+
+        this.hud.setLoading(0.48, 'Chamando o pet…');
+        this.pet = new Pet(this.profile, this.quality);
+        this.scene.add(this.pet.root);
+
+        this.effects = new Effects(this.scene);
+        this.setupLights();
+
+        const pmrem = new THREE.PMREMGenerator(this.renderer);
+        this.scene.environment = pmrem.fromScene(new RoomEnvironment(), 0.05).texture;
+        this.scene.environmentIntensity = 0.42;
+        pmrem.dispose();
+
+        this.controls = new OrbitControls(this.camera, this.canvas);
+        this.controls.enableDamping = true;
+        this.controls.dampingFactor = 0.08;
+        this.controls.target.copy(HOME_TARGET);
+        this.controls.minDistance = 1.15;
+        this.controls.maxDistance = 4.2;
+        this.controls.minPolarAngle = 0.35;
+        this.controls.maxPolarAngle = 1.38;
+        this.controls.enablePan = false;
+        this.controls.autoRotate = true;
+        this.controls.autoRotateSpeed = 0.55;
+
+        this.hud.setLoading(0.72, 'Luz da janela…');
+        await this.setupBloom();
+        this.bind();
+
+        const qSel = $('#qualitySelect');
+        const vol = $('#volumeSlider');
+        if (qSel) qSel.value = this.settings.quality;
+        if (vol) {
+            vol.value = this.settings.volume;
+            $('#volumeValue').textContent = this.settings.volume;
+        }
+        this.audio.setVolume(this.settings.volume / 100);
+        this.audio.setEnabled(!this.settings.muted);
+        this.hud.setMuted(this.settings.muted);
+
+        this.hud.fillBreeds(this.draft.species, this.draft.breed);
+        this.hud.fillCoats(this.draft.coat);
+        if (this.hud.els.nameInput) this.hud.els.nameInput.value = this.draft.name;
+
+        this.renderer.compile(this.scene, this.camera);
+        this.hud.setLoading(1, 'Tudo pronto.');
+        setTimeout(() => {
+            this.hud.hideLoading();
+            const saved = loadProfile();
+            if (saved) this.hud.showWelcome(saved);
+            else this.enterCreate();
+        }, 420);
+
+        this.clock = new THREE.Clock();
+        this.renderer.setAnimationLoop(() => this.frame());
+        window.addEventListener('resize', () => this.resize());
+    }
+
+    setupLights() {
+        RectAreaLightUniformsLib.init();
+        this.scene.add(new THREE.HemisphereLight(LIGHT.sky, LIGHT.ground, 0.55));
+
+        const sun = new THREE.DirectionalLight(LIGHT.sun, 2.15);
+        sun.position.set(-0.4, 3.4, -4.2);
+        sun.castShadow = this.quality.shadows;
+        sun.shadow.mapSize.set(this.quality.shadowSize, this.quality.shadowSize);
+        sun.shadow.camera.near = 0.5;
+        sun.shadow.camera.far = 14;
+        sun.shadow.camera.left = -4;
+        sun.shadow.camera.right = 4;
+        sun.shadow.camera.top = 4;
+        sun.shadow.camera.bottom = -4;
+        sun.shadow.bias = -0.0003;
+        sun.shadow.normalBias = 0.025;
+        this.scene.add(sun);
+
+        const windowLight = new THREE.RectAreaLight(0xffe0b8, 6.5, 2.0, 1.5);
+        windowLight.position.set(0, 1.55, -2.45);
+        windowLight.lookAt(0, 0.8, 0);
+        this.scene.add(windowLight);
+
+        const lamp = new THREE.PointLight(0xffd0a0, 1.15, 5.5, 1.4);
+        lamp.position.set(2.4, 1.35, -1.7);
+        this.scene.add(lamp);
+
+        const fill = new THREE.PointLight(0xc8d8f0, 0.28, 7, 1.2);
+        fill.position.set(-1.4, 2.1, 1.4);
+        this.scene.add(fill);
+    }
+
+    async setupBloom() {
+        if (!this.quality.bloom) return;
+        try {
+            const [{ EffectComposer }, { RenderPass }, { UnrealBloomPass }, { OutputPass }] = await Promise.all([
+                import('three/addons/postprocessing/EffectComposer.js'),
+                import('three/addons/postprocessing/RenderPass.js'),
+                import('three/addons/postprocessing/UnrealBloomPass.js'),
+                import('three/addons/postprocessing/OutputPass.js')
+            ]);
+            const composer = new EffectComposer(this.renderer);
+            composer.setPixelRatio(this.renderer.getPixelRatio());
+            composer.setSize(window.innerWidth, window.innerHeight);
+            composer.addPass(new RenderPass(this.scene, this.camera));
+            composer.addPass(new UnrealBloomPass(new THREE.Vector2(window.innerWidth, window.innerHeight), 0.18, 0.5, 0.86));
+            composer.addPass(new OutputPass());
+            this.composer = composer;
+        } catch {
+            this.composer = null;
+        }
+    }
+
+    bind() {
+        $('#continueButton')?.addEventListener('click', () => this.enterCare(true));
+        $('#newPetButton')?.addEventListener('click', () => this.enterCreate());
+        $('#arriveButton')?.addEventListener('click', () => this.commitCreate());
+        $('#resumeButton')?.addEventListener('click', () => this.setPaused(false));
+        $('#pauseMenuButton')?.addEventListener('click', () => {
+            this.setPaused(false);
+            this.hud.showWelcome(this.profile);
+            this.mode = 'welcome';
+            this.controls.autoRotate = true;
+        });
+        $('#resetPetButton')?.addEventListener('click', () => {
+            clearProfile();
+            this.enterCreate();
+        });
+
+        document.querySelectorAll('[data-create-step]').forEach((btn) => {
+            btn.addEventListener('click', () => this.hud.setCreateStep(btn.dataset.createStep));
+        });
+        document.querySelectorAll('[data-species]').forEach((btn) => {
+            btn.addEventListener('click', () => this.pickSpecies(btn.dataset.species));
+        });
+        this.hud.els.breedGrid?.addEventListener('click', (e) => {
+            const card = e.target.closest('[data-breed]');
+            if (card) this.pickBreed(card.dataset.breed);
+        });
+        this.hud.els.coatGrid?.addEventListener('click', (e) => {
+            const sw = e.target.closest('[data-coat]');
+            if (sw) this.pickCoat(sw.dataset.coat);
+        });
+        this.hud.els.nameInput?.addEventListener('input', (e) => {
+            this.draft.name = e.target.value.slice(0, 16);
+        });
+
+        $('#actionDock')?.addEventListener('click', (e) => {
+            const btn = e.target.closest('[data-action]');
+            if (btn) this.doAction(btn.dataset.action);
+        });
+
+        this.hud.els.sound?.addEventListener('click', () => {
+            this.settings.muted = !this.settings.muted;
+            this.audio.setEnabled(!this.settings.muted);
+            this.hud.setMuted(this.settings.muted);
+            this.saveSettings();
+        });
+        this.hud.els.pauseBtn?.addEventListener('click', () => this.setPaused(true));
+
+        $('#qualitySelect')?.addEventListener('change', (e) => {
+            this.settings.quality = e.target.value;
+            this.saveSettings();
+            this.hud.say('Qualidade na próxima visita.');
+        });
+        $('#volumeSlider')?.addEventListener('input', (e) => {
+            this.settings.volume = Number(e.target.value);
+            $('#volumeValue').textContent = this.settings.volume;
+            this.audio.setVolume(this.settings.volume / 100);
+            this.saveSettings();
+        });
+
+        this.canvas.addEventListener('pointerdown', (e) => this.onDown(e));
+        this.canvas.addEventListener('pointerup', (e) => this.onUp(e));
+
+        window.addEventListener('keydown', (e) => {
+            if (e.key === 'p' || e.key === 'P') this.setPaused(!this.paused);
+            if (e.key === 'm' || e.key === 'M') this.hud.els.sound?.click();
+            if (e.key === 'Escape' && this.mode === 'care') this.setPaused(true);
+        });
+
+        document.addEventListener('pointerdown', () => this.audio.resume(), { once: true });
+    }
+
+    pickSpecies(species) {
+        this.draft.species = species;
+        const list = species === 'cat'
+            ? ['siamese', 'persian', 'mainecoon', 'orange', 'black', 'ragdoll', 'british', 'calico']
+            : ['golden', 'labrador', 'shiba', 'poodle', 'bulldog', 'husky', 'dachshund', 'collie'];
+        if (!list.includes(this.draft.breed)) this.draft.breed = list[0];
+        const b = breedById(species, this.draft.breed);
+        this.draft.coat = b.coat;
+        this.draft.name = b.names[0];
+        if (this.hud.els.nameInput) this.hud.els.nameInput.value = this.draft.name;
+        this.hud.fillBreeds(species, this.draft.breed);
+        this.hud.fillCoats(this.draft.coat);
+        document.querySelectorAll('[data-species]').forEach((el) => {
+            el.classList.toggle('is-on', el.dataset.species === species);
+        });
+        this.rebuildDraft();
+        this.hud.setCreateStep('breed');
+        this.audio.chirp(species);
+    }
+
+    pickBreed(id) {
+        this.draft.breed = id;
+        const b = breedById(this.draft.species, id);
+        this.draft.coat = b.coat;
+        if (!this.hud.els.nameInput?.value || b.names.includes(this.draft.name)) {
+            this.draft.name = b.names[Math.floor(Math.random() * b.names.length)];
+            if (this.hud.els.nameInput) this.hud.els.nameInput.value = this.draft.name;
+        }
+        this.hud.fillBreeds(this.draft.species, id);
+        this.hud.fillCoats(this.draft.coat);
+        this.rebuildDraft();
+        this.audio.chime();
+    }
+
+    pickCoat(id) {
+        this.draft.coat = id;
+        this.hud.fillCoats(id);
+        this.rebuildDraft();
+    }
+
+    rebuildDraft() {
+        this.pet.rebuild({ ...this.draft, needs: this.profile.needs });
+    }
+
+    enterCreate() {
+        this.mode = 'create';
+        this.paused = false;
+        this.hud.setPaused(false);
+        this.draft = {
+            species: 'dog',
+            breed: 'golden',
+            coat: 'gold',
+            name: 'Mel',
+            bornAt: Date.now(),
+            needs: { hunger: 80, joy: 85, hygiene: 95, energy: 88, love: 80 }
+        };
+        this.hud.fillBreeds('dog', 'golden');
+        this.hud.fillCoats('gold');
+        if (this.hud.els.nameInput) this.hud.els.nameInput.value = 'Mel';
+        document.querySelectorAll('[data-species]').forEach((el) => {
+            el.classList.toggle('is-on', el.dataset.species === 'dog');
+        });
+        this.rebuildDraft();
+        this.hud.showCreate();
+        this.controls.autoRotate = true;
+        this.pet.setAction('idle');
+        if (this.refs.tub) this.refs.tub.visible = false;
+    }
+
+    commitCreate() {
+        const name = (this.hud.els.nameInput?.value || this.draft.name || 'Mimo').trim().slice(0, 16);
+        if (!name) {
+            this.hud.els.nameInput?.focus();
+            return;
+        }
+        this.draft.name = name;
+        this.profile = {
+            ...this.draft,
+            bornAt: Date.now(),
+            needs: { hunger: 80, joy: 88, hygiene: 95, energy: 90, love: 82 }
+        };
+        saveProfile(this.profile);
+        this.pet.rebuild(this.profile);
+        this.enterCare(false);
+        this.hud.say(`${this.profile.name} chegou em casa.`);
+        this.audio.chime();
+        this.audio.chirp(this.profile.species);
+    }
+
+    enterCare(fromSave) {
+        this.mode = 'care';
+        this.paused = false;
+        this.controls.autoRotate = false;
+        this.hud.showCare();
+        this.hud.syncProfile(this.profile);
+        this.pet.setAction('idle');
+        if (this.refs.tub) this.refs.tub.visible = false;
+        this.audio.resume();
+        if (fromSave) this.hud.say(`${this.profile.name} sentiu sua falta.`);
+        document.body.dataset.state = 'care';
+    }
+
+    setPaused(on) {
+        if (this.mode !== 'care' && on) return;
+        this.paused = on;
+        this.hud.setPaused(on);
+        this.controls.enabled = !on;
+    }
+
+    hitPet(e) {
+        const rect = this.canvas.getBoundingClientRect();
+        this.pointer.x = ((e.clientX - rect.left) / rect.width) * 2 - 1;
+        this.pointer.y = -((e.clientY - rect.top) / rect.height) * 2 + 1;
+        this.raycaster.setFromCamera(this.pointer, this.camera);
+        return this.raycaster.intersectObject(this.pet.root, true).length > 0;
+    }
+
+    onDown(e) {
+        this._down = { x: e.clientX, y: e.clientY, pet: this.hitPet(e) };
+    }
+
+    onUp(e) {
+        if (!this._down || this.mode !== 'care' || this.paused) return;
+        const dx = e.clientX - this._down.x;
+        const dy = e.clientY - this._down.y;
+        if (Math.hypot(dx, dy) < 8 && this._down.pet) this.doAction('pet');
+        this._down = null;
+    }
+
+    doAction(id) {
+        if (this.mode !== 'care' || this.paused) return;
+        if (this.busy && id !== 'pet') return;
+        const spec = ACTIONS[id];
+        if (!spec) return;
+
+        if (id === 'pet') {
+            this.profile.needs = applyAction(this.profile.needs, 'pet');
+            this.pet.setAction('pet');
+            this.pet.headWorld(this._head);
+            this.effects.love(this._head.clone().add(TMP.set(0, 0.12, 0)));
+            this.audio.chime();
+            if (this.profile.species === 'cat') this.audio.startPurr();
+            else this.audio.chirp('dog');
+            this.hud.say(`Carinho em ${this.profile.name}.`);
+            this.hud.syncProfile(this.profile);
+            saveProfile(this.profile);
+            setTimeout(() => {
+                if (this.pet.action === 'pet') this.pet.setAction('idle');
+                this.audio.stopPurr();
+            }, 700);
+            return;
+        }
+
+        this.busy = true;
+        this.hud.setBusy(true);
+        this.profile.needs = applyAction(this.profile.needs, id);
+        saveProfile(this.profile);
+
+        if (id === 'feed') {
+            this.pet.setAction('eat');
+            this.audio.eat();
+            this.pet.headWorld(this._head);
+            this.effects.eat(this._head.clone());
+            this.hud.say(`${this.profile.name} está comendo.`);
+            this.tweenCam(new THREE.Vector3(1.1, 0.85, 1.6), new THREE.Vector3(0, 0.3, 0.2), spec.duration);
+        } else if (id === 'treat') {
+            this.pet.setAction('eat');
+            this.audio.eat();
+            this.hud.say('Um petisco!');
+        } else if (id === 'play') {
+            this.pet.setAction('play');
+            this.audio.chirp(this.profile.species);
+            this.hud.say(this.profile.species === 'cat' ? 'Novelo voando!' : 'Pega a bolinha!');
+        } else if (id === 'bath') {
+            if (this.refs.tub) this.refs.tub.visible = true;
+            this.pet.setAction('bath');
+            this.pet.setWet(1);
+            this.audio.water();
+            this.pet.headWorld(this._head);
+            this.effects.splash(this._head.clone());
+            this.effects.foam(this._head.clone().add(TMP.set(0, 0.1, 0)));
+            this.hud.say('Banho quentinho.');
+            this.tweenCam(new THREE.Vector3(2.6, 1.1, 2.4), new THREE.Vector3(2.0, 0.3, 1.5), spec.duration * 0.6);
+        } else if (id === 'sleep') {
+            this.pet.setAction('sleep');
+            this.hud.say(`${this.profile.name} cochilou no almofadão.`);
+            this.tweenCam(new THREE.Vector3(-0.4, 0.95, 2.1), new THREE.Vector3(-1.1, 0.2, 1.1), 1.2);
+        }
+
+        const wait = id === 'sleep' ? Math.max(2.4, (100 - this.profile.needs.energy) / 8) : spec.duration;
+        clearTimeout(this._actTimer);
+        this._actTimer = setTimeout(() => this.endAction(id), wait * 1000);
+        this.hud.syncProfile(this.profile);
+    }
+
+    endAction(id) {
+        this.busy = false;
+        this.hud.setBusy(false);
+        if (id === 'bath') {
+            this.pet.setAction('shake');
+            this.audio.shake();
+            this.pet.headWorld(this._head);
+            this.effects.splash(this._head.clone());
+            setTimeout(() => {
+                this.pet.setWet(0);
+                this.pet.setAction('idle');
+                if (this.refs.tub) this.refs.tub.visible = false;
+                this.resetCam();
+            }, 900);
+            return;
+        }
+        if (id === 'sleep') {
+            this.profile.needs.energy = 100;
+            saveProfile(this.profile);
+            this.hud.syncProfile(this.profile);
+        }
+        this.pet.setAction('idle');
+        this.resetCam();
+        this.audio.chirp(this.profile.species);
+    }
+
+    tweenCam(pos, target, dur) {
+        this._camFrom = this.camera.position.clone();
+        this._tgtFrom = this.controls.target.clone();
+        this._camTo = pos;
+        this._tgtTo = target;
+        this._camT = 0;
+        this._camDur = Math.max(0.4, dur * 0.35);
+        this.controls.autoRotate = false;
+    }
+
+    resetCam() {
+        this.tweenCam(HOME_CAM, HOME_TARGET, 1.1);
+    }
+
+    frame() {
+        const dt = Math.min(0.05, this.clock.getDelta());
+        this.time += dt;
+
+        if (this._camTo && this._camT < this._camDur) {
+            this._camT += dt;
+            const k = 1 - Math.pow(1 - clamp(this._camT / this._camDur, 0, 1), 3);
+            this.camera.position.lerpVectors(this._camFrom, this._camTo, k);
+            this.controls.target.lerpVectors(this._tgtFrom, this._tgtTo, k);
+            if (k >= 1) this._camTo = null;
+        }
+
+        this.controls.update();
+        updateRoom(this.refs, this.time);
+        this.effects.update(dt);
+
+        const playing = this.mode === 'care' && !this.paused;
+        if (playing) {
+            const sleeping = this.pet.action === 'sleep';
+            this.profile.needs = tickNeeds(this.profile.needs, dt, sleeping);
+            this.saveAcc += dt;
+            if (this.saveAcc > 4) {
+                saveProfile(this.profile);
+                this.saveAcc = 0;
+            }
+            this.hudAcc += dt;
+            if (this.hudAcc > 0.4) {
+                this.hud.syncProfile(this.profile);
+                this.hudAcc = 0;
+            }
+            if (this.pet.action === 'idle' && this.profile.needs.energy < 18) this.pet.setAction('sit');
+            if (this.pet.action === 'sit' && this.profile.needs.energy > 30) this.pet.setAction('idle');
+        }
+
+        this.pet.update(dt, this.profile.needs);
+
+        if (this.composer) this.composer.render();
+        else this.renderer.render(this.scene, this.camera);
+    }
+
+    resize() {
+        const w = window.innerWidth;
+        const h = window.innerHeight;
+        this.camera.aspect = w / h;
+        this.camera.updateProjectionMatrix();
+        this.renderer.setSize(w, h, false);
+        this.composer?.setSize(w, h);
+    }
+}
+
+const game = new Mimo();
+game.init();

--- a/labs/mimo/src/pet.js
+++ b/labs/mimo/src/pet.js
@@ -1,0 +1,459 @@
+/**
+ * Pet paramétrico: cão ou gato, raça, pelagem e animação por poses.
+ * Origem no chão, pet olha para +Z.
+ */
+
+import * as THREE from 'three';
+import { breedById, coatById } from './config.js';
+import { furMaps } from './textures.js';
+import { damp, clamp } from './utils.js';
+
+const geoCache = new Map();
+
+function geo(key, factory) {
+    if (!geoCache.has(key)) geoCache.set(key, factory());
+    return geoCache.get(key);
+}
+
+function mesh(geometry, material, { pos, scale, rot, cast = true, receive = true } = {}) {
+    const m = new THREE.Mesh(geometry, material);
+    if (pos) m.position.set(...pos);
+    if (scale) m.scale.set(...scale);
+    if (rot) m.rotation.set(...rot);
+    m.castShadow = cast;
+    m.receiveShadow = receive;
+    return m;
+}
+
+function physical(color, maps, extra = {}) {
+    return new THREE.MeshPhysicalMaterial({
+        color,
+        map: maps?.map || null,
+        normalMap: maps?.normalMap || null,
+        roughnessMap: maps?.roughnessMap || null,
+        roughness: extra.roughness ?? 0.76,
+        metalness: 0.02,
+        sheen: extra.sheen ?? 1,
+        sheenColor: extra.sheenColor || new THREE.Color(color).lerp(new THREE.Color(0xfff4e8), 0.45),
+        sheenRoughness: extra.sheenRoughness ?? 0.48,
+        clearcoat: extra.clearcoat ?? 0.06,
+        clearcoatRoughness: extra.clearcoatRoughness ?? 0.55,
+        envMapIntensity: extra.env ?? 0.55
+    });
+}
+
+function eyeMaps() {
+    const el = document.createElement('canvas');
+    el.width = el.height = 128;
+    const ctx = el.getContext('2d');
+    const g = ctx.createRadialGradient(64, 64, 8, 64, 64, 64);
+    g.addColorStop(0, '#1a100c');
+    g.addColorStop(0.22, '#1a100c');
+    g.addColorStop(0.24, '#4a7a38');
+    g.addColorStop(0.55, '#2a4a22');
+    g.addColorStop(0.72, '#f4efe8');
+    g.addColorStop(1, '#e8e0d4');
+    ctx.fillStyle = g;
+    ctx.fillRect(0, 0, 128, 128);
+    const tex = new THREE.CanvasTexture(el);
+    tex.colorSpace = THREE.SRGBColorSpace;
+    return tex;
+}
+
+export class Pet {
+    constructor(profile, quality) {
+        this.profile = profile;
+        this.quality = quality;
+        this.root = new THREE.Group();
+        this.root.name = 'pet';
+        this.parts = { legs: [], ears: [], tail: [], mats: [] };
+        this.action = 'idle';
+        this.actionT = 0;
+        this.wet = 0;
+        this.look = new THREE.Vector2();
+        this.wag = 1;
+        this.sit = 0;
+        this.sleep = 0;
+        this.headDip = 0;
+        this.shake = 0;
+        this.bounce = 0;
+        this.walk = 0;
+        this.phase = 0;
+        this.build();
+    }
+
+    rebuild(profile) {
+        this.profile = profile;
+        while (this.root.children.length) this.root.remove(this.root.children[0]);
+        this.parts = { legs: [], ears: [], tail: [], mats: [], eyes: [] };
+        this.build();
+    }
+
+    build() {
+        const breed = breedById(this.profile.species, this.profile.breed);
+        const coat = coatById(this.profile.coat || breed.coat);
+        this.breed = breed;
+        this.coat = coat;
+        const segs = this.quality?.segs ?? 18;
+        const fur = furMaps(coat.primary, coat.secondary, coat.belly, breed.pattern, this.quality?.aniso ?? 4);
+        const sheenCol = new THREE.Color(coat.primary).lerp(new THREE.Color(0xfff0e0), 0.4);
+        const furMat = physical(0xffffff, fur, {
+            sheenColor: sheenCol,
+            sheen: 0.7 + breed.fur * 0.4,
+            sheenRoughness: 0.35 + (1 - breed.fur) * 0.3,
+            roughness: 0.7 + (1 - breed.fur) * 0.15
+        });
+        const bellyMat = physical(coat.belly, fur, { sheenColor: new THREE.Color(coat.belly) });
+        const noseMat = new THREE.MeshPhysicalMaterial({
+            color: coat.nose, roughness: 0.28, metalness: 0.08, clearcoat: 0.55, clearcoatRoughness: 0.25
+        });
+        const padMat = new THREE.MeshPhysicalMaterial({ color: 0x2a1814, roughness: 0.7 });
+        const innerEar = new THREE.MeshPhysicalMaterial({
+            color: 0xe8a8a0, roughness: 0.55, sheen: 0.4, sheenColor: 0xffd0c8
+        });
+        this.parts.mats.push(furMat, bellyMat);
+        this.furMat = furMat;
+
+        const sph = geo(`sph${segs}`, () => new THREE.SphereGeometry(1, segs, segs - 2));
+        const sphLo = geo('sphLo', () => new THREE.SphereGeometry(1, 12, 10));
+        const cap = geo(`cap${segs}`, () => new THREE.CapsuleGeometry(1, 1, 6, segs));
+        const cyl = geo('cyl', () => new THREE.CylinderGeometry(1, 1, 1, 12));
+
+        const hipY = breed.legLen + 0.02;
+        this.restHip = hipY;
+
+        const body = new THREE.Group();
+        body.position.y = hipY;
+        this.root.add(body);
+        this.parts.body = body;
+
+        const torso = mesh(sph, furMat, {
+            scale: [breed.bodyW, breed.bodyH, breed.bodyLen * 0.5],
+            pos: [0, breed.bodyH * 0.15, 0]
+        });
+        body.add(torso);
+        this.parts.torso = torso;
+
+        body.add(mesh(sph, furMat, {
+            scale: [breed.bodyW * 0.92, breed.bodyH * 0.9, breed.bodyW * 0.85],
+            pos: [0, breed.bodyH * 0.12, breed.bodyLen * 0.28]
+        }));
+        body.add(mesh(sph, furMat, {
+            scale: [breed.bodyW * 0.88, breed.bodyH * 0.85, breed.bodyW * 0.8],
+            pos: [0, breed.bodyH * 0.08, -breed.bodyLen * 0.28]
+        }));
+        body.add(mesh(sphLo, bellyMat, {
+            scale: [breed.bodyW * 0.62, breed.bodyH * 0.42, breed.bodyLen * 0.38],
+            pos: [0, -breed.bodyH * 0.18, 0.04],
+            cast: false
+        }));
+
+        if (breed.fur > 0.7) {
+            body.add(mesh(sphLo, furMat, {
+                scale: [breed.bodyW * 1.05, breed.bodyH * 0.7, breed.bodyLen * 0.22],
+                pos: [0, breed.bodyH * 0.08, -breed.bodyLen * 0.38]
+            }));
+        }
+
+        if (breed.pattern === 'poodle') {
+            body.add(mesh(sph, furMat, {
+                scale: [breed.bodyW * 0.7, breed.bodyH * 0.7, breed.bodyW * 0.7],
+                pos: [0, breed.bodyH * 0.22, breed.bodyLen * 0.22]
+            }));
+        }
+
+        const cat = this.profile.species === 'cat';
+        const neck = new THREE.Group();
+        neck.position.set(0, breed.bodyH * 0.35, breed.bodyLen * 0.38);
+        body.add(neck);
+        this.parts.neck = neck;
+
+        const head = new THREE.Group();
+        head.position.set(0, breed.head * 0.15, breed.head * 0.15);
+        neck.add(head);
+        this.parts.head = head;
+
+        const hs = breed.head;
+        head.add(mesh(sph, furMat, { scale: [hs * 0.95, hs * (cat ? 0.88 : 0.92), hs] }));
+        if (breed.snout > 0.1) {
+            head.add(mesh(sph, bellyMat, {
+                scale: [hs * 0.42 * (0.6 + breed.snout), hs * 0.32, hs * breed.snout * 1.15],
+                pos: [0, -hs * 0.18, hs * (0.55 + breed.snout * 0.4)]
+            }));
+        }
+        head.add(mesh(sphLo, noseMat, {
+            scale: [0.045 + breed.snout * 0.04, 0.035, 0.04],
+            pos: [0, -hs * 0.16, hs * (0.72 + breed.snout * 0.55)]
+        }));
+
+        const eyeMat = new THREE.MeshPhysicalMaterial({
+            map: eyeMaps(),
+            color: new THREE.Color(coat.eyes),
+            roughness: 0.12,
+            metalness: 0.05,
+            clearcoat: 0.9,
+            clearcoatRoughness: 0.08,
+            envMapIntensity: 1.1
+        });
+        const spark = new THREE.MeshPhysicalMaterial({
+            color: 0xffffff, emissive: 0xffffff, emissiveIntensity: 0.45, roughness: 0.1
+        });
+        const eyeZ = hs * (0.62 + breed.snout * 0.1);
+        const eyeY = cat ? hs * 0.08 : hs * 0.06;
+        const eyeSpread = hs * (cat ? 0.32 : 0.3);
+        const eyeS = cat ? 0.072 : 0.078;
+        this.parts.eyes = [];
+        for (const sx of [-1, 1]) {
+            const eye = mesh(sph, eyeMat, {
+                scale: [eyeS, eyeS * 1.05, eyeS * 0.7],
+                pos: [sx * eyeSpread, eyeY, eyeZ],
+                cast: false
+            });
+            head.add(eye);
+            this.parts.eyes.push(eye);
+            head.add(mesh(sphLo, spark, {
+                scale: [0.018, 0.02, 0.012],
+                pos: [sx * eyeSpread + 0.018, eyeY + 0.02, eyeZ + 0.04],
+                cast: false
+            }));
+        }
+
+        head.add(mesh(sphLo, innerEar, {
+            scale: [0.06, 0.04, 0.04], pos: [hs * 0.42, -hs * 0.12, hs * 0.5], cast: false
+        }));
+        head.add(mesh(sphLo, innerEar, {
+            scale: [0.06, 0.04, 0.04], pos: [-hs * 0.42, -hs * 0.12, hs * 0.5], cast: false
+        }));
+
+        this._ears(head, breed, furMat, innerEar, sph, segs);
+
+        if (cat) {
+            const whisker = new THREE.MeshPhysicalMaterial({
+                color: 0xf4efe8, roughness: 0.4, transparent: true, opacity: 0.75
+            });
+            const wgeo = geo('whisk', () => new THREE.CylinderGeometry(0.006, 0.004, 0.28, 4));
+            for (const sx of [-1, 1]) {
+                for (const k of [-0.08, 0, 0.08]) {
+                    head.add(mesh(wgeo, whisker, {
+                        pos: [sx * hs * 0.28, -hs * 0.12 + k * 0.4, hs * 0.55],
+                        rot: [0, 0, sx * (1.15 + k)],
+                        cast: false
+                    }));
+                }
+            }
+        }
+
+        neck.add(mesh(cyl, new THREE.MeshPhysicalMaterial({
+            color: 0xc45a48, roughness: 0.4, metalness: 0.15, clearcoat: 0.3
+        }), {
+            scale: [hs * 0.72, 0.04, hs * 0.72],
+            pos: [0, -hs * 0.42, -hs * 0.05],
+            rot: [0.15, 0, 0]
+        }));
+        neck.add(mesh(sphLo, new THREE.MeshPhysicalMaterial({
+            color: 0xe8c878, roughness: 0.25, metalness: 0.7
+        }), { scale: [0.04, 0.05, 0.012], pos: [0, -hs * 0.52, hs * 0.28] }));
+
+        this._legs(breed, furMat, padMat, cap, sphLo);
+        this._tail(breed, furMat, sph, sphLo);
+
+        const shadow = new THREE.Mesh(
+            geo('shad', () => new THREE.CircleGeometry(0.55, 24)),
+            new THREE.MeshBasicMaterial({ color: 0x1a100c, transparent: true, opacity: 0.22, depthWrite: false })
+        );
+        shadow.rotation.x = -Math.PI / 2;
+        shadow.position.y = 0.01;
+        this.root.add(shadow);
+        this.parts.shadow = shadow;
+    }
+
+    _ears(head, breed, furMat, innerEar, sph, segs) {
+        const type = breed.ear;
+        const s = breed.earSize * breed.head;
+        const cone = geo(`cone${segs}`, () => new THREE.ConeGeometry(1, 1.4, 10));
+        for (const sx of [-1, 1]) {
+            const ear = new THREE.Group();
+            ear.position.set(sx * breed.head * 0.52, breed.head * 0.55, -breed.head * 0.08);
+            head.add(ear);
+            this.parts.ears.push(ear);
+
+            if (type === 'floppy') {
+                ear.rotation.set(0.15, sx * 0.15, sx * 0.9);
+                ear.add(mesh(sph, furMat, { scale: [s * 0.22, s * 0.55, s * 0.16], pos: [0, -s * 0.2, 0] }));
+                ear.add(mesh(sph, innerEar, {
+                    scale: [s * 0.14, s * 0.4, s * 0.08], pos: [sx * -0.02, -s * 0.18, s * 0.08], cast: false
+                }));
+            } else if (type === 'fold') {
+                ear.rotation.set(0.4, sx * 0.2, sx * 0.6);
+                ear.add(mesh(sph, furMat, { scale: [s * 0.2, s * 0.28, s * 0.12] }));
+            } else if (type === 'small') {
+                ear.rotation.set(0, 0, sx * 0.35);
+                ear.add(mesh(sph, furMat, { scale: [s * 0.18, s * 0.28, s * 0.12], pos: [0, s * 0.1, 0] }));
+                ear.add(mesh(sph, innerEar, {
+                    scale: [s * 0.1, s * 0.18, s * 0.06], pos: [0, s * 0.1, s * 0.06], cast: false
+                }));
+            } else if (type === 'tuft') {
+                ear.rotation.set(-0.15, sx * 0.1, sx * 0.25);
+                ear.add(mesh(cone, furMat, { scale: [s * 0.22, s * 0.55, s * 0.18], pos: [0, s * 0.28, 0] }));
+                ear.add(mesh(cone, innerEar, {
+                    scale: [s * 0.12, s * 0.38, s * 0.08], pos: [0, s * 0.22, s * 0.06], cast: false
+                }));
+                ear.add(mesh(sph, furMat, { scale: [0.03, s * 0.18, 0.03], pos: [0, s * 0.72, 0] }));
+            } else if (type === 'semi') {
+                ear.rotation.set(-0.2, sx * 0.15, sx * 0.4);
+                ear.add(mesh(sph, furMat, { scale: [s * 0.18, s * 0.42, s * 0.12], pos: [0, s * 0.12, 0] }));
+                ear.add(mesh(sph, innerEar, {
+                    scale: [s * 0.1, s * 0.28, s * 0.06], pos: [0, s * 0.1, s * 0.06], cast: false
+                }));
+            } else {
+                ear.rotation.set(-0.25, sx * 0.12, sx * 0.22);
+                ear.add(mesh(cone, furMat, { scale: [s * 0.22, s * 0.55, s * 0.16], pos: [0, s * 0.28, 0] }));
+                ear.add(mesh(cone, innerEar, {
+                    scale: [s * 0.12, s * 0.4, s * 0.07], pos: [0, s * 0.22, s * 0.05], cast: false
+                }));
+            }
+        }
+    }
+
+    _legs(breed, furMat, padMat, cap, sphLo) {
+        const len = breed.legLen;
+        const r = breed.legR;
+        const zf = breed.bodyLen * 0.28;
+        const zb = -breed.bodyLen * 0.26;
+        const x = breed.bodyW * 0.55;
+        const places = [[-x, zf], [x, zf], [-x, zb], [x, zb]];
+        for (let i = 0; i < 4; i++) {
+            const [px, pz] = places[i];
+            const leg = new THREE.Group();
+            leg.position.set(px, this.restHip, pz);
+            this.root.add(leg);
+            leg.add(mesh(cap, furMat, { scale: [r, len * 0.55, r], pos: [0, -len * 0.35, 0] }));
+            leg.add(mesh(sphLo, padMat, {
+                scale: [r * 1.35, r * 0.55, r * 1.5], pos: [0, -len * 0.92, r * 0.3]
+            }));
+            this.parts.legs.push(leg);
+        }
+    }
+
+    _tail(breed, furMat, sph, sphLo) {
+        const holder = new THREE.Group();
+        holder.position.set(0, this.restHip + breed.bodyH * 0.25, -breed.bodyLen * 0.48);
+        this.root.add(holder);
+        this.parts.tailRoot = holder;
+        const n = breed.tail === 'short' ? 2 : 5;
+        let parent = holder;
+        const thick = breed.tail === 'whip' ? 0.045 : breed.tail === 'otter' ? 0.07 : 0.09;
+        for (let i = 0; i < n; i++) {
+            const seg = new THREE.Group();
+            parent.add(seg);
+            const s = thick * (1 - i * 0.12);
+            const len = breed.tail === 'short' ? 0.08 : 0.14;
+            const puff = breed.tail === 'bushy' || breed.tail === 'plume' || breed.tail === 'pompon';
+            const sc = puff ? [s * 1.6, s * 1.6, len] : [s, s, len];
+            seg.add(mesh(puff ? sph : sphLo, furMat, { scale: sc, pos: [0, 0, -len * 0.5] }));
+            if (breed.tail === 'pompon' && i === n - 1) {
+                seg.add(mesh(sph, furMat, { scale: [0.12, 0.12, 0.12], pos: [0, 0, -len] }));
+            }
+            seg.rotation.x = breed.tail === 'curl' ? -0.55 : breed.tail === 'short' ? 0.4 : -0.25;
+            this.parts.tail.push(seg);
+            parent = seg;
+        }
+    }
+
+    setAction(name) {
+        this.action = name;
+        this.actionT = 0;
+        if (name !== 'sleep') this.sleep = Math.min(this.sleep, 0.3);
+    }
+
+    setWet(v) {
+        this.wet = clamp(v, 0, 1);
+        for (const mat of this.parts.mats) {
+            mat.clearcoat = 0.06 + this.wet * 0.7;
+            mat.clearcoatRoughness = 0.55 - this.wet * 0.4;
+            mat.roughness = 0.76 - this.wet * 0.28;
+        }
+    }
+
+    headWorld(out) {
+        this.parts.head.getWorldPosition(out);
+        return out;
+    }
+
+    update(dt, needs) {
+        this.actionT += dt;
+        this.phase += dt;
+        const tired = needs.energy < 28;
+        const sad = needs.joy < 28;
+        const dirty = needs.hygiene < 30;
+
+        const wantSit = this.action === 'sit' || this.action === 'eat' || this.action === 'bath'
+            || (tired && this.action === 'idle');
+        const wantSleep = this.action === 'sleep';
+        this.sit = damp(this.sit, wantSit ? 1 : 0, 4.2, dt);
+        this.sleep = damp(this.sleep, wantSleep ? 1 : 0, 2.4, dt);
+        this.headDip = damp(this.headDip, this.action === 'eat' ? 1 : 0, 6, dt);
+        const playing = this.action === 'play';
+        this.walk = damp(this.walk, (this.action === 'walk' || playing) ? 1 : 0, 5, dt);
+        this.bounce = damp(this.bounce, playing ? 1 : 0, 5, dt);
+        this.shake = damp(this.shake, this.action === 'shake' ? 1 : 0, 8, dt);
+        this.wag = damp(this.wag, sad ? 0.15 : this.action === 'pet' ? 1.8 : 1, 3, dt);
+
+        const breath = 1 + Math.sin(this.phase * (wantSleep ? 1.4 : 2.4)) * 0.03;
+        this.parts.torso.scale.y = this.breed.bodyH * breath;
+
+        const hipDrop = this.sit * this.restHip * 0.42 + this.sleep * this.restHip * 0.55;
+        this.parts.body.position.y = this.restHip - hipDrop;
+        this.parts.body.rotation.x = this.sit * 0.22 + this.sleep * 0.55;
+        this.root.rotation.z = this.sleep * 0.7;
+        this.root.position.y = this.bounce * Math.abs(Math.sin(this.phase * 8)) * 0.12;
+
+        if (this.action === 'play') {
+            this.root.position.x = Math.sin(this.phase * 1.6) * 0.55;
+            this.root.position.z = Math.cos(this.phase * 1.6) * 0.35;
+            this.root.rotation.y = Math.sin(this.phase * 1.6) * 0.4 + Math.PI * 0.15;
+        } else if (this.action !== 'walk') {
+            this.root.position.x = damp(this.root.position.x, 0, 3, dt);
+            this.root.position.z = damp(this.root.position.z, 0, 3, dt);
+            if (this.action === 'idle' && !wantSleep) {
+                this.root.rotation.y = damp(this.root.rotation.y, Math.sin(this.phase * 0.25) * 0.15, 2, dt);
+            }
+        }
+
+        this.parts.neck.rotation.x = this.headDip * 0.7 - this.sit * 0.1 + Math.sin(this.phase * 1.1) * 0.04;
+        this.parts.head.rotation.y = this.look.x + Math.sin(this.phase * 0.6) * 0.08;
+        this.parts.head.rotation.x = this.look.y - this.headDip * 0.25;
+        this.parts.head.rotation.z = this.shake * Math.sin(this.phase * 28) * 0.35;
+
+        const blink = (this.phase % 4.6) < 0.12 || this.sleep > 0.5 || this.action === 'pet';
+        for (const eye of this.parts.eyes || []) {
+            eye.scale.y = blink ? 0.012 : eye.scale.x * 1.05;
+        }
+
+        const gait = this.phase * 10;
+        this.parts.legs.forEach((leg, i) => {
+            const front = i < 2;
+            const stride = Math.sin(gait + (i % 2 === 0 ? 0 : Math.PI)) * this.walk * 0.55;
+            leg.rotation.x = stride + (front ? this.sit * 0.15 : this.sit * 1.15);
+            leg.position.y = this.restHip - hipDrop * (front ? 0.15 : 0.85);
+            if (!front) leg.position.z = -this.breed.bodyLen * 0.26 + this.sit * 0.12;
+        });
+
+        const wagSpeed = 7 + this.wag * 4;
+        const wagAmp = 0.22 * this.wag * (1 - this.sleep);
+        this.parts.tail.forEach((seg, i) => {
+            const curl = this.breed.tail === 'curl' ? -0.5 : this.breed.tail === 'short' ? 0.35 : -0.22;
+            seg.rotation.x = curl + this.sit * 0.2;
+            seg.rotation.y = Math.sin(this.phase * wagSpeed - i * 0.7) * wagAmp * ((i + 1) / this.parts.tail.length);
+        });
+
+        if (this.parts.shadow) {
+            this.parts.shadow.scale.setScalar(1 + this.sit * 0.15);
+            this.parts.shadow.material.opacity = 0.18 + this.sleep * 0.08;
+        }
+
+        this.furMat.color.setHex(0xffffff).multiplyScalar(dirty ? 0.72 : 1);
+        this.look.x = damp(this.look.x, 0, 1.6, dt);
+        this.look.y = damp(this.look.y, 0, 1.6, dt);
+    }
+}

--- a/labs/mimo/src/room.js
+++ b/labs/mimo/src/room.js
@@ -1,0 +1,270 @@
+/**
+ * Sala de estar ao fim da tarde: janela, tapete, sofá, planta e o cantinho do pet.
+ */
+
+import * as THREE from 'three';
+import { woodMaps, plasterMaps, fabricMaps, rugMaps, cushionMaps, skyTexture, leafMaps } from './textures.js';
+
+function mesh(geo, mat, { pos, scale, rot, cast = true, receive = true } = {}) {
+    const m = new THREE.Mesh(geo, mat);
+    if (pos) m.position.set(...pos);
+    if (scale) m.scale.set(...scale);
+    if (rot) m.rotation.set(...rot);
+    m.castShadow = cast;
+    m.receiveShadow = receive;
+    return m;
+}
+
+export function buildRoom(quality) {
+    const aniso = quality.aniso ?? 4;
+    const root = new THREE.Group();
+    const refs = {};
+
+    const wood = woodMaps(aniso);
+    const plaster = plasterMaps(aniso);
+    const fabric = fabricMaps(aniso);
+    const rug = rugMaps(aniso);
+    const cushion = cushionMaps(aniso);
+    const leaf = leafMaps(aniso);
+
+    const woodMat = new THREE.MeshPhysicalMaterial({
+        ...wood, color: 0xc4a070, roughness: 0.62, metalness: 0.02, envMapIntensity: 0.5
+    });
+    const wallMat = new THREE.MeshPhysicalMaterial({
+        ...plaster, color: 0xf0e4d4, roughness: 0.92, envMapIntensity: 0.25
+    });
+    const wallWarm = new THREE.MeshPhysicalMaterial({
+        ...plaster, color: 0xe8c8a8, roughness: 0.9, envMapIntensity: 0.25
+    });
+    const fabricMat = new THREE.MeshPhysicalMaterial({
+        ...fabric, color: 0x8a4030, roughness: 0.88, sheen: 0.6, sheenColor: 0xd08060
+    });
+    const rugMat = new THREE.MeshPhysicalMaterial({
+        ...rug, roughness: 0.95, sheen: 0.35, sheenColor: 0xe8a070
+    });
+    const cushionMat = new THREE.MeshPhysicalMaterial({
+        ...cushion, color: 0xe8c888, roughness: 0.86, sheen: 0.5, sheenColor: 0xffe8c0
+    });
+    const ceramic = new THREE.MeshPhysicalMaterial({
+        color: 0xf4efe8, roughness: 0.22, metalness: 0.05, clearcoat: 0.8, clearcoatRoughness: 0.12
+    });
+    const ceramicBlue = new THREE.MeshPhysicalMaterial({
+        color: 0x6a8aa8, roughness: 0.25, clearcoat: 0.7, clearcoatRoughness: 0.15
+    });
+    const metal = new THREE.MeshPhysicalMaterial({
+        color: 0xc8b090, roughness: 0.28, metalness: 0.72
+    });
+    const glass = new THREE.MeshPhysicalMaterial({
+        color: 0xc8e0f4, roughness: 0.08, metalness: 0.05,
+        transparent: true, opacity: 0.22
+    });
+    const leafMat = new THREE.MeshPhysicalMaterial({
+        ...leaf, color: 0x3d8a48, roughness: 0.62, sheen: 0.4, sheenColor: 0xa0d070
+    });
+    const soil = new THREE.MeshStandardMaterial({ color: 0x3a2418, roughness: 0.95 });
+    const waterMat = new THREE.MeshPhysicalMaterial({
+        color: 0x6ab0d8, roughness: 0.08, metalness: 0.05, transparent: true, opacity: 0.55
+    });
+
+    const box = new THREE.BoxGeometry(1, 1, 1);
+    const sph = new THREE.SphereGeometry(1, 16, 12);
+    const cyl = new THREE.CylinderGeometry(1, 1, 1, 20);
+    const plane = new THREE.PlaneGeometry(1, 1);
+    const circ = new THREE.CircleGeometry(1, 48);
+
+    root.add(mesh(box, woodMat, { scale: [6.4, 0.08, 5.2], pos: [0, -0.04, 0], cast: false }));
+    root.add(mesh(box, wallMat, { scale: [6.4, 3.1, 0.12], pos: [0, 1.5, -2.55], cast: false }));
+    root.add(mesh(box, wallWarm, { scale: [0.12, 3.1, 5.2], pos: [-3.15, 1.5, 0], cast: false }));
+    root.add(mesh(box, wallMat, { scale: [0.12, 3.1, 5.2], pos: [3.15, 1.5, 0], cast: false }));
+    root.add(mesh(box, woodMat, { scale: [6.4, 0.1, 5.2], pos: [0, 3.08, 0], cast: false }));
+    root.add(mesh(box, woodMat, { scale: [6.4, 0.12, 0.08], pos: [0, 0.06, -2.48], cast: false }));
+    root.add(mesh(box, woodMat, { scale: [0.08, 0.12, 5.0], pos: [-3.08, 0.06, 0], cast: false }));
+    root.add(mesh(box, woodMat, { scale: [0.08, 0.12, 5.0], pos: [3.08, 0.06, 0], cast: false }));
+
+    const winW = 2.1;
+    const winH = 1.55;
+    const winY = 1.55;
+    root.add(mesh(box, metal, { scale: [winW + 0.16, 0.06, 0.08], pos: [0, winY + winH / 2, -2.48] }));
+    root.add(mesh(box, metal, { scale: [winW + 0.16, 0.06, 0.08], pos: [0, winY - winH / 2, -2.48] }));
+    root.add(mesh(box, metal, { scale: [0.06, winH, 0.08], pos: [-winW / 2, winY, -2.48] }));
+    root.add(mesh(box, metal, { scale: [0.06, winH, 0.08], pos: [winW / 2, winY, -2.48] }));
+    root.add(mesh(box, metal, { scale: [0.04, winH, 0.06], pos: [0, winY, -2.48] }));
+    root.add(mesh(box, metal, { scale: [winW, 0.04, 0.06], pos: [0, winY, -2.48] }));
+
+    root.add(mesh(plane, new THREE.MeshBasicMaterial({ map: skyTexture() }), {
+        scale: [winW * 1.4, winH * 1.5, 1], pos: [0, winY, -2.72], cast: false, receive: false
+    }));
+    root.add(mesh(box, glass, {
+        scale: [winW * 0.96, winH * 0.96, 0.02], pos: [0, winY, -2.49], cast: false, receive: false
+    }));
+
+    const curtainMat = new THREE.MeshPhysicalMaterial({
+        color: 0xf4e8d8, roughness: 0.85, sheen: 0.5, sheenColor: 0xfff6e8, transparent: true, opacity: 0.88
+    });
+    const curtainGeo = new THREE.PlaneGeometry(0.7, 2.2, 8, 20);
+    const posAttr = curtainGeo.attributes.position;
+    for (let i = 0; i < posAttr.count; i++) {
+        posAttr.setZ(i, Math.sin(posAttr.getX(i) * 14 + posAttr.getY(i) * 2) * 0.04);
+    }
+    curtainGeo.computeVertexNormals();
+    const c1 = new THREE.Mesh(curtainGeo, curtainMat);
+    c1.position.set(-1.35, 1.55, -2.42);
+    c1.castShadow = true;
+    const c2 = c1.clone();
+    c2.position.x = 1.35;
+    c2.scale.x = -1;
+    root.add(c1, c2);
+
+    const shaft = new THREE.Mesh(
+        new THREE.BoxGeometry(1.8, 1.6, 2.4),
+        new THREE.MeshBasicMaterial({
+            color: 0xffe0b0, transparent: true, opacity: 0.045, depthWrite: false, blending: THREE.AdditiveBlending
+        })
+    );
+    shaft.position.set(0, 1.1, -1.1);
+    shaft.rotation.x = 0.35;
+    root.add(shaft);
+    refs.shaft = shaft;
+
+    root.add(mesh(circ, rugMat, {
+        scale: [1.55, 1.55, 1], pos: [0, 0.015, 0.15], rot: [-Math.PI / 2, 0, 0], cast: false
+    }));
+
+    const sofa = new THREE.Group();
+    sofa.position.set(1.85, 0, 0.15);
+    sofa.rotation.y = -Math.PI / 2.4;
+    sofa.add(mesh(box, fabricMat, { scale: [1.7, 0.38, 0.78], pos: [0, 0.28, 0] }));
+    sofa.add(mesh(box, fabricMat, { scale: [1.7, 0.7, 0.16], pos: [0, 0.7, -0.32] }));
+    sofa.add(mesh(box, fabricMat, { scale: [0.14, 0.5, 0.78], pos: [-0.8, 0.52, 0] }));
+    sofa.add(mesh(box, fabricMat, { scale: [0.14, 0.5, 0.78], pos: [0.8, 0.52, 0] }));
+    sofa.add(mesh(box, fabricMat, { scale: [0.5, 0.28, 0.18], pos: [-0.4, 0.72, -0.18], rot: [-0.25, 0, 0] }));
+    sofa.add(mesh(box, fabricMat, { scale: [0.5, 0.28, 0.18], pos: [0.4, 0.72, -0.18], rot: [-0.25, 0, 0] }));
+    for (const [x, z] of [[-0.72, 0.32], [0.72, 0.32], [-0.72, -0.32], [0.72, -0.32]]) {
+        sofa.add(mesh(box, woodMat, { scale: [0.08, 0.22, 0.08], pos: [x, 0.08, z] }));
+    }
+    root.add(sofa);
+
+    const plant = new THREE.Group();
+    plant.position.set(-2.35, 0, -1.7);
+    plant.add(mesh(cyl, ceramic, { scale: [0.18, 0.28, 0.18], pos: [0, 0.14, 0] }));
+    plant.add(mesh(cyl, soil, { scale: [0.16, 0.04, 0.16], pos: [0, 0.28, 0], cast: false }));
+    plant.add(mesh(cyl, new THREE.MeshStandardMaterial({ color: 0x3a5a28 }), {
+        scale: [0.025, 0.7, 0.025], pos: [0, 0.62, 0]
+    }));
+    for (let i = 0; i < 7; i++) {
+        const a = (i / 7) * Math.PI * 2;
+        plant.add(mesh(sph, leafMat, {
+            scale: [0.18, 0.28, 0.06],
+            pos: [Math.cos(a) * 0.22, 0.7 + (i % 3) * 0.18, Math.sin(a) * 0.18],
+            rot: [0.6, a, 0.3]
+        }));
+    }
+    root.add(plant);
+
+    const shelf = new THREE.Group();
+    shelf.position.set(-2.85, 1.15, 0.6);
+    shelf.add(mesh(box, woodMat, { scale: [0.28, 0.04, 1.4], pos: [0, 0, 0] }));
+    shelf.add(mesh(box, woodMat, { scale: [0.28, 0.04, 1.4], pos: [0, 0.42, 0] }));
+    const bookColors = [0x8a3030, 0x3a5080, 0xc4a050, 0x4a6a48, 0x6a3a58];
+    for (let i = 0; i < 5; i++) {
+        shelf.add(mesh(box, new THREE.MeshStandardMaterial({ color: bookColors[i], roughness: 0.7 }), {
+            scale: [0.16, 0.28, 0.06], pos: [0.02, 0.16, -0.5 + i * 0.14]
+        }));
+    }
+    root.add(shelf);
+
+    const lamp = new THREE.Group();
+    lamp.position.set(2.4, 0, -1.7);
+    lamp.add(mesh(cyl, metal, { scale: [0.12, 0.04, 0.12], pos: [0, 0.02, 0] }));
+    lamp.add(mesh(cyl, metal, { scale: [0.025, 1.15, 0.025], pos: [0, 0.6, 0] }));
+    lamp.add(mesh(new THREE.ConeGeometry(0.22, 0.28, 16, 1, true), new THREE.MeshPhysicalMaterial({
+        color: 0xf4e0c0, roughness: 0.7, emissive: 0xffd8a0, emissiveIntensity: 0.35, side: THREE.DoubleSide
+    }), { pos: [0, 1.22, 0], rot: [Math.PI, 0, 0] }));
+    root.add(lamp);
+    refs.lamp = lamp;
+
+    const bed = new THREE.Group();
+    bed.position.set(-1.35, 0, 1.15);
+    bed.add(mesh(cyl, cushionMat, { scale: [0.42, 0.1, 0.42], pos: [0, 0.08, 0] }));
+    bed.add(mesh(new THREE.TorusGeometry(0.38, 0.08, 10, 24), cushionMat, {
+        pos: [0, 0.12, 0], rot: [Math.PI / 2, 0, 0]
+    }));
+    root.add(bed);
+    refs.bed = bed;
+
+    const bowls = new THREE.Group();
+    bowls.position.set(-2.15, 0, 0.55);
+    bowls.add(mesh(cyl, ceramic, { scale: [0.12, 0.05, 0.12], pos: [0, 0.04, 0] }));
+    bowls.add(mesh(cyl, ceramicBlue, { scale: [0.12, 0.05, 0.12], pos: [0.32, 0.04, 0] }));
+    const kibble = new THREE.MeshPhysicalMaterial({ color: 0xc48a40, roughness: 0.7 });
+    for (let i = 0; i < 8; i++) {
+        bowls.add(mesh(sph, kibble, {
+            scale: [0.018, 0.012, 0.018],
+            pos: [(Math.random() - 0.5) * 0.12, 0.07, (Math.random() - 0.5) * 0.12]
+        }));
+    }
+    root.add(bowls);
+    refs.bowls = bowls;
+
+    const ball = mesh(sph, new THREE.MeshPhysicalMaterial({
+        color: 0xe85a4a, roughness: 0.35, clearcoat: 0.4
+    }), { scale: [0.09, 0.09, 0.09], pos: [0.85, 0.09, 0.7] });
+    root.add(ball);
+    refs.ball = ball;
+
+    const yarn = mesh(sph, new THREE.MeshPhysicalMaterial({
+        color: 0x6a9ad0, roughness: 0.7, sheen: 0.5, sheenColor: 0xa0c8f0
+    }), { scale: [0.08, 0.08, 0.08], pos: [0.55, 0.08, 0.95] });
+    root.add(yarn);
+    refs.yarn = yarn;
+
+    const frame = mesh(box, woodMat, { scale: [0.42, 0.32, 0.03], pos: [2.55, 1.7, -1.1] });
+    frame.add(mesh(plane, new THREE.MeshBasicMaterial({ color: 0xd8b090 }), {
+        scale: [0.85, 0.78, 1], pos: [0, 0, 0.55], cast: false, receive: false
+    }));
+    root.add(frame);
+
+    const tub = new THREE.Group();
+    tub.position.set(2.15, 0, 1.55);
+    tub.add(mesh(cyl, ceramic, { scale: [0.42, 0.22, 0.32], pos: [0, 0.14, 0] }));
+    tub.add(mesh(cyl, waterMat, { scale: [0.36, 0.04, 0.26], pos: [0, 0.2, 0], cast: false }));
+    tub.visible = false;
+    root.add(tub);
+    refs.tub = tub;
+
+    const n = quality.dust ?? 80;
+    const dustPos = new Float32Array(n * 3);
+    for (let i = 0; i < n; i++) {
+        dustPos[i * 3] = (Math.random() - 0.5) * 4;
+        dustPos[i * 3 + 1] = 0.4 + Math.random() * 1.8;
+        dustPos[i * 3 + 2] = (Math.random() - 0.5) * 3;
+    }
+    const dust = new THREE.Points(
+        new THREE.BufferGeometry().setAttribute('position', new THREE.BufferAttribute(dustPos, 3)),
+        new THREE.PointsMaterial({
+            color: 0xffe6c0, size: 0.012, transparent: true, opacity: 0.28,
+            depthWrite: false, blending: THREE.AdditiveBlending
+        })
+    );
+    root.add(dust);
+    refs.dust = dust;
+
+    return { root, refs };
+}
+
+export function updateRoom(refs, time) {
+    if (refs.dust) {
+        refs.dust.rotation.y = time * 0.02;
+        const p = refs.dust.geometry.attributes.position;
+        for (let i = 0; i < p.count; i++) {
+            let y = p.getY(i) + Math.sin(time * 0.4 + i) * 0.0008;
+            if (y > 2.4) y = 0.3;
+            p.setY(i, y);
+        }
+        p.needsUpdate = true;
+    }
+    if (refs.shaft) {
+        refs.shaft.material.opacity = 0.035 + Math.sin(time * 0.5) * 0.012;
+    }
+    if (refs.ball) refs.ball.rotation.z = time * 0.3;
+}

--- a/labs/mimo/src/state.js
+++ b/labs/mimo/src/state.js
@@ -1,0 +1,90 @@
+/**
+ * Persistência e simulação das necessidades do pet.
+ * Ausência usa o relógio real; em jogo o loop chama tick(dt).
+ */
+
+import {
+    STORAGE_KEY, NEED_KEYS, DECAY_PLAY, DECAY_AWAY_PER_HOUR,
+    SLEEP_ENERGY, ACTIONS
+} from './config.js';
+import { clamp, moodLabel, moodScore } from './utils.js';
+
+export function defaultNeeds() {
+    return { hunger: 72, joy: 78, hygiene: 88, energy: 80, love: 70 };
+}
+
+export function defaultProfile() {
+    return {
+        species: 'dog',
+        breed: 'golden',
+        coat: 'gold',
+        name: 'Mel',
+        bornAt: Date.now(),
+        needs: defaultNeeds(),
+        savedAt: Date.now()
+    };
+}
+
+export function loadProfile() {
+    try {
+        const raw = localStorage.getItem(STORAGE_KEY);
+        if (!raw) return null;
+        const data = JSON.parse(raw);
+        if (!data?.species || !data?.breed || !data?.name) return null;
+        data.needs = applyAway(data.needs || defaultNeeds(), data.savedAt || Date.now());
+        return data;
+    } catch {
+        return null;
+    }
+}
+
+export function saveProfile(profile) {
+    try {
+        const payload = { ...profile, savedAt: Date.now() };
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+    } catch { /* privado */ }
+}
+
+export function clearProfile() {
+    try { localStorage.removeItem(STORAGE_KEY); } catch { /* */ }
+}
+
+function applyAway(needs, savedAt) {
+    const hours = Math.max(0, (Date.now() - savedAt) / 3600000);
+    const next = { ...needs };
+    for (const key of NEED_KEYS) {
+        next[key] = clamp(next[key] + DECAY_AWAY_PER_HOUR[key] * hours, 0, 100);
+    }
+    return next;
+}
+
+export function tickNeeds(needs, dt, sleeping) {
+    const next = { ...needs };
+    for (const key of NEED_KEYS) {
+        let rate = DECAY_PLAY[key];
+        if (sleeping) {
+            if (key === 'energy') {
+                next.energy = clamp(next.energy + SLEEP_ENERGY * dt, 0, 100);
+                continue;
+            }
+            rate *= 0.45;
+        }
+        next[key] = clamp(next[key] - rate * dt, 0, 100);
+    }
+    return next;
+}
+
+export function applyAction(needs, actionId) {
+    const spec = ACTIONS[actionId];
+    if (!spec) return needs;
+    const next = { ...needs };
+    for (const key of NEED_KEYS) {
+        if (typeof spec[key] === 'number') next[key] = clamp(next[key] + spec[key], 0, 100);
+    }
+    if (spec.setHygiene) next.hygiene = 100;
+    return next;
+}
+
+export function describe(needs) {
+    return { ...moodLabel(needs), score: moodScore(needs) };
+}

--- a/labs/mimo/src/textures.js
+++ b/labs/mimo/src/textures.js
@@ -1,0 +1,309 @@
+/**
+ * Mapas PBR procedurais — albedo, normal e roughness, sem arquivos externos.
+ */
+
+import * as THREE from 'three';
+
+const cache = new Map();
+
+function canvas(w, h = w) {
+    const el = document.createElement('canvas');
+    el.width = w;
+    el.height = h;
+    return el;
+}
+
+function ctx2d(el) {
+    return el.getContext('2d', { willReadFrequently: true });
+}
+
+function rng(seed = 1) {
+    let s = seed >>> 0;
+    return () => (s = (Math.imul(s, 1664525) + 1013904223) >>> 0) / 4294967296;
+}
+
+function toTex(el, { repeat = [1, 1], srgb = true, aniso = 8, wrap = true } = {}) {
+    const tex = new THREE.CanvasTexture(el);
+    tex.wrapS = tex.wrapT = wrap ? THREE.RepeatWrapping : THREE.ClampToEdgeWrapping;
+    tex.repeat.set(repeat[0], repeat[1]);
+    tex.anisotropy = aniso;
+    tex.colorSpace = srgb ? THREE.SRGBColorSpace : THREE.NoColorSpace;
+    tex.needsUpdate = true;
+    return tex;
+}
+
+function heightToNormal(srcCtx, w, h, strength = 2.2) {
+    const src = srcCtx.getImageData(0, 0, w, h).data;
+    const out = canvas(w, h);
+    const ctx = ctx2d(out);
+    const img = ctx.createImageData(w, h);
+    const d = img.data;
+    const lum = (x, y) => {
+        const i = (((y + h) % h) * w + ((x + w) % w)) * 4;
+        return (src[i] * 0.299 + src[i + 1] * 0.587 + src[i + 2] * 0.114) / 255;
+    };
+    for (let y = 0; y < h; y++) {
+        for (let x = 0; x < w; x++) {
+            const dx = (lum(x + 1, y) - lum(x - 1, y)) * strength;
+            const dy = (lum(x, y + 1) - lum(x, y - 1)) * strength;
+            const len = Math.hypot(dx, dy, 1) || 1;
+            const i = (y * w + x) * 4;
+            d[i] = ((-dx / len) * 0.5 + 0.5) * 255;
+            d[i + 1] = ((-dy / len) * 0.5 + 0.5) * 255;
+            d[i + 2] = (1 / len) * 0.5 * 255 + 128;
+            d[i + 3] = 255;
+        }
+    }
+    ctx.putImageData(img, 0, 0);
+    return out;
+}
+
+function roughnessFrom(srcCtx, w, h, base = 0.78, contrast = 0.22) {
+    const src = srcCtx.getImageData(0, 0, w, h).data;
+    const out = canvas(w, h);
+    const ctx = ctx2d(out);
+    const img = ctx.createImageData(w, h);
+    const d = img.data;
+    for (let i = 0; i < src.length; i += 4) {
+        const v = (src[i] + src[i + 1] + src[i + 2]) / (3 * 255);
+        const r = Math.max(0, Math.min(1, base + (v - 0.5) * contrast));
+        d[i] = d[i + 1] = d[i + 2] = r * 255;
+        d[i + 3] = 255;
+    }
+    ctx.putImageData(img, 0, 0);
+    return out;
+}
+
+function pack(key, w, h, draw, opts = {}) {
+    if (cache.has(key)) return cache.get(key);
+    const {
+        strength = 2.1, roughBase = 0.8, roughContrast = 0.2,
+        aniso = 8, repeat = [1, 1], wrap = true
+    } = opts;
+    const el = canvas(w, h);
+    const ctx = ctx2d(el);
+    draw(ctx, w, h);
+    const map = toTex(el, { repeat, srgb: true, aniso, wrap });
+    const nEl = heightToNormal(ctx, w, h, strength);
+    const normalMap = toTex(nEl, { repeat, srgb: false, aniso, wrap });
+    const rEl = roughnessFrom(ctx, w, h, roughBase, roughContrast);
+    const roughnessMap = toTex(rEl, { repeat, srgb: false, aniso, wrap });
+    const set = { map, normalMap, roughnessMap };
+    cache.set(key, set);
+    return set;
+}
+
+function hexTo(hex) {
+    const n = parseInt(String(hex).replace('#', ''), 16);
+    return [(n >> 16) & 255, (n >> 8) & 255, n & 255];
+}
+
+function clamp255(v) {
+    return Math.max(0, Math.min(255, v));
+}
+
+function saturate(v) {
+    return Math.max(0, Math.min(1, v));
+}
+
+function lerp(a, b, t) {
+    return a + (b - a) * t;
+}
+
+export function woodMaps(aniso = 8) {
+    return pack('wood', 512, 512, (ctx, w, h) => {
+        const rnd = rng(42);
+        ctx.fillStyle = '#8a5a32';
+        ctx.fillRect(0, 0, w, h);
+        const plank = 64;
+        for (let y = 0; y < h; y += plank) {
+            const hue = 28 + rnd() * 8;
+            ctx.fillStyle = `hsl(${hue} 42% ${38 + rnd() * 10}%)`;
+            ctx.fillRect(0, y, w, plank - 1);
+            for (let i = 0; i < 18; i++) {
+                ctx.strokeStyle = `rgba(40, 20, 10, ${0.06 + rnd() * 0.1})`;
+                ctx.lineWidth = 1 + rnd() * 1.4;
+                ctx.beginPath();
+                const yy = y + rnd() * plank;
+                ctx.moveTo(0, yy);
+                ctx.bezierCurveTo(w * 0.3, yy + (rnd() - 0.5) * 8, w * 0.7, yy + (rnd() - 0.5) * 8, w, yy);
+                ctx.stroke();
+            }
+            ctx.fillStyle = 'rgba(30, 16, 8, 0.35)';
+            ctx.fillRect(0, y + plank - 2, w, 2);
+        }
+    }, { strength: 1.6, roughBase: 0.72, roughContrast: 0.18, aniso, repeat: [4, 4] });
+}
+
+export function plasterMaps(aniso = 8) {
+    return pack('plaster', 256, 256, (ctx, w, h) => {
+        const rnd = rng(9);
+        ctx.fillStyle = '#e8d8c4';
+        ctx.fillRect(0, 0, w, h);
+        for (let i = 0; i < 1800; i++) {
+            ctx.fillStyle = `rgba(255, 244, 228, ${0.04 + rnd() * 0.08})`;
+            ctx.fillRect(rnd() * w, rnd() * h, 2, 2);
+        }
+        ctx.fillStyle = 'rgba(180, 140, 110, 0.08)';
+        ctx.fillRect(0, 0, 8, h);
+    }, { strength: 0.7, roughBase: 0.9, roughContrast: 0.08, aniso, repeat: [2, 2] });
+}
+
+export function fabricMaps(aniso = 8) {
+    return pack('fabric', 256, 256, (ctx, w, h) => {
+        const rnd = rng(21);
+        ctx.fillStyle = '#6a3a28';
+        ctx.fillRect(0, 0, w, h);
+        for (let y = 0; y < h; y += 4) {
+            ctx.fillStyle = y % 8 === 0 ? 'rgba(255,220,180,0.07)' : 'rgba(20,8,4,0.08)';
+            ctx.fillRect(0, y, w, 2);
+        }
+        for (let i = 0; i < 400; i++) {
+            ctx.fillStyle = `rgba(240, 200, 160, ${rnd() * 0.12})`;
+            ctx.fillRect(rnd() * w, rnd() * h, 3, 3);
+        }
+    }, { strength: 1.4, roughBase: 0.86, roughContrast: 0.12, aniso, repeat: [3, 3] });
+}
+
+export function rugMaps(aniso = 8) {
+    return pack('rug', 512, 512, (ctx, w, h) => {
+        const rnd = rng(77);
+        const g = ctx.createRadialGradient(w / 2, h / 2, 20, w / 2, h / 2, w * 0.5);
+        g.addColorStop(0, '#c45a3a');
+        g.addColorStop(0.45, '#8a3028');
+        g.addColorStop(1, '#5a2018');
+        ctx.fillStyle = g;
+        ctx.fillRect(0, 0, w, h);
+        ctx.strokeStyle = 'rgba(240, 200, 140, 0.35)';
+        ctx.lineWidth = 10;
+        ctx.beginPath();
+        ctx.arc(w / 2, h / 2, w * 0.42, 0, Math.PI * 2);
+        ctx.stroke();
+        ctx.lineWidth = 4;
+        ctx.beginPath();
+        ctx.arc(w / 2, h / 2, w * 0.28, 0, Math.PI * 2);
+        ctx.stroke();
+        for (let i = 0; i < 24; i++) {
+            const a = (i / 24) * Math.PI * 2;
+            ctx.strokeStyle = `rgba(240, 210, 160, ${0.12 + rnd() * 0.12})`;
+            ctx.beginPath();
+            ctx.moveTo(w / 2, h / 2);
+            ctx.lineTo(w / 2 + Math.cos(a) * w * 0.48, h / 2 + Math.sin(a) * h * 0.48);
+            ctx.stroke();
+        }
+    }, { strength: 1.8, roughBase: 0.92, roughContrast: 0.1, aniso, wrap: false });
+}
+
+export function cushionMaps(aniso = 8) {
+    return pack('cushion', 256, 256, (ctx, w, h) => {
+        ctx.fillStyle = '#d8b070';
+        ctx.fillRect(0, 0, w, h);
+        for (let y = 0; y < h; y += 6) {
+            ctx.fillStyle = 'rgba(90, 50, 20, 0.08)';
+            ctx.fillRect(0, y, w, 2);
+        }
+        ctx.strokeStyle = 'rgba(255, 240, 210, 0.25)';
+        ctx.lineWidth = 8;
+        ctx.strokeRect(16, 16, w - 32, h - 32);
+    }, { strength: 1.2, roughBase: 0.88, aniso, wrap: false });
+}
+
+function furPattern(u, v, pattern) {
+    if (pattern === 'tabby') {
+        return Math.sin(u * 28 + Math.sin(v * 10) * 1.4) * 0.5 + 0.5;
+    }
+    if (pattern === 'spots') {
+        const gx = Math.floor(u * 9);
+        const gy = Math.floor(v * 7);
+        const r = rng(gx * 13 + gy * 29)();
+        const dx = u * 9 - gx - 0.5;
+        const dy = v * 7 - gy - 0.5;
+        return r > 0.55 && dx * dx + dy * dy < 0.12 ? 1 : 0;
+    }
+    if (pattern === 'patches') {
+        const n = Math.sin(u * 7.1 + 2) * Math.cos(v * 5.3) + Math.sin(u * 3.7 + v * 4.2);
+        if (n > 0.45) return 1;
+        if (n < -0.35) return 0.35;
+        return 0;
+    }
+    if (pattern === 'bicolor') {
+        return v < 0.42 || (u > 0.35 && u < 0.65 && v < 0.62) ? 0 : 1;
+    }
+    if (pattern === 'mask') {
+        const face = Math.hypot(u - 0.5, v - 0.55);
+        return face < 0.22 || v > 0.78 ? 0 : 1;
+    }
+    if (pattern === 'colorpoint') {
+        const edge = Math.min(u, 1 - u, v, 1 - v);
+        return edge < 0.18 || v < 0.16 || v > 0.86 ? 1 : 0;
+    }
+    if (pattern === 'poodle') {
+        return (Math.sin(u * 40) * Math.sin(v * 40) > 0.15) ? 1 : 0.4;
+    }
+    return 0.08;
+}
+
+export function furMaps(primary, secondary, belly, pattern = 'solid', aniso = 8) {
+    const key = `fur:${primary}:${secondary}:${pattern}`;
+    return pack(key, 256, 256, (ctx, w, h) => {
+        const rnd = rng(primary.length * 17 + pattern.length * 9);
+        const img = ctx.createImageData(w, h);
+        const d = img.data;
+        const p = hexTo(primary);
+        const s = hexTo(secondary);
+        const b = hexTo(belly);
+        for (let y = 0; y < h; y++) {
+            for (let x = 0; x < w; x++) {
+                const u = x / w;
+                const v = y / h;
+                const stroke = 0.55 + 0.45 * Math.sin((x * 0.9 + y * 2.4) * 0.35);
+                const grain = rnd();
+                const pat = furPattern(u, v, pattern);
+                const bellyMix = saturate((v - 0.55) * 2.4);
+                let r = p[0];
+                let g = p[1];
+                let bl = p[2];
+                r = lerp(r, s[0], pat * 0.85);
+                g = lerp(g, s[1], pat * 0.85);
+                bl = lerp(bl, s[2], pat * 0.85);
+                r = lerp(r, b[0], bellyMix * 0.7);
+                g = lerp(g, b[1], bellyMix * 0.7);
+                bl = lerp(bl, b[2], bellyMix * 0.7);
+                const shade = 0.78 + stroke * 0.18 + grain * 0.08;
+                const i = (y * w + x) * 4;
+                d[i] = clamp255(r * shade);
+                d[i + 1] = clamp255(g * shade);
+                d[i + 2] = clamp255(bl * shade);
+                d[i + 3] = 255;
+            }
+        }
+        ctx.putImageData(img, 0, 0);
+    }, { strength: 2.6, roughBase: 0.78, roughContrast: 0.16, aniso, wrap: true });
+}
+
+export function skyTexture() {
+    const el = canvas(8, 256);
+    const ctx = ctx2d(el);
+    const g = ctx.createLinearGradient(0, 0, 0, 256);
+    g.addColorStop(0, '#7eb4e8');
+    g.addColorStop(0.45, '#c8dcf0');
+    g.addColorStop(0.72, '#f0d8b8');
+    g.addColorStop(1, '#e8b888');
+    ctx.fillStyle = g;
+    ctx.fillRect(0, 0, 8, 256);
+    return toTex(el, { wrap: false, aniso: 1, repeat: [1, 1] });
+}
+
+export function leafMaps(aniso = 4) {
+    return pack('leaf', 128, 128, (ctx, w, h) => {
+        ctx.fillStyle = '#2f7a3a';
+        ctx.fillRect(0, 0, w, h);
+        ctx.strokeStyle = 'rgba(20, 60, 24, 0.4)';
+        ctx.beginPath();
+        ctx.moveTo(w / 2, 4);
+        ctx.lineTo(w / 2, h - 4);
+        ctx.stroke();
+        ctx.fillStyle = 'rgba(180, 220, 120, 0.18)';
+        ctx.fillRect(8, 8, w * 0.4, h * 0.4);
+    }, { strength: 1.1, roughBase: 0.7, aniso });
+}

--- a/labs/mimo/src/utils.js
+++ b/labs/mimo/src/utils.js
@@ -1,0 +1,76 @@
+export function clamp(v, a = 0, b = 1) {
+    return Math.max(a, Math.min(b, v));
+}
+
+export function lerp(a, b, t) {
+    return a + (b - a) * t;
+}
+
+export function damp(current, target, lambda, dt) {
+    return lerp(current, target, 1 - Math.exp(-lambda * dt));
+}
+
+export function saturate(v) {
+    return clamp(v, 0, 1);
+}
+
+export function detectMobile() {
+    return /Mobi|Android|iPhone|iPad/i.test(navigator.userAgent)
+        || window.matchMedia('(pointer: coarse)').matches
+        || window.innerWidth < 720;
+}
+
+export function detectSoftwareGL() {
+    try {
+        const gl = document.createElement('canvas').getContext('webgl2')
+            || document.createElement('canvas').getContext('webgl');
+        const info = gl?.getExtension('WEBGL_debug_renderer_info');
+        const name = info ? String(gl.getParameter(info.UNMASKED_RENDERER_WEBGL) || '') : '';
+        return /swiftshader|llvmpipe|softpipe|microsoft basic render|\bcpu\b/i.test(name);
+    } catch {
+        return false;
+    }
+}
+
+export function rendererIsSoftware(renderer) {
+    try {
+        const gl = renderer.getContext();
+        const info = gl?.getExtension('WEBGL_debug_renderer_info');
+        const name = info ? String(gl.getParameter(info.UNMASKED_RENDERER_WEBGL) || '') : '';
+        return /swiftshader|llvmpipe|softpipe|microsoft basic render|\bcpu\b/i.test(name);
+    } catch {
+        return false;
+    }
+}
+
+export function moodScore(needs) {
+    return (
+        needs.hunger * 0.28
+        + needs.joy * 0.26
+        + needs.hygiene * 0.16
+        + needs.energy * 0.16
+        + needs.love * 0.14
+    );
+}
+
+export function moodLabel(needs) {
+    if (needs.hunger < 22) return { id: 'hungry', text: 'com fome', emoji: '🍽️' };
+    if (needs.energy < 22) return { id: 'sleepy', text: 'com sono', emoji: '😴' };
+    if (needs.hygiene < 28) return { id: 'dirty', text: 'precisando de banho', emoji: '🛁' };
+    if (needs.joy < 22) return { id: 'sad', text: 'triste', emoji: '🥺' };
+    if (needs.love < 28) return { id: 'lonely', text: 'querendo colo', emoji: '🤍' };
+    const score = moodScore(needs);
+    if (score > 84) return { id: 'joy', text: 'radiante', emoji: '✨' };
+    if (score > 62) return { id: 'happy', text: 'contente', emoji: '🐾' };
+    return { id: 'ok', text: 'de boa', emoji: '·' };
+}
+
+export function formatAge(ms) {
+    const m = Math.floor(ms / 60000);
+    if (m < 1) return 'recém-chegado';
+    if (m < 60) return `${m} min juntos`;
+    const h = Math.floor(m / 60);
+    if (h < 24) return `${h} h juntos`;
+    const d = Math.floor(h / 24);
+    return d === 1 ? '1 dia juntos' : `${d} dias juntos`;
+}

--- a/labs/mimo/style.css
+++ b/labs/mimo/style.css
@@ -1,0 +1,659 @@
+/* ================================================================
+   Mimo — lar ao entardecer
+   Paleta: âmbar da janela, terracota, creme, sage.
+   ================================================================ */
+
+:root {
+    --ink: oklch(14% 0.03 50);
+    --ink-deep: oklch(10% 0.03 48);
+    --amber: oklch(78% 0.14 70);
+    --amber-deep: oklch(62% 0.14 58);
+    --terra: oklch(58% 0.14 40);
+    --cream: oklch(94% 0.03 85);
+
+    --text: oklch(96% 0.02 80);
+    --text-soft: oklch(84% 0.03 75);
+    --text-dim: oklch(68% 0.03 70);
+
+    --panel: color-mix(in oklab, oklch(16% 0.04 48) 64%, transparent);
+    --panel-strong: color-mix(in oklab, oklch(12% 0.04 48) 86%, transparent);
+    --line: color-mix(in oklab, var(--amber) 28%, transparent);
+    --line-soft: color-mix(in oklab, var(--cream) 12%, transparent);
+
+    --radius: 16px;
+    --radius-lg: 24px;
+    --blur: 20px;
+    --safe-top: env(safe-area-inset-top, 0px);
+    --safe-bottom: env(safe-area-inset-bottom, 0px);
+    --safe-left: env(safe-area-inset-left, 0px);
+    --safe-right: env(safe-area-inset-right, 0px);
+    --ease: cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+*, *::before, *::after {
+    box-sizing: border-box;
+    -webkit-tap-highlight-color: transparent;
+}
+
+html, body {
+    margin: 0;
+    width: 100%;
+    height: 100%;
+    overflow: clip;
+    overscroll-behavior: none;
+    background: var(--ink-deep);
+}
+
+body {
+    min-height: 100dvh;
+    padding: 0 !important;
+    display: block !important;
+    color: var(--text);
+    font-family: 'Outfit', system-ui, sans-serif;
+    user-select: none;
+    -webkit-user-select: none;
+    touch-action: none;
+}
+
+button, input, select {
+    font: inherit;
+    color: inherit;
+}
+
+button {
+    background: none;
+    border: 0;
+    cursor: pointer;
+}
+
+input, select {
+    background: color-mix(in oklab, var(--ink) 55%, transparent);
+    border: 1px solid var(--line);
+    border-radius: 12px;
+    padding: 0.7rem 0.85rem;
+    min-height: 44px;
+    width: 100%;
+}
+
+:focus-visible {
+    outline: 2px solid var(--amber);
+    outline-offset: 3px;
+}
+
+.game-shell {
+    position: fixed;
+    inset: 0;
+    overflow: hidden;
+    background: radial-gradient(120% 90% at 50% 0%, oklch(28% 0.06 50) 0%, var(--ink-deep) 70%);
+}
+
+#scene {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    display: block;
+    touch-action: none;
+}
+
+.vignette {
+    position: absolute;
+    inset: 0;
+    z-index: 8;
+    pointer-events: none;
+    background:
+        radial-gradient(ellipse at 50% 42%, transparent 50%, oklch(12% 0.04 48 / 0.5) 100%),
+        linear-gradient(180deg, oklch(18% 0.04 50 / 0.22), transparent 26%, transparent 70%, oklch(10% 0.03 48 / 0.4));
+}
+
+.game-shell > header {
+    position: absolute;
+    top: calc(0.85rem + var(--safe-top));
+    left: calc(1rem + var(--safe-left));
+    right: calc(1rem + var(--safe-right));
+    z-index: 40;
+    margin: 0;
+    padding: 0;
+    max-width: none;
+    width: auto;
+    pointer-events: none;
+    gap: 0.6rem;
+}
+
+.game-shell > header > * { pointer-events: auto; }
+
+.app-logo {
+    display: flex;
+    align-items: center;
+    gap: 0.45rem;
+    font-family: 'Fraunces', Georgia, serif;
+    font-weight: 600;
+    letter-spacing: -0.02em;
+}
+
+.brand-mark { font-size: 1.1rem; }
+
+.hud {
+    position: absolute;
+    inset: 0;
+    z-index: 20;
+    pointer-events: none;
+}
+
+.hud-top {
+    position: absolute;
+    top: calc(4.35rem + var(--safe-top));
+    left: calc(1rem + var(--safe-left));
+    right: calc(1rem + var(--safe-right));
+    display: grid;
+    grid-template-columns: minmax(0, 14rem) minmax(0, 1fr);
+    gap: 0.7rem;
+    align-items: stretch;
+}
+
+.panel {
+    pointer-events: auto;
+    background: var(--panel);
+    backdrop-filter: blur(var(--blur));
+    -webkit-backdrop-filter: blur(var(--blur));
+    border: 1px solid var(--line);
+    border-radius: var(--radius);
+    padding: 0.75rem 0.9rem;
+    box-shadow: 0 14px 40px rgba(20, 10, 6, 0.32);
+    min-width: 0;
+}
+
+.hud-label {
+    display: block;
+    font-size: 0.68rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--text-dim);
+    font-weight: 600;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+#petName {
+    display: block;
+    font-family: 'Fraunces', Georgia, serif;
+    font-size: clamp(1.25rem, 3vw, 1.7rem);
+    font-weight: 600;
+    letter-spacing: -0.03em;
+    margin-top: 0.15rem;
+    background: linear-gradient(180deg, #fff6e8, var(--amber));
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+}
+
+.hud-sub {
+    display: block;
+    margin-top: 0.2rem;
+    font-size: 0.78rem;
+    color: var(--text-dim);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.needs-panel {
+    display: grid;
+    gap: 0.28rem;
+}
+
+.need {
+    display: grid;
+    grid-template-columns: 4.2rem minmax(0, 1fr) 1.8rem;
+    gap: 0.45rem;
+    align-items: center;
+    font-size: 0.72rem;
+    color: var(--text-soft);
+}
+
+.need i {
+    display: block;
+    height: 0.42rem;
+    border-radius: 999px;
+    background: color-mix(in oklab, white 10%, transparent);
+    overflow: hidden;
+}
+
+.need b {
+    display: block;
+    height: 100%;
+    width: 0%;
+    border-radius: inherit;
+    background: linear-gradient(90deg, var(--terra), var(--amber));
+    transition: width 0.4s var(--ease);
+}
+
+.need.is-low b {
+    background: linear-gradient(90deg, #c45a48, #e8a060);
+}
+
+.need em {
+    font-style: normal;
+    font-variant-numeric: tabular-nums;
+    text-align: right;
+    color: var(--text-dim);
+}
+
+.message {
+    position: absolute;
+    left: 50%;
+    top: calc(11.5rem + var(--safe-top));
+    transform: translateX(-50%) translateY(8px);
+    margin: 0;
+    padding: 0.55rem 1rem;
+    max-width: min(90vw, 28rem);
+    text-align: center;
+    background: var(--panel-strong);
+    border: 1px solid var(--line);
+    border-radius: 999px;
+    font-size: 0.9rem;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.35s var(--ease), transform 0.35s var(--ease);
+}
+
+.message[data-show="true"] {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0);
+}
+
+.hud-actions {
+    position: absolute;
+    top: calc(4.35rem + var(--safe-top));
+    right: calc(1rem + var(--safe-right));
+    display: flex;
+    gap: 0.4rem;
+    pointer-events: auto;
+    z-index: 2;
+}
+
+.icon-button {
+    width: 44px;
+    height: 44px;
+    border-radius: 14px;
+    background: var(--panel);
+    border: 1px solid var(--line);
+    backdrop-filter: blur(var(--blur));
+    color: var(--text);
+}
+
+.icon-button[aria-pressed="false"] { opacity: 0.55; }
+
+.dock {
+    position: absolute;
+    left: 50%;
+    bottom: calc(1rem + var(--safe-bottom));
+    transform: translateX(-50%);
+    display: flex;
+    gap: 0.4rem;
+    pointer-events: auto;
+    padding: 0.4rem;
+    background: var(--panel-strong);
+    border: 1px solid var(--line);
+    border-radius: 22px;
+    backdrop-filter: blur(var(--blur));
+    max-width: calc(100% - 1.6rem - var(--safe-left) - var(--safe-right));
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+}
+
+.dock button {
+    min-width: 72px;
+    min-height: 64px;
+    padding: 0.45rem 0.55rem;
+    border-radius: 16px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.15rem;
+    font-size: 0.72rem;
+    font-weight: 600;
+    color: var(--text-soft);
+    flex: 0 0 auto;
+}
+
+.dock button span { font-size: 1.2rem; line-height: 1; }
+
+.dock button:hover,
+.dock button:active {
+    background: color-mix(in oklab, var(--amber) 18%, transparent);
+    color: var(--text);
+}
+
+.dock.is-busy button:disabled { opacity: 0.4; }
+
+.overlay {
+    position: absolute;
+    inset: 0;
+    z-index: 30;
+    display: grid;
+    place-items: end center;
+    padding: calc(5.2rem + var(--safe-top)) 1rem calc(1.2rem + var(--safe-bottom));
+    background:
+        radial-gradient(ellipse at 50% 18%, oklch(42% 0.1 55 / 0.28), transparent 52%),
+        color-mix(in oklab, var(--ink-deep) 55%, transparent);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+}
+
+.overlay[hidden] { display: none !important; }
+
+.overlay-card, .loading-card {
+    width: min(42rem, 100%);
+    max-height: min(92dvh, 46rem);
+    overflow-y: auto;
+    background: color-mix(in oklab, oklch(14% 0.04 48) 84%, transparent);
+    border: 1px solid var(--line);
+    border-radius: var(--radius-lg);
+    padding: 1.4rem 1.5rem 1.25rem;
+    box-shadow:
+        0 30px 80px rgba(12, 6, 4, 0.5),
+        inset 0 1px 0 color-mix(in oklab, white 12%, transparent);
+}
+
+.loading-overlay { place-items: center; }
+
+.loading-card {
+    width: min(24rem, 100%);
+    text-align: center;
+}
+
+.loading-card h1,
+.menu-head h1,
+.compact-card h2 {
+    font-family: 'Fraunces', Georgia, serif;
+    font-weight: 600;
+    letter-spacing: -0.03em;
+    font-size: clamp(2rem, 6vw, 3.2rem);
+    line-height: 0.95;
+    margin: 0.2rem 0 0.5rem;
+    background: linear-gradient(180deg, #fff8ec 8%, var(--amber) 55%, var(--terra) 100%);
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+}
+
+.star-loader {
+    display: inline-block;
+    font-size: 2rem;
+    animation: bounce 1.2s ease-in-out infinite;
+}
+
+@keyframes bounce {
+    50% { transform: translateY(-8px) rotate(-8deg); }
+}
+
+.loading-bar {
+    margin-top: 1rem;
+    height: 0.4rem;
+    border-radius: 999px;
+    background: color-mix(in oklab, white 10%, transparent);
+    overflow: hidden;
+}
+
+.loading-bar i {
+    display: block;
+    height: 100%;
+    width: 8%;
+    border-radius: inherit;
+    background: linear-gradient(90deg, var(--terra), var(--amber));
+    transition: width 0.35s var(--ease);
+}
+
+.eyebrow {
+    display: flex;
+    align-items: center;
+    gap: 0.45rem;
+    text-transform: uppercase;
+    letter-spacing: 0.16em;
+    font-size: 0.68rem;
+    color: var(--amber);
+    font-weight: 600;
+    margin: 0;
+}
+
+.eyebrow i {
+    width: 0.45rem;
+    height: 0.45rem;
+    border-radius: 50%;
+    background: var(--amber);
+    box-shadow: 0 0 10px var(--amber);
+}
+
+.lede {
+    color: var(--text-soft);
+    line-height: 1.45;
+    margin: 0 0 1rem;
+    max-width: 36rem;
+}
+
+.create-steps {
+    display: flex;
+    gap: 0.4rem;
+    margin: 0.4rem 0 1rem;
+    flex-wrap: wrap;
+}
+
+.create-steps button {
+    min-height: 40px;
+    padding: 0.4rem 0.8rem;
+    border-radius: 999px;
+    border: 1px solid var(--line-soft);
+    color: var(--text-dim);
+    font-size: 0.8rem;
+}
+
+.create-steps button[aria-current="step"] {
+    border-color: var(--line);
+    color: var(--text);
+    background: color-mix(in oklab, var(--amber) 16%, transparent);
+}
+
+.species-grid, .breed-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.7rem;
+}
+
+.species-card, .breed-card {
+    min-height: 96px;
+    padding: 0.9rem;
+    border-radius: 18px;
+    border: 1px solid var(--line-soft);
+    background: color-mix(in oklab, white 4%, transparent);
+    text-align: left;
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+}
+
+.species-card.is-on, .breed-card.is-on {
+    border-color: var(--amber);
+    background: color-mix(in oklab, var(--amber) 14%, transparent);
+    box-shadow: 0 0 0 1px color-mix(in oklab, var(--amber) 40%, transparent);
+}
+
+.species-art { font-size: 1.8rem; }
+.species-card strong, .breed-card strong { font-weight: 650; }
+.species-card em { font-style: normal; color: var(--text-dim); font-size: 0.82rem; }
+
+.breed-grid {
+    grid-template-columns: repeat(auto-fill, minmax(9.5rem, 1fr));
+}
+
+.breed-card { min-height: 72px; align-items: flex-start; }
+
+.field { display: grid; gap: 0.35rem; margin-bottom: 0.9rem; }
+.field span { font-size: 0.78rem; color: var(--text-dim); }
+.field-label { margin: 0 0 0.4rem; font-size: 0.78rem; color: var(--text-dim); }
+.section-note { font-size: 0.82rem; color: var(--text-dim); margin: 0.6rem 0 0; }
+
+.coat-grid {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.coat-swatch {
+    width: 44px;
+    height: 44px;
+    border-radius: 50%;
+    background: linear-gradient(135deg, var(--sw), var(--sw2));
+    border: 2px solid color-mix(in oklab, white 20%, transparent);
+}
+
+.coat-swatch.is-on {
+    box-shadow: 0 0 0 3px var(--ink-deep), 0 0 0 5px var(--amber);
+}
+
+.create-foot {
+    display: flex;
+    flex-direction: column;
+    gap: 0.9rem;
+    margin-top: 1rem;
+}
+
+.settings-inline {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.7rem;
+}
+
+.field-mini { margin: 0; }
+
+.primary-button, .ghost-button {
+    min-height: 48px;
+    border-radius: 999px;
+    padding: 0.7rem 1.2rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    font-weight: 600;
+}
+
+.primary-button {
+    background: linear-gradient(180deg, #f0c070, var(--terra));
+    color: #2a1810;
+    width: 100%;
+}
+
+.ghost-button {
+    background: transparent;
+    border: 1px solid var(--line);
+    color: var(--text-soft);
+    width: 100%;
+}
+
+.ghost-button.danger { color: #e8a090; }
+
+.card-actions {
+    display: grid;
+    gap: 0.55rem;
+}
+
+.compact-card { width: min(28rem, 100%); }
+
+@media (max-width: 768px) {
+    .hud-top {
+        grid-template-columns: 1fr;
+        right: calc(4.2rem + var(--safe-right));
+    }
+
+    .needs-panel {
+        grid-template-columns: 1fr 1fr;
+        gap: 0.35rem 0.7rem;
+    }
+
+    .need {
+        grid-template-columns: 3.4rem minmax(0, 1fr) 1.5rem;
+        font-size: 0.68rem;
+    }
+
+    .hud-actions { flex-direction: column; }
+
+    .dock {
+        bottom: calc(0.7rem + var(--safe-bottom));
+        gap: 0.28rem;
+        padding: 0.32rem;
+        border-radius: 18px;
+    }
+
+    .dock button {
+        min-width: 56px;
+        min-height: 56px;
+        font-size: 0.64rem;
+        padding: 0.3rem 0.35rem;
+    }
+
+    .message {
+        top: auto;
+        bottom: calc(5.6rem + var(--safe-bottom));
+    }
+
+    .settings-inline { grid-template-columns: 1fr; }
+
+    .overlay {
+        place-items: end center;
+        padding-bottom: calc(0.8rem + var(--safe-bottom));
+    }
+
+    .overlay-card { padding: 1.1rem 1.1rem 1rem; }
+}
+
+@media (max-width: 390px) {
+    .breed-grid { grid-template-columns: 1fr 1fr; }
+    .dock button span { font-size: 1.05rem; }
+    #petName { font-size: 1.2rem; }
+}
+
+@media (max-height: 520px) and (orientation: landscape) {
+    .hud-top {
+        grid-template-columns: minmax(0, 11rem) minmax(0, 1fr);
+        top: calc(3.4rem + var(--safe-top));
+        gap: 0.4rem;
+    }
+
+    .panel { padding: 0.45rem 0.65rem; }
+
+    .needs-panel {
+        grid-template-columns: 1fr 1fr;
+        gap: 0.2rem 0.6rem;
+    }
+
+    .need { font-size: 0.62rem; }
+
+    .dock {
+        bottom: calc(0.4rem + var(--safe-bottom));
+        padding: 0.22rem;
+    }
+
+    .dock button {
+        min-width: 52px;
+        min-height: 44px;
+        flex-direction: row;
+        gap: 0.25rem;
+        font-size: 0.62rem;
+    }
+
+    .overlay {
+        place-items: center;
+        padding: calc(3.4rem + var(--safe-top)) 0.8rem calc(0.6rem + var(--safe-bottom));
+    }
+
+    .overlay-card { max-height: min(92dvh, 100%); }
+    .species-card { min-height: 72px; padding: 0.55rem; }
+    .menu-head .lede { display: none; }
+    .hud-actions { top: calc(3.4rem + var(--safe-top)); }
+}
+
+@media (pointer: coarse) {
+    .dock button { min-height: 56px; }
+}

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -169,6 +169,12 @@
     <priority>0.7</priority>
   </url>
   <url>
+    <loc>https://diogopaulino.com.br/labs/mimo/</loc>
+    <lastmod>2026-08-18</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
     <loc>https://diogopaulino.com.br/labs/minesweeper/</loc>
     <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 🎯 Objetivo

Novo lab **Mimo**: um pet virtual 3D em three.js para escolher cão ou gato, dar nome e raça, e cuidar dele em um lar ao entardecer.

## ✨ O que mudou

- Lab autocontido em `/labs/mimo/` — sala PBR, pet paramétrico (8 raças de cão e 8 de gato), pelagem e animações
- Ciclo de cuidado: fome, alegria, higiene, energia e carinho, com persistência em `localStorage`
- Ações: comer, petisco, brincar, banho, dormir e carinho (toque no pet)
- Catálogo atualizado: galeria, README, sitemap e contagem (54 experimentos)

## 🧪 Como testar

1. Na raiz do repo: `python3 -m http.server 8000`
2. Abrir [http://localhost:8000/](http://localhost:8000/) (home) e [http://localhost:8000/labs/](http://localhost:8000/labs/) (galeria)
3. Abrir [http://localhost:8000/labs/mimo/](http://localhost:8000/labs/mimo/)
4. Escolher cão ou gato, raça, pelagem e nome → **Chegar em casa**
5. Testar Comer, Brincar, Banho, Dormir e toque no pet para carinho
6. Responsivo: DevTools em **375×667**, **390×844** e landscape curto (~667×375) — sem overflow horizontal, HUD/controles utilizáveis, alvos ≥ 44px
7. Conferir pasta ↔ card da galeria ↔ README ↔ `sitemap.xml` ↔ canonical/OG

## ✅ Checklist

- [x] Links conferidos: pasta do lab ↔ card da galeria ↔ README ↔ sitemap (e corrigidos se quebravam)
- [x] README atualizado (linha na tabela + URL + contagem no badge/texto) — obrigatório em lab novo, renomeado ou removido
- [x] SEO consistente: title, description, canonical, author, robots, OG, Twitter, JSON-LD (e contagem nos metas da galeria)
- [ ] Testado via HTTP na raiz, não via `file://`
- [ ] Responsivo: 375px / 390px / landscape — overflow, HUD, toque, safe-area (`viewport-fit=cover`)
- [x] Nada fora do escopo foi quebrado

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a00107-8874-7049-98b4-7c070b08fea1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a00107-8874-7049-98b4-7c070b08fea1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

