### PR TITLE
🐛 Revisão dos 54 labs: quatro quebrados de volta ao ar, som e gestos nos clássicos, e alvos de toque em todo o playground

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Cada pasta em `/labs/<slug>/` é o mesmo slug do card da galeria, da linha abaix
 
 | Projeto | O que é? |
 | :--- | :--- |
-| 🤖 **[Claude Bros](https://diogopaulino.com.br/labs/claude-bros/)** | Jogo de plataforma com IAs (Claude, Gemini e ChatGPT) usando PixiJS |
+| 🤖 **[Claude Bros](https://diogopaulino.com.br/labs/claude-bros/)** | Plataforma 2D em canvas puro: colete estrelas Gemini, pule nos rivais ChatGPT e chegue à bandeira |
 | 🐒 **[Kong Kong](https://diogopaulino.com.br/labs/kong-kong/)** | Platformer estilo SNES — o macaquinho do lenço vermelho, canhões-barril e o Rei Croco |
 | 🎈 **[Ravi 1·2·3](https://diogopaulino.com.br/labs/ravi-123/)** | Festa surpresa com heróis — conte 1 a 9 estilo Mickey's 123 |
 | 🥊 **[Rock Kombat](https://diogopaulino.com.br/labs/rock-kombat/)** | Luta 2D cinematográfica com lendas do rock |

--- a/labs/aurora-flow/index.html
+++ b/labs/aurora-flow/index.html
@@ -29,7 +29,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600;700;800&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=9">
+    <link rel="stylesheet" href="/labs/shared.css?v=10">
     <link rel="stylesheet" href="style.css">
     <script type="application/ld+json">
     {
@@ -239,7 +239,7 @@
 
     <footer data-lab-footer data-home-href="/"></footer>
 
-    <script src="/labs/shared.js?v=8" defer></script>
+    <script src="/labs/shared.js?v=9" defer></script>
     <script src="script.js" defer></script>
 </body>
 

--- a/labs/aurora-flow/index.html
+++ b/labs/aurora-flow/index.html
@@ -239,7 +239,7 @@
 
     <footer data-lab-footer data-home-href="/"></footer>
 
-    <script src="/labs/shared.js?v=10" defer></script>
+    <script src="/labs/shared.js?v=11" defer></script>
     <script src="script.js" defer></script>
 </body>
 

--- a/labs/aurora-flow/index.html
+++ b/labs/aurora-flow/index.html
@@ -29,7 +29,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600;700;800&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=10">
+    <link rel="stylesheet" href="/labs/shared.css?v=11">
     <link rel="stylesheet" href="style.css">
     <script type="application/ld+json">
     {
@@ -239,7 +239,7 @@
 
     <footer data-lab-footer data-home-href="/"></footer>
 
-    <script src="/labs/shared.js?v=9" defer></script>
+    <script src="/labs/shared.js?v=10" defer></script>
     <script src="script.js" defer></script>
 </body>
 

--- a/labs/aurora-flow/style.css
+++ b/labs/aurora-flow/style.css
@@ -447,11 +447,28 @@ input[type="range"] {
     -webkit-appearance: none;
     appearance: none;
     width: 100%;
-    height: 4px;
+    /* 44px de alvo tocável; o trilho visível de 4px vive nos
+       pseudo-elementos abaixo, então o desenho não muda. */
+    height: var(--touch-target);
     border: none;
+    background: transparent;
+    outline: none;
+    cursor: pointer;
+    touch-action: pan-y;
+}
+
+input[type="range"]::-webkit-slider-runnable-track {
+    height: 4px;
     border-radius: 999px;
     background: rgba(255, 255, 255, 0.12);
-    outline: none;
+    border: none;
+}
+
+input[type="range"]::-moz-range-track {
+    height: 4px;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.12);
+    border: none;
 }
 
 input[type="range"]::-webkit-slider-thumb {
@@ -463,6 +480,8 @@ input[type="range"]::-webkit-slider-thumb {
     background: var(--accent);
     cursor: pointer;
     box-shadow: 0 2px 8px color-mix(in srgb, var(--a1) 35%, transparent);
+    /* (trilho 4px - thumb 16px) / 2 */
+    margin-top: -6px;
 }
 
 input[type="range"]::-moz-range-thumb {

--- a/labs/beige-box/index.html
+++ b/labs/beige-box/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=Outfit:wght@300;400;500;600;700&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=10">
+    <link rel="stylesheet" href="/labs/shared.css?v=11">
     <link rel="stylesheet" href="style.css?v=1">
 
     <script type="importmap">
@@ -146,7 +146,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=9" defer></script>
+    <script src="/labs/shared.js?v=10" defer></script>
     <script type="module" src="src/main.js?v=3"></script>
 </body>
 

--- a/labs/beige-box/index.html
+++ b/labs/beige-box/index.html
@@ -146,7 +146,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=10" defer></script>
+    <script src="/labs/shared.js?v=11" defer></script>
     <script type="module" src="src/main.js?v=3"></script>
 </body>
 

--- a/labs/beige-box/index.html
+++ b/labs/beige-box/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=Outfit:wght@300;400;500;600;700&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=9">
+    <link rel="stylesheet" href="/labs/shared.css?v=10">
     <link rel="stylesheet" href="style.css?v=1">
 
     <script type="importmap">
@@ -146,7 +146,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=8" defer></script>
+    <script src="/labs/shared.js?v=9" defer></script>
     <script type="module" src="src/main.js?v=3"></script>
 </body>
 

--- a/labs/calculator/index.html
+++ b/labs/calculator/index.html
@@ -24,7 +24,7 @@
     <meta name="twitter:title" content="Calculator | Diogo Paulino">
     <meta name="twitter:description" content="Calculadora online com modos simples, científico e conversor de moedas em tempo real.">
     <link rel="stylesheet" href="/labs/shared.css?v=11">
-    <link rel="stylesheet" href="style.css?v=3">
+    <link rel="stylesheet" href="style.css?v=6">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;500;700&display=swap" rel="stylesheet">

--- a/labs/calculator/index.html
+++ b/labs/calculator/index.html
@@ -23,7 +23,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Calculator | Diogo Paulino">
     <meta name="twitter:description" content="Calculadora online com modos simples, científico e conversor de moedas em tempo real.">
-    <link rel="stylesheet" href="/labs/shared.css?v=9">
+    <link rel="stylesheet" href="/labs/shared.css?v=10">
     <link rel="stylesheet" href="style.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -243,7 +243,7 @@
 
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
-    <script src="/labs/shared.js?v=8" defer></script>
+    <script src="/labs/shared.js?v=9" defer></script>
     <script src="script.js" defer></script>
 </body>
 

--- a/labs/calculator/index.html
+++ b/labs/calculator/index.html
@@ -23,7 +23,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Calculator | Diogo Paulino">
     <meta name="twitter:description" content="Calculadora online com modos simples, científico e conversor de moedas em tempo real.">
-    <link rel="stylesheet" href="/labs/shared.css?v=10">
+    <link rel="stylesheet" href="/labs/shared.css?v=11">
     <link rel="stylesheet" href="style.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -243,7 +243,7 @@
 
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
-    <script src="/labs/shared.js?v=9" defer></script>
+    <script src="/labs/shared.js?v=10" defer></script>
     <script src="script.js" defer></script>
 </body>
 

--- a/labs/calculator/index.html
+++ b/labs/calculator/index.html
@@ -239,7 +239,7 @@
 
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
-    <script src="/labs/shared.js?v=10" defer></script>
+    <script src="/labs/shared.js?v=11" defer></script>
     <script src="script.js" defer></script>
 </body>
 

--- a/labs/calculator/index.html
+++ b/labs/calculator/index.html
@@ -24,12 +24,10 @@
     <meta name="twitter:title" content="Calculator | Diogo Paulino">
     <meta name="twitter:description" content="Calculadora online com modos simples, científico e conversor de moedas em tempo real.">
     <link rel="stylesheet" href="/labs/shared.css?v=11">
-    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="style.css?v=3">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;500;700&display=swap" rel="stylesheet">
-    <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
-    <script src="https://cdn.jsdelivr.net/npm/@phosphor-icons/web@2.1.2" defer></script>
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
@@ -83,7 +81,7 @@
         <header data-lab-header data-title="Calculator">
             <template data-slot="logo">
                 <div class="app-logo">
-                    <i class="ph ph-calculator"></i>
+                    <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="4" y="2" width="16" height="20" rx="2"/><rect x="7" y="5" width="10" height="4" rx="1"/><path d="M8 13h.01M12 13h.01M16 13h.01M8 17h.01M12 17h.01M16 17h.01"/></svg>
                     Calculator
                 </div>
             </template>
@@ -91,13 +89,13 @@
         <div class="calculator-wrapper">
             <div class="mode-switch">
                 <button class="mode-btn active" data-mode="calculator">
-                    <i class="ph ph-calculator"></i> Simple
+                    <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="4" y="2" width="16" height="20" rx="2"/><rect x="7" y="5" width="10" height="4" rx="1"/><path d="M8 13h.01M12 13h.01M16 13h.01M8 17h.01M12 17h.01M16 17h.01"/></svg> Simple
                 </button>
                 <button class="mode-btn" data-mode="scientific">
-                    <i class="ph ph-flask"></i> Scientific
+                    <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M9 3h6"/><path d="M10 3v6.5L4.5 18a2 2 0 0 0 1.7 3h11.6a2 2 0 0 0 1.7-3L14 9.5V3"/><path d="M7.5 14h9"/></svg> Scientific
                 </button>
                 <button class="mode-btn" data-mode="currency">
-                    <i class="ph ph-coins"></i> Currency
+                    <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><ellipse cx="9" cy="7" rx="6" ry="3"/><path d="M3 7v4c0 1.7 2.7 3 6 3s6-1.3 6-3V7"/><path d="M9 14v3c0 1.7 2.7 3 6 3s6-1.3 6-3v-4"/><ellipse cx="15" cy="13" rx="6" ry="3"/></svg> Currency
                 </button>
             </div>
 
@@ -109,8 +107,7 @@
                 </div>
                 <div class="buttons">
                     <button class="btn function" data-action="clear">AC</button>
-                    <button class="btn function" data-action="delete" aria-label="Apagar último dígito"><i
-                            class="ph ph-backspace" aria-hidden="true"></i></button>
+                    <button class="btn function" data-action="delete" aria-label="Apagar último dígito"><svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M20 5H9.5a2 2 0 0 0-1.5.7L3 12l5 6.3a2 2 0 0 0 1.5.7H20a1 1 0 0 0 1-1V6a1 1 0 0 0-1-1z"/><path d="M17 9l-5 6M12 9l5 6"/></svg></button>
                     <button class="btn operator" data-action="percent">%</button>
                     <button class="btn operator" data-action="divide">÷</button>
                     <button class="btn number">7</button>
@@ -140,8 +137,7 @@
                 <div class="buttons scientific-grid">
                     <!-- Row 1 -->
                     <button class="btn function" data-action="sci-clear">AC</button>
-                    <button class="btn function" data-action="sci-delete" aria-label="Apagar último dígito"><i
-                            class="ph ph-backspace" aria-hidden="true"></i></button>
+                    <button class="btn function" data-action="sci-delete" aria-label="Apagar último dígito"><svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M20 5H9.5a2 2 0 0 0-1.5.7L3 12l5 6.3a2 2 0 0 0 1.5.7H20a1 1 0 0 0 1-1V6a1 1 0 0 0-1-1z"/><path d="M17 9l-5 6M12 9l5 6"/></svg></button>
                     <button class="btn sci-func" data-action="sin">sin</button>
                     <button class="btn sci-func" data-action="cos">cos</button>
                     <button class="btn sci-func" data-action="tan">tan</button>
@@ -196,7 +192,7 @@
                     <h3>Real-time Converter</h3>
                     <div class="last-updated">Loading rates...</div>
                     <button id="refresh-rates" class="btn-refresh" title="Refresh Rates" aria-label="Atualizar cotações">
-                        <i class="ph ph-arrows-clockwise" aria-hidden="true"></i>
+                        <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M20 11A8 8 0 0 0 6.3 6.3L3 9.5"/><path d="M3 4.5v5h5"/><path d="M4 13a8 8 0 0 0 13.7 4.7L21 14.5"/><path d="M21 19.5v-5h-5"/></svg>
                     </button>
                 </div>
 
@@ -218,7 +214,7 @@
 
                 <div class="swap-container">
                     <button class="btn-swap" id="swap" aria-label="Inverter as moedas">
-                        <i class="ph ph-arrows-down-up" aria-hidden="true"></i>
+                        <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M7 3v18"/><path d="M3.5 17.5 7 21l3.5-3.5"/><path d="M17 21V3"/><path d="M13.5 6.5 17 3l3.5 3.5"/></svg>
                     </button>
                     <div class="rate-info" id="rate">1 USD = ...</div>
                 </div>

--- a/labs/calculator/style.css
+++ b/labs/calculator/style.css
@@ -67,6 +67,9 @@ body {
     border: none;
     background: transparent;
     padding: 10px;
+    /* A aba é o controle principal do lab: precisa caber o dedo mesmo quando o
+       padding encolhe em telas baixas. */
+    min-height: var(--touch-target);
     border-radius: 12px;
     font-size: 0.9rem;
     font-weight: 500;

--- a/labs/calculator/style.css
+++ b/labs/calculator/style.css
@@ -509,15 +509,17 @@ body {
         margin-bottom: 12px;
     }
 
+    /* Em paisagem o teclado encolhe para caber na altura, mas 44px é o piso:
+       é o controle que o usuário mais toca no lab. */
     .btn {
         padding: 8px 0;
-        min-height: 40px;
+        min-height: var(--touch-target);
         font-size: 1.05rem;
     }
 
     .scientific-grid .btn {
         padding: 8px 0;
-        min-height: 40px;
+        min-height: var(--touch-target);
     }
 }
 

--- a/labs/calculator/style.css
+++ b/labs/calculator/style.css
@@ -520,3 +520,20 @@ body {
         min-height: 40px;
     }
 }
+
+/* Ícones agora são SVG inline (antes vinham de um pacote de fontes num CDN:
+   quando ele não carregava, o botão de apagar virava um quadrado vazio sem
+   rótulo). O tamanho acompanha a tipografia do botão que os contém. */
+.icon {
+    width: 1.15em;
+    height: 1.15em;
+    flex: 0 0 auto;
+    display: inline-block;
+    vertical-align: -0.18em;
+}
+
+.mode-btn .icon,
+.app-logo .icon {
+    width: 1.1em;
+    height: 1.1em;
+}

--- a/labs/castelo-estelar/index.html
+++ b/labs/castelo-estelar/index.html
@@ -186,7 +186,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=10" defer></script>
+    <script src="/labs/shared.js?v=11" defer></script>
     <script>
         (function () {
             function hasGpu() {

--- a/labs/castelo-estelar/index.html
+++ b/labs/castelo-estelar/index.html
@@ -34,7 +34,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;600;700&family=Outfit:wght@300;400;500;600;700&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=10">
+    <link rel="stylesheet" href="/labs/shared.css?v=11">
     <link rel="stylesheet" href="style.css">
 
     <script type="importmap">
@@ -186,7 +186,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=9" defer></script>
+    <script src="/labs/shared.js?v=10" defer></script>
     <script>
         (function () {
             function hasGpu() {

--- a/labs/castelo-estelar/index.html
+++ b/labs/castelo-estelar/index.html
@@ -34,7 +34,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;600;700&family=Outfit:wght@300;400;500;600;700&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=9">
+    <link rel="stylesheet" href="/labs/shared.css?v=10">
     <link rel="stylesheet" href="style.css">
 
     <script type="importmap">
@@ -186,7 +186,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=8" defer></script>
+    <script src="/labs/shared.js?v=9" defer></script>
     <script>
         (function () {
             function hasGpu() {

--- a/labs/claude-bros/index.html
+++ b/labs/claude-bros/index.html
@@ -117,7 +117,7 @@
     <footer data-lab-footer data-home-href="/"></footer>
   </main>
 
-  <script src="/labs/shared.js?v=10" defer></script>
+  <script src="/labs/shared.js?v=11" defer></script>
   <script src="main.js?v=2" defer></script>
 </body>
 

--- a/labs/claude-bros/index.html
+++ b/labs/claude-bros/index.html
@@ -65,7 +65,7 @@
   }
   </script>
 
-  <link rel="stylesheet" href="/labs/shared.css?v=10">
+  <link rel="stylesheet" href="/labs/shared.css?v=11">
   <link rel="stylesheet" href="style.css?v=2">
 </head>
 
@@ -117,7 +117,7 @@
     <footer data-lab-footer data-home-href="/"></footer>
   </main>
 
-  <script src="/labs/shared.js?v=9" defer></script>
+  <script src="/labs/shared.js?v=10" defer></script>
   <script src="main.js?v=2" defer></script>
 </body>
 

--- a/labs/claude-bros/index.html
+++ b/labs/claude-bros/index.html
@@ -3,89 +3,122 @@
 
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover">
-  <title>Claude Bros — Jogo de plataforma PixiJS com IAs | Diogo Paulino</title>
-  <meta name="description" content="Um jogo de plataforma ao estilo Mario Bros com Claude, Gemini e ChatGPT, feito em PixiJS.">
+  <meta name="viewport"
+    content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover">
+  <title>Claude Bros — plataforma 2D com as IAs | Diogo Paulino</title>
+  <meta name="description"
+    content="Plataforma 2D em canvas puro: corra com o Claude, colete estrelas Gemini, pule nos rivais e chegue à bandeira.">
   <meta name="author" content="Diogo Paulino">
   <meta name="robots" content="index, follow">
-  <meta name="theme-color" content="#1a1a1a">
-  
+  <meta name="theme-color" content="#5aa9e6">
+
   <link rel="canonical" href="https://diogopaulino.com.br/labs/claude-bros/">
   <link rel="icon" href="/favicon.ico" sizes="any">
   <link rel="apple-touch-icon" href="/assets/img/diogo-avatar.png">
-  
+
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="Diogo Paulino · Labs">
-  <meta property="og:title" content="Claude Bros — Jogo de plataforma PixiJS com IAs | Diogo Paulino">
-  <meta property="og:description" content="Um jogo de plataforma ao estilo Mario Bros com Claude, Gemini e ChatGPT, feito em PixiJS.">
+  <meta property="og:title" content="Claude Bros — plataforma 2D com as IAs | Diogo Paulino">
+  <meta property="og:description"
+    content="Plataforma 2D em canvas puro: corra com o Claude, colete estrelas Gemini, pule nos rivais e chegue à bandeira.">
   <meta property="og:url" content="https://diogopaulino.com.br/labs/claude-bros/">
   <meta property="og:image" content="https://diogopaulino.com.br/assets/img/diogo.jpeg">
   <meta property="og:image:alt" content="Diogo Paulino">
   <meta property="og:locale" content="pt_BR">
-  
+
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="Claude Bros — Jogo de plataforma PixiJS com IAs | Diogo Paulino">
-  <meta name="twitter:description" content="Um jogo de plataforma ao estilo Mario Bros com Claude, Gemini e ChatGPT, feito em PixiJS.">
+  <meta name="twitter:title" content="Claude Bros — plataforma 2D com as IAs | Diogo Paulino">
+  <meta name="twitter:description"
+    content="Plataforma 2D em canvas puro: corra com o Claude, colete estrelas Gemini, pule nos rivais e chegue à bandeira.">
   <meta name="twitter:image" content="https://diogopaulino.com.br/assets/img/diogo.jpeg">
 
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
-    "@type": "WebApplication",
-    "name": "Claude Bros",
-    "url": "https://diogopaulino.com.br/labs/claude-bros/",
-    "description": "Um jogo de plataforma ao estilo Mario Bros com Claude, Gemini e ChatGPT, feito em PixiJS.",
-    "applicationCategory": "GameApplication",
-    "genre": "Platformer",
-    "browserRequirements": "Requires JavaScript and WebGL",
-    "author": {
-      "@type": "Person",
-      "name": "Diogo Paulino",
-      "url": "https://diogopaulino.com.br"
-    }
+    "@graph": [
+      {
+        "@type": "WebApplication",
+        "name": "Claude Bros",
+        "url": "https://diogopaulino.com.br/labs/claude-bros/",
+        "description": "Plataforma 2D em canvas puro: corra com o Claude, colete estrelas Gemini, pule nos rivais e chegue à bandeira.",
+        "applicationCategory": "GameApplication",
+        "genre": "Platformer",
+        "operatingSystem": "Any",
+        "inLanguage": "pt-BR",
+        "isAccessibleForFree": true,
+        "author": {
+          "@type": "Person",
+          "name": "Diogo Paulino",
+          "url": "https://diogopaulino.com.br/"
+        },
+        "image": "https://diogopaulino.com.br/assets/img/diogo.jpeg"
+      },
+      {
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          { "@type": "ListItem", "position": 1, "name": "Diogo Paulino", "item": "https://diogopaulino.com.br/" },
+          { "@type": "ListItem", "position": 2, "name": "Labs", "item": "https://diogopaulino.com.br/labs/" },
+          { "@type": "ListItem", "position": 3, "name": "Claude Bros", "item": "https://diogopaulino.com.br/labs/claude-bros/" }
+        ]
+      }
+    ]
   }
   </script>
 
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;700&display=swap" rel="stylesheet">
-  
-  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="/labs/shared.css?v=10">
+  <link rel="stylesheet" href="style.css?v=2">
 </head>
 
 <body>
-  <header class="lab-header">
-    <a href="/labs/" class="back-link">
-      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m15 18-6-6 6-6"/></svg>
-      Labs
-    </a>
-    <h1 class="lab-title">Claude Bros</h1>
-  </header>
-
-  <main class="game-container">
-    <div id="pixi-container"></div>
-    
-    <div class="hud">
-      <div class="hud-score">Score: <span id="score-display">0</span></div>
-      <div class="hud-controls" id="touch-controls">
-        <div class="dpad">
-          <button id="btn-left" class="control-btn">◀</button>
-          <button id="btn-right" class="control-btn">▶</button>
+  <main class="game-shell">
+    <header data-lab-header data-title="Claude Bros" data-back-label="Labs">
+      <template data-slot="logo">
+        <div class="app-logo">
+          <span class="brand-mark" aria-hidden="true">🍄</span>
+          <span>Claude Bros</span>
         </div>
-        <div class="action-buttons">
-          <button id="btn-jump" class="control-btn action-btn">A</button>
+      </template>
+      <template data-slot="actions">
+        <button type="button" id="btnPause" class="lab-icon-btn" aria-label="Pausar o jogo" title="Pausar (P)">⏸</button>
+      </template>
+    </header>
+
+    <div class="stage">
+      <canvas id="stage" role="img" aria-label="Fase de plataforma com o Claude, estrelas e rivais"></canvas>
+
+      <div class="hud" aria-hidden="true">
+        <div class="hud-chip"><span class="hud-key">PTS</span><strong id="scoreValue">0</strong></div>
+        <div class="hud-chip"><span class="hud-key">★</span><strong id="coinValue">0</strong></div>
+        <div class="hud-chip"><span class="hud-key">VIDAS</span><strong id="lifeValue">❤️❤️❤️</strong></div>
+        <div class="hud-chip"><span class="hud-key">TEMPO</span><strong id="timeValue">00:00</strong></div>
+      </div>
+
+      <div class="overlay" id="overlay">
+        <div class="overlay-card">
+          <h2 id="overlayTitle">Claude Bros</h2>
+          <p id="overlayText">Colete as estrelas, pule nos rivais e chegue à bandeira.</p>
+          <button type="button" class="primary-btn" id="overlayButton">Começar</button>
+          <p class="overlay-hint fine-only">Setas ou A/D para andar · Espaço para pular · P pausa</p>
+          <p class="overlay-hint touch-only">Use os botões na base da tela</p>
         </div>
       </div>
+
+      <div class="touch-controls" id="touchControls" hidden>
+        <div class="touch-move">
+          <button type="button" id="btnLeft" class="touch-btn" aria-label="Andar para a esquerda">◀</button>
+          <button type="button" id="btnRight" class="touch-btn" aria-label="Andar para a direita">▶</button>
+        </div>
+        <button type="button" id="btnJump" class="touch-btn touch-btn--jump" aria-label="Pular">▲</button>
+      </div>
     </div>
-    
-    <div id="game-over-screen" class="overlay hidden">
-      <h2 id="end-title">Game Over</h2>
-      <button id="btn-restart" class="btn">Tentar Novamente</button>
-    </div>
+
+    <p id="gameStatus" class="sr-only" role="status" aria-live="polite"></p>
+
+    <footer data-lab-footer data-home-href="/"></footer>
   </main>
 
-  <!-- PixiJS from CDN -->
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/pixi.js/7.3.2/pixi.min.js"></script>
-  <script type="module" src="main.js"></script>
+  <script src="/labs/shared.js?v=9" defer></script>
+  <script src="main.js?v=2" defer></script>
 </body>
+
 </html>

--- a/labs/claude-bros/main.js
+++ b/labs/claude-bros/main.js
@@ -1,369 +1,1056 @@
-// main.js - Claude Bros
-// Jogo de plataforma simples com PixiJS
+/* Claude Bros — plataforma 2D em canvas puro.
+ *
+ * Sem PixiJS e sem CDN: tudo é desenhado com Canvas 2D, então o lab não depende
+ * de rede externa para abrir (a versão anterior mostrava tela preta se o CDN
+ * falhasse) e segue a regra vanilla do repositório.
+ *
+ * --- Simulação --------------------------------------------------------------
+ * Passo fixo de 1/120s com acumulador: a física não muda com o refresh rate do
+ * monitor (60Hz, 120Hz ou um frame perdido dão o mesmo salto).
+ *
+ * Unidades: 1 tile = 32px de mundo. Velocidades em px/s, acelerações em px/s².
+ *
+ *   GRAVITY        1900 px/s²   queda com peso, sem virar pedra
+ *   JUMP_VELOCITY  -560 px/s    ~2.6 tiles de altura, passa por cima do inimigo
+ *   RUN_SPEED       210 px/s    ~6.5 tiles/s
+ *
+ * --- Sensação de controle ---------------------------------------------------
+ * Três perdões que todo plataforma bom tem e o anterior não tinha:
+ *   · coyote time (90ms) — pular logo depois de sair da plataforma ainda vale
+ *   · jump buffer (120ms) — apertar pulo pouco antes de pousar ainda vale
+ *   · pulo variável — soltar o botão corta a subida pela metade
+ */
 
-const TILE_SIZE = 40;
-const GRAVITY = 0.6;
-const JUMP_FORCE = -12;
-const MOVE_SPEED = 5;
-const MAX_FALL_SPEED = 12;
+const TILE = 32;
+const GRAVITY = 1900;
+const JUMP_VELOCITY = -560;
+const JUMP_CUT = 0.45;      // fator aplicado à subida quando o botão é solto
+const RUN_SPEED = 210;
+const RUN_ACCEL = 1500;
+const RUN_FRICTION = 1900;
+const MAX_FALL = 780;
+const COYOTE_TIME = 0.09;
+const JUMP_BUFFER = 0.12;
+const ENEMY_SPEED = 52;
+const STOMP_BOUNCE = -380;
+const FIXED_STEP = 1 / 120;
 
-// SVG Textures encoded in base64
-const SVGS = {
-  claude: `data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40"><rect width="40" height="40" rx="8" fill="%23d97757"/><circle cx="12" cy="16" r="4" fill="%23fff"/><circle cx="28" cy="16" r="4" fill="%23fff"/><rect x="14" y="26" width="12" height="4" rx="2" fill="%23fff"/><path d="M 8 8 L 12 4 M 32 8 L 28 4" stroke="%239c4a30" stroke-width="3" stroke-linecap="round"/></svg>`,
-  gemini: `data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40"><path d="M20 2 L23 16 L38 20 L23 24 L20 38 L17 24 L2 20 L17 16 Z" fill="%234285F4"/><circle cx="20" cy="20" r="6" fill="%23fff"/></svg>`,
-  chatgpt: `data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40"><rect width="40" height="40" rx="20" fill="%2310a37f"/><circle cx="14" cy="18" r="3" fill="%23fff"/><circle cx="26" cy="18" r="3" fill="%23fff"/><path d="M 12 28 Q 20 32 28 28" fill="none" stroke="%23fff" stroke-width="3" stroke-linecap="round"/></svg>`,
-  block: `data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40"><rect width="40" height="40" fill="%23b86038"/><rect width="38" height="38" fill="%23d67f56"/><path d="M0 10 L40 10 M0 20 L40 20 M0 30 L40 30 M10 0 L10 10 M30 10 L30 20 M15 20 L15 30 M25 30 L25 40" stroke="%239c4a30" stroke-width="2"/></svg>`,
-  ground: `data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40"><rect width="40" height="40" fill="%2353a847"/><rect y="10" width="40" height="30" fill="%238c5b3e"/></svg>`,
-};
-
-// Nível: 1 = chao, 2 = bloco, 3 = gemini (moeda), 4 = chatgpt (inimigo)
+/* Mapa. Cada caractere é um tile de 32px.
+ *   #  chão            =  plataforma
+ *   ?  bloco de bônus  o  estrela (Gemini)
+ *   e  inimigo (ChatGPT)   ^  espinho
+ *   P  nascimento do jogador   F  bandeira final                */
 const LEVEL = [
-  "                                                  ",
-  "                                                  ",
-  "                                                  ",
-  "                                        3         ",
-  "           2222                        222        ",
-  "                                                  ",
-  "                   33                             ",
-  "                  2222                            ",
-  "        3                   4                     ",
-  "       22                  2222     22            ",
-  "                                                  ",
-  "                                            4     ",
-  "11111111111111  1111111111111111111111111111111111"
+    '                                                                                        ',
+    '                                                                                        ',
+    '                                                                                        ',
+    '                                                    o o o                               ',
+    '                                        o          =======                              ',
+    '                              o o      ===                                   o o o      ',
+    '                    ?        =====                        o  o              =======     ',
+    '            o o                                 ?        ======                         ',
+    '           =====        e              e                              e                F',
+    '                                                     o                          ?      =',
+    '     o                       ?    o o                                  o o             =',
+    '   =====        e                =====        e            ^^        =======       e   =',
+    '###########   ############   #############   ########   ########   ##############   #####',
+    '###########   ############   #############   ########   ########   ##############   #####',
 ];
 
-const GAME_WIDTH = 800;
-const GAME_HEIGHT = LEVEL.length * TILE_SIZE; // 13 * 40 = 520
+const COLS = Math.max(...LEVEL.map(row => row.length));
+const ROWS = LEVEL.length;
+const WORLD_WIDTH = COLS * TILE;
+const WORLD_HEIGHT = ROWS * TILE;
 
-class Game {
-  constructor() {
-    this.app = new PIXI.Application({
-      background: '#87CEEB', // Sky blue
-      width: GAME_WIDTH,
-      height: GAME_HEIGHT,
-      resolution: window.devicePixelRatio || 1,
-      autoDensity: true,
-    });
+/* A câmera enquadra ~24 tiles de largura. Menos que isso e o jogador não vê o
+   inimigo a tempo de reagir; mais e os sprites viram formigas no celular. */
+const VIEW_TILES_X = 24;
+const VIEW_WIDTH = VIEW_TILES_X * TILE;
 
-    document.getElementById('pixi-container').appendChild(this.app.view);
-    
-    // Scale container appropriately
-    this.resize();
-    window.addEventListener('resize', () => this.resize());
+const canvas = document.getElementById('stage');
+const ctx = canvas.getContext('2d');
+const hud = {
+    score: document.getElementById('scoreValue'),
+    coins: document.getElementById('coinValue'),
+    lives: document.getElementById('lifeValue'),
+    time: document.getElementById('timeValue'),
+};
+const overlay = document.getElementById('overlay');
+const overlayTitle = document.getElementById('overlayTitle');
+const overlayText = document.getElementById('overlayText');
+const overlayButton = document.getElementById('overlayButton');
+const statusLive = document.getElementById('gameStatus');
+const touchLayer = document.getElementById('touchControls');
 
-    this.container = new PIXI.Container();
-    this.app.stage.addChild(this.container);
+const audio = window.LabAudio;
 
-    this.textures = {};
-    this.entities = [];
-    this.tiles = [];
-    this.coins = [];
-    this.enemies = [];
-    
-    this.score = 0;
-    this.isGameOver = false;
+/* ---------------------------------------------------------------- estado --- */
 
-    this.keys = { left: false, right: false, up: false };
-    
-    this.loadAssets().then(() => {
-      this.buildLevel();
-      this.setupInput();
-      this.app.ticker.add((delta) => this.update(delta));
-    });
-  }
+const solids = [];   // tiles com colisão
+const decor = [];    // tiles sem colisão (topo de grama etc.)
+let coins = [];
+let enemies = [];
+let spikes = [];
+let particles = [];
+let goal = null;
+let spawn = { x: TILE * 2, y: TILE * 8 };
 
-  resize() {
-    const parent = this.app.view.parentNode;
-    const parentWidth = parent.clientWidth;
-    const parentHeight = parent.clientHeight;
+const player = {
+    x: 0, y: 0, w: 24, h: 28,
+    vx: 0, vy: 0,
+    facing: 1,
+    grounded: false,
+    coyote: 0,
+    buffer: 0,
+    jumpHeld: false,
+    invuln: 0,
+    walkPhase: 0,
+    squash: 0,
+};
 
-    const scale = Math.min(parentWidth / GAME_WIDTH, parentHeight / GAME_HEIGHT);
-    this.app.view.style.width = `${GAME_WIDTH * scale}px`;
-    this.app.view.style.height = `${GAME_HEIGHT * scale}px`;
-  }
+let state = 'ready';   // ready | playing | paused | dead | over | won
+let score = 0;
+let coinsTaken = 0;
+let lives = 3;
+let elapsed = 0;
+let camera = { x: 0, y: 0 };
+let shake = 0;
+let scale = 1;
+let viewHeight = 0;
 
-  async loadAssets() {
-    for (const [key, b64] of Object.entries(SVGS)) {
-      this.textures[key] = await PIXI.Texture.fromURL(b64);
-    }
-  }
+const keys = { left: false, right: false, jump: false };
 
-  buildLevel() {
-    for (let y = 0; y < LEVEL.length; y++) {
-      const row = LEVEL[y];
-      for (let x = 0; x < row.length; x++) {
-        const char = row[x];
-        const px = x * TILE_SIZE;
-        const py = y * TILE_SIZE;
+/* ------------------------------------------------------------------ nível --- */
 
-        if (char === '1') {
-          this.createTile(px, py, this.textures.ground);
-        } else if (char === '2') {
-          this.createTile(px, py, this.textures.block);
-        } else if (char === '3') {
-          this.createCoin(px, py);
-        } else if (char === '4') {
-          this.createEnemy(px, py);
+function buildLevel() {
+    solids.length = 0;
+    decor.length = 0;
+    coins = [];
+    enemies = [];
+    spikes = [];
+    particles = [];
+    goal = null;
+
+    for (let row = 0; row < ROWS; row++) {
+        const line = LEVEL[row];
+        for (let col = 0; col < COLS; col++) {
+            const char = line[col] || ' ';
+            const x = col * TILE;
+            const y = row * TILE;
+
+            switch (char) {
+                case '#':
+                    // Só o tile mais alto de uma coluna de terra ganha grama.
+                    solids.push({ x, y, w: TILE, h: TILE, kind: (LEVEL[row - 1] || '')[col] === '#' ? 'dirt' : 'grass' });
+                    break;
+                case '=':
+                    solids.push({ x, y, w: TILE, h: TILE, kind: 'platform' });
+                    break;
+                case '?':
+                    solids.push({ x, y, w: TILE, h: TILE, kind: 'bonus', bumped: false, bump: 0 });
+                    break;
+                case 'o':
+                    coins.push({ x: x + TILE / 2, y: y + TILE / 2, phase: Math.random() * Math.PI * 2, taken: false });
+                    break;
+                case 'e':
+                    enemies.push({ x: x + 3, y: y + 4, w: 26, h: 28, vx: -ENEMY_SPEED, vy: 0, alive: true, squash: 0, blink: Math.random() * 3 });
+                    break;
+                case '^':
+                    spikes.push({ x, y: y + TILE / 2, w: TILE, h: TILE / 2 });
+                    break;
+                case 'F':
+                    goal = { x: x + TILE / 2, y: y - TILE * 3, h: TILE * 4 };
+                    break;
+                case 'P':
+                    spawn = { x, y };
+                    break;
+            }
         }
-      }
     }
 
-    // Create player
-    this.player = new PIXI.Sprite(this.textures.claude);
-    this.player.x = 100;
-    this.player.y = 100;
-    this.player.vx = 0;
-    this.player.vy = 0;
-    this.player.width = 36;
-    this.player.height = 36;
-    // Centering anchor for flipping
-    this.player.anchor.set(0.5, 0.5); 
-    // Adjust position because of anchor
-    this.player.x += 18;
-    this.player.y += 18;
-    
-    this.container.addChild(this.player);
-  }
-
-  createTile(x, y, texture) {
-    const tile = new PIXI.Sprite(texture);
-    tile.x = x;
-    tile.y = y;
-    tile.width = TILE_SIZE;
-    tile.height = TILE_SIZE;
-    this.container.addChild(tile);
-    this.tiles.push(tile);
-  }
-
-  createCoin(x, y) {
-    const coin = new PIXI.Sprite(this.textures.gemini);
-    coin.x = x + 4;
-    coin.y = y + 4;
-    coin.width = 32;
-    coin.height = 32;
-    this.container.addChild(coin);
-    this.coins.push({ sprite: coin, active: true, startY: coin.y, time: Math.random() * 100 });
-  }
-
-  createEnemy(x, y) {
-    const enemy = new PIXI.Sprite(this.textures.chatgpt);
-    enemy.x = x;
-    enemy.y = y;
-    enemy.width = 36;
-    enemy.height = 36;
-    enemy.vx = -1.5; // Starts moving left
-    this.container.addChild(enemy);
-    this.enemies.push({ sprite: enemy, vx: -1.5, active: true });
-  }
-
-  setupInput() {
-    window.addEventListener('keydown', (e) => {
-      if (e.code === 'ArrowLeft') this.keys.left = true;
-      if (e.code === 'ArrowRight') this.keys.right = true;
-      if (e.code === 'Space' || e.code === 'ArrowUp') this.keys.up = true;
-    });
-
-    window.addEventListener('keyup', (e) => {
-      if (e.code === 'ArrowLeft') this.keys.left = false;
-      if (e.code === 'ArrowRight') this.keys.right = false;
-      if (e.code === 'Space' || e.code === 'ArrowUp') this.keys.up = false;
-    });
-
-    // Touch controls
-    const bindTouch = (id, key) => {
-      const el = document.getElementById(id);
-      if (!el) return;
-      el.addEventListener('touchstart', (e) => { e.preventDefault(); this.keys[key] = true; el.classList.add('active'); });
-      el.addEventListener('touchend', (e) => { e.preventDefault(); this.keys[key] = false; el.classList.remove('active'); });
-    };
-
-    bindTouch('btn-left', 'left');
-    bindTouch('btn-right', 'right');
-    bindTouch('btn-jump', 'up');
-
-    document.getElementById('btn-restart').addEventListener('click', () => {
-      location.reload();
-    });
-  }
-
-  checkAABB(a, b) {
-    // a is player (centered anchor), b is tile (top-left anchor)
-    const ax = a.x - a.width/2;
-    const ay = a.y - a.height/2;
-    const aw = a.width;
-    const ah = a.height;
-
-    const bx = b.x;
-    const by = b.y;
-    const bw = b.width;
-    const bh = b.height;
-
-    return ax < bx + bw &&
-           ax + aw > bx &&
-           ay < by + bh &&
-           ay + ah > by;
-  }
-
-  update(delta) {
-    if (this.isGameOver) return;
-
-    // Player input
-    if (this.keys.left) {
-      this.player.vx = -MOVE_SPEED;
-      this.player.scale.x = -1; // Flip left
-    } else if (this.keys.right) {
-      this.player.vx = MOVE_SPEED;
-      this.player.scale.x = 1; // Flip right
-    } else {
-      this.player.vx = 0;
+    // Sem 'P' no mapa, nasce no primeiro chão à esquerda.
+    if (!LEVEL.some(row => row.includes('P'))) {
+        spawn = { x: TILE * 2, y: (ROWS - 3) * TILE };
     }
-
-    // Apply gravity
-    this.player.vy += GRAVITY * delta;
-    if (this.player.vy > MAX_FALL_SPEED) this.player.vy = MAX_FALL_SPEED;
-
-    // Horizontal Movement & Collision
-    this.player.x += this.player.vx * delta;
-    for (const tile of this.tiles) {
-      if (this.checkAABB(this.player, tile)) {
-        if (this.player.vx > 0) {
-          this.player.x = tile.x - this.player.width/2;
-        } else if (this.player.vx < 0) {
-          this.player.x = tile.x + tile.width + this.player.width/2;
-        }
-        this.player.vx = 0;
-      }
-    }
-
-    // Vertical Movement & Collision
-    this.player.y += this.player.vy * delta;
-    let grounded = false;
-    for (const tile of this.tiles) {
-      if (this.checkAABB(this.player, tile)) {
-        if (this.player.vy > 0) {
-          this.player.y = tile.y - this.player.height/2;
-          grounded = true;
-        } else if (this.player.vy < 0) {
-          this.player.y = tile.y + tile.height + this.player.height/2;
-        }
-        this.player.vy = 0;
-      }
-    }
-
-    // Jumping
-    if (this.keys.up && grounded) {
-      this.player.vy = JUMP_FORCE;
-    }
-
-    // Death by falling
-    if (this.player.y > GAME_HEIGHT + 100) {
-      this.gameOver(false);
-    }
-
-    // Update Enemies
-    for (const enemyData of this.enemies) {
-      if (!enemyData.active) continue;
-      const enemy = enemyData.sprite;
-      
-      // Basic gravity for enemies
-      let enemyVy = 4; // constant fall
-      enemy.y += enemyVy * delta;
-      for (const tile of this.tiles) {
-        if (this.checkAABB({x: enemy.x + enemy.width/2, y: enemy.y + enemy.height/2, width: enemy.width, height: enemy.height}, tile)) {
-           enemy.y = tile.y - enemy.height;
-           break;
-        }
-      }
-
-      enemy.x += enemyData.vx * delta;
-      
-      // Simple enemy wall collision
-      let hitWall = false;
-      for (const tile of this.tiles) {
-        if (this.checkAABB({x: enemy.x + enemy.width/2, y: enemy.y + enemy.height/2, width: enemy.width, height: enemy.height}, tile)) {
-          hitWall = true;
-          break;
-        }
-      }
-      
-      // If going to fall off edge, turn around (simple AI)
-      let holeAhead = true;
-      const probeX = enemyData.vx > 0 ? enemy.x + enemy.width + 5 : enemy.x - 5;
-      for (const tile of this.tiles) {
-        if (this.checkAABB({x: probeX + enemy.width/2, y: enemy.y + enemy.height + 5 + enemy.height/2, width: enemy.width, height: enemy.height}, tile)) {
-          holeAhead = false;
-          break;
-        }
-      }
-
-      if (hitWall || holeAhead) {
-        enemyData.vx *= -1;
-      }
-
-      // Enemy Player Collision
-      if (this.checkAABB(this.player, {x: enemy.x + enemy.width/2, y: enemy.y + enemy.height/2, width: enemy.width, height: enemy.height})) {
-        // Did we jump on top?
-        if (this.player.vy > 0 && this.player.y < enemy.y) {
-          enemyData.active = false;
-          enemy.visible = false;
-          this.player.vy = JUMP_FORCE * 0.8; // Bounce
-          this.addScore(100);
-        } else {
-          this.gameOver(false);
-        }
-      }
-    }
-
-    // Update Coins
-    for (const coin of this.coins) {
-      if (!coin.active) continue;
-      
-      // Hover animation
-      coin.time += delta * 0.1;
-      coin.sprite.y = coin.startY + Math.sin(coin.time) * 5;
-
-      if (this.checkAABB(this.player, {x: coin.sprite.x + coin.sprite.width/2, y: coin.sprite.y + coin.sprite.height/2, width: coin.sprite.width, height: coin.sprite.height})) {
-        coin.active = false;
-        coin.sprite.visible = false;
-        this.addScore(50);
-      }
-    }
-
-    // Camera follow (center player on X axis)
-    const targetX = GAME_WIDTH / 2 - this.player.x;
-    // Clamp camera so it doesn't show left of the map
-    const clampedX = Math.min(0, targetX);
-    this.container.x = clampedX;
-    
-    // Win condition (reaching far right)
-    if (this.player.x > LEVEL[0].length * TILE_SIZE - 200) {
-      this.gameOver(true);
-    }
-  }
-
-  addScore(points) {
-    this.score += points;
-    document.getElementById('score-display').innerText = this.score;
-  }
-
-  gameOver(win) {
-    this.isGameOver = true;
-    const screen = document.getElementById('game-over-screen');
-    const title = document.getElementById('end-title');
-    
-    screen.classList.remove('hidden');
-    if (win) {
-      title.innerText = "Você Venceu!";
-      title.style.color = "#53a847";
-    } else {
-      title.innerText = "Game Over";
-      title.style.color = "#d97757";
-    }
-  }
 }
 
-// Ensure PIXI is available before starting
-window.onload = () => {
-  new Game();
+function respawn() {
+    player.x = spawn.x;
+    player.y = spawn.y;
+    player.vx = 0;
+    player.vy = 0;
+    player.facing = 1;
+    player.invuln = 1.4;
+    player.squash = 0;
+    camera.x = 0;
+}
+
+function resetGame() {
+    buildLevel();
+    score = 0;
+    coinsTaken = 0;
+    lives = 3;
+    elapsed = 0;
+    shake = 0;
+    respawn();
+    player.invuln = 0;
+    updateHud();
+}
+
+/* --------------------------------------------------------------- colisão --- */
+
+function overlaps(a, b) {
+    return a.x < b.x + b.w && a.x + a.w > b.x && a.y < b.y + b.h && a.y + a.h > b.y;
+}
+
+/* Movimento resolvido eixo a eixo: primeiro X (e empurra para fora), depois Y.
+   Fazer os dois juntos faria o jogador "escalar" paredes ao correr contra elas. */
+function moveAxis(entity, dx, dy) {
+    let landed = false;
+
+    entity.x += dx;
+    for (const tile of solids) {
+        if (!overlaps(entity, tile)) continue;
+        if (dx > 0) entity.x = tile.x - entity.w;
+        else if (dx < 0) entity.x = tile.x + tile.w;
+        entity.vx = 0;
+    }
+
+    entity.y += dy;
+    for (const tile of solids) {
+        if (!overlaps(entity, tile)) continue;
+        if (dy > 0) {
+            entity.y = tile.y - entity.h;
+            landed = true;
+        } else if (dy < 0) {
+            entity.y = tile.y + tile.h;
+            // Cabeçada em bloco de bônus: solta uma estrela e vira bloco usado.
+            if (tile.kind === 'bonus' && !tile.bumped) {
+                tile.bumped = true;
+                tile.bump = 1;
+                coins.push({ x: tile.x + TILE / 2, y: tile.y - TILE * 0.6, phase: 0, taken: false, popped: true });
+                sfx('bonus');
+            }
+        }
+        entity.vy = 0;
+    }
+
+    return landed;
+}
+
+/* ------------------------------------------------------------------- som --- */
+
+function sfx(name) {
+    if (!audio) return;
+    switch (name) {
+        case 'jump':
+            audio.tone({ freq: 320, duration: 0.14, gain: 0.13, slideTo: 620, type: 'square' });
+            break;
+        case 'coin':
+            audio.tone({ freq: 988, duration: 0.07, gain: 0.12 });
+            audio.tone({ freq: 1319, duration: 0.11, gain: 0.11, delay: 0.06 });
+            break;
+        case 'stomp':
+            audio.tone({ freq: 220, duration: 0.1, gain: 0.14, slideTo: 90, type: 'triangle' });
+            audio.noise({ duration: 0.1, gain: 0.1, filter: 1400 });
+            break;
+        case 'bonus':
+            audio.sequence([523, 784, 1047], { step: 0.05, duration: 0.1, gain: 0.13 });
+            break;
+        case 'hurt':
+            audio.tone({ freq: 420, duration: 0.5, gain: 0.16, slideTo: 90, type: 'sawtooth' });
+            break;
+        case 'win':
+            audio.sequence([523, 659, 784, 1047, 1319, 1568], { step: 0.11, duration: 0.2, gain: 0.14, type: 'triangle' });
+            break;
+        case 'over':
+            audio.sequence([392, 330, 262, 196], { step: 0.16, duration: 0.3, gain: 0.15, type: 'sawtooth' });
+            break;
+        case 'start':
+            audio.sequence([392, 523, 659], { step: 0.08, duration: 0.12, gain: 0.13 });
+            break;
+    }
+}
+
+/* ------------------------------------------------------------- partículas --- */
+
+function burst(x, y, color, count = 10, speed = 160) {
+    for (let i = 0; i < count; i++) {
+        const angle = (Math.PI * 2 * i) / count + Math.random() * 0.5;
+        particles.push({
+            x, y,
+            vx: Math.cos(angle) * speed * (0.4 + Math.random() * 0.8),
+            vy: Math.sin(angle) * speed * (0.4 + Math.random() * 0.8) - 60,
+            life: 0.5 + Math.random() * 0.35,
+            maxLife: 0.85,
+            color,
+            size: 2 + Math.random() * 3,
+        });
+    }
+}
+
+/* ---------------------------------------------------------------- update --- */
+
+function step(dt) {
+    if (state !== 'playing') return;
+
+    elapsed += dt;
+
+    /* --- jogador --- */
+    const wantsLeft = keys.left;
+    const wantsRight = keys.right;
+    const target = (wantsRight ? RUN_SPEED : 0) - (wantsLeft ? RUN_SPEED : 0);
+
+    if (target !== 0) {
+        player.vx += Math.sign(target - player.vx) * RUN_ACCEL * dt;
+        // Não deixa a aceleração passar do alvo em um frame gordo.
+        if ((target > 0 && player.vx > target) || (target < 0 && player.vx < target)) player.vx = target;
+        player.facing = target > 0 ? 1 : -1;
+    } else {
+        const drop = RUN_FRICTION * dt;
+        player.vx = Math.abs(player.vx) <= drop ? 0 : player.vx - Math.sign(player.vx) * drop;
+    }
+
+    player.vy = Math.min(MAX_FALL, player.vy + GRAVITY * dt);
+
+    // Coyote time e jump buffer decaem em tempo real.
+    player.coyote = player.grounded ? COYOTE_TIME : Math.max(0, player.coyote - dt);
+    player.buffer = Math.max(0, player.buffer - dt);
+
+    if (player.buffer > 0 && player.coyote > 0) {
+        player.vy = JUMP_VELOCITY;
+        player.buffer = 0;
+        player.coyote = 0;
+        player.grounded = false;
+        player.squash = -0.35;
+        sfx('jump');
+    }
+
+    // Pulo variável: soltar o botão na subida corta o impulso.
+    if (!player.jumpHeld && player.vy < 0) {
+        player.vy += (1 - JUMP_CUT) * -JUMP_VELOCITY * dt * 3;
+        if (player.vy > 0) player.vy = 0;
+    }
+
+    const wasAirborne = !player.grounded;
+    player.grounded = moveAxis(player, player.vx * dt, player.vy * dt);
+    if (player.grounded && wasAirborne && player.vy >= 0) {
+        player.squash = 0.35;
+        burst(player.x + player.w / 2, player.y + player.h, 'rgba(255,255,255,0.7)', 5, 70);
+    }
+
+    player.squash *= Math.pow(0.0015, dt);
+    player.walkPhase += Math.abs(player.vx) * dt * 0.06;
+    player.invuln = Math.max(0, player.invuln - dt);
+
+    // Bordas do mundo: para no início, cai no vazio no fim de uma fossa.
+    if (player.x < 0) { player.x = 0; player.vx = 0; }
+    if (player.x + player.w > WORLD_WIDTH) { player.x = WORLD_WIDTH - player.w; player.vx = 0; }
+    if (player.y > WORLD_HEIGHT + TILE * 2) loseLife();
+
+    /* --- moedas --- */
+    for (const coin of coins) {
+        if (coin.taken) continue;
+        coin.phase += dt * 3.4;
+        if (coin.popped) {
+            // A estrela do bloco sobe um pouco e para.
+            coin.y -= 40 * dt;
+            if (coin.y < coin.yStop ?? -Infinity) coin.popped = false;
+        }
+        const box = { x: coin.x - 11, y: coin.y - 11, w: 22, h: 22 };
+        if (overlaps(player, box)) {
+            coin.taken = true;
+            coinsTaken++;
+            score += 50;
+            burst(coin.x, coin.y, '#8ab4f8', 8, 130);
+            sfx('coin');
+            updateHud();
+        }
+    }
+
+    /* --- inimigos --- */
+    for (const enemy of enemies) {
+        if (!enemy.alive) {
+            enemy.squash = Math.max(0, enemy.squash - dt * 3);
+            continue;
+        }
+
+        enemy.blink += dt;
+        enemy.vy = Math.min(MAX_FALL, enemy.vy + GRAVITY * dt);
+
+        const beforeX = enemy.x;
+        const landed = moveAxis(enemy, enemy.vx * dt, enemy.vy * dt);
+        enemy.grounded = landed;
+
+        // Bateu em parede: o eixo X não andou o que devia.
+        if (Math.abs(enemy.x - beforeX) < Math.abs(enemy.vx * dt) - 0.01) {
+            enemy.vx *= -1;
+        }
+
+        /* Não anda para fora da plataforma: sonda o chão logo à frente do pé
+           que está avançando. Sem isso o inimigo se joga em todo buraco. */
+        if (landed) {
+            const probeX = enemy.vx > 0 ? enemy.x + enemy.w + 2 : enemy.x - 2;
+            const probe = { x: probeX, y: enemy.y + enemy.h + 2, w: 2, h: 4 };
+            if (!solids.some(tile => overlaps(probe, tile))) enemy.vx *= -1;
+        }
+
+        if (player.invuln <= 0 && overlaps(player, enemy)) {
+            // Pisar em cima só conta caindo e vindo de cima do inimigo.
+            const fromAbove = player.vy > 0 && (player.y + player.h) - enemy.y < enemy.h * 0.6;
+            if (fromAbove) {
+                enemy.alive = false;
+                enemy.squash = 1;
+                player.vy = STOMP_BOUNCE;
+                player.buffer = 0;
+                score += 100;
+                shake = 0.22;
+                burst(enemy.x + enemy.w / 2, enemy.y + enemy.h / 2, '#10a37f', 12, 170);
+                sfx('stomp');
+                updateHud();
+            } else {
+                loseLife();
+            }
+        }
+    }
+
+    /* --- espinhos --- */
+    if (player.invuln <= 0) {
+        for (const spike of spikes) {
+            if (overlaps(player, spike)) { loseLife(); break; }
+        }
+    }
+
+    /* --- bandeira --- */
+    if (goal && player.x + player.w > goal.x - 12 && player.y < goal.y + goal.h) {
+        win();
+    }
+
+    /* --- partículas e blocos --- */
+    particles = particles.filter(p => {
+        p.life -= dt;
+        p.vy += GRAVITY * 0.35 * dt;
+        p.x += p.vx * dt;
+        p.y += p.vy * dt;
+        return p.life > 0;
+    });
+
+    for (const tile of solids) {
+        if (tile.bump > 0) tile.bump = Math.max(0, tile.bump - dt * 5);
+    }
+
+    shake = Math.max(0, shake - dt * 1.6);
+
+    /* --- câmera: segue com folga e nunca mostra fora do mundo --- */
+    const targetX = player.x + player.w / 2 - VIEW_WIDTH / 2;
+    camera.x += (targetX - camera.x) * Math.min(1, dt * 7);
+    camera.x = Math.max(0, Math.min(WORLD_WIDTH - VIEW_WIDTH, camera.x));
+
+    const targetY = player.y + player.h / 2 - viewHeight / 2;
+    camera.y += (targetY - camera.y) * Math.min(1, dt * 4);
+    camera.y = Math.max(0, Math.min(Math.max(0, WORLD_HEIGHT - viewHeight), camera.y));
+
+    updateTime();
+}
+
+function loseLife() {
+    if (state !== 'playing') return;
+
+    lives--;
+    shake = 0.5;
+    burst(player.x + player.w / 2, player.y + player.h / 2, '#d97757', 16, 210);
+    sfx(lives > 0 ? 'hurt' : 'over');
+    updateHud();
+
+    if (lives <= 0) {
+        state = 'over';
+        showOverlay('Fim de jogo', `${score} pontos · ${coinsTaken} estrelas`, 'Recomeçar');
+        announce(`Fim de jogo. ${score} pontos.`);
+    } else {
+        state = 'dead';
+        announce(`Você perdeu uma vida. Restam ${lives}.`);
+        setTimeout(() => {
+            if (state !== 'dead') return;
+            respawn();
+            state = 'playing';
+        }, 700);
+    }
+}
+
+function win() {
+    if (state !== 'playing') return;
+    state = 'won';
+    // Bônus de tempo: terminar rápido vale mais.
+    const bonus = Math.max(0, Math.round((120 - elapsed) * 10));
+    score += bonus;
+    burst(goal.x, goal.y + goal.h / 2, '#f5c542', 26, 240);
+    sfx('win');
+    updateHud();
+    showOverlay('Você venceu!', `${score} pontos · bônus de tempo ${bonus}`, 'Jogar de novo');
+    announce(`Você venceu com ${score} pontos.`);
+}
+
+/* ---------------------------------------------------------------- render --- */
+
+function roundRect(x, y, w, h, r) {
+    ctx.beginPath();
+    ctx.moveTo(x + r, y);
+    ctx.arcTo(x + w, y, x + w, y + h, r);
+    ctx.arcTo(x + w, y + h, x, y + h, r);
+    ctx.arcTo(x, y + h, x, y, r);
+    ctx.arcTo(x, y, x + w, y, r);
+    ctx.closePath();
+}
+
+/* Céu + camadas de parallax. Cada camada anda uma fração da câmera: quanto mais
+   longe, mais devagar — é o que dá profundidade sem nenhuma textura. */
+function drawBackground() {
+    const sky = ctx.createLinearGradient(0, 0, 0, viewHeight);
+    sky.addColorStop(0, '#5aa9e6');
+    sky.addColorStop(0.55, '#93cdf0');
+    sky.addColorStop(1, '#d7eefb');
+    ctx.fillStyle = sky;
+    ctx.fillRect(0, 0, VIEW_WIDTH, viewHeight);
+
+    // Sol
+    ctx.fillStyle = 'rgba(255, 245, 200, 0.9)';
+    ctx.beginPath();
+    ctx.arc(VIEW_WIDTH - 90, 70, 34, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.fillStyle = 'rgba(255, 245, 200, 0.22)';
+    ctx.beginPath();
+    ctx.arc(VIEW_WIDTH - 90, 70, 58, 0, Math.PI * 2);
+    ctx.fill();
+
+    // Morros distantes (parallax 0.25)
+    const hillOffset = -camera.x * 0.25;
+    ctx.fillStyle = '#6fb8a0';
+    ctx.beginPath();
+    ctx.moveTo(0, viewHeight);
+    for (let i = -1; i < 14; i++) {
+        const baseX = hillOffset % 260 + i * 260;
+        ctx.lineTo(baseX, viewHeight - 90);
+        ctx.quadraticCurveTo(baseX + 130, viewHeight - 215, baseX + 260, viewHeight - 90);
+    }
+    ctx.lineTo(VIEW_WIDTH + 300, viewHeight);
+    ctx.closePath();
+    ctx.fill();
+
+    // Morros próximos (parallax 0.45)
+    const nearOffset = -camera.x * 0.45;
+    ctx.fillStyle = '#4f9c86';
+    ctx.beginPath();
+    ctx.moveTo(0, viewHeight);
+    for (let i = -1; i < 16; i++) {
+        const baseX = nearOffset % 200 + i * 200;
+        ctx.lineTo(baseX, viewHeight - 50);
+        ctx.quadraticCurveTo(baseX + 100, viewHeight - 140, baseX + 200, viewHeight - 50);
+    }
+    ctx.lineTo(VIEW_WIDTH + 300, viewHeight);
+    ctx.closePath();
+    ctx.fill();
+
+    // Nuvens (parallax 0.15)
+    ctx.fillStyle = 'rgba(255, 255, 255, 0.85)';
+    const cloudOffset = -camera.x * 0.15;
+    for (let i = 0; i < 9; i++) {
+        const cx = ((cloudOffset + i * 310) % (VIEW_WIDTH + 400) + VIEW_WIDTH + 400) % (VIEW_WIDTH + 400) - 200;
+        const cy = 48 + (i % 3) * 46;
+        const s = 0.75 + (i % 4) * 0.16;
+        ctx.beginPath();
+        ctx.arc(cx, cy, 20 * s, 0, Math.PI * 2);
+        ctx.arc(cx + 22 * s, cy - 8 * s, 26 * s, 0, Math.PI * 2);
+        ctx.arc(cx + 48 * s, cy, 19 * s, 0, Math.PI * 2);
+        ctx.fill();
+    }
+}
+
+function drawTiles() {
+    for (const tile of solids) {
+        // Culling: fora do enquadramento não desenha.
+        if (tile.x + TILE < camera.x - TILE || tile.x > camera.x + VIEW_WIDTH + TILE) continue;
+
+        const x = tile.x - camera.x;
+        const y = tile.y - camera.y - (tile.bump || 0) * 6;
+
+        if (tile.kind === 'grass' || tile.kind === 'dirt') {
+            ctx.fillStyle = '#8c5b3e';
+            ctx.fillRect(x, y, TILE, TILE);
+            ctx.fillStyle = 'rgba(0,0,0,0.12)';
+            ctx.fillRect(x, y + TILE - 5, TILE, 5);
+            // Pedrinhas: posição derivada do próprio tile, então não tremem.
+            ctx.fillStyle = 'rgba(255,255,255,0.10)';
+            ctx.fillRect(x + ((tile.x / TILE) % 3) * 8 + 4, y + 14, 5, 4);
+
+            if (tile.kind === 'grass') {
+                ctx.fillStyle = '#53a847';
+                ctx.fillRect(x, y, TILE, 9);
+                ctx.fillStyle = '#67c95a';
+                ctx.fillRect(x, y, TILE, 4);
+            }
+        } else if (tile.kind === 'platform') {
+            ctx.fillStyle = '#b8763f';
+            roundRect(x + 1, y + 1, TILE - 2, TILE - 2, 5);
+            ctx.fill();
+            ctx.fillStyle = '#d99a5f';
+            roundRect(x + 1, y + 1, TILE - 2, TILE - 8, 5);
+            ctx.fill();
+            ctx.strokeStyle = 'rgba(120, 70, 30, 0.55)';
+            ctx.lineWidth = 2;
+            ctx.beginPath();
+            ctx.moveTo(x + 6, y + 13);
+            ctx.lineTo(x + TILE - 6, y + 13);
+            ctx.stroke();
+        } else if (tile.kind === 'bonus') {
+            const used = tile.bumped;
+            ctx.fillStyle = used ? '#8a7a63' : '#e8a63c';
+            roundRect(x + 1, y + 1, TILE - 2, TILE - 2, 5);
+            ctx.fill();
+            ctx.fillStyle = used ? '#6f6250' : '#f6c860';
+            roundRect(x + 4, y + 4, TILE - 8, TILE - 8, 4);
+            ctx.fill();
+            if (!used) {
+                ctx.fillStyle = '#7a4a15';
+                ctx.font = 'bold 17px system-ui, sans-serif';
+                ctx.textAlign = 'center';
+                ctx.textBaseline = 'middle';
+                ctx.fillText('?', x + TILE / 2, y + TILE / 2 + 1);
+            }
+        }
+    }
+
+    for (const spike of spikes) {
+        if (spike.x + TILE < camera.x - TILE || spike.x > camera.x + VIEW_WIDTH + TILE) continue;
+        const x = spike.x - camera.x;
+        const y = spike.y - camera.y;
+        ctx.fillStyle = '#c2c8d0';
+        for (let i = 0; i < 4; i++) {
+            ctx.beginPath();
+            ctx.moveTo(x + i * 8, y + spike.h);
+            ctx.lineTo(x + i * 8 + 4, y);
+            ctx.lineTo(x + i * 8 + 8, y + spike.h);
+            ctx.closePath();
+            ctx.fill();
+        }
+        ctx.fillStyle = '#8a919c';
+        ctx.fillRect(x, y + spike.h - 3, TILE, 3);
+    }
+}
+
+/* Estrela Gemini: quatro pontas, girando devagar e flutuando. */
+function drawCoins() {
+    for (const coin of coins) {
+        if (coin.taken) continue;
+        const x = coin.x - camera.x;
+        const y = coin.y - camera.y + Math.sin(coin.phase) * 4;
+        if (x < -TILE || x > VIEW_WIDTH + TILE) continue;
+
+        ctx.save();
+        ctx.translate(x, y);
+        // O brilho pulsa junto com a flutuação.
+        ctx.fillStyle = 'rgba(138, 180, 248, 0.25)';
+        ctx.beginPath();
+        ctx.arc(0, 0, 15 + Math.sin(coin.phase) * 2, 0, Math.PI * 2);
+        ctx.fill();
+
+        ctx.rotate(coin.phase * 0.35);
+        ctx.fillStyle = '#4285f4';
+        ctx.beginPath();
+        for (let i = 0; i < 8; i++) {
+            const angle = (Math.PI / 4) * i;
+            const radius = i % 2 === 0 ? 11 : 4;
+            const px = Math.cos(angle) * radius;
+            const py = Math.sin(angle) * radius;
+            if (i === 0) ctx.moveTo(px, py); else ctx.lineTo(px, py);
+        }
+        ctx.closePath();
+        ctx.fill();
+        ctx.fillStyle = '#ffffff';
+        ctx.beginPath();
+        ctx.arc(0, 0, 3.4, 0, Math.PI * 2);
+        ctx.fill();
+        ctx.restore();
+    }
+}
+
+/* Inimigo ChatGPT: bolha verde com olhos que piscam e sorriso. */
+function drawEnemies() {
+    for (const enemy of enemies) {
+        if (!enemy.alive && enemy.squash <= 0) continue;
+        const x = enemy.x - camera.x;
+        const y = enemy.y - camera.y;
+        if (x < -TILE * 2 || x > VIEW_WIDTH + TILE * 2) continue;
+
+        const flat = enemy.alive ? 0 : 1 - enemy.squash;
+        const h = enemy.h * (1 - flat * 0.75);
+        const w = enemy.w * (1 + flat * 0.35);
+        const cx = x + enemy.w / 2;
+        const top = y + enemy.h - h;
+
+        ctx.fillStyle = 'rgba(0,0,0,0.16)';
+        ctx.beginPath();
+        ctx.ellipse(cx, y + enemy.h + 2, w * 0.45, 4, 0, 0, Math.PI * 2);
+        ctx.fill();
+
+        ctx.fillStyle = '#10a37f';
+        roundRect(cx - w / 2, top, w, h, Math.min(w, h) / 2.4);
+        ctx.fill();
+        ctx.fillStyle = 'rgba(255,255,255,0.18)';
+        roundRect(cx - w / 2 + 3, top + 3, w - 6, h * 0.4, Math.min(w, h) / 3);
+        ctx.fill();
+
+        if (enemy.alive) {
+            // Pisca por ~120ms a cada ~3s.
+            const blinking = enemy.blink % 3 < 0.12;
+            ctx.fillStyle = '#0b2c24';
+            const eyeY = top + h * 0.38;
+            const dir = Math.sign(enemy.vx) || 1;
+            if (blinking) {
+                ctx.fillRect(cx - 8 + dir, eyeY - 1, 5, 2);
+                ctx.fillRect(cx + 3 + dir, eyeY - 1, 5, 2);
+            } else {
+                ctx.beginPath();
+                ctx.arc(cx - 5.5 + dir * 1.5, eyeY, 2.8, 0, Math.PI * 2);
+                ctx.arc(cx + 5.5 + dir * 1.5, eyeY, 2.8, 0, Math.PI * 2);
+                ctx.fill();
+            }
+            ctx.strokeStyle = '#0b2c24';
+            ctx.lineWidth = 2;
+            ctx.beginPath();
+            ctx.arc(cx, top + h * 0.62, 5.5, 0.15 * Math.PI, 0.85 * Math.PI);
+            ctx.stroke();
+        }
+    }
+}
+
+/* Claude: quadrado arredondado laranja, com antenas, olhos que olham para onde
+   anda e pernas que alternam com a fase da caminhada. */
+function drawPlayer() {
+    const blink = player.invuln > 0 && Math.floor(player.invuln * 14) % 2 === 0;
+    if (blink) return;
+
+    const squash = player.squash;
+    const w = player.w * (1 + squash * 0.3);
+    const h = player.h * (1 - squash * 0.3);
+    const cx = player.x + player.w / 2 - camera.x;
+    const bottom = player.y + player.h - camera.y;
+    const top = bottom - h;
+
+    ctx.fillStyle = 'rgba(0,0,0,0.18)';
+    ctx.beginPath();
+    ctx.ellipse(cx, bottom + 3, w * 0.45, 4, 0, 0, Math.PI * 2);
+    ctx.fill();
+
+    // Pernas: no chão alternam; no ar ficam recolhidas.
+    ctx.fillStyle = '#9c4a30';
+    const stride = player.grounded ? Math.sin(player.walkPhase) * 5 : -3;
+    ctx.fillRect(cx - 8, bottom - 4, 6, 6 + stride);
+    ctx.fillRect(cx + 2, bottom - 4, 6, 6 - stride);
+
+    // Antenas
+    ctx.strokeStyle = '#9c4a30';
+    ctx.lineWidth = 2.5;
+    ctx.lineCap = 'round';
+    ctx.beginPath();
+    ctx.moveTo(cx - 6, top + 3);
+    ctx.lineTo(cx - 10, top - 6);
+    ctx.moveTo(cx + 6, top + 3);
+    ctx.lineTo(cx + 10, top - 6);
+    ctx.stroke();
+
+    ctx.fillStyle = '#d97757';
+    roundRect(cx - w / 2, top, w, h, 7);
+    ctx.fill();
+    ctx.fillStyle = 'rgba(255,255,255,0.16)';
+    roundRect(cx - w / 2 + 3, top + 3, w - 6, h * 0.35, 5);
+    ctx.fill();
+
+    // Olhos com pupila deslocada na direção do movimento.
+    const look = player.facing * 1.6;
+    ctx.fillStyle = '#ffffff';
+    ctx.beginPath();
+    ctx.arc(cx - 5.5, top + h * 0.38, 4.2, 0, Math.PI * 2);
+    ctx.arc(cx + 5.5, top + h * 0.38, 4.2, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.fillStyle = '#3a1a10';
+    ctx.beginPath();
+    ctx.arc(cx - 5.5 + look, top + h * 0.38, 2.1, 0, Math.PI * 2);
+    ctx.arc(cx + 5.5 + look, top + h * 0.38, 2.1, 0, Math.PI * 2);
+    ctx.fill();
+
+    // Boca
+    ctx.fillStyle = '#ffffff';
+    roundRect(cx - 5, top + h * 0.66, 10, 3.4, 1.7);
+    ctx.fill();
+}
+
+function drawGoal() {
+    if (!goal) return;
+    const x = goal.x - camera.x;
+    const y = goal.y - camera.y;
+    if (x < -TILE * 3 || x > VIEW_WIDTH + TILE * 3) return;
+
+    ctx.fillStyle = '#c8cdd6';
+    ctx.fillRect(x - 2, y, 4, goal.h);
+    ctx.fillStyle = '#f5c542';
+    ctx.beginPath();
+    ctx.arc(x, y, 6, 0, Math.PI * 2);
+    ctx.fill();
+
+    // Bandeira ondulando: dois picos de seno ao longo do comprimento.
+    const t = performance.now() / 340;
+    ctx.fillStyle = '#d97757';
+    ctx.beginPath();
+    ctx.moveTo(x + 2, y + 6);
+    for (let i = 0; i <= 10; i++) {
+        const p = i / 10;
+        ctx.lineTo(x + 2 + p * 44, y + 6 + Math.sin(t + p * 4) * 4 + p * 2);
+    }
+    for (let i = 10; i >= 0; i--) {
+        const p = i / 10;
+        ctx.lineTo(x + 2 + p * 44, y + 30 + Math.sin(t + p * 4) * 4 + p * 2);
+    }
+    ctx.closePath();
+    ctx.fill();
+}
+
+function drawParticles() {
+    for (const p of particles) {
+        const alpha = Math.max(0, p.life / p.maxLife);
+        ctx.globalAlpha = alpha;
+        ctx.fillStyle = p.color;
+        ctx.fillRect(p.x - camera.x - p.size / 2, p.y - camera.y - p.size / 2, p.size, p.size);
+    }
+    ctx.globalAlpha = 1;
+}
+
+function render() {
+    ctx.setTransform(scale, 0, 0, scale, 0, 0);
+
+    // Tremida de tela: deslocamento aleatório que decai junto com `shake`.
+    if (shake > 0) {
+        ctx.translate((Math.random() - 0.5) * shake * 14, (Math.random() - 0.5) * shake * 14);
+    }
+
+    drawBackground();
+    drawTiles();
+    drawGoal();
+    drawCoins();
+    drawEnemies();
+    if (state !== 'dead' || Math.floor(performance.now() / 90) % 2 === 0) drawPlayer();
+    drawParticles();
+}
+
+/* ------------------------------------------------------------------ loop --- */
+
+let lastTime = 0;
+let accumulator = 0;
+
+function frame(now) {
+    requestAnimationFrame(frame);
+
+    if (!lastTime) lastTime = now;
+    // Trava a 250ms: uma aba que voltou do background não replica meio segundo
+    // de física de uma vez.
+    const delta = Math.min((now - lastTime) / 1000, 0.25);
+    lastTime = now;
+
+    accumulator += delta;
+    let guard = 0;
+    while (accumulator >= FIXED_STEP && guard++ < 240) {
+        step(FIXED_STEP);
+        accumulator -= FIXED_STEP;
+    }
+
+    render();
+}
+
+/* -------------------------------------------------------------------- ui --- */
+
+function updateHud() {
+    hud.score.textContent = String(score);
+    hud.coins.textContent = String(coinsTaken);
+    hud.lives.textContent = '❤️'.repeat(Math.max(0, lives)) || '—';
+}
+
+function updateTime() {
+    const total = Math.floor(elapsed);
+    hud.time.textContent = `${String(Math.floor(total / 60)).padStart(2, '0')}:${String(total % 60).padStart(2, '0')}`;
+}
+
+function announce(message) {
+    if (statusLive) statusLive.textContent = message;
+}
+
+function showOverlay(title, text, button) {
+    overlayTitle.textContent = title;
+    overlayText.textContent = text;
+    overlayButton.textContent = button;
+    overlay.hidden = false;
+}
+
+function hideOverlay() {
+    overlay.hidden = true;
+}
+
+function startGame() {
+    resetGame();
+    hideOverlay();
+    state = 'playing';
+    updateTime();
+    sfx('start');
+    announce('Partida iniciada.');
+}
+
+function togglePause() {
+    if (state === 'playing') {
+        state = 'paused';
+        showOverlay('Pausa', 'Respire — o nível espera.', 'Continuar');
+        announce('Jogo pausado.');
+    } else if (state === 'paused') {
+        hideOverlay();
+        state = 'playing';
+        announce('Jogo retomado.');
+    }
+}
+
+overlayButton.addEventListener('click', () => {
+    if (state === 'paused') togglePause();
+    else startGame();
+});
+
+/* ---------------------------------------------------------------- input --- */
+
+function pressJump() {
+    player.buffer = JUMP_BUFFER;
+    player.jumpHeld = true;
+}
+
+function releaseJump() {
+    player.jumpHeld = false;
+}
+
+const KEY_MAP = {
+    ArrowLeft: 'left', KeyA: 'left',
+    ArrowRight: 'right', KeyD: 'right',
 };
+
+window.addEventListener('keydown', event => {
+    if (event.repeat) return;
+
+    if (KEY_MAP[event.code]) {
+        event.preventDefault();
+        keys[KEY_MAP[event.code]] = true;
+        return;
+    }
+
+    if (event.code === 'Space' || event.code === 'ArrowUp' || event.code === 'KeyW') {
+        event.preventDefault();
+        if (state === 'playing') pressJump();
+        else if (state === 'ready' || state === 'over' || state === 'won') startGame();
+        return;
+    }
+
+    if (event.code === 'Enter') {
+        if (state !== 'playing') { event.preventDefault(); startGame(); }
+        return;
+    }
+
+    if (event.code === 'KeyP' || event.code === 'Escape') {
+        event.preventDefault();
+        togglePause();
+    }
+});
+
+window.addEventListener('keyup', event => {
+    if (KEY_MAP[event.code]) keys[KEY_MAP[event.code]] = false;
+    if (event.code === 'Space' || event.code === 'ArrowUp' || event.code === 'KeyW') releaseJump();
+});
+
+/* Botões de toque em pointer events: um só caminho cobre dedo, caneta e mouse
+   (a versão anterior escutava só touchstart, então não funcionava no desktop).
+   `setPointerCapture` mantém o botão pressionado mesmo se o dedo escorregar. */
+function bindHold(id, onPress, onRelease) {
+    const el = document.getElementById(id);
+    if (!el) return;
+
+    const release = event => {
+        if (event) el.releasePointerCapture?.(event.pointerId);
+        el.classList.remove('is-active');
+        onRelease?.();
+    };
+
+    el.addEventListener('pointerdown', event => {
+        event.preventDefault();
+        el.setPointerCapture?.(event.pointerId);
+        el.classList.add('is-active');
+        onPress();
+    });
+    el.addEventListener('pointerup', release);
+    el.addEventListener('pointercancel', release);
+    el.addEventListener('contextmenu', event => event.preventDefault());
+}
+
+bindHold('btnLeft', () => { keys.left = true; }, () => { keys.left = false; });
+bindHold('btnRight', () => { keys.right = true; }, () => { keys.right = false; });
+bindHold('btnJump', () => {
+    if (state === 'playing') pressJump();
+    else if (state !== 'paused') startGame();
+}, releaseJump);
+
+document.getElementById('btnPause')?.addEventListener('click', togglePause);
+
+// Sair da aba pausa em vez de deixar o jogador morrer sozinho.
+document.addEventListener('visibilitychange', () => {
+    if (document.hidden && state === 'playing') togglePause();
+});
+
+/* ---------------------------------------------------------------- layout --- */
+
+/* O jogo é desenhado sempre em VIEW_WIDTH px de mundo; o canvas é escalado para
+   ocupar o espaço disponível. Assim o enquadramento é o mesmo em todo aparelho
+   — o celular não ganha vantagem nem desvantagem de campo de visão. */
+function resize() {
+    const stage = canvas.parentElement;
+    const rect = stage.getBoundingClientRect();
+    const dpr = Math.min(window.devicePixelRatio || 1, 2);
+
+    const cssWidth = Math.max(240, rect.width);
+    const cssHeight = Math.max(180, rect.height);
+
+    scale = cssWidth / VIEW_WIDTH;
+    viewHeight = cssHeight / scale;
+
+    canvas.width = Math.round(cssWidth * dpr);
+    canvas.height = Math.round(cssHeight * dpr);
+    canvas.style.width = `${cssWidth}px`;
+    canvas.style.height = `${cssHeight}px`;
+
+    scale *= dpr;
+    ctx.imageSmoothingEnabled = true;
+}
+
+const resizeObserver = new ResizeObserver(resize);
+resizeObserver.observe(canvas.parentElement);
+window.addEventListener('orientationchange', () => setTimeout(resize, 120));
+
+/* ------------------------------------------------------------------ boot --- */
+
+if (audio) {
+    audio.configure({ storageKey: 'claude-bros:muted', volume: 0.4 });
+}
+
+function mountAudioToggle() {
+    const host = document.querySelector('[data-lab-header] .header-actions');
+    if (host && audio) audio.mountToggle(host);
+    else if (audio) setTimeout(mountAudioToggle, 60);
+}
+mountAudioToggle();
+
+// Mostra os controles de toque só onde eles servem.
+if (touchLayer && !window.matchMedia('(pointer: fine)').matches) touchLayer.hidden = false;
+
+resetGame();
+resize();
+showOverlay('Claude Bros', 'Colete as estrelas, pule nos rivais e chegue à bandeira.', 'Começar');
+requestAnimationFrame(frame);

--- a/labs/claude-bros/style.css
+++ b/labs/claude-bros/style.css
@@ -1,250 +1,297 @@
-:root {
-  --bg-color: #1a1a1a;
-  --text-color: #f1f1f1;
-  --primary-color: #d97757; /* Claude orange */
-  --header-bg: rgba(20, 20, 20, 0.8);
-  --btn-bg: rgba(255, 255, 255, 0.2);
-  --btn-active: rgba(255, 255, 255, 0.4);
+/* Claude Bros — layout do jogo.
+   O shell compartilhado (labs/shared.css) entrega header, footer, tema e os
+   tokens de safe-area; aqui só entra o que é do jogo. */
+
+body {
+    /* Fullscreen: o palco ocupa a altura livre e a página não rola.
+       O fundo continua sendo o token do tema — o azul é do céu da fase, dentro
+       do palco, não da página (senão o header claro fica ilegível). */
+    padding: 0;
+    overflow: hidden;
 }
 
-* {
-  box-sizing: border-box;
-  margin: 0;
-  padding: 0;
+.game-shell {
+    width: 100%;
+    max-width: 1200px;
+    min-height: 100dvh;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    padding: max(0.75rem, var(--safe-top))
+        max(0.75rem, var(--safe-right))
+        max(0.5rem, var(--safe-bottom))
+        max(0.75rem, var(--safe-left));
+    margin: 0 auto;
 }
 
-html, body {
-  width: 100%;
-  height: 100dvh;
-  overflow: hidden;
-  background-color: var(--bg-color);
-  color: var(--text-color);
-  font-family: 'Outfit', sans-serif;
-  touch-action: none; /* Prevent zooming/panning on mobile */
+[data-lab-header] {
+    margin-bottom: 0;
+    padding: 0;
+    flex: 0 0 auto;
 }
 
-/* Header */
-.lab-header {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 44px;
-  padding: 0 16px;
-  padding-top: env(safe-area-inset-top);
-  padding-left: env(safe-area-inset-left);
-  padding-right: env(safe-area-inset-right);
-  background: var(--header-bg);
-  backdrop-filter: blur(8px);
-  -webkit-backdrop-filter: blur(8px);
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  z-index: 100;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+/* O palco toma a altura que sobra; `min-height: 0` é o que permite ao flex
+   encolhê-lo em telas baixas em vez de estourar a página. */
+.stage {
+    position: relative;
+    flex: 1 1 auto;
+    min-height: 0;
+    width: 100%;
+    border-radius: 1rem;
+    overflow: hidden;
+    background: #5aa9e6;
+    box-shadow: 0 18px 48px rgba(4, 20, 34, 0.45);
+    /* Os gestos do jogo não podem virar scroll/zoom da página. */
+    touch-action: none;
+    user-select: none;
+    -webkit-user-select: none;
 }
 
-.back-link {
-  color: var(--text-color);
-  text-decoration: none;
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  font-size: 14px;
-  font-weight: 700;
-  opacity: 0.8;
-  transition: opacity 0.2s;
+.stage canvas {
+    display: block;
+    width: 100%;
+    height: 100%;
 }
 
-.back-link:hover {
-  opacity: 1;
-}
+/* ------------------------------------------------------------------- HUD --- */
 
-.lab-title {
-  font-size: 16px;
-  font-weight: 700;
-  margin: 0;
-  opacity: 0.5;
-}
-
-/* Game Container */
-.game-container {
-  position: relative;
-  width: 100%;
-  height: 100%;
-  display: flex;
-  flex-direction: column;
-}
-
-#pixi-container {
-  width: 100%;
-  height: 100%;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-}
-
-#pixi-container canvas {
-  display: block;
-  max-width: 100%;
-  max-height: 100%;
-  object-fit: contain;
-}
-
-/* HUD */
 .hud {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  pointer-events: none;
-  z-index: 10;
-  padding: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+    padding: 0.6rem;
+    pointer-events: none;
 }
 
-.hud-score {
-  position: absolute;
-  top: 60px;
-  left: 16px;
-  font-size: 24px;
-  font-weight: 700;
-  text-shadow: 2px 2px 0 #000;
-  pointer-events: auto;
+.hud-chip {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 0.35rem;
+    padding: 0.3rem 0.6rem;
+    border-radius: 999px;
+    background: rgba(8, 26, 42, 0.55);
+    backdrop-filter: blur(6px);
+    -webkit-backdrop-filter: blur(6px);
+    color: #fff;
+    font-size: 0.8rem;
+    line-height: 1.2;
+    font-variant-numeric: tabular-nums;
+    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.4);
 }
 
-.hud-controls {
-  position: absolute;
-  bottom: 24px;
-  left: 0;
-  width: 100%;
-  display: flex;
-  justify-content: space-between;
-  padding: 0 24px;
-  opacity: 0;
-  pointer-events: none;
-  transition: opacity 0.3s;
+.hud-key {
+    font-size: 0.62rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    opacity: 0.72;
 }
 
-/* Only show touch controls on coarse pointer devices */
-@media (pointer: coarse) {
-  .hud-controls {
-    opacity: 1;
-    pointer-events: auto;
-  }
+.hud-chip strong {
+    font-weight: 700;
 }
 
-.dpad {
-  display: flex;
-  gap: 16px;
-}
+/* --------------------------------------------------------------- overlay --- */
 
-.action-buttons {
-  display: flex;
-}
-
-.control-btn {
-  width: 64px;
-  height: 64px;
-  border-radius: 50%;
-  background: var(--btn-bg);
-  border: 2px solid rgba(255,255,255,0.3);
-  color: white;
-  font-size: 24px;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  user-select: none;
-  -webkit-user-select: none;
-  backdrop-filter: blur(4px);
-  -webkit-backdrop-filter: blur(4px);
-  cursor: pointer;
-}
-
-.control-btn:active, .control-btn.active {
-  background: var(--btn-active);
-  transform: scale(0.95);
-}
-
-.action-btn {
-  width: 72px;
-  height: 72px;
-  font-weight: 700;
-  font-family: 'Outfit', sans-serif;
-}
-
-/* Overlay */
 .overlay {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background: rgba(0, 0, 0, 0.8);
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  z-index: 50;
-  gap: 24px;
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 1rem;
+    background: rgba(6, 20, 34, 0.55);
+    /* Blur leve: o menu precisa se destacar sem apagar a fase atrás dele. */
+    backdrop-filter: blur(3px);
+    -webkit-backdrop-filter: blur(3px);
+    z-index: 20;
 }
 
-.overlay.hidden {
-  display: none;
+.overlay[hidden] {
+    display: none;
 }
 
-.overlay h2 {
-  font-size: 48px;
-  font-weight: 700;
-  text-shadow: 0 4px 12px rgba(0,0,0,0.5);
-  color: var(--primary-color);
-  text-align: center;
-  padding: 0 16px;
+.overlay-card {
+    /* Menu longo em tela baixa rola dentro do card, sem empurrar o jogo. */
+    max-width: min(30rem, 100%);
+    max-height: min(92dvh, 100%);
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.85rem;
+    padding: clamp(1.25rem, 4vw, 2rem);
+    text-align: center;
+    border-radius: 1.25rem;
+    background: rgba(12, 30, 48, 0.92);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    color: #f2f7fb;
+    box-shadow: 0 24px 60px rgba(0, 0, 0, 0.45);
 }
 
-.btn {
-  padding: 16px 32px;
-  font-size: 18px;
-  font-family: 'Outfit', sans-serif;
-  font-weight: 700;
-  color: #fff;
-  background: var(--primary-color);
-  border: none;
-  border-radius: 32px;
-  cursor: pointer;
-  transition: transform 0.2s, filter 0.2s;
+.overlay-card h2 {
+    font-size: clamp(1.5rem, 6vw, 2.25rem);
+    font-weight: 700;
+    letter-spacing: -0.02em;
+    color: #ffb894;
 }
 
-.btn:hover {
-  transform: scale(1.05);
-  filter: brightness(1.2);
+.overlay-card p {
+    font-size: clamp(0.9rem, 3.2vw, 1rem);
+    line-height: 1.5;
+    color: rgba(242, 247, 251, 0.82);
 }
 
-.btn:active {
-  transform: scale(0.95);
+.overlay-hint {
+    font-size: 0.8rem !important;
+    opacity: 0.65;
 }
 
-/* Responsive adjustments */
+.primary-btn {
+    min-height: var(--touch-target);
+    padding: 0.75rem 2rem;
+    border: 0;
+    border-radius: 999px;
+    background: #d97757;
+    color: #fff;
+    font-family: inherit;
+    font-size: 1rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: transform 0.2s ease, filter 0.2s ease;
+}
+
+.primary-btn:hover {
+    filter: brightness(1.08);
+    transform: translateY(-2px);
+}
+
+.primary-btn:active {
+    transform: translateY(0) scale(0.97);
+}
+
+.primary-btn:focus-visible {
+    outline: 3px solid var(--focus-ring);
+    outline-offset: 3px;
+}
+
+/* ------------------------------------------------------ controles de toque --- */
+
+.touch-controls {
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between;
+    gap: 1rem;
+    /* Os controles sobem acima do home indicator. */
+    padding: 0 max(0.9rem, var(--safe-left)) max(0.9rem, var(--safe-bottom))
+        max(0.9rem, var(--safe-right));
+    z-index: 15;
+}
+
+.touch-controls[hidden] {
+    display: none;
+}
+
+.touch-move {
+    display: flex;
+    gap: 0.75rem;
+}
+
+.touch-btn {
+    /* 60px: acima do mínimo de 44px, porque aqui o dedo fica apoiado. */
+    width: 60px;
+    height: 60px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    border: 2px solid rgba(255, 255, 255, 0.35);
+    background: rgba(10, 28, 45, 0.42);
+    backdrop-filter: blur(6px);
+    -webkit-backdrop-filter: blur(6px);
+    color: #fff;
+    font-size: 1.4rem;
+    font-family: inherit;
+    cursor: pointer;
+    touch-action: none;
+    transition: background 0.12s ease, transform 0.12s ease;
+}
+
+.touch-btn.is-active,
+.touch-btn:active {
+    background: rgba(217, 119, 87, 0.75);
+    transform: scale(0.94);
+}
+
+.touch-btn--jump {
+    width: 74px;
+    height: 74px;
+    font-size: 1.6rem;
+    background: rgba(217, 119, 87, 0.42);
+}
+
+.touch-btn:focus-visible {
+    outline: 3px solid var(--focus-ring);
+    outline-offset: 3px;
+}
+
+/* --------------------------------------------------------------- responsivo --- */
+
 @media (max-width: 768px) {
-  .overlay h2 {
-    font-size: 36px;
-  }
+    .game-shell {
+        gap: 0.5rem;
+    }
+
+    .hud {
+        padding: 0.45rem;
+        gap: 0.3rem;
+    }
+
+    .hud-chip {
+        padding: 0.25rem 0.5rem;
+        font-size: 0.72rem;
+    }
 }
 
+/* Landscape curto: o header encolhe (shared.css já cuida) e os controles
+   ficam mais baixos e menores para não cobrir o chão da fase. */
 @media (max-height: 520px) and (orientation: landscape) {
-  .hud-score {
-    top: 52px;
-  }
-  .control-btn {
-    width: 56px;
-    height: 56px;
-    font-size: 20px;
-  }
-  .action-btn {
-    width: 64px;
-    height: 64px;
-  }
-  .hud-controls {
-    bottom: 16px;
-  }
+    .game-shell {
+        gap: 0.4rem;
+        padding-bottom: max(0.25rem, var(--safe-bottom));
+    }
+
+    [data-lab-footer] {
+        display: none;
+    }
+
+    .touch-btn {
+        width: 52px;
+        height: 52px;
+        font-size: 1.2rem;
+    }
+
+    .touch-btn--jump {
+        width: 62px;
+        height: 62px;
+        font-size: 1.35rem;
+    }
+
+    .hud {
+        padding: 0.35rem 0.5rem;
+    }
+}
+
+/* Com mouse/teclado os botões de toque só atrapalham a vista. */
+@media (pointer: fine) {
+    .touch-controls {
+        display: none;
+    }
 }

--- a/labs/cupola-64/index.html
+++ b/labs/cupola-64/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600;700;800&family=Press+Start+2P&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=9">
+    <link rel="stylesheet" href="/labs/shared.css?v=10">
     <link rel="stylesheet" href="style.css">
 
     <script type="importmap">
@@ -271,7 +271,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=8" defer></script>
+    <script src="/labs/shared.js?v=9" defer></script>
     <script>
         (function () {
             function hasGpu() {

--- a/labs/cupola-64/index.html
+++ b/labs/cupola-64/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600;700;800&family=Press+Start+2P&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=10">
+    <link rel="stylesheet" href="/labs/shared.css?v=11">
     <link rel="stylesheet" href="style.css">
 
     <script type="importmap">
@@ -271,7 +271,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=9" defer></script>
+    <script src="/labs/shared.js?v=10" defer></script>
     <script>
         (function () {
             function hasGpu() {

--- a/labs/cupola-64/index.html
+++ b/labs/cupola-64/index.html
@@ -271,7 +271,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=10" defer></script>
+    <script src="/labs/shared.js?v=11" defer></script>
     <script>
         (function () {
             function hasGpu() {

--- a/labs/cyberos/index.html
+++ b/labs/cyberos/index.html
@@ -29,8 +29,8 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=VT323&display=swap"
     rel="stylesheet">
-  <link rel="stylesheet" href="/labs/shared.css?v=10">
-  <link rel="stylesheet" href="style.css?v=2">
+  <link rel="stylesheet" href="/labs/shared.css?v=11">
+  <link rel="stylesheet" href="style.css?v=3">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -246,7 +246,7 @@
 
   <footer data-lab-footer data-home-href="/" class="cyber-lab-footer"></footer>
 
-  <script src="/labs/shared.js?v=9" defer></script>
+  <script src="/labs/shared.js?v=10" defer></script>
   <script src="script.js?v=2" defer></script>
 </body>
 

--- a/labs/cyberos/index.html
+++ b/labs/cyberos/index.html
@@ -29,7 +29,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=VT323&display=swap"
     rel="stylesheet">
-  <link rel="stylesheet" href="/labs/shared.css?v=9">
+  <link rel="stylesheet" href="/labs/shared.css?v=10">
   <link rel="stylesheet" href="style.css?v=2">
   <script type="application/ld+json">
   {
@@ -246,7 +246,7 @@
 
   <footer data-lab-footer data-home-href="/" class="cyber-lab-footer"></footer>
 
-  <script src="/labs/shared.js?v=8" defer></script>
+  <script src="/labs/shared.js?v=9" defer></script>
   <script src="script.js?v=2" defer></script>
 </body>
 

--- a/labs/cyberos/index.html
+++ b/labs/cyberos/index.html
@@ -246,7 +246,7 @@
 
   <footer data-lab-footer data-home-href="/" class="cyber-lab-footer"></footer>
 
-  <script src="/labs/shared.js?v=10" defer></script>
+  <script src="/labs/shared.js?v=11" defer></script>
   <script src="script.js?v=2" defer></script>
 </body>
 

--- a/labs/cyberos/style.css
+++ b/labs/cyberos/style.css
@@ -952,3 +952,50 @@ select {
     .window { height: 52% !important; top: 10% !important; max-width: calc(100% - 1rem); }
     .phos-btn { min-width: 44px; min-height: 44px; padding: 0.35rem 0.5rem; }
 }
+
+/* Paisagem curta: o dock virava faixa horizontal no rodapé (regra de ≤820px) e
+   caía DENTRO da janela — deitado sobra largura, não altura, então a janela
+   ocupava a faixa inteira e os ícones ficavam por baixo, inalcançáveis.
+
+   Aqui o dock volta a ser coluna à esquerda (que é o que a forma da tela pede)
+   e a janela recua para começar depois dele. */
+@media (max-height: 540px) and (orientation: landscape) {
+  .crt-bezel {
+    min-height: calc(100dvh - 2rem);
+    padding: 8px;
+  }
+
+  .crt-screen {
+    min-height: calc(100dvh - 3rem);
+  }
+
+  .dock {
+    top: 50%;
+    bottom: auto;
+    left: max(0.4rem, env(safe-area-inset-left, 0px));
+    transform: translateY(-50%);
+    flex-direction: column;
+    gap: 0.3rem;
+    padding: 0.3rem;
+  }
+
+  .dock-icon {
+    min-width: 3.1rem;
+    min-height: var(--touch-target);
+    padding: 0.25rem 0.3rem;
+    font-size: 0.54rem;
+  }
+
+  .window {
+    left: 4.4rem !important;
+    right: max(0.6rem, env(safe-area-inset-right, 0px));
+    width: auto !important;
+    top: 2% !important;
+    height: 94% !important;
+  }
+
+  .os-statusbar {
+    font-size: 0.52rem;
+    padding-block: 0.25rem;
+  }
+}

--- a/labs/cyberos/style.css
+++ b/labs/cyberos/style.css
@@ -427,6 +427,18 @@ body .container {
   cursor: pointer;
   opacity: 0.7;
   padding: 0 0.2rem;
+  /* O glifo continua pequeno (é uma barra de título retrô), mas a área tocável
+     cresce por pseudo-elemento até 44px. */
+  position: relative;
+}
+
+.win-close::after {
+  content: "";
+  position: absolute;
+  inset: 50% auto auto 50%;
+  width: var(--touch-target);
+  height: var(--touch-target);
+  transform: translate(-50%, -50%);
 }
 
 .win-close:hover {

--- a/labs/english-duo/index.html
+++ b/labs/english-duo/index.html
@@ -417,7 +417,7 @@
     </div>
 
     <div id="toast-container" class="toast-container"></div>
-    <script src="/labs/shared.js?v=10" defer></script>
+    <script src="/labs/shared.js?v=11" defer></script>
     <script src="script.js" defer></script>
 </body>
 

--- a/labs/english-duo/index.html
+++ b/labs/english-duo/index.html
@@ -22,7 +22,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Talk | Diogo Paulino">
     <meta name="twitter:description" content="Aprenda idiomas de forma divertida e interativa com o Talk.">
-    <link rel="stylesheet" href="/labs/shared.css?v=10">
+    <link rel="stylesheet" href="/labs/shared.css?v=11">
     <link rel="stylesheet" href="style.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -417,7 +417,7 @@
     </div>
 
     <div id="toast-container" class="toast-container"></div>
-    <script src="/labs/shared.js?v=9" defer></script>
+    <script src="/labs/shared.js?v=10" defer></script>
     <script src="script.js" defer></script>
 </body>
 

--- a/labs/english-duo/index.html
+++ b/labs/english-duo/index.html
@@ -22,7 +22,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Talk | Diogo Paulino">
     <meta name="twitter:description" content="Aprenda idiomas de forma divertida e interativa com o Talk.">
-    <link rel="stylesheet" href="/labs/shared.css?v=9">
+    <link rel="stylesheet" href="/labs/shared.css?v=10">
     <link rel="stylesheet" href="style.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -417,7 +417,7 @@
     </div>
 
     <div id="toast-container" class="toast-container"></div>
-    <script src="/labs/shared.js?v=8" defer></script>
+    <script src="/labs/shared.js?v=9" defer></script>
     <script src="script.js" defer></script>
 </body>
 

--- a/labs/eyra/index.html
+++ b/labs/eyra/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;600;700;800&family=Outfit:wght@400;500;600;700;800&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=9">
+    <link rel="stylesheet" href="/labs/shared.css?v=10">
     <link rel="stylesheet" href="style.css">
 
     <script type="importmap">
@@ -261,7 +261,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=8" defer></script>
+    <script src="/labs/shared.js?v=9" defer></script>
     <script>
         (function () {
             function hasGpu() {

--- a/labs/eyra/index.html
+++ b/labs/eyra/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;600;700;800&family=Outfit:wght@400;500;600;700;800&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=10">
+    <link rel="stylesheet" href="/labs/shared.css?v=11">
     <link rel="stylesheet" href="style.css">
 
     <script type="importmap">
@@ -261,7 +261,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=9" defer></script>
+    <script src="/labs/shared.js?v=10" defer></script>
     <script>
         (function () {
             function hasGpu() {

--- a/labs/eyra/index.html
+++ b/labs/eyra/index.html
@@ -261,7 +261,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=10" defer></script>
+    <script src="/labs/shared.js?v=11" defer></script>
     <script>
         (function () {
             function hasGpu() {

--- a/labs/f1-racing/index.html
+++ b/labs/f1-racing/index.html
@@ -28,7 +28,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="preconnect" href="https://cdn.babylonjs.com" crossorigin>
-    <link rel="stylesheet" href="/labs/shared.css?v=10">
+    <link rel="stylesheet" href="/labs/shared.css?v=11">
     <link rel="stylesheet" href="style.css?v=13">
     <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700&family=Orbitron:wght@500;600;700;800;900&display=swap"
         rel="stylesheet">
@@ -180,7 +180,7 @@
 
     <script src="https://cdn.babylonjs.com/babylon.js"></script>
     <script src="https://cdn.babylonjs.com/loaders/babylonjs.loaders.min.js"></script>
-    <script src="/labs/shared.js?v=9" defer></script>
+    <script src="/labs/shared.js?v=10" defer></script>
     <script type="module" src="src/main.js"></script>
 </body>
 

--- a/labs/f1-racing/index.html
+++ b/labs/f1-racing/index.html
@@ -180,7 +180,7 @@
 
     <script src="https://cdn.babylonjs.com/babylon.js"></script>
     <script src="https://cdn.babylonjs.com/loaders/babylonjs.loaders.min.js"></script>
-    <script src="/labs/shared.js?v=10" defer></script>
+    <script src="/labs/shared.js?v=11" defer></script>
     <script type="module" src="src/main.js"></script>
 </body>
 

--- a/labs/f1-racing/index.html
+++ b/labs/f1-racing/index.html
@@ -28,7 +28,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="preconnect" href="https://cdn.babylonjs.com" crossorigin>
-    <link rel="stylesheet" href="/labs/shared.css?v=9">
+    <link rel="stylesheet" href="/labs/shared.css?v=10">
     <link rel="stylesheet" href="style.css?v=13">
     <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700&family=Orbitron:wght@500;600;700;800;900&display=swap"
         rel="stylesheet">
@@ -180,7 +180,7 @@
 
     <script src="https://cdn.babylonjs.com/babylon.js"></script>
     <script src="https://cdn.babylonjs.com/loaders/babylonjs.loaders.min.js"></script>
-    <script src="/labs/shared.js?v=8" defer></script>
+    <script src="/labs/shared.js?v=9" defer></script>
     <script type="module" src="src/main.js"></script>
 </body>
 

--- a/labs/f1-racing/src/utils.js
+++ b/labs/f1-racing/src/utils.js
@@ -1,0 +1,39 @@
+/**
+ * Utilidades numéricas compartilhadas pelos módulos do F1 Grand Prix.
+ *
+ * Existe porque `main.js` já importava daqui — sem este arquivo o import
+ * devolvia 404 e o módulo inteiro do jogo nunca chegava a executar.
+ */
+
+/** Prende `v` no intervalo [lo, hi]. */
+export function clamp(v, lo, hi) {
+    return v < lo ? lo : v > hi ? hi : v;
+}
+
+/** Interpolação linear de `a` até `b`. `t` fora de [0,1] extrapola. */
+export function lerp(a, b, t) {
+    return a + (b - a) * t;
+}
+
+/**
+ * Interpolação exponencial independente de framerate.
+ *
+ * `lerp(a, b, dt * k)` acelera junto com o refresh rate: a 120Hz o valor
+ * converge duas vezes mais rápido que a 60Hz. Esta versão converge no mesmo
+ * tempo real em qualquer taxa — é a que a câmera e a telemetria devem usar.
+ */
+export function damp(a, b, lambda, dt) {
+    return lerp(a, b, 1 - Math.exp(-lambda * dt));
+}
+
+/** -1, 0 ou 1, preservando o zero com sinal como 0. */
+export function sign(v) {
+    return v > 0 ? 1 : v < 0 ? -1 : 0;
+}
+
+/** Remapeia `v` da faixa [inMin, inMax] para [outMin, outMax], travando nas pontas. */
+export function mapRange(v, inMin, inMax, outMin, outMax) {
+    if (inMax === inMin) return outMin;
+    return clamp(outMin + ((v - inMin) / (inMax - inMin)) * (outMax - outMin),
+        Math.min(outMin, outMax), Math.max(outMin, outMax));
+}

--- a/labs/forrest-run/index.html
+++ b/labs/forrest-run/index.html
@@ -260,7 +260,7 @@
 
     <script src="https://cdn.babylonjs.com/babylon.js"></script>
     <script src="https://cdn.babylonjs.com/loaders/babylonjs.loaders.min.js"></script>
-    <script src="/labs/shared.js?v=10" defer></script>
+    <script src="/labs/shared.js?v=11" defer></script>
     <script type="module" src="src/main.js"></script>
 </body>
 

--- a/labs/forrest-run/index.html
+++ b/labs/forrest-run/index.html
@@ -34,7 +34,7 @@
     <link rel="preconnect" href="https://cdn.babylonjs.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,500;0,700;1,500&family=Outfit:wght@400;500;600;700&family=Share+Tech+Mono&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=10">
+    <link rel="stylesheet" href="/labs/shared.css?v=11">
     <link rel="stylesheet" href="style.css">
 
     <script type="application/ld+json">
@@ -260,7 +260,7 @@
 
     <script src="https://cdn.babylonjs.com/babylon.js"></script>
     <script src="https://cdn.babylonjs.com/loaders/babylonjs.loaders.min.js"></script>
-    <script src="/labs/shared.js?v=9" defer></script>
+    <script src="/labs/shared.js?v=10" defer></script>
     <script type="module" src="src/main.js"></script>
 </body>
 

--- a/labs/forrest-run/index.html
+++ b/labs/forrest-run/index.html
@@ -34,7 +34,7 @@
     <link rel="preconnect" href="https://cdn.babylonjs.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,500;0,700;1,500&family=Outfit:wght@400;500;600;700&family=Share+Tech+Mono&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=9">
+    <link rel="stylesheet" href="/labs/shared.css?v=10">
     <link rel="stylesheet" href="style.css">
 
     <script type="application/ld+json">
@@ -260,7 +260,7 @@
 
     <script src="https://cdn.babylonjs.com/babylon.js"></script>
     <script src="https://cdn.babylonjs.com/loaders/babylonjs.loaders.min.js"></script>
-    <script src="/labs/shared.js?v=8" defer></script>
+    <script src="/labs/shared.js?v=9" defer></script>
     <script type="module" src="src/main.js"></script>
 </body>
 

--- a/labs/grao/index.html
+++ b/labs/grao/index.html
@@ -29,7 +29,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=9">
+    <link rel="stylesheet" href="/labs/shared.css?v=10">
     <link rel="stylesheet" href="style.css">
     <script type="application/ld+json">
     {
@@ -273,7 +273,7 @@
     <div class="toast-region" id="toast-region" aria-live="polite"></div>
     <p class="sr-only" id="live-region" role="status" aria-live="polite"></p>
 
-    <script src="/labs/shared.js?v=8" defer></script>
+    <script src="/labs/shared.js?v=9" defer></script>
     <script type="module" src="script.js"></script>
 </body>
 

--- a/labs/grao/index.html
+++ b/labs/grao/index.html
@@ -273,7 +273,7 @@
     <div class="toast-region" id="toast-region" aria-live="polite"></div>
     <p class="sr-only" id="live-region" role="status" aria-live="polite"></p>
 
-    <script src="/labs/shared.js?v=10" defer></script>
+    <script src="/labs/shared.js?v=11" defer></script>
     <script type="module" src="script.js"></script>
 </body>
 

--- a/labs/grao/index.html
+++ b/labs/grao/index.html
@@ -29,7 +29,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=10">
+    <link rel="stylesheet" href="/labs/shared.css?v=11">
     <link rel="stylesheet" href="style.css">
     <script type="application/ld+json">
     {
@@ -273,7 +273,7 @@
     <div class="toast-region" id="toast-region" aria-live="polite"></div>
     <p class="sr-only" id="live-region" role="status" aria-live="polite"></p>
 
-    <script src="/labs/shared.js?v=9" defer></script>
+    <script src="/labs/shared.js?v=10" defer></script>
     <script type="module" src="script.js"></script>
 </body>
 

--- a/labs/grao/style.css
+++ b/labs/grao/style.css
@@ -328,7 +328,11 @@ header .app-logo .logo-mark {
     color: var(--bean);
     font-weight: 600;
     font-size: 0.85rem;
-    padding: 0.25rem;
+    padding: 0.25rem 0.5rem;
+    /* Botão de texto continua sem moldura, mas com altura de alvo tocável. */
+    display: inline-flex;
+    align-items: center;
+    min-height: var(--touch-target);
 }
 
 .text-btn:hover {

--- a/labs/gravity/index.html
+++ b/labs/gravity/index.html
@@ -270,7 +270,7 @@
 
     <footer data-lab-footer data-home-href="/"></footer>
 
-    <script src="/labs/shared.js?v=10" defer></script>
+    <script src="/labs/shared.js?v=11" defer></script>
     <script src="script.js" defer></script>
 </body>
 

--- a/labs/gravity/index.html
+++ b/labs/gravity/index.html
@@ -26,7 +26,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=9">
+    <link rel="stylesheet" href="/labs/shared.css?v=10">
     <link rel="stylesheet" href="style.css">
     <script type="application/ld+json">
     {
@@ -270,7 +270,7 @@
 
     <footer data-lab-footer data-home-href="/"></footer>
 
-    <script src="/labs/shared.js?v=8" defer></script>
+    <script src="/labs/shared.js?v=9" defer></script>
     <script src="script.js" defer></script>
 </body>
 

--- a/labs/gravity/index.html
+++ b/labs/gravity/index.html
@@ -26,7 +26,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=10">
+    <link rel="stylesheet" href="/labs/shared.css?v=11">
     <link rel="stylesheet" href="style.css">
     <script type="application/ld+json">
     {
@@ -270,7 +270,7 @@
 
     <footer data-lab-footer data-home-href="/"></footer>
 
-    <script src="/labs/shared.js?v=9" defer></script>
+    <script src="/labs/shared.js?v=10" defer></script>
     <script src="script.js" defer></script>
 </body>
 

--- a/labs/gravity/style.css
+++ b/labs/gravity/style.css
@@ -216,8 +216,10 @@ header .app-logo svg {
 }
 
 .warp-btn {
-    min-width: 44px;
-    min-height: 32px;
+    min-width: var(--touch-target);
+    /* 44px: o seletor de velocidade é usado em pleno movimento da simulação,
+       errar o alvo custa o enquadramento que o usuário estava observando. */
+    min-height: var(--touch-target);
     padding: 0 10px;
     border: none;
     border-radius: 999px;
@@ -513,11 +515,28 @@ input[type="range"] {
     -webkit-appearance: none;
     appearance: none;
     width: 100%;
-    height: 4px;
+    /* 44px de alvo tocável; o trilho visível de 4px vive nos
+       pseudo-elementos abaixo, então o desenho não muda. */
+    height: var(--touch-target);
     border: none;
+    background: transparent;
+    outline: none;
+    cursor: pointer;
+    touch-action: pan-y;
+}
+
+input[type="range"]::-webkit-slider-runnable-track {
+    height: 4px;
     border-radius: 999px;
     background: rgba(255, 255, 255, 0.12);
-    outline: none;
+    border: none;
+}
+
+input[type="range"]::-moz-range-track {
+    height: 4px;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.12);
+    border: none;
 }
 
 input[type="range"]::-webkit-slider-thumb {
@@ -528,6 +547,8 @@ input[type="range"]::-webkit-slider-thumb {
     border: 2px solid rgba(255, 255, 255, 0.9);
     background: var(--accent);
     cursor: pointer;
+    /* (trilho 4px - thumb 16px) / 2 */
+    margin-top: -6px;
 }
 
 input[type="range"]::-moz-range-thumb {

--- a/labs/gravity/style.css
+++ b/labs/gravity/style.css
@@ -775,7 +775,7 @@ body.fullscreen:hover header {
     }
 
     .warp-btn {
-        min-width: 40px;
+        min-width: var(--touch-target);
         padding: 0 8px;
     }
 }

--- a/labs/gravity/style.css
+++ b/labs/gravity/style.css
@@ -808,10 +808,18 @@ body.fullscreen:hover header {
         max-width: calc(100vw - 24px);
     }
 
+    /* Em paisagem curta a fonte e o respiro encolhem, mas a altura tocável
+       fica em 44px: o seletor de cena troca a simulação inteira. */
     .scene-chip {
-        min-height: 36px;
+        min-height: var(--touch-target);
         padding: 4px 10px 4px 8px;
         font-size: 0.62rem;
+    }
+
+    .tool-btn {
+        width: var(--touch-target);
+        height: var(--touch-target);
+        border-radius: 12px;
     }
 
     .dock {
@@ -823,12 +831,6 @@ body.fullscreen:hover header {
     .dock-tools {
         padding: 4px;
         gap: 4px;
-    }
-
-    .tool-btn {
-        width: 40px;
-        height: 40px;
-        border-radius: 12px;
     }
 
     .tune-panel {

--- a/labs/guerreiro-castelo/index.html
+++ b/labs/guerreiro-castelo/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.babylonjs.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;600;700;800&family=Outfit:wght@300;400;500;600;700&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=9">
+    <link rel="stylesheet" href="/labs/shared.css?v=10">
     <link rel="stylesheet" href="css/style.css">
 
     <script type="application/ld+json">
@@ -256,7 +256,7 @@
     <script src="https://cdn.babylonjs.com/babylon.js"></script>
     <script src="https://cdn.babylonjs.com/loaders/babylonjs.loaders.min.js"></script>
     <script src="https://cdn.babylonjs.com/materialsLibrary/babylonjs.materials.min.js"></script>
-    <script src="/labs/shared.js?v=8" defer></script>
+    <script src="/labs/shared.js?v=9" defer></script>
     <script type="module" src="js/main.js"></script>
 </body>
 

--- a/labs/guerreiro-castelo/index.html
+++ b/labs/guerreiro-castelo/index.html
@@ -256,7 +256,7 @@
     <script src="https://cdn.babylonjs.com/babylon.js"></script>
     <script src="https://cdn.babylonjs.com/loaders/babylonjs.loaders.min.js"></script>
     <script src="https://cdn.babylonjs.com/materialsLibrary/babylonjs.materials.min.js"></script>
-    <script src="/labs/shared.js?v=10" defer></script>
+    <script src="/labs/shared.js?v=11" defer></script>
     <script type="module" src="js/main.js"></script>
 </body>
 

--- a/labs/guerreiro-castelo/index.html
+++ b/labs/guerreiro-castelo/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.babylonjs.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;600;700;800&family=Outfit:wght@300;400;500;600;700&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=10">
+    <link rel="stylesheet" href="/labs/shared.css?v=11">
     <link rel="stylesheet" href="css/style.css">
 
     <script type="application/ld+json">
@@ -256,7 +256,7 @@
     <script src="https://cdn.babylonjs.com/babylon.js"></script>
     <script src="https://cdn.babylonjs.com/loaders/babylonjs.loaders.min.js"></script>
     <script src="https://cdn.babylonjs.com/materialsLibrary/babylonjs.materials.min.js"></script>
-    <script src="/labs/shared.js?v=9" defer></script>
+    <script src="/labs/shared.js?v=10" defer></script>
     <script type="module" src="js/main.js"></script>
 </body>
 

--- a/labs/guerreiro-castelo/js/world/Textures.js
+++ b/labs/guerreiro-castelo/js/world/Textures.js
@@ -88,6 +88,92 @@ export function darkWoodTexture(scene, uScale = 3, vScale = 3) {
     });
 }
 
+/* Casca de árvore: sulcos verticais irregulares sobre marrom acinzentado.
+   O `vScale` alto no uso (1x2) estica a fibra ao longo do tronco, que é como a
+   casca real se comporta. */
+export function barkTexture(scene, uScale = 1, vScale = 2) {
+    return cached('bark', scene, () => {
+        const size = 256;
+        const el = createCanvas(size);
+        const ctx = el.getContext('2d');
+        ctx.fillStyle = '#4a3524';
+        ctx.fillRect(0, 0, size, size);
+
+        // Sulcos: linhas verticais que serpenteiam, com largura e tom variados.
+        for (let i = 0; i < 44; i++) {
+            const x = hash2(i, 11) * size;
+            ctx.strokeStyle = hash2(i, 12) > 0.5 ? '#3a2818' : '#5d4530';
+            ctx.lineWidth = 2 + hash2(i, 13) * 5;
+            ctx.globalAlpha = 0.55;
+            ctx.beginPath();
+            ctx.moveTo(x, 0);
+            ctx.bezierCurveTo(
+                x + (hash2(i, 14) - 0.5) * 22, size * 0.33,
+                x + (hash2(i, 15) - 0.5) * 22, size * 0.66,
+                x + (hash2(i, 16) - 0.5) * 14, size
+            );
+            ctx.stroke();
+        }
+
+        // Nós da madeira.
+        for (let i = 0; i < 5; i++) {
+            const x = hash2(i, 21) * size;
+            const y = hash2(i, 22) * size;
+            const r = 6 + hash2(i, 23) * 10;
+            ctx.globalAlpha = 0.4;
+            ctx.strokeStyle = '#2d1e10';
+            ctx.lineWidth = 2;
+            for (let ring = 0; ring < 3; ring++) {
+                ctx.beginPath();
+                ctx.ellipse(x, y, r - ring * 2, (r - ring * 2) * 0.6, 0, 0, Math.PI * 2);
+                ctx.stroke();
+            }
+        }
+
+        ctx.globalAlpha = 1;
+        grain(ctx, size, size, 30, 12);
+        return createBabylonDynamicTexture('tex_bark', el, scene, uScale, vScale);
+    });
+}
+
+/* Folhagem: aglomerado de manchas verdes em três tons. Aplicada nos cones da
+   copa, o que evita o verde chapado que denuncia primitiva sem textura. */
+export function leafTexture(scene, uScale = 2, vScale = 2) {
+    return cached('leaf', scene, () => {
+        const size = 256;
+        const el = createCanvas(size);
+        const ctx = el.getContext('2d');
+        ctx.fillStyle = '#2f5220';
+        ctx.fillRect(0, 0, size, size);
+
+        const tones = ['#3f6b28', '#264618', '#4f8033', '#1d3a12'];
+        for (let i = 0; i < 260; i++) {
+            const x = hash2(i, 31) * size;
+            const y = hash2(i, 32) * size;
+            const rx = 5 + hash2(i, 33) * 11;
+            const ry = rx * (0.45 + hash2(i, 34) * 0.4);
+            ctx.fillStyle = tones[Math.floor(hash2(i, 35) * tones.length) % tones.length];
+            ctx.globalAlpha = 0.5 + hash2(i, 36) * 0.4;
+            ctx.beginPath();
+            ctx.ellipse(x, y, rx, ry, hash2(i, 37) * Math.PI, 0, Math.PI * 2);
+            ctx.fill();
+        }
+
+        // Alguns pontos de luz, como sol furando a copa.
+        ctx.globalAlpha = 0.25;
+        ctx.fillStyle = '#8fc45c';
+        for (let i = 0; i < 30; i++) {
+            ctx.beginPath();
+            ctx.arc(hash2(i, 41) * size, hash2(i, 42) * size, 2 + hash2(i, 43) * 3, 0, Math.PI * 2);
+            ctx.fill();
+        }
+
+        ctx.globalAlpha = 1;
+        grain(ctx, size, size, 18, 15);
+        return createBabylonDynamicTexture('tex_leaf', el, scene, uScale, vScale);
+    });
+}
+
 export function stoneTexture(scene, uScale = 8, vScale = 8) {
     return cached('stone', scene, () => {
         const size = 256;

--- a/labs/honor-front/index.html
+++ b/labs/honor-front/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.babylonjs.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@600;700;800&family=Oswald:wght@400;500;600;700&family=Outfit:wght@300;400;500;600;700&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=9">
+    <link rel="stylesheet" href="/labs/shared.css?v=10">
     <link rel="stylesheet" href="style.css?v=1">
 
     <script type="application/ld+json">

--- a/labs/honor-front/index.html
+++ b/labs/honor-front/index.html
@@ -216,7 +216,7 @@
 
     <script src="https://cdn.babylonjs.com/babylon.js"></script>
     <script src="https://cdn.babylonjs.com/loaders/babylonjs.loaders.min.js"></script>
-    <script src="/labs/shared.js?v=10" defer></script>
+    <script src="/labs/shared.js?v=11" defer></script>
     <script type="module" src="src/main.js"></script>
 </body>
 

--- a/labs/honor-front/index.html
+++ b/labs/honor-front/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.babylonjs.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@600;700;800&family=Oswald:wght@400;500;600;700&family=Outfit:wght@300;400;500;600;700&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=10">
+    <link rel="stylesheet" href="/labs/shared.css?v=11">
     <link rel="stylesheet" href="style.css?v=1">
 
     <script type="application/ld+json">
@@ -216,7 +216,7 @@
 
     <script src="https://cdn.babylonjs.com/babylon.js"></script>
     <script src="https://cdn.babylonjs.com/loaders/babylonjs.loaders.min.js"></script>
-    <script src="/labs/shared.js?v=9" defer></script>
+    <script src="/labs/shared.js?v=10" defer></script>
     <script type="module" src="src/main.js"></script>
 </body>
 

--- a/labs/honor-front/src/audio.js
+++ b/labs/honor-front/src/audio.js
@@ -182,3 +182,46 @@ export class GameAudio {
         }
     }
 }
+
+/**
+ * Fachada de combate usada pelo loop do jogo.
+ *
+ * `GameAudio` fala em termos de síntese (`unlock`, `shot`, `setMuted`); o jogo
+ * fala em termos de ação (`init`, `shoot`, `playerHurt`). Esta camada traduz
+ * uma na outra — é o contrato que `main.js` importa.
+ */
+export class CombatAudio extends GameAudio {
+    /** Destrava o contexto no primeiro gesto do usuário. */
+    init() {
+        return this.unlock();
+    }
+
+    /** Alterna o mudo e devolve o novo estado, para o botão do HUD refletir. */
+    toggleMute() {
+        this.setMuted(!this.muted);
+        return this.muted;
+    }
+
+    /** Disparo do jogador: o timbre muda com a arma equipada. */
+    shoot(kind = 'garand') {
+        this.shot(kind);
+    }
+
+    /** Inimigo atirando: mesmo disparo, mais abafado e distante. */
+    enemyShoot() {
+        this._noiseBurst(0.12, 0.14, 400, 0.6);
+        this._tone(110, 0.07, 0.06, 'square');
+    }
+
+    /** Gatilho sem munição: só o estalo metálico do ferrolho. */
+    empty() {
+        this._noiseBurst(0.05, 0.09, 2200, 2.2);
+    }
+
+    /** Jogador levando dano: impacto grave com zumbido curto no ouvido. */
+    playerHurt() {
+        this._noiseBurst(0.22, 0.26, 160, 0.5);
+        this._tone(90, 0.3, 0.16, 'sine');
+        this._tone(1800, 0.5, 0.05, 'sine');
+    }
+}

--- a/labs/image-editor/index.html
+++ b/labs/image-editor/index.html
@@ -218,7 +218,7 @@
 
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
-    <script src="/labs/shared.js?v=10" defer></script>
+    <script src="/labs/shared.js?v=11" defer></script>
     <script src="script.js" defer></script>
 </body>
 

--- a/labs/image-editor/index.html
+++ b/labs/image-editor/index.html
@@ -24,7 +24,7 @@
     <meta name="twitter:description" content="Editor de imagens no navegador: recorte, filtros, ajustes de brilho, contraste e saturação, tudo processado localmente sem enviar nada para servidor.">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="stylesheet" href="/labs/shared.css?v=9">
+    <link rel="stylesheet" href="/labs/shared.css?v=10">
     <link rel="stylesheet" href="style.css">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <script type="application/ld+json">
@@ -218,7 +218,7 @@
 
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
-    <script src="/labs/shared.js?v=8" defer></script>
+    <script src="/labs/shared.js?v=9" defer></script>
     <script src="script.js" defer></script>
 </body>
 

--- a/labs/image-editor/index.html
+++ b/labs/image-editor/index.html
@@ -24,7 +24,7 @@
     <meta name="twitter:description" content="Editor de imagens no navegador: recorte, filtros, ajustes de brilho, contraste e saturação, tudo processado localmente sem enviar nada para servidor.">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="stylesheet" href="/labs/shared.css?v=10">
+    <link rel="stylesheet" href="/labs/shared.css?v=11">
     <link rel="stylesheet" href="style.css">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <script type="application/ld+json">
@@ -218,7 +218,7 @@
 
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
-    <script src="/labs/shared.js?v=9" defer></script>
+    <script src="/labs/shared.js?v=10" defer></script>
     <script src="script.js" defer></script>
 </body>
 

--- a/labs/image-editor/style.css
+++ b/labs/image-editor/style.css
@@ -214,20 +214,50 @@ canvas.comparing {
     font-weight: 500;
 }
 
+/* O trilho continua com 6px de desenho, mas o input inteiro tem 44px de altura:
+   o alvo tocável é o controle todo, não a linha fininha. Por isso o fundo sai do
+   input (fica transparente) e vai para o pseudo-elemento do trilho. */
 input[type="range"] {
     -webkit-appearance: none;
     appearance: none;
     width: 100%;
+    height: var(--touch-target);
+    background: transparent;
+    outline: none;
+    cursor: pointer;
+    touch-action: pan-y;
+}
+
+input[type="range"]::-webkit-slider-runnable-track {
     height: 6px;
     background: var(--bg-body);
     border-radius: 3px;
-    outline: none;
+}
+
+input[type="range"]::-moz-range-track {
+    height: 6px;
+    background: var(--bg-body);
+    border-radius: 3px;
+    border: 0;
 }
 
 input[type="range"]::-webkit-slider-thumb {
     -webkit-appearance: none;
-    width: 18px;
-    height: 18px;
+    width: 20px;
+    height: 20px;
+    /* (6px de trilho - 20px de thumb) / 2 = -7px: centraliza o polegar no trilho. */
+    margin-top: -7px;
+    border-radius: 50%;
+    background: var(--accent);
+    cursor: pointer;
+    border: 2px solid var(--bg-card);
+    box-shadow: 0 1px 3px var(--shadow-md);
+    transition: transform 0.1s;
+}
+
+input[type="range"]::-moz-range-thumb {
+    width: 20px;
+    height: 20px;
     border-radius: 50%;
     background: var(--accent);
     cursor: pointer;
@@ -238,6 +268,20 @@ input[type="range"]::-webkit-slider-thumb {
 
 input[type="range"]::-webkit-slider-thumb:hover {
     transform: scale(1.1);
+}
+
+input[type="range"]::-moz-range-thumb:hover {
+    transform: scale(1.1);
+}
+
+input[type="range"]:focus-visible::-webkit-slider-thumb {
+    outline: 3px solid var(--focus-ring);
+    outline-offset: 2px;
+}
+
+input[type="range"]:focus-visible::-moz-range-thumb {
+    outline: 3px solid var(--focus-ring);
+    outline-offset: 2px;
 }
 
 /* Filters Filmstrip (Instagram-style: thumbnail preview + label) */

--- a/labs/image-optimizer/index.html
+++ b/labs/image-optimizer/index.html
@@ -24,7 +24,7 @@
     <meta name="twitter:description" content="Otimize e converta suas imagens para JPG, PNG ou WEBP diretamente no navegador.">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="stylesheet" href="/labs/shared.css?v=9">
+    <link rel="stylesheet" href="/labs/shared.css?v=10">
     <link rel="stylesheet" href="style.css">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <script type="application/ld+json">
@@ -130,7 +130,7 @@
 
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
-    <script src="/labs/shared.js?v=8" defer></script>
+    <script src="/labs/shared.js?v=9" defer></script>
     <script src="script.js" defer></script>
 </body>
 

--- a/labs/image-optimizer/index.html
+++ b/labs/image-optimizer/index.html
@@ -24,7 +24,7 @@
     <meta name="twitter:description" content="Otimize e converta suas imagens para JPG, PNG ou WEBP diretamente no navegador.">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="stylesheet" href="/labs/shared.css?v=10">
+    <link rel="stylesheet" href="/labs/shared.css?v=11">
     <link rel="stylesheet" href="style.css">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <script type="application/ld+json">
@@ -130,7 +130,7 @@
 
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
-    <script src="/labs/shared.js?v=9" defer></script>
+    <script src="/labs/shared.js?v=10" defer></script>
     <script src="script.js" defer></script>
 </body>
 

--- a/labs/image-optimizer/index.html
+++ b/labs/image-optimizer/index.html
@@ -130,7 +130,7 @@
 
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
-    <script src="/labs/shared.js?v=10" defer></script>
+    <script src="/labs/shared.js?v=11" defer></script>
     <script src="script.js" defer></script>
 </body>
 

--- a/labs/image-optimizer/style.css
+++ b/labs/image-optimizer/style.css
@@ -127,11 +127,30 @@ body {
 }
 
 input[type="range"] {
-    width: 100%;
-    height: 6px;
-    background: var(--bg-body);
-    border-radius: 3px;
+    -webkit-appearance: none;
     appearance: none;
+    width: 100%;
+    /* 44px de alvo tocável; o trilho visível de 6px vive nos
+       pseudo-elementos abaixo, então o desenho não muda. */
+    height: var(--touch-target);
+    border: none;
+    background: transparent;
+    outline: none;
+    cursor: pointer;
+    touch-action: pan-y;
+}
+
+input[type="range"]::-webkit-slider-runnable-track {
+    height: 6px;
+    border-radius: 3px;
+    background: var(--bg-body);
+    border: 1px solid var(--border-subtle);
+}
+
+input[type="range"]::-moz-range-track {
+    height: 6px;
+    border-radius: 3px;
+    background: var(--bg-body);
     border: 1px solid var(--border-subtle);
 }
 
@@ -142,6 +161,8 @@ input[type="range"]::-webkit-slider-thumb {
     background: var(--accent);
     border-radius: 50%;
     cursor: pointer;
+    /* (trilho 6px - thumb 16px) / 2 */
+    margin-top: -5px;
 }
 
 input[type="number"] {

--- a/labs/index.html
+++ b/labs/index.html
@@ -1171,6 +1171,29 @@
           </div>
         </div>
       </a>
+      <a href="/labs/claude-bros/" class="project-card" data-groups="game,creative">
+        <div class="project-icon">
+          <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+            stroke-linecap="round" stroke-linejoin="round">
+            <path d="M4 20h16"></path>
+            <path d="M4 20v-4h4v4"></path>
+            <path d="M14 20v-6h6v6"></path>
+            <circle cx="9" cy="7" r="3"></circle>
+            <path d="M9 10v3"></path>
+            <path d="M7 5.5 5.5 4"></path>
+            <path d="M11 5.5 12.5 4"></path>
+          </svg>
+        </div>
+        <div class="project-content">
+          <h2>Claude Bros</h2>
+          <p>Plataforma 2D em canvas puro: estrelas Gemini, rivais ChatGPT e a bandeira no fim da fase</p>
+          <div class="project-tags">
+            <span class="tag">Game</span>
+            <span class="tag">Plataforma</span>
+            <span class="tag">Canvas</span>
+          </div>
+        </div>
+      </a>
       <a href="/labs/snake/" class="project-card" data-groups="game">
         <div class="project-icon">
           <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"

--- a/labs/joao-e-o-pe-de-feijao/index.html
+++ b/labs/joao-e-o-pe-de-feijao/index.html
@@ -35,7 +35,7 @@
     <link rel="preconnect" href="https://assets.babylonjs.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;600;700;800&family=Nunito:wght@400;600;700;800&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=10">
+    <link rel="stylesheet" href="/labs/shared.css?v=11">
     <link rel="stylesheet" href="style.css?v=2">
 
     <script type="application/ld+json">
@@ -292,7 +292,7 @@
 
     <script src="https://cdn.babylonjs.com/babylon.js"></script>
     <script src="https://cdn.babylonjs.com/loaders/babylonjs.loaders.min.js"></script>
-    <script src="/labs/shared.js?v=9" defer></script>
+    <script src="/labs/shared.js?v=10" defer></script>
     <script>
         (function () {
             function hasGpu() {

--- a/labs/joao-e-o-pe-de-feijao/index.html
+++ b/labs/joao-e-o-pe-de-feijao/index.html
@@ -292,7 +292,7 @@
 
     <script src="https://cdn.babylonjs.com/babylon.js"></script>
     <script src="https://cdn.babylonjs.com/loaders/babylonjs.loaders.min.js"></script>
-    <script src="/labs/shared.js?v=10" defer></script>
+    <script src="/labs/shared.js?v=11" defer></script>
     <script>
         (function () {
             function hasGpu() {

--- a/labs/joao-e-o-pe-de-feijao/index.html
+++ b/labs/joao-e-o-pe-de-feijao/index.html
@@ -35,7 +35,7 @@
     <link rel="preconnect" href="https://assets.babylonjs.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;600;700;800&family=Nunito:wght@400;600;700;800&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=9">
+    <link rel="stylesheet" href="/labs/shared.css?v=10">
     <link rel="stylesheet" href="style.css?v=2">
 
     <script type="application/ld+json">
@@ -292,7 +292,7 @@
 
     <script src="https://cdn.babylonjs.com/babylon.js"></script>
     <script src="https://cdn.babylonjs.com/loaders/babylonjs.loaders.min.js"></script>
-    <script src="/labs/shared.js?v=8" defer></script>
+    <script src="/labs/shared.js?v=9" defer></script>
     <script>
         (function () {
             function hasGpu() {

--- a/labs/joao-e-o-pe-de-feijao/index.html
+++ b/labs/joao-e-o-pe-de-feijao/index.html
@@ -301,17 +301,24 @@
                     return !!(c.getContext('webgl2') || c.getContext('webgl'));
                 } catch (e) { return false; }
             }
-            if (!hasGpu() || (typeof BABYLON !== 'undefined' && !BABYLON.Engine?.isSupported())) {
+            // Duas causas diferentes, mensagens diferentes: sem GPU o problema é
+            // o navegador; sem BABYLON o problema é a rede que não trouxe o CDN.
+            var noEngine = typeof BABYLON === 'undefined';
+            if (!hasGpu() || noEngine || !BABYLON.Engine?.isSupported()) {
                 document.addEventListener('DOMContentLoaded', function () {
                     var err = document.getElementById('errorOverlay');
                     var load = document.getElementById('loadingOverlay');
+                    var txt = document.getElementById('errorText');
                     if (load) load.hidden = true;
+                    if (txt && noEngine) {
+                        txt.textContent = 'O motor 3D (Babylon.js) não pôde ser baixado. Verifique a conexão e recarregue a página.';
+                    }
                     if (err) err.hidden = false;
                 });
             }
         })();
     </script>
-    <script type="module" src="src/main.js"></script>
+    <script type="module" src="src/main.js?v=2"></script>
 </body>
 
 </html>

--- a/labs/joao-e-o-pe-de-feijao/src/main.js
+++ b/labs/joao-e-o-pe-de-feijao/src/main.js
@@ -14,8 +14,12 @@ import { setModelQuality } from './models.js';
 import { nearestInteractable } from './npcs.js';
 
 const B = window.BABYLON;
-const LOOK = new B.Vector3();
-const CAM = new B.Vector3();
+/* Criados sob demanda, não na avaliação do módulo: sem Babylon carregado,
+   `new B.Vector3()` no topo do arquivo derrubava o módulo inteiro antes de
+   qualquer guarda rodar — nem a própria tela de erro do lab chegava a aparecer.
+   São scratch vectors reaproveitados a cada frame, então continuam únicos. */
+let LOOK = null;
+let CAM = null;
 
 class Game {
     constructor() {
@@ -489,6 +493,10 @@ class Game {
         const t = clamp(this.introT / 3.2, 0, 1);
         const e = t * t * (3 - 2 * t);
         const o = this.world.overview;
+        if (!CAM) {
+            CAM = new B.Vector3();
+            LOOK = new B.Vector3();
+        }
         this.player.cameraPosition(CAM);
         this.player.lookAt(LOOK);
         this.camera.position.set(

--- a/labs/jornada-do-anel/index.html
+++ b/labs/jornada-do-anel/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;600;700;800&family=Outfit:wght@300;400;500;600;700&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=10">
+    <link rel="stylesheet" href="/labs/shared.css?v=11">
     <link rel="stylesheet" href="style.css?v=1">
 
     <script type="importmap">
@@ -294,7 +294,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=9" defer></script>
+    <script src="/labs/shared.js?v=10" defer></script>
     <script>
         (function () {
             function hasGpu() {

--- a/labs/jornada-do-anel/index.html
+++ b/labs/jornada-do-anel/index.html
@@ -294,7 +294,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=10" defer></script>
+    <script src="/labs/shared.js?v=11" defer></script>
     <script>
         (function () {
             function hasGpu() {

--- a/labs/jornada-do-anel/index.html
+++ b/labs/jornada-do-anel/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;600;700;800&family=Outfit:wght@300;400;500;600;700&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=9">
+    <link rel="stylesheet" href="/labs/shared.css?v=10">
     <link rel="stylesheet" href="style.css?v=1">
 
     <script type="importmap">
@@ -294,7 +294,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=8" defer></script>
+    <script src="/labs/shared.js?v=9" defer></script>
     <script>
         (function () {
             function hasGpu() {

--- a/labs/jungle-run/index.html
+++ b/labs/jungle-run/index.html
@@ -28,7 +28,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@600;900&family=Plus+Jakarta+Sans:wght@400;500;700;800&display=swap" rel="stylesheet">
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
-    <link rel="stylesheet" href="/labs/shared.css?v=9">
+    <link rel="stylesheet" href="/labs/shared.css?v=10">
     <link rel="stylesheet" href="style.css?v=3">
     <script src="https://cdn.jsdelivr.net/npm/pixi.js@8.6.6/dist/pixi.min.js" defer></script>
     <script type="application/ld+json">
@@ -305,7 +305,7 @@
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
 
-    <script src="/labs/shared.js?v=8" defer></script>
+    <script src="/labs/shared.js?v=9" defer></script>
     <script src="script.js?v=5" defer></script>
 </body>
 

--- a/labs/jungle-run/index.html
+++ b/labs/jungle-run/index.html
@@ -28,7 +28,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@600;900&family=Plus+Jakarta+Sans:wght@400;500;700;800&display=swap" rel="stylesheet">
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
-    <link rel="stylesheet" href="/labs/shared.css?v=10">
+    <link rel="stylesheet" href="/labs/shared.css?v=11">
     <link rel="stylesheet" href="style.css?v=3">
     <script src="https://cdn.jsdelivr.net/npm/pixi.js@8.6.6/dist/pixi.min.js" defer></script>
     <script type="application/ld+json">
@@ -305,7 +305,7 @@
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
 
-    <script src="/labs/shared.js?v=9" defer></script>
+    <script src="/labs/shared.js?v=10" defer></script>
     <script src="script.js?v=5" defer></script>
 </body>
 

--- a/labs/jungle-run/index.html
+++ b/labs/jungle-run/index.html
@@ -305,7 +305,7 @@
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
 
-    <script src="/labs/shared.js?v=10" defer></script>
+    <script src="/labs/shared.js?v=11" defer></script>
     <script src="script.js?v=5" defer></script>
 </body>
 

--- a/labs/jurassic/index.html
+++ b/labs/jurassic/index.html
@@ -285,7 +285,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=10" defer></script>
+    <script src="/labs/shared.js?v=11" defer></script>
     <script>
         (function () {
             function hasGpu() {

--- a/labs/jurassic/index.html
+++ b/labs/jurassic/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,500;0,600;0,700;1,500&family=Barlow:wght@400;500;600;700&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=9">
+    <link rel="stylesheet" href="/labs/shared.css?v=10">
     <link rel="stylesheet" href="style.css?v=1">
 
     <script type="importmap">
@@ -285,7 +285,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=8" defer></script>
+    <script src="/labs/shared.js?v=9" defer></script>
     <script>
         (function () {
             function hasGpu() {

--- a/labs/jurassic/index.html
+++ b/labs/jurassic/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,500;0,600;0,700;1,500&family=Barlow:wght@400;500;600;700&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=10">
+    <link rel="stylesheet" href="/labs/shared.css?v=11">
     <link rel="stylesheet" href="style.css?v=1">
 
     <script type="importmap">
@@ -285,7 +285,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=9" defer></script>
+    <script src="/labs/shared.js?v=10" defer></script>
     <script>
         (function () {
             function hasGpu() {

--- a/labs/kong-kong/index.html
+++ b/labs/kong-kong/index.html
@@ -29,7 +29,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@500;700;800&family=Titan+One&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="/labs/shared.css?v=8">
+  <link rel="stylesheet" href="/labs/shared.css?v=10">
   <link rel="stylesheet" href="style.css">
   <script type="application/ld+json">
   {
@@ -147,7 +147,7 @@
   </div>
 
   <p class="sr-only" id="announcer" aria-live="assertive"></p>
-  <script src="/labs/shared.js?v=7" defer></script>
+  <script src="/labs/shared.js?v=9" defer></script>
   <script type="module" src="src/main.js"></script>
 </body>
 

--- a/labs/kong-kong/index.html
+++ b/labs/kong-kong/index.html
@@ -29,7 +29,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@500;700;800&family=Titan+One&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="/labs/shared.css?v=10">
+  <link rel="stylesheet" href="/labs/shared.css?v=11">
   <link rel="stylesheet" href="style.css">
   <script type="application/ld+json">
   {
@@ -147,7 +147,7 @@
   </div>
 
   <p class="sr-only" id="announcer" aria-live="assertive"></p>
-  <script src="/labs/shared.js?v=9" defer></script>
+  <script src="/labs/shared.js?v=10" defer></script>
   <script type="module" src="src/main.js"></script>
 </body>
 

--- a/labs/kong-kong/index.html
+++ b/labs/kong-kong/index.html
@@ -147,7 +147,7 @@
   </div>
 
   <p class="sr-only" id="announcer" aria-live="assertive"></p>
-  <script src="/labs/shared.js?v=10" defer></script>
+  <script src="/labs/shared.js?v=11" defer></script>
   <script type="module" src="src/main.js"></script>
 </body>
 

--- a/labs/lander/index.html
+++ b/labs/lander/index.html
@@ -185,7 +185,7 @@
     </div>
 
     <script src="/labs/shared.js?v=9" defer></script>
-    <script src="script.js?v=3" defer></script>
+    <script src="script.js?v=4" defer></script>
 </body>
 
 </html>

--- a/labs/lander/index.html
+++ b/labs/lander/index.html
@@ -24,7 +24,7 @@
     <meta name="twitter:description" content="Pouso lunar com física realista: gravidade, inércia, consumo de combustível e terreno gerado por procedimento. Desça devagar e no ângulo certo.">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="stylesheet" href="/labs/shared.css?v=9">
+    <link rel="stylesheet" href="/labs/shared.css?v=10">
     <link rel="stylesheet" href="style.css?v=4">
     <link href="https://fonts.googleapis.com/css2?family=VT323&display=swap" rel="stylesheet">
     <script type="application/ld+json">
@@ -184,7 +184,7 @@
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
 
-    <script src="/labs/shared.js?v=8" defer></script>
+    <script src="/labs/shared.js?v=9" defer></script>
     <script src="script.js?v=3" defer></script>
 </body>
 

--- a/labs/lander/index.html
+++ b/labs/lander/index.html
@@ -24,7 +24,7 @@
     <meta name="twitter:description" content="Pouso lunar com física realista: gravidade, inércia, consumo de combustível e terreno gerado por procedimento. Desça devagar e no ângulo certo.">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="stylesheet" href="/labs/shared.css?v=10">
+    <link rel="stylesheet" href="/labs/shared.css?v=11">
     <link rel="stylesheet" href="style.css?v=4">
     <link href="https://fonts.googleapis.com/css2?family=VT323&display=swap" rel="stylesheet">
     <script type="application/ld+json">
@@ -184,7 +184,7 @@
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
 
-    <script src="/labs/shared.js?v=9" defer></script>
+    <script src="/labs/shared.js?v=10" defer></script>
     <script src="script.js?v=4" defer></script>
 </body>
 

--- a/labs/lander/index.html
+++ b/labs/lander/index.html
@@ -184,7 +184,7 @@
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
 
-    <script src="/labs/shared.js?v=10" defer></script>
+    <script src="/labs/shared.js?v=11" defer></script>
     <script src="script.js?v=4" defer></script>
 </body>
 

--- a/labs/lander/script.js
+++ b/labs/lander/script.js
@@ -47,6 +47,96 @@ let engineParticleBudget = 0;
 
 const keys = {};
 
+/* --- Som -------------------------------------------------------------------
+   O propulsor não é um "efeito": é um ruído contínuo cuja intensidade segue o
+   acelerador. Por isso ele tem grafo próprio (ruído em loop + passa-baixa),
+   enquanto pouso, colisão e reabastecimento passam pelo LabAudio.
+
+   O contexto só nasce no primeiro gesto do jogador — navegadores recusam áudio
+   antes disso. */
+const labAudio = window.LabAudio;
+
+const engine = {
+    ctx: null,
+    source: null,
+    gain: null,
+    filter: null,
+    running: false,
+};
+
+function ensureEngineAudio() {
+    if (!labAudio || labAudio.isMuted()) return null;
+    if (engine.ctx) {
+        if (engine.ctx.state === 'suspended') engine.ctx.resume();
+        return engine.ctx;
+    }
+
+    const Ctx = window.AudioContext || window.webkitAudioContext;
+    if (!Ctx) return null;
+
+    const ctxAudio = new Ctx();
+    const seconds = 2;
+    const buffer = ctxAudio.createBuffer(1, ctxAudio.sampleRate * seconds, ctxAudio.sampleRate);
+    const data = buffer.getChannelData(0);
+    for (let i = 0; i < data.length; i++) data[i] = Math.random() * 2 - 1;
+
+    const source = ctxAudio.createBufferSource();
+    source.buffer = buffer;
+    source.loop = true;
+
+    const filter = ctxAudio.createBiquadFilter();
+    filter.type = 'lowpass';
+    filter.frequency.value = 420;
+    filter.Q.value = 0.9;
+
+    const gain = ctxAudio.createGain();
+    gain.gain.value = 0;
+
+    source.connect(filter).connect(gain).connect(ctxAudio.destination);
+    source.start();
+
+    engine.ctx = ctxAudio;
+    engine.source = source;
+    engine.filter = filter;
+    engine.gain = gain;
+    engine.running = true;
+    return ctxAudio;
+}
+
+/* `level` é a fração de empuxo efetivo (0 sem combustível, 1 no talo). */
+function setEngineLevel(level) {
+    const ctxAudio = engine.running ? engine.ctx : ensureEngineAudio();
+    if (!ctxAudio || !engine.gain) return;
+
+    const muted = labAudio ? labAudio.isMuted() : false;
+    const target = muted ? 0 : level * 0.12;
+    // setTargetAtTime evita o estalo que um corte seco no ganho produziria.
+    engine.gain.gain.setTargetAtTime(target, ctxAudio.currentTime, 0.04);
+    engine.filter.frequency.setTargetAtTime(360 + level * 520, ctxAudio.currentTime, 0.06);
+}
+
+function sfx(name) {
+    if (!labAudio) return;
+    switch (name) {
+        case 'land':
+            labAudio.sequence([523, 659, 784], { step: 0.09, duration: 0.18, gain: 0.13, type: 'triangle' });
+            break;
+        case 'refuel':
+            labAudio.tone({ freq: 300, duration: 0.35, gain: 0.1, slideTo: 720, type: 'sine' });
+            break;
+        case 'crash':
+            labAudio.noise({ duration: 0.7, gain: 0.28, filter: 260 });
+            labAudio.tone({ freq: 110, duration: 0.8, gain: 0.18, slideTo: 35, type: 'sawtooth' });
+            break;
+        case 'launch':
+            labAudio.tone({ freq: 180, duration: 0.5, gain: 0.1, slideTo: 420, type: 'triangle' });
+            break;
+        case 'lowfuel':
+            labAudio.tone({ freq: 880, duration: 0.09, gain: 0.09, type: 'square' });
+            break;
+    }
+}
+
 function setGameState(nextState) {
     gameState = nextState;
     document.querySelector('.game-viewport').dataset.state = nextState.toLowerCase();
@@ -60,6 +150,9 @@ const lander = {
     angle: 0,
     fuel: INITIAL_FUEL,
     thrusting: false,
+    // Espelha `thrusting` mas só muda quando o propulsor de fato queima
+    // combustível — é o que liga e desliga o ruído contínuo do motor.
+    engineOn: false,
     rotatingLeft: false,
     rotatingRight: false,
     onGround: true,
@@ -75,6 +168,7 @@ const lander = {
         this.angle = 0;
         this.fuel = INITIAL_FUEL;
         this.thrusting = false;
+        this.engineOn = false;
         this.rotatingLeft = false;
         this.rotatingRight = false;
         this.onGround = true;
@@ -115,6 +209,11 @@ const lander = {
             this.vy -= Math.cos(this.angle) * acceleration;
             this.fuel -= usedFuel;
             emitEngineParticles(dt);
+            setEngineLevel(thrustFraction);
+            this.engineOn = true;
+        } else if (this.engineOn) {
+            setEngineLevel(0);
+            this.engineOn = false;
         }
 
         this.x += this.vx * dt;
@@ -305,6 +404,7 @@ function checkCollision() {
 }
 
 function land(pad) {
+    setEngineLevel(0);
     const landingVerticalSpeed = lander.vy;
     lander.x = Math.max(pad.x1 + LANDER_HALF_WIDTH, Math.min(pad.x2 - LANDER_HALF_WIDTH, lander.x));
     lander.y = pad.y - LANDER_FOOT_OFFSET;
@@ -317,6 +417,7 @@ function land(pad) {
         lander.onGround = true;
         lander.fuel = INITIAL_FUEL;
         setFlightStatus('REFUELED', 'safe');
+        sfx('refuel');
         return;
     }
 
@@ -332,12 +433,16 @@ function land(pad) {
         'success'
     );
     setFlightStatus('LANDED', 'safe');
+    sfx('land');
 }
 
 function crash() {
     setGameState('CRASHED');
     lander.crashed = true;
     lander.thrusting = false;
+    lander.engineOn = false;
+    setEngineLevel(0);
+    sfx('crash');
     createCrashDebris();
     setStatusMessage('CRASHED<br><small>Press Space to try again</small>', 'danger');
     setFlightStatus('HULL LOST', 'danger');
@@ -370,7 +475,28 @@ function startMission({ nextLevel = false, newGame = false } = {}) {
     document.getElementById('startMsg').classList.add('hidden');
     document.getElementById('gameOverMsg').classList.add('hidden');
     lander.reset();
+    lander.engineOn = false;
+    setEngineLevel(0);
+    lowFuelWarned = false;
     setFlightStatus('READY');
+    sfx('launch');
+}
+
+/* Bipe único ao cruzar 15% de combustível: repetir a cada frame viraria alarme
+   de incêndio, e avisar tarde demais não deixa tempo de reagir. */
+const LOW_FUEL_RATIO = 0.15;
+let lowFuelWarned = false;
+
+function checkLowFuel() {
+    if (gameState !== 'PLAYING') return;
+    const low = lander.fuel <= INITIAL_FUEL * LOW_FUEL_RATIO;
+    if (low && !lowFuelWarned) {
+        lowFuelWarned = true;
+        sfx('lowfuel');
+        setFlightStatus('LOW FUEL', 'danger');
+    } else if (!low) {
+        lowFuelWarned = false;
+    }
 }
 
 function emitEngineParticles(dt) {
@@ -532,6 +658,7 @@ function gameLoop(timestamp) {
         updateParticles(frameTime);
     }
 
+    checkLowFuel();
     updateHUD();
     draw();
     requestAnimationFrame(gameLoop);
@@ -588,6 +715,19 @@ document.getElementById('btnStart').addEventListener('click', () => {
 bindButton('btnLeft', 'ArrowLeft');
 bindButton('btnRight', 'ArrowRight');
 bindButton('btnThrust', 'ArrowUp');
+
+if (labAudio) {
+    labAudio.configure({ storageKey: 'lander:muted', volume: 0.5 });
+    const host = document.querySelector('[data-lab-header] .header-actions');
+    if (host) labAudio.mountToggle(host);
+    // Mudo pelo botão precisa calar o propulsor contínuo na hora.
+    labAudio.onChange(() => setEngineLevel(lander.engineOn ? 1 : 0));
+}
+
+// Aba escondida: o motor não pode continuar roncando em segundo plano.
+document.addEventListener('visibilitychange', () => {
+    if (document.hidden) setEngineLevel(0);
+});
 
 generateStars();
 generateTerrain();

--- a/labs/lander/style.css
+++ b/labs/lander/style.css
@@ -84,6 +84,18 @@ body {
     font: inherit;
     padding: 1px 4px;
     cursor: pointer;
+    /* A barra de menu imita o Windows 95, então o item continua raso; o alvo
+       tocável cresce por pseudo-elemento sem engordar a barra. */
+    position: relative;
+}
+
+.menu-item::after {
+    content: "";
+    position: absolute;
+    inset: 50% auto auto 50%;
+    width: 100%;
+    height: var(--touch-target);
+    transform: translate(-50%, -50%);
 }
 
 .menu-item:hover,

--- a/labs/lavandula/index.html
+++ b/labs/lavandula/index.html
@@ -264,7 +264,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=10" defer></script>
+    <script src="/labs/shared.js?v=11" defer></script>
     <script>
         (function () {
             function hasGpu() {

--- a/labs/lavandula/index.html
+++ b/labs/lavandula/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;600;700;800&family=Outfit:wght@300;400;500;600;700&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=10">
+    <link rel="stylesheet" href="/labs/shared.css?v=11">
     <link rel="stylesheet" href="style.css?v=1">
 
     <script type="importmap">
@@ -264,7 +264,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=9" defer></script>
+    <script src="/labs/shared.js?v=10" defer></script>
     <script>
         (function () {
             function hasGpu() {

--- a/labs/lavandula/index.html
+++ b/labs/lavandula/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;600;700;800&family=Outfit:wght@300;400;500;600;700&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=9">
+    <link rel="stylesheet" href="/labs/shared.css?v=10">
     <link rel="stylesheet" href="style.css?v=1">
 
     <script type="importmap">
@@ -264,7 +264,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=8" defer></script>
+    <script src="/labs/shared.js?v=9" defer></script>
     <script>
         (function () {
             function hasGpu() {

--- a/labs/matrix/index.html
+++ b/labs/matrix/index.html
@@ -27,7 +27,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Share+Tech+Mono&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=10">
+    <link rel="stylesheet" href="/labs/shared.css?v=11">
     <link rel="stylesheet" href="style.css">
     <script type="application/ld+json">
     {
@@ -336,7 +336,7 @@
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
 
-    <script src="/labs/shared.js?v=9" defer></script>
+    <script src="/labs/shared.js?v=10" defer></script>
     <script src="script.js" defer></script>
 </body>
 

--- a/labs/matrix/index.html
+++ b/labs/matrix/index.html
@@ -27,7 +27,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Share+Tech+Mono&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=9">
+    <link rel="stylesheet" href="/labs/shared.css?v=10">
     <link rel="stylesheet" href="style.css">
     <script type="application/ld+json">
     {
@@ -336,7 +336,7 @@
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
 
-    <script src="/labs/shared.js?v=8" defer></script>
+    <script src="/labs/shared.js?v=9" defer></script>
     <script src="script.js" defer></script>
 </body>
 

--- a/labs/matrix/index.html
+++ b/labs/matrix/index.html
@@ -28,7 +28,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Share+Tech+Mono&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/labs/shared.css?v=11">
-    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="style.css?v=4">
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",

--- a/labs/matrix/index.html
+++ b/labs/matrix/index.html
@@ -336,7 +336,7 @@
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
 
-    <script src="/labs/shared.js?v=10" defer></script>
+    <script src="/labs/shared.js?v=11" defer></script>
     <script src="script.js" defer></script>
 </body>
 

--- a/labs/matrix/style.css
+++ b/labs/matrix/style.css
@@ -407,6 +407,8 @@ header .app-logo svg {
 }
 
 .depth-btn {
+    /* 44px: o seletor troca o modo do lab inteiro, errar o alvo é caro. */
+    min-height: var(--touch-target);
     padding: 9px 4px;
     background: rgba(255, 255, 255, 0.03);
     border: 1px solid transparent;

--- a/labs/matrix/style.css
+++ b/labs/matrix/style.css
@@ -470,12 +470,28 @@ input[type="range"] {
     -webkit-appearance: none;
     appearance: none;
     width: 100%;
-    height: 3px;
-    background: rgba(0, 255, 65, 0.15);
-    border-radius: 2px;
-    outline: none;
+    /* 44px de alvo tocável; o trilho visível de 3px vive nos
+       pseudo-elementos abaixo, então o desenho não muda. */
+    height: var(--touch-target);
     border: none;
+    background: transparent;
+    outline: none;
     cursor: pointer;
+    touch-action: pan-y;
+}
+
+input[type="range"]::-webkit-slider-runnable-track {
+    height: 3px;
+    border-radius: 2px;
+    background: rgba(0, 255, 65, 0.15);
+    border: none;
+}
+
+input[type="range"]::-moz-range-track {
+    height: 3px;
+    border-radius: 2px;
+    background: rgba(0, 255, 65, 0.15);
+    border: none;
 }
 
 input[type="range"]::-webkit-slider-thumb {
@@ -487,6 +503,8 @@ input[type="range"]::-webkit-slider-thumb {
     cursor: pointer;
     box-shadow: 0 0 10px var(--mx-glow);
     transition: transform 0.15s ease;
+    /* (trilho 3px - thumb 13px) / 2 */
+    margin-top: -5px;
 }
 
 input[type="range"]::-webkit-slider-thumb:hover {

--- a/labs/matrix/style.css
+++ b/labs/matrix/style.css
@@ -960,8 +960,11 @@ body.cinema.pointer-idle .cinema-exit {
 
 .boot-skip {
     position: absolute;
-    bottom: 28px;
-    right: 28px;
+    /* Primeiro controle que o usuário encontra no lab (a abertura roda antes de
+       tudo), e ficava com 24px de altura — precisa caber o dedo. */
+    min-height: var(--touch-target);
+    bottom: max(28px, var(--safe-bottom));
+    right: max(28px, var(--safe-right));
     background: transparent;
     border: 1px solid var(--panel-border);
     border-radius: 6px;

--- a/labs/menina-da-lanterna/index.html
+++ b/labs/menina-da-lanterna/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@500;600;700&family=Nunito:wght@400;600;700;800&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=10">
+    <link rel="stylesheet" href="/labs/shared.css?v=11">
     <link rel="stylesheet" href="style.css?v=2">
 
     <script type="importmap">
@@ -312,7 +312,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=9" defer></script>
+    <script src="/labs/shared.js?v=10" defer></script>
     <script>
         (function () {
             function hasGpu() {

--- a/labs/menina-da-lanterna/index.html
+++ b/labs/menina-da-lanterna/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@500;600;700&family=Nunito:wght@400;600;700;800&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=9">
+    <link rel="stylesheet" href="/labs/shared.css?v=10">
     <link rel="stylesheet" href="style.css?v=2">
 
     <script type="importmap">
@@ -312,7 +312,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=8" defer></script>
+    <script src="/labs/shared.js?v=9" defer></script>
     <script>
         (function () {
             function hasGpu() {

--- a/labs/menina-da-lanterna/index.html
+++ b/labs/menina-da-lanterna/index.html
@@ -312,7 +312,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=10" defer></script>
+    <script src="/labs/shared.js?v=11" defer></script>
     <script>
         (function () {
             function hasGpu() {

--- a/labs/mimo/index.html
+++ b/labs/mimo/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;600;700&family=Outfit:wght@400;500;600;700&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=9">
+    <link rel="stylesheet" href="/labs/shared.css?v=10">
     <link rel="stylesheet" href="style.css">
 
     <script type="importmap">
@@ -275,7 +275,7 @@
         </div>
     </main>
 
-    <script src="/labs/shared.js?v=8"></script>
+    <script src="/labs/shared.js?v=9"></script>
     <script type="module" src="src/main.js"></script>
 </body>
 

--- a/labs/mimo/index.html
+++ b/labs/mimo/index.html
@@ -275,7 +275,7 @@
         </div>
     </main>
 
-    <script src="/labs/shared.js?v=10"></script>
+    <script src="/labs/shared.js?v=11"></script>
     <script type="module" src="src/main.js"></script>
 </body>
 

--- a/labs/mimo/index.html
+++ b/labs/mimo/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;600;700&family=Outfit:wght@400;500;600;700&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=10">
+    <link rel="stylesheet" href="/labs/shared.css?v=11">
     <link rel="stylesheet" href="style.css">
 
     <script type="importmap">
@@ -275,7 +275,7 @@
         </div>
     </main>
 
-    <script src="/labs/shared.js?v=9"></script>
+    <script src="/labs/shared.js?v=10"></script>
     <script type="module" src="src/main.js"></script>
 </body>
 

--- a/labs/minesweeper/index.html
+++ b/labs/minesweeper/index.html
@@ -22,7 +22,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Campo Minado 95 | Diogo Paulino">
     <meta name="twitter:description" content="Clássico jogo de Campo Minado estilo Windows 95.">
-    <link rel="stylesheet" href="/labs/shared.css?v=10">
+    <link rel="stylesheet" href="/labs/shared.css?v=11">
     <link rel="stylesheet" href="style.css?v=2">
     <script type="application/ld+json">
     {
@@ -145,7 +145,7 @@
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
 
-    <script src="/labs/shared.js?v=9" defer></script>
+    <script src="/labs/shared.js?v=10" defer></script>
     <script src="script.js?v=2" defer></script>
 </body>
 

--- a/labs/minesweeper/index.html
+++ b/labs/minesweeper/index.html
@@ -22,8 +22,8 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Campo Minado 95 | Diogo Paulino">
     <meta name="twitter:description" content="Clássico jogo de Campo Minado estilo Windows 95.">
-    <link rel="stylesheet" href="/labs/shared.css?v=9">
-    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="/labs/shared.css?v=10">
+    <link rel="stylesheet" href="style.css?v=2">
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
@@ -91,18 +91,27 @@
             </div>
             <div class="window-body">
                 <div class="menu-bar">
-                    <select id="difficulty-select">
+                    <select id="difficulty-select" aria-label="Dificuldade">
                         <option value="beginner">Iniciante (9x9)</option>
                         <option value="intermediate">Intermediário (16x16)</option>
                         <option value="expert">Especialista (30x16)</option>
                     </select>
+                    <span class="best-time" title="Melhor tempo nesta dificuldade">🏆 <span
+                            id="best-time">—</span></span>
                 </div>
                 <div class="status-bar">
                     <div class="counter" id="mine-count">010</div>
-                    <button class="face-btn" id="reset-btn">🙂</button>
+                    <div class="status-actions">
+                        <button class="face-btn" id="reset-btn" type="button"
+                            aria-label="Nova partida">🙂</button>
+                        <button class="face-btn flag-toggle" id="flag-toggle" type="button" aria-pressed="false"
+                            aria-label="Modo escavar — tocar revela a célula" title="Modo escavar">⛏️</button>
+                    </div>
                     <div class="counter" id="timer">000</div>
                 </div>
-                <div class="game-board" id="board"></div>
+                <div class="board-scroll">
+                    <div class="game-board" id="board"></div>
+                </div>
             </div>
         </div>
 
@@ -117,14 +126,24 @@
                     <span class="mouse-btn">Segurar / Botão Direito</span>
                     <span>Bandeira</span>
                 </div>
+                <div class="key-combo">
+                    <span class="mouse-btn">⛏️ / 🚩</span>
+                    <span>Alternar modo (tecla F)</span>
+                </div>
+                <div class="key-combo">
+                    <span class="mouse-btn">Duplo clique</span>
+                    <span>Abrir vizinhos de um número</span>
+                </div>
             </div>
         </div>
+
+        <p id="gameStatus" class="sr-only" role="status" aria-live="polite"></p>
 
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
 
-    <script src="/labs/shared.js?v=8" defer></script>
-    <script src="script.js" defer></script>
+    <script src="/labs/shared.js?v=9" defer></script>
+    <script src="script.js?v=2" defer></script>
 </body>
 
 </html>

--- a/labs/minesweeper/index.html
+++ b/labs/minesweeper/index.html
@@ -83,10 +83,13 @@
         <div class="window">
             <div class="title-bar">
                 <div class="title-bar-text">Campo Minado</div>
-                <div class="title-bar-controls">
-                    <button aria-label="Minimize"></button>
-                    <button aria-label="Maximize"></button>
-                    <button aria-label="Close"></button>
+                <!-- Enfeite da moldura Win95: não fazem nada, então não são
+                     botões — como <button> eles entravam na navegação por Tab e
+                     eram anunciados como controles acionáveis. -->
+                <div class="title-bar-controls" aria-hidden="true">
+                    <span></span>
+                    <span></span>
+                    <span></span>
                 </div>
             </div>
             <div class="window-body">

--- a/labs/minesweeper/index.html
+++ b/labs/minesweeper/index.html
@@ -145,7 +145,7 @@
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
 
-    <script src="/labs/shared.js?v=10" defer></script>
+    <script src="/labs/shared.js?v=11" defer></script>
     <script src="script.js?v=2" defer></script>
 </body>
 

--- a/labs/minesweeper/script.js
+++ b/labs/minesweeper/script.js
@@ -4,6 +4,10 @@ document.addEventListener('DOMContentLoaded', () => {
     const timerElement = document.getElementById('timer');
     const resetBtn = document.getElementById('reset-btn');
     const difficultySelect = document.getElementById('difficulty-select');
+    const flagToggle = document.getElementById('flag-toggle');
+    const bestTimeElement = document.getElementById('best-time');
+    const statusLive = document.getElementById('gameStatus');
+    const audio = window.LabAudio;
 
     const DIFFICULTIES = {
         beginner: { rows: 9, cols: 9, mines: 10 },
@@ -21,10 +25,101 @@ document.addEventListener('DOMContentLoaded', () => {
     let timer = 0;
     let timerInterval = null;
     let firstClick = true;
+    /* Modo bandeira: no toque, segurar 500ms para marcar é lento e falha se o
+       dedo escorrega. O botão de alternância transforma o toque simples em
+       bandeira — é como todo Campo Minado de celular funciona. */
+    let flagMode = false;
+
+    const BEST_KEY = 'minesweeper95:best';
+
+    function sfx(name) {
+        if (!audio) return;
+        switch (name) {
+            case 'reveal':
+                audio.tone({ freq: 520, duration: 0.03, gain: 0.05, type: 'triangle' });
+                break;
+            case 'flag':
+                audio.tone({ freq: 780, duration: 0.05, gain: 0.08 });
+                break;
+            case 'unflag':
+                audio.tone({ freq: 480, duration: 0.05, gain: 0.06 });
+                break;
+            case 'boom':
+                audio.noise({ duration: 0.5, gain: 0.22, filter: 320 });
+                audio.tone({ freq: 90, duration: 0.6, gain: 0.16, slideTo: 40, type: 'sawtooth' });
+                break;
+            case 'win':
+                audio.sequence([523, 659, 784, 1047], { step: 0.09, duration: 0.16, gain: 0.13, type: 'triangle' });
+                break;
+        }
+    }
+
+    /* Vibração curta confirma bandeira/explosão no celular, onde não há o
+       "clique" tátil do mouse. Ignorado em silêncio onde não existe. */
+    function buzz(pattern) {
+        try {
+            navigator.vibrate?.(pattern);
+        } catch (err) {
+            /* Alguns navegadores expõem vibrate mas recusam a chamada. */
+        }
+    }
+
+    function announce(message) {
+        if (statusLive) statusLive.textContent = message;
+    }
+
+    function readBest() {
+        try {
+            return JSON.parse(localStorage.getItem(BEST_KEY)) || {};
+        } catch (err) {
+            return {};
+        }
+    }
+
+    function saveBest(all) {
+        try {
+            localStorage.setItem(BEST_KEY, JSON.stringify(all));
+        } catch (err) {
+            /* Sem persistência: o recorde vale só para esta sessão. */
+        }
+    }
+
+    function renderBest() {
+        if (!bestTimeElement) return;
+        const best = readBest()[difficultySelect.value];
+        bestTimeElement.textContent = best ? `${best}s` : '—';
+    }
+
+    function recordBest() {
+        const key = difficultySelect.value;
+        const all = readBest();
+        if (!all[key] || timer < all[key]) {
+            all[key] = timer;
+            saveBest(all);
+        }
+        renderBest();
+    }
+
+    function setFlagMode(next) {
+        flagMode = next;
+        if (!flagToggle) return;
+        flagToggle.setAttribute('aria-pressed', String(flagMode));
+        flagToggle.classList.toggle('is-on', flagMode);
+        flagToggle.textContent = flagMode ? '🚩' : '⛏️';
+        flagToggle.title = flagMode ? 'Modo bandeira (ativo)' : 'Modo escavar';
+        flagToggle.setAttribute('aria-label',
+            flagMode ? 'Modo bandeira ativo — tocar marca a célula' : 'Modo escavar — tocar revela a célula');
+    }
 
     function updateCellSize() {
         const available = Math.min(window.innerWidth - 48, 720);
-        const cell = Math.max(14, Math.min(24, Math.floor(available / COLS)));
+        /* Com o dedo, uma célula de 14px é impossível de acertar. No toque o
+           piso sobe para 26px e o tabuleiro rola dentro da janela (o Especialista
+           de 30 colunas não cabe em 375px de jeito nenhum) — melhor rolar do que
+           errar a célula. */
+        const coarse = window.matchMedia('(pointer: coarse)').matches;
+        const floor = coarse ? 26 : 14;
+        const cell = Math.max(floor, Math.min(28, Math.floor(available / COLS)));
         document.documentElement.style.setProperty('--cell-size', cell + 'px');
         boardElement.style.gridTemplateColumns = `repeat(${COLS}, var(--cell-size))`;
         boardElement.style.gridTemplateRows = `repeat(${ROWS}, var(--cell-size))`;
@@ -79,59 +174,79 @@ document.addEventListener('DOMContentLoaded', () => {
                 cell.dataset.r = r;
                 cell.dataset.c = c;
 
-                cell.addEventListener('mousedown', (e) => {
-                    if (gameOver) return;
-                    if (e.button === 0) {
-                        resetBtn.innerText = '😮';
+                /* Um único caminho de entrada em pointer events cobre mouse,
+                   caneta e dedo. Antes eram dois (mouse* + touch*), que em
+                   navegadores que emitem os dois disparavam a jogada duas vezes. */
+                let holdTimer = null;
+                let moved = false;
+                let longPressed = false;
+
+                const cancelHold = () => {
+                    if (holdTimer) {
+                        clearTimeout(holdTimer);
+                        holdTimer = null;
                     }
-                });
+                };
 
-                cell.addEventListener('mouseup', (e) => {
+                cell.addEventListener('pointerdown', (e) => {
                     if (gameOver) return;
-                    resetBtn.innerText = '🙂';
-                    if (e.button === 0) {
-                        handleClick(r, c);
-                    } else if (e.button === 2) {
-                        handleRightClick(r, c);
-                    }
-                });
-
-                cell.addEventListener('contextmenu', e => e.preventDefault());
-
-                let touchTimer = null;
-                let touchMoved = false;
-
-                cell.addEventListener('touchstart', (e) => {
-                    if (gameOver) return;
-                    touchMoved = false;
+                    moved = false;
+                    longPressed = false;
                     resetBtn.innerText = '😮';
-                    touchTimer = setTimeout(() => {
-                        if (!touchMoved) {
-                            handleRightClick(r, c);
-                            touchTimer = null;
-                        }
-                    }, 500);
-                }, { passive: true });
 
-                cell.addEventListener('touchmove', () => {
-                    touchMoved = true;
-                    if (touchTimer) {
-                        clearTimeout(touchTimer);
-                        touchTimer = null;
+                    if (e.pointerType === 'mouse' && e.button === 2) return;
+
+                    // Segurar continua marcando bandeira, para quem não usa o
+                    // botão de modo.
+                    holdTimer = setTimeout(() => {
+                        holdTimer = null;
+                        if (moved) return;
+                        longPressed = true;
+                        handleRightClick(r, c);
+                        resetBtn.innerText = '🙂';
+                    }, 450);
+                });
+
+                cell.addEventListener('pointermove', (e) => {
+                    // Um deslize pequeno é tremor de dedo, não intenção de rolar.
+                    if (Math.abs(e.movementX) + Math.abs(e.movementY) > 4) {
+                        moved = true;
+                        cancelHold();
                     }
-                }, { passive: true });
+                });
 
-                cell.addEventListener('touchend', (e) => {
+                cell.addEventListener('pointerup', (e) => {
+                    cancelHold();
                     if (gameOver) return;
                     resetBtn.innerText = '🙂';
-                    if (touchTimer) {
-                        clearTimeout(touchTimer);
-                        touchTimer = null;
-                        if (!touchMoved) {
-                            e.preventDefault();
-                            handleClick(r, c);
-                        }
+                    if (moved || longPressed) return;
+
+                    if (e.pointerType === 'mouse' && e.button === 2) {
+                        handleRightClick(r, c);
+                        return;
                     }
+                    if (e.button > 0) return;
+
+                    if (flagMode) handleRightClick(r, c);
+                    else handleClick(r, c);
+                });
+
+                cell.addEventListener('pointercancel', () => {
+                    cancelHold();
+                    resetBtn.innerText = '🙂';
+                });
+
+                cell.addEventListener('contextmenu', e => {
+                    e.preventDefault();
+                    if (!gameOver) handleRightClick(r, c);
+                });
+
+                /* Duplo clique/toque numa célula já revelada = "chord": revela os
+                   vizinhos quando as bandeiras ao redor batem com o número.
+                   É o atalho que torna o jogo rápido em vez de tedioso. */
+                cell.addEventListener('dblclick', (e) => {
+                    e.preventDefault();
+                    chord(r, c);
                 });
 
                 boardElement.appendChild(cell);
@@ -192,9 +307,43 @@ document.addEventListener('DOMContentLoaded', () => {
             cellElement.style.backgroundColor = 'red';
             resetBtn.innerText = '😵';
             stopTimer();
+            sfx('boom');
+            buzz([40, 60, 120]);
+            announce(`Você acertou uma mina. Fim de jogo em ${timer} segundos.`);
         } else {
             revealCell(r, c);
+            sfx('reveal');
             checkWin();
+        }
+    }
+
+    /* Chord: numa célula revelada com número N, se já houver N bandeiras
+       vizinhas, revela todos os vizinhos não marcados. Se alguma bandeira
+       estiver errada, o jogador explode — é o risco que dá graça ao atalho. */
+    function chord(r, c) {
+        if (gameOver || firstClick) return;
+        const cellData = board[r][c];
+        if (!cellData.isRevealed || cellData.neighborMines === 0) return;
+
+        let flagged = 0;
+        const targets = [];
+        for (let dr = -1; dr <= 1; dr++) {
+            for (let dc = -1; dc <= 1; dc++) {
+                if (dr === 0 && dc === 0) continue;
+                const nr = r + dr;
+                const nc = c + dc;
+                if (nr < 0 || nr >= ROWS || nc < 0 || nc >= COLS) continue;
+                const neighbour = board[nr][nc];
+                if (neighbour.isFlagged) flagged++;
+                else if (!neighbour.isRevealed) targets.push(neighbour);
+            }
+        }
+
+        if (flagged !== cellData.neighborMines || !targets.length) return;
+
+        for (const target of targets) {
+            handleClick(target.r, target.c);
+            if (gameOver) return;
         }
     }
 
@@ -208,14 +357,18 @@ document.addEventListener('DOMContentLoaded', () => {
             cellData.isFlagged = false;
             cellElement.innerText = '';
             flags--;
+            sfx('unflag');
         } else {
             if (flags < MINES) {
                 cellData.isFlagged = true;
                 cellElement.innerText = '🚩';
                 flags++;
+                sfx('flag');
+                buzz(18);
             }
         }
         mineCountElement.innerText = formatNumber(MINES - flags);
+        announce(`${MINES - flags} minas restantes.`);
     }
 
     function revealCell(r, c) {
@@ -281,6 +434,10 @@ document.addEventListener('DOMContentLoaded', () => {
                 }
             }
             mineCountElement.innerText = '000';
+            sfx('win');
+            buzz([25, 40, 25, 40, 60]);
+            recordBest();
+            announce(`Campo limpo em ${timer} segundos.`);
         }
     }
 
@@ -305,8 +462,31 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     resetBtn.addEventListener('click', initGame);
-    difficultySelect.addEventListener('change', initGame);
+    difficultySelect.addEventListener('change', () => {
+        renderBest();
+        initGame();
+    });
     window.addEventListener('resize', updateCellSize);
+    window.addEventListener('orientationchange', () => setTimeout(updateCellSize, 120));
 
+    flagToggle?.addEventListener('click', () => setFlagMode(!flagMode));
+
+    /* F alterna o modo pelo teclado — o equivalente do botão direito para quem
+       joga no notebook sem mouse. */
+    document.addEventListener('keydown', (e) => {
+        if (e.key === 'f' || e.key === 'F') {
+            if (e.target.closest('input, select, textarea')) return;
+            setFlagMode(!flagMode);
+        }
+    });
+
+    if (audio) {
+        audio.configure({ storageKey: 'minesweeper95:muted', volume: 0.4 });
+        const host = document.querySelector('[data-lab-header] .header-actions');
+        if (host) audio.mountToggle(host);
+    }
+
+    setFlagMode(false);
+    renderBest();
     initGame();
 });

--- a/labs/minesweeper/style.css
+++ b/labs/minesweeper/style.css
@@ -57,7 +57,7 @@ body {
     gap: 2px;
 }
 
-.title-bar-controls button {
+.title-bar-controls span {
     width: 16px;
     height: 14px;
     background: var(--win-gray);
@@ -258,6 +258,7 @@ body {
 }
 
 #difficulty-select {
+    min-height: var(--touch-target);
     background: var(--win-gray);
     border: 2px solid;
     border-color: var(--win-light) var(--win-black) var(--win-black) var(--win-light);

--- a/labs/minesweeper/style.css
+++ b/labs/minesweeper/style.css
@@ -105,6 +105,9 @@ body {
 }
 
 .face-btn {
+    /* O desenho continua sendo o botão quadradinho do Windows 95; o alvo real
+       cresce por pseudo-elemento (ver .face-btn::after). */
+    position: relative;
     width: 26px;
     height: 26px;
     font-size: 18px;
@@ -122,6 +125,50 @@ body {
     border-color: var(--win-black) var(--win-light) var(--win-light) var(--win-black);
     padding: 1px 0 0 1px;
     /* Shift content */
+}
+
+.face-btn::after {
+    content: "";
+    position: absolute;
+    inset: 50% auto auto 50%;
+    width: var(--touch-target);
+    height: var(--touch-target);
+    transform: translate(-50%, -50%);
+}
+
+.face-btn:focus-visible {
+    outline: 2px solid var(--focus-ring);
+    outline-offset: 2px;
+}
+
+.status-actions {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+/* Modo bandeira ligado: o botão fica afundado, como um toggle do Win95. */
+.flag-toggle.is-on {
+    border-color: var(--win-black) var(--win-light) var(--win-light) var(--win-black);
+    background: var(--win-light);
+}
+
+/* O tabuleiro rola dentro da janela em vez de esticar a página: no
+   Especialista (30 colunas) nenhuma célula tocável cabe em 375px. */
+.board-scroll {
+    max-width: 100%;
+    overflow: auto;
+    overscroll-behavior: contain;
+    -webkit-overflow-scrolling: touch;
+}
+
+.best-time {
+    margin-left: auto;
+    font-size: 11px;
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    white-space: nowrap;
 }
 
 /* Game Board */
@@ -205,6 +252,8 @@ body {
 .menu-bar {
     margin-bottom: 6px;
     display: flex;
+    align-items: center;
+    gap: 8px;
     justify-content: flex-start;
 }
 
@@ -233,7 +282,8 @@ body {
     border: 1px solid rgba(255, 255, 255, 0.2);
     color: var(--text-primary);
     text-align: center;
-    max-width: 300px;
+    /* Quatro instruções em 300px viravam quatro colunas de uma palavra cada. */
+    max-width: min(34rem, 100%);
 }
 
 .instructions-card h3 {
@@ -245,9 +295,12 @@ body {
 }
 
 .instruction-row {
-    display: flex;
+    /* Grid fluido: 4 colunas no desktop, 2 no celular — sem media query e sem
+       coluna de uma palavra por linha. */
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(7.5rem, 1fr));
     justify-content: center;
-    gap: 20px;
+    gap: 14px 20px;
 }
 
 .key-combo {
@@ -281,6 +334,10 @@ body {
         width: 24px;
         height: 24px;
         font-size: 16px;
+    }
+
+    .status-actions {
+        gap: 8px;
     }
 
     .title-bar-text {

--- a/labs/neon-rider/index.html
+++ b/labs/neon-rider/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Audiowide&family=Outfit:wght@400;500;600;700&family=Share+Tech+Mono&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=9">
+    <link rel="stylesheet" href="/labs/shared.css?v=10">
     <link rel="stylesheet" href="style.css?v=2">
 
     <script type="importmap">
@@ -268,7 +268,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=8" defer></script>
+    <script src="/labs/shared.js?v=9" defer></script>
     <script type="module" src="src/main.js?v=4"></script>
 </body>
 

--- a/labs/neon-rider/index.html
+++ b/labs/neon-rider/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Audiowide&family=Outfit:wght@400;500;600;700&family=Share+Tech+Mono&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=10">
+    <link rel="stylesheet" href="/labs/shared.css?v=11">
     <link rel="stylesheet" href="style.css?v=2">
 
     <script type="importmap">
@@ -268,7 +268,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=9" defer></script>
+    <script src="/labs/shared.js?v=10" defer></script>
     <script type="module" src="src/main.js?v=4"></script>
 </body>
 

--- a/labs/neon-rider/index.html
+++ b/labs/neon-rider/index.html
@@ -268,7 +268,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=10" defer></script>
+    <script src="/labs/shared.js?v=11" defer></script>
     <script type="module" src="src/main.js?v=4"></script>
 </body>
 

--- a/labs/nereida/index.html
+++ b/labs/nereida/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,500;0,600;0,700;1,500&family=Figtree:wght@400;600;700;800&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=9">
+    <link rel="stylesheet" href="/labs/shared.css?v=10">
     <link rel="stylesheet" href="style.css">
 
     <script type="importmap">
@@ -248,7 +248,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=8" defer></script>
+    <script src="/labs/shared.js?v=9" defer></script>
     <script>
         (function () {
             function hasGpu() {

--- a/labs/nereida/index.html
+++ b/labs/nereida/index.html
@@ -248,7 +248,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=10" defer></script>
+    <script src="/labs/shared.js?v=11" defer></script>
     <script>
         (function () {
             function hasGpu() {

--- a/labs/nereida/index.html
+++ b/labs/nereida/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,500;0,600;0,700;1,500&family=Figtree:wght@400;600;700;800&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=10">
+    <link rel="stylesheet" href="/labs/shared.css?v=11">
     <link rel="stylesheet" href="style.css">
 
     <script type="importmap">
@@ -248,7 +248,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=9" defer></script>
+    <script src="/labs/shared.js?v=10" defer></script>
     <script>
         (function () {
             function hasGpu() {

--- a/labs/nina/index.html
+++ b/labs/nina/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Fredoka:wght@500;600;700&family=Nunito:wght@400;600;700;800&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=10">
+    <link rel="stylesheet" href="/labs/shared.css?v=11">
     <link rel="stylesheet" href="style.css">
 
     <script type="importmap">
@@ -248,7 +248,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=9" defer></script>
+    <script src="/labs/shared.js?v=10" defer></script>
     <script>
         (function () {
             function hasGpu() {

--- a/labs/nina/index.html
+++ b/labs/nina/index.html
@@ -248,7 +248,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=10" defer></script>
+    <script src="/labs/shared.js?v=11" defer></script>
     <script>
         (function () {
             function hasGpu() {

--- a/labs/nina/index.html
+++ b/labs/nina/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Fredoka:wght@500;600;700&family=Nunito:wght@400;600;700;800&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=9">
+    <link rel="stylesheet" href="/labs/shared.css?v=10">
     <link rel="stylesheet" href="style.css">
 
     <script type="importmap">
@@ -248,7 +248,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=8" defer></script>
+    <script src="/labs/shared.js?v=9" defer></script>
     <script>
         (function () {
             function hasGpu() {

--- a/labs/orbis/index.html
+++ b/labs/orbis/index.html
@@ -34,7 +34,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;600;700&family=Syne:wght@400;500;600;700;800&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=10">
+    <link rel="stylesheet" href="/labs/shared.css?v=11">
     <link rel="stylesheet" href="style.css">
 
     <script type="importmap">
@@ -175,7 +175,7 @@
         <p class="fps-badge" aria-hidden="true"><span id="fps">60</span> fps</p>
     </main>
 
-    <script src="/labs/shared.js?v=9" defer></script>
+    <script src="/labs/shared.js?v=10" defer></script>
     <script type="module" src="./src/main.js"></script>
 </body>
 

--- a/labs/orbis/index.html
+++ b/labs/orbis/index.html
@@ -34,7 +34,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;600;700&family=Syne:wght@400;500;600;700;800&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=9">
+    <link rel="stylesheet" href="/labs/shared.css?v=10">
     <link rel="stylesheet" href="style.css">
 
     <script type="importmap">
@@ -175,7 +175,7 @@
         <p class="fps-badge" aria-hidden="true"><span id="fps">60</span> fps</p>
     </main>
 
-    <script src="/labs/shared.js?v=8" defer></script>
+    <script src="/labs/shared.js?v=9" defer></script>
     <script type="module" src="./src/main.js"></script>
 </body>
 

--- a/labs/orbis/index.html
+++ b/labs/orbis/index.html
@@ -175,7 +175,7 @@
         <p class="fps-badge" aria-hidden="true"><span id="fps">60</span> fps</p>
     </main>
 
-    <script src="/labs/shared.js?v=10" defer></script>
+    <script src="/labs/shared.js?v=11" defer></script>
     <script type="module" src="./src/main.js"></script>
 </body>
 

--- a/labs/orbis/style.css
+++ b/labs/orbis/style.css
@@ -404,12 +404,31 @@ h2 {
 }
 
 .slider input[type="range"] {
-    width: 100%;
+    -webkit-appearance: none;
     appearance: none;
+    width: 100%;
+    /* 44px de alvo tocável; o trilho visível de 4px vive nos
+       pseudo-elementos abaixo, então o desenho não muda. */
+    height: var(--touch-target);
+    border: none;
+    background: transparent;
+    outline: none;
+    cursor: pointer;
+    touch-action: pan-y;
+}
+
+.slider input[type="range"]::-webkit-slider-runnable-track {
     height: 4px;
     border-radius: 99px;
     background: color-mix(in oklab, white 14%, transparent);
-    outline: none;
+    border: none;
+}
+
+.slider input[type="range"]::-moz-range-track {
+    height: 4px;
+    border-radius: 99px;
+    background: color-mix(in oklab, white 14%, transparent);
+    border: none;
 }
 
 .slider input[type="range"]::-webkit-slider-thumb {
@@ -420,6 +439,8 @@ h2 {
     background: var(--gold);
     box-shadow: 0 0 10px #f0c67588;
     cursor: grab;
+    /* (trilho 4px - thumb 14px) / 2 */
+    margin-top: -5px;
 }
 
 .dock {

--- a/labs/orbis/style.css
+++ b/labs/orbis/style.css
@@ -336,6 +336,7 @@ h2 {
     align-items: center;
     justify-content: center;
     gap: 0.35rem;
+    min-height: var(--touch-target);
     padding: 0.55rem 0.9rem;
     border-radius: 999px;
     border: 1px solid var(--line);

--- a/labs/paint/index.html
+++ b/labs/paint/index.html
@@ -29,7 +29,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@100..900&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/labs/shared.css?v=11">
-    <link rel="stylesheet" href="style.css?v=7">
+    <link rel="stylesheet" href="style.css?v=5">
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
@@ -305,7 +305,7 @@
 
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
-    <script src="/labs/shared.js?v=10" defer></script>
+    <script src="/labs/shared.js?v=11" defer></script>
     <script src="script.js?v=3" defer></script>
 </body>
 

--- a/labs/paint/index.html
+++ b/labs/paint/index.html
@@ -28,7 +28,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@100..900&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=9">
+    <link rel="stylesheet" href="/labs/shared.css?v=10">
     <link rel="stylesheet" href="style.css?v=7">
     <script type="application/ld+json">
     {
@@ -305,7 +305,7 @@
 
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
-    <script src="/labs/shared.js?v=8" defer></script>
+    <script src="/labs/shared.js?v=9" defer></script>
     <script src="script.js?v=3" defer></script>
 </body>
 

--- a/labs/paint/index.html
+++ b/labs/paint/index.html
@@ -28,7 +28,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@100..900&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=10">
+    <link rel="stylesheet" href="/labs/shared.css?v=11">
     <link rel="stylesheet" href="style.css?v=7">
     <script type="application/ld+json">
     {
@@ -305,7 +305,7 @@
 
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
-    <script src="/labs/shared.js?v=9" defer></script>
+    <script src="/labs/shared.js?v=10" defer></script>
     <script src="script.js?v=3" defer></script>
 </body>
 

--- a/labs/paint/style.css
+++ b/labs/paint/style.css
@@ -359,6 +359,9 @@ input[type="color"] {
 }
 
 .color-palette .color-swatch {
+    /* A amostra continua com 32px de desenho (a paleta precisa caber na barra),
+       mas o alvo cresce por pseudo-elemento até 44px — ver ::after abaixo. */
+    position: relative;
     width: 32px;
     height: 32px;
     min-width: 32px;
@@ -369,6 +372,15 @@ input[type="color"] {
     background: var(--swatch, transparent);
     border: 1px solid var(--border-subtle);
     transition: transform 0.1s ease, box-shadow 0.15s ease;
+}
+
+.color-palette .color-swatch::after {
+    content: "";
+    position: absolute;
+    inset: 50% auto auto 50%;
+    width: var(--touch-target);
+    height: var(--touch-target);
+    transform: translate(-50%, -50%);
 }
 
 .color-swatch:hover {

--- a/labs/paint/style.css
+++ b/labs/paint/style.css
@@ -381,12 +381,31 @@ input[type="color"] {
 }
 
 input[type="range"] {
-    width: 100%;
-    height: 4px;
-    background: var(--surface-hover);
-    border-radius: 2px;
+    -webkit-appearance: none;
     appearance: none;
+    width: 100%;
+    /* 44px de alvo tocável; o trilho visível de 4px vive nos
+       pseudo-elementos abaixo, então o desenho não muda. */
+    height: var(--touch-target);
+    border: none;
+    background: transparent;
     outline: none;
+    cursor: pointer;
+    touch-action: pan-y;
+}
+
+input[type="range"]::-webkit-slider-runnable-track {
+    height: 4px;
+    border-radius: 2px;
+    background: var(--surface-hover);
+    border: none;
+}
+
+input[type="range"]::-moz-range-track {
+    height: 4px;
+    border-radius: 2px;
+    background: var(--surface-hover);
+    border: none;
 }
 
 input[type="range"]::-webkit-slider-thumb {
@@ -397,6 +416,8 @@ input[type="range"]::-webkit-slider-thumb {
     border-radius: 50%;
     cursor: pointer;
     border: 2px solid var(--bg-card);
+    /* (trilho 4px - thumb 16px) / 2 */
+    margin-top: -6px;
 }
 
 input[type="range"]::-moz-range-thumb {

--- a/labs/paint/style.css
+++ b/labs/paint/style.css
@@ -359,8 +359,6 @@ input[type="color"] {
 }
 
 .color-palette .color-swatch {
-    /* A amostra continua com 32px de desenho (a paleta precisa caber na barra),
-       mas o alvo cresce por pseudo-elemento até 44px — ver ::after abaixo. */
     position: relative;
     width: 32px;
     height: 32px;
@@ -372,15 +370,6 @@ input[type="color"] {
     background: var(--swatch, transparent);
     border: 1px solid var(--border-subtle);
     transition: transform 0.1s ease, box-shadow 0.15s ease;
-}
-
-.color-palette .color-swatch::after {
-    content: "";
-    position: absolute;
-    inset: 50% auto auto 50%;
-    width: var(--touch-target);
-    height: var(--touch-target);
-    transform: translate(-50%, -50%);
 }
 
 .color-swatch:hover {
@@ -647,17 +636,22 @@ kbd {
         margin-bottom: 0;
     }
 
+    /* Amostras de 24px são impossíveis de acertar com o dedo, e alargar o alvo
+       por pseudo-elemento não resolve numa grade densa (as áreas se sobrepõem e
+       o toque escolhe a cor vizinha). A grade passa a preencher a largura
+       disponível com células de no mínimo 40px. */
     .side-bar.right .color-palette {
-        grid-template-columns: repeat(9, 24px);
-        justify-content: start;
-        gap: 4px;
+        grid-template-columns: repeat(auto-fill, minmax(40px, 1fr));
+        justify-content: stretch;
+        gap: 6px;
     }
 
     .side-bar.right .color-palette .color-swatch {
-        width: 24px;
-        height: 24px;
-        min-width: 24px;
-        min-height: 24px;
+        width: 100%;
+        height: auto;
+        min-width: 40px;
+        min-height: 40px;
+        aspect-ratio: 1;
     }
 
     .side-bar.right .separator,
@@ -759,15 +753,16 @@ kbd {
     }
 
     .side-bar.right .color-palette {
-        grid-template-columns: repeat(5, 28px);
+        grid-template-columns: repeat(auto-fill, minmax(40px, 1fr));
         gap: 6px;
     }
 
     .side-bar.right .color-palette .color-swatch {
-        width: 28px;
-        height: 28px;
-        min-width: 28px;
-        min-height: 28px;
+        width: 100%;
+        height: auto;
+        min-width: 40px;
+        min-height: 40px;
+        aspect-ratio: 1;
     }
 
     .side-bar.right .shortcuts-hint {

--- a/labs/partitura/index.html
+++ b/labs/partitura/index.html
@@ -27,7 +27,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;500;700;800&family=Space+Mono:wght@400;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="/labs/shared.css?v=10">
+  <link rel="stylesheet" href="/labs/shared.css?v=11">
   <link rel="stylesheet" href="style.css">
   <script type="application/ld+json">
   {
@@ -275,7 +275,7 @@
     <footer data-lab-footer data-home-href="/" class="compact-footer"></footer>
   </div>
 
-  <script src="/labs/shared.js?v=9" defer></script>
+  <script src="/labs/shared.js?v=10" defer></script>
   <script src="script.js" defer></script>
 </body>
 

--- a/labs/partitura/index.html
+++ b/labs/partitura/index.html
@@ -275,7 +275,7 @@
     <footer data-lab-footer data-home-href="/" class="compact-footer"></footer>
   </div>
 
-  <script src="/labs/shared.js?v=10" defer></script>
+  <script src="/labs/shared.js?v=11" defer></script>
   <script src="script.js" defer></script>
 </body>
 

--- a/labs/partitura/index.html
+++ b/labs/partitura/index.html
@@ -27,7 +27,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;500;700;800&family=Space+Mono:wght@400;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="/labs/shared.css?v=9">
+  <link rel="stylesheet" href="/labs/shared.css?v=10">
   <link rel="stylesheet" href="style.css">
   <script type="application/ld+json">
   {
@@ -275,7 +275,7 @@
     <footer data-lab-footer data-home-href="/" class="compact-footer"></footer>
   </div>
 
-  <script src="/labs/shared.js?v=8" defer></script>
+  <script src="/labs/shared.js?v=9" defer></script>
   <script src="script.js" defer></script>
 </body>
 

--- a/labs/partitura/style.css
+++ b/labs/partitura/style.css
@@ -222,6 +222,7 @@ body {
   color: #f8fafc;
   border: 1px solid var(--border-glow);
   border-radius: 8px;
+  min-height: var(--touch-target);
   padding: 0.35rem 0.65rem;
   font-size: 0.82rem;
   font-weight: 700;

--- a/labs/piano/index.html
+++ b/labs/piano/index.html
@@ -24,7 +24,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Piano | Diogo Paulino">
     <meta name="twitter:description" content="Piano minimalista com sons ultra realistas. 4 oitavas completas.">
-  <link rel="stylesheet" href="/labs/shared.css?v=10">
+  <link rel="stylesheet" href="/labs/shared.css?v=11">
   <link rel="stylesheet" href="style.css">
   <script type="application/ld+json">
   {
@@ -133,7 +133,7 @@
     <footer data-lab-footer data-home-href="/"></footer>
   </div>
 
-  <script src="/labs/shared.js?v=9" defer></script>
+  <script src="/labs/shared.js?v=10" defer></script>
   <script src="script.js" defer></script>
 </body>
 

--- a/labs/piano/index.html
+++ b/labs/piano/index.html
@@ -133,7 +133,7 @@
     <footer data-lab-footer data-home-href="/"></footer>
   </div>
 
-  <script src="/labs/shared.js?v=10" defer></script>
+  <script src="/labs/shared.js?v=11" defer></script>
   <script src="script.js" defer></script>
 </body>
 

--- a/labs/piano/index.html
+++ b/labs/piano/index.html
@@ -24,7 +24,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Piano | Diogo Paulino">
     <meta name="twitter:description" content="Piano minimalista com sons ultra realistas. 4 oitavas completas.">
-  <link rel="stylesheet" href="/labs/shared.css?v=9">
+  <link rel="stylesheet" href="/labs/shared.css?v=10">
   <link rel="stylesheet" href="style.css">
   <script type="application/ld+json">
   {
@@ -133,7 +133,7 @@
     <footer data-lab-footer data-home-href="/"></footer>
   </div>
 
-  <script src="/labs/shared.js?v=8" defer></script>
+  <script src="/labs/shared.js?v=9" defer></script>
   <script src="script.js" defer></script>
 </body>
 

--- a/labs/piano/style.css
+++ b/labs/piano/style.css
@@ -217,13 +217,27 @@ body {
 
 #volume {
   width: 100px;
-  height: 3px;
-  background: #222;
-  border-radius: 1.5px;
+  /* 44px de alvo; o trilho de 3px passa a viver nos pseudo-elementos. */
+  height: var(--touch-target);
+  background: transparent;
   outline: none;
   -webkit-appearance: none;
   appearance: none;
   cursor: pointer;
+  touch-action: pan-y;
+}
+
+#volume::-webkit-slider-runnable-track {
+  height: 3px;
+  background: #222;
+  border-radius: 1.5px;
+}
+
+#volume::-moz-range-track {
+  height: 3px;
+  background: #222;
+  border-radius: 1.5px;
+  border: 0;
 }
 
 #volume::-webkit-slider-thumb {
@@ -275,8 +289,8 @@ body {
 }
 
 .octave-btn {
-  width: 32px;
-  height: 32px;
+  width: var(--touch-target);
+  height: var(--touch-target);
   background: var(--bg-body);
   color: var(--text-secondary);
   border: 1px solid var(--border-subtle);

--- a/labs/pomodoro/index.html
+++ b/labs/pomodoro/index.html
@@ -26,7 +26,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=9">
+    <link rel="stylesheet" href="/labs/shared.css?v=10">
     <link rel="stylesheet" href="style.css?v=3">
     <script type="application/ld+json">
     {
@@ -357,7 +357,7 @@
     <div class="toast-region" id="toast-region" aria-live="polite" aria-atomic="false"></div>
     <p class="sr-only" id="live-region" role="status" aria-live="polite"></p>
 
-    <script src="/labs/shared.js?v=8" defer></script>
+    <script src="/labs/shared.js?v=9" defer></script>
     <script src="script.js?v=3" defer></script>
 </body>
 

--- a/labs/pomodoro/index.html
+++ b/labs/pomodoro/index.html
@@ -26,7 +26,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=10">
+    <link rel="stylesheet" href="/labs/shared.css?v=11">
     <link rel="stylesheet" href="style.css?v=3">
     <script type="application/ld+json">
     {
@@ -357,7 +357,7 @@
     <div class="toast-region" id="toast-region" aria-live="polite" aria-atomic="false"></div>
     <p class="sr-only" id="live-region" role="status" aria-live="polite"></p>
 
-    <script src="/labs/shared.js?v=9" defer></script>
+    <script src="/labs/shared.js?v=10" defer></script>
     <script src="script.js?v=3" defer></script>
 </body>
 

--- a/labs/pomodoro/index.html
+++ b/labs/pomodoro/index.html
@@ -27,7 +27,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/labs/shared.css?v=11">
-    <link rel="stylesheet" href="style.css?v=3">
+    <link rel="stylesheet" href="style.css?v=4">
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
@@ -357,7 +357,7 @@
     <div class="toast-region" id="toast-region" aria-live="polite" aria-atomic="false"></div>
     <p class="sr-only" id="live-region" role="status" aria-live="polite"></p>
 
-    <script src="/labs/shared.js?v=10" defer></script>
+    <script src="/labs/shared.js?v=11" defer></script>
     <script src="script.js?v=3" defer></script>
 </body>
 

--- a/labs/pomodoro/style.css
+++ b/labs/pomodoro/style.css
@@ -200,6 +200,9 @@ select:focus-visible {
 }
 
 .mode-btn {
+    /* 44px aqui, e não só no bloco de 480px: um celular deitado tem 667px de
+       largura e continua sendo dedo. */
+    min-height: var(--touch-target);
     border: none;
     background: transparent;
     color: var(--text-secondary);
@@ -211,6 +214,23 @@ select:focus-visible {
     cursor: pointer;
     white-space: nowrap;
     transition: background 0.25s ease, color 0.25s ease;
+}
+
+.task-remove::after,
+.close-btn::after {
+    content: "";
+    position: absolute;
+    inset: 50% auto auto 50%;
+    width: var(--touch-target);
+    height: var(--touch-target);
+    transform: translate(-50%, -50%);
+}
+
+@media (pointer: coarse) {
+    .icon-btn {
+        width: var(--touch-target);
+        height: var(--touch-target);
+    }
 }
 
 .mode-btn:hover {
@@ -573,6 +593,8 @@ kbd {
 
 .task-remove {
     flex-shrink: 0;
+    /* O X continua desenhado pequeno; o alvo real vem do ::after. */
+    position: relative;
     width: 26px;
     height: 26px;
     display: inline-flex;
@@ -751,6 +773,7 @@ kbd {
 }
 
 .close-btn {
+    position: relative;
     width: 34px;
     height: 34px;
     display: inline-flex;

--- a/labs/pomodoro/style.css
+++ b/labs/pomodoro/style.css
@@ -467,6 +467,8 @@ kbd {
     display: inline-flex;
     align-items: center;
     justify-content: center;
+    min-width: var(--touch-target);
+    min-height: var(--touch-target);
     border: none;
     border-radius: 10px;
     background: var(--mode-color);

--- a/labs/pulsar/index.html
+++ b/labs/pulsar/index.html
@@ -29,7 +29,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Oxanium:wght@400;600;700;800&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=9">
+    <link rel="stylesheet" href="/labs/shared.css?v=10">
     <link rel="stylesheet" href="style.css">
     <script type="application/ld+json">
     {
@@ -182,7 +182,7 @@
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
 
-    <script src="/labs/shared.js?v=8" defer></script>
+    <script src="/labs/shared.js?v=9" defer></script>
     <script src="script.js" defer></script>
 </body>
 

--- a/labs/pulsar/index.html
+++ b/labs/pulsar/index.html
@@ -29,7 +29,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Oxanium:wght@400;600;700;800&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=10">
+    <link rel="stylesheet" href="/labs/shared.css?v=11">
     <link rel="stylesheet" href="style.css">
     <script type="application/ld+json">
     {
@@ -182,7 +182,7 @@
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
 
-    <script src="/labs/shared.js?v=9" defer></script>
+    <script src="/labs/shared.js?v=10" defer></script>
     <script src="script.js" defer></script>
 </body>
 

--- a/labs/pulsar/index.html
+++ b/labs/pulsar/index.html
@@ -182,7 +182,7 @@
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
 
-    <script src="/labs/shared.js?v=10" defer></script>
+    <script src="/labs/shared.js?v=11" defer></script>
     <script src="script.js" defer></script>
 </body>
 

--- a/labs/quimera/index.html
+++ b/labs/quimera/index.html
@@ -34,7 +34,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,500;0,9..144,650;1,9..144,500&family=Outfit:wght@300;400;500;600;700&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=10">
+    <link rel="stylesheet" href="/labs/shared.css?v=11">
     <link rel="stylesheet" href="style.css">
 
     <script type="importmap">
@@ -194,7 +194,7 @@
         <footer data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=9" defer></script>
+    <script src="/labs/shared.js?v=10" defer></script>
     <script type="module" src="./src/main.js"></script>
 </body>
 

--- a/labs/quimera/index.html
+++ b/labs/quimera/index.html
@@ -34,7 +34,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,500;0,9..144,650;1,9..144,500&family=Outfit:wght@300;400;500;600;700&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=9">
+    <link rel="stylesheet" href="/labs/shared.css?v=10">
     <link rel="stylesheet" href="style.css">
 
     <script type="importmap">
@@ -194,7 +194,7 @@
         <footer data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=8" defer></script>
+    <script src="/labs/shared.js?v=9" defer></script>
     <script type="module" src="./src/main.js"></script>
 </body>
 

--- a/labs/quimera/index.html
+++ b/labs/quimera/index.html
@@ -194,7 +194,7 @@
         <footer data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=10" defer></script>
+    <script src="/labs/shared.js?v=11" defer></script>
     <script type="module" src="./src/main.js"></script>
 </body>
 

--- a/labs/quimera/style.css
+++ b/labs/quimera/style.css
@@ -277,7 +277,8 @@ header[data-lab-header] {
 }
 
 .step {
-    height: 2.4rem;
+    /* O sequenciador é tocado em ritmo: alvo curto = passo errado ligado. */
+    height: max(2.4rem, var(--touch-target));
     border-radius: 12px;
     font-size: 1.4rem;
     line-height: 1;

--- a/labs/rastro-vermelho/index.html
+++ b/labs/rastro-vermelho/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.babylonjs.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;600;700;800&family=Outfit:wght@300;400;500;600;700&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=10">
+    <link rel="stylesheet" href="/labs/shared.css?v=11">
     <link rel="stylesheet" href="style.css?v=1">
 
     <script type="application/ld+json">
@@ -257,7 +257,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=9" defer></script>
+    <script src="/labs/shared.js?v=10" defer></script>
     <script>
         (function () {
             function hasGpu() {

--- a/labs/rastro-vermelho/index.html
+++ b/labs/rastro-vermelho/index.html
@@ -257,7 +257,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=10" defer></script>
+    <script src="/labs/shared.js?v=11" defer></script>
     <script>
         (function () {
             function hasGpu() {

--- a/labs/rastro-vermelho/index.html
+++ b/labs/rastro-vermelho/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.babylonjs.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;600;700;800&family=Outfit:wght@300;400;500;600;700&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=8">
+    <link rel="stylesheet" href="/labs/shared.css?v=10">
     <link rel="stylesheet" href="style.css?v=1">
 
     <script type="application/ld+json">
@@ -257,7 +257,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=6" defer></script>
+    <script src="/labs/shared.js?v=9" defer></script>
     <script>
         (function () {
             function hasGpu() {

--- a/labs/ravi-123/index.html
+++ b/labs/ravi-123/index.html
@@ -27,7 +27,7 @@
     content="Conte de 1 a 9 e ajude o Ravi a convidar heróis para a maior festa surpresa do reino. Pixel art 320×200, tudo em vanilla.">
   <meta property="og:locale" content="pt_BR">
 
-  <link rel="stylesheet" href="/labs/shared.css?v=9">
+  <link rel="stylesheet" href="/labs/shared.css?v=10">
   <link rel="stylesheet" href="style.css?v=23">
   <script type="application/ld+json">
   {
@@ -104,7 +104,7 @@
   </noscript>
 
   <script type="module" src="main.js?v=23"></script>
-  <script src="/labs/shared.js?v=8" defer></script>
+  <script src="/labs/shared.js?v=9" defer></script>
 </body>
 
 </html>

--- a/labs/ravi-123/index.html
+++ b/labs/ravi-123/index.html
@@ -104,7 +104,7 @@
   </noscript>
 
   <script type="module" src="main.js?v=23"></script>
-  <script src="/labs/shared.js?v=10" defer></script>
+  <script src="/labs/shared.js?v=11" defer></script>
 </body>
 
 </html>

--- a/labs/ravi-123/index.html
+++ b/labs/ravi-123/index.html
@@ -27,7 +27,7 @@
     content="Conte de 1 a 9 e ajude o Ravi a convidar heróis para a maior festa surpresa do reino. Pixel art 320×200, tudo em vanilla.">
   <meta property="og:locale" content="pt_BR">
 
-  <link rel="stylesheet" href="/labs/shared.css?v=10">
+  <link rel="stylesheet" href="/labs/shared.css?v=11">
   <link rel="stylesheet" href="style.css?v=23">
   <script type="application/ld+json">
   {
@@ -104,7 +104,7 @@
   </noscript>
 
   <script type="module" src="main.js?v=23"></script>
-  <script src="/labs/shared.js?v=9" defer></script>
+  <script src="/labs/shared.js?v=10" defer></script>
 </body>
 
 </html>

--- a/labs/riftball/index.html
+++ b/labs/riftball/index.html
@@ -284,7 +284,7 @@
     </main>
 
     <script src="https://cdn.jsdelivr.net/npm/peerjs@1.5.4/dist/peerjs.min.js" defer></script>
-    <script src="/labs/shared.js?v=10" defer></script>
+    <script src="/labs/shared.js?v=11" defer></script>
     <script type="module" src="src/main.js"></script>
 </body>
 

--- a/labs/riftball/index.html
+++ b/labs/riftball/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600;700;800&family=Syne:wght@700;800&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=9">
+    <link rel="stylesheet" href="/labs/shared.css?v=10">
     <link rel="stylesheet" href="style.css">
 
     <script type="importmap">
@@ -284,7 +284,7 @@
     </main>
 
     <script src="https://cdn.jsdelivr.net/npm/peerjs@1.5.4/dist/peerjs.min.js" defer></script>
-    <script src="/labs/shared.js?v=8" defer></script>
+    <script src="/labs/shared.js?v=9" defer></script>
     <script type="module" src="src/main.js"></script>
 </body>
 

--- a/labs/riftball/index.html
+++ b/labs/riftball/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600;700;800&family=Syne:wght@700;800&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=10">
+    <link rel="stylesheet" href="/labs/shared.css?v=11">
     <link rel="stylesheet" href="style.css">
 
     <script type="importmap">
@@ -284,7 +284,7 @@
     </main>
 
     <script src="https://cdn.jsdelivr.net/npm/peerjs@1.5.4/dist/peerjs.min.js" defer></script>
-    <script src="/labs/shared.js?v=9" defer></script>
+    <script src="/labs/shared.js?v=10" defer></script>
     <script type="module" src="src/main.js"></script>
 </body>
 

--- a/labs/river-knight/index.html
+++ b/labs/river-knight/index.html
@@ -300,7 +300,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=10" defer></script>
+    <script src="/labs/shared.js?v=11" defer></script>
     <script type="module" src="src/main.js?v=16"></script>
 </body>
 

--- a/labs/river-knight/index.html
+++ b/labs/river-knight/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;600;700;800&family=Outfit:wght@300;400;500;600;700&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=10">
+    <link rel="stylesheet" href="/labs/shared.css?v=11">
     <link rel="stylesheet" href="style.css?v=5">
 
     <script type="importmap">
@@ -300,7 +300,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=9" defer></script>
+    <script src="/labs/shared.js?v=10" defer></script>
     <script type="module" src="src/main.js?v=16"></script>
 </body>
 

--- a/labs/river-knight/index.html
+++ b/labs/river-knight/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;600;700;800&family=Outfit:wght@300;400;500;600;700&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=9">
+    <link rel="stylesheet" href="/labs/shared.css?v=10">
     <link rel="stylesheet" href="style.css?v=5">
 
     <script type="importmap">
@@ -300,7 +300,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=8" defer></script>
+    <script src="/labs/shared.js?v=9" defer></script>
     <script type="module" src="src/main.js?v=16"></script>
 </body>
 

--- a/labs/river-knight/style.css
+++ b/labs/river-knight/style.css
@@ -1015,10 +1015,28 @@ input[type="range"] {
     -webkit-appearance: none;
     appearance: none;
     width: 100%;
+    /* 44px de alvo tocável; o trilho visível de 5px vive nos
+       pseudo-elementos abaixo, então o desenho não muda. */
+    height: var(--touch-target);
+    border: none;
+    background: transparent;
+    outline: none;
+    cursor: pointer;
+    touch-action: pan-y;
+}
+
+input[type="range"]::-webkit-slider-runnable-track {
     height: 5px;
     border-radius: 99px;
     background: rgba(255, 255, 255, 0.12);
-    outline: none;
+    border: none;
+}
+
+input[type="range"]::-moz-range-track {
+    height: 5px;
+    border-radius: 99px;
+    background: rgba(255, 255, 255, 0.12);
+    border: none;
 }
 
 input[type="range"]::-webkit-slider-thumb {
@@ -1029,6 +1047,8 @@ input[type="range"]::-webkit-slider-thumb {
     background: var(--gold);
     box-shadow: 0 0 12px oklch(75% 0.15 80 / 0.7);
     cursor: pointer;
+    /* (trilho 5px - thumb 16px) / 2 */
+    margin-top: -5.5px;
 }
 
 input[type="range"]::-moz-range-thumb {

--- a/labs/rock-kombat/index.html
+++ b/labs/rock-kombat/index.html
@@ -264,7 +264,7 @@
 
   <footer data-lab-footer data-home-href="/"></footer>
 
-  <script src="/labs/shared.js?v=10" defer></script>
+  <script src="/labs/shared.js?v=11" defer></script>
   <script type="module" src="main.js?v=4"></script>
 </body>
 </html>

--- a/labs/rock-kombat/index.html
+++ b/labs/rock-kombat/index.html
@@ -22,7 +22,7 @@
   <meta property="og:title" content="Rock Kombat — 2D Arcade Fight | Diogo Paulino">
   <meta property="og:description" content="Escolha sua lenda. Leia a distância. Domine o palco.">
   <meta property="og:url" content="https://diogopaulino.com.br/labs/rock-kombat/">
-  <link rel="stylesheet" href="/labs/shared.css?v=10">
+  <link rel="stylesheet" href="/labs/shared.css?v=11">
   <link rel="stylesheet" href="style.css?v=6">
   <script type="application/ld+json">
   {
@@ -264,7 +264,7 @@
 
   <footer data-lab-footer data-home-href="/"></footer>
 
-  <script src="/labs/shared.js?v=9" defer></script>
+  <script src="/labs/shared.js?v=10" defer></script>
   <script type="module" src="main.js?v=4"></script>
 </body>
 </html>

--- a/labs/rock-kombat/index.html
+++ b/labs/rock-kombat/index.html
@@ -22,7 +22,7 @@
   <meta property="og:title" content="Rock Kombat — 2D Arcade Fight | Diogo Paulino">
   <meta property="og:description" content="Escolha sua lenda. Leia a distância. Domine o palco.">
   <meta property="og:url" content="https://diogopaulino.com.br/labs/rock-kombat/">
-  <link rel="stylesheet" href="/labs/shared.css?v=9">
+  <link rel="stylesheet" href="/labs/shared.css?v=10">
   <link rel="stylesheet" href="style.css?v=6">
   <script type="application/ld+json">
   {
@@ -264,7 +264,7 @@
 
   <footer data-lab-footer data-home-href="/"></footer>
 
-  <script src="/labs/shared.js?v=8" defer></script>
+  <script src="/labs/shared.js?v=9" defer></script>
   <script type="module" src="main.js?v=4"></script>
 </body>
 </html>

--- a/labs/safari-dourado/index.html
+++ b/labs/safari-dourado/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.babylonjs.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@500;600;700;800&family=Outfit:wght@300;400;500;600;700&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=9">
+    <link rel="stylesheet" href="/labs/shared.css?v=10">
     <link rel="stylesheet" href="style.css?v=1">
 
     <script type="application/ld+json">

--- a/labs/safari-dourado/index.html
+++ b/labs/safari-dourado/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.babylonjs.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@500;600;700;800&family=Outfit:wght@300;400;500;600;700&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=10">
+    <link rel="stylesheet" href="/labs/shared.css?v=11">
     <link rel="stylesheet" href="style.css?v=1">
 
     <script type="application/ld+json">
@@ -206,7 +206,7 @@
 
     <script src="https://cdn.babylonjs.com/babylon.js"></script>
     <script src="https://cdn.babylonjs.com/loaders/babylonjs.loaders.min.js"></script>
-    <script src="/labs/shared.js?v=9" defer></script>
+    <script src="/labs/shared.js?v=10" defer></script>
     <script type="module" src="src/main.js"></script>
 </body>
 

--- a/labs/safari-dourado/index.html
+++ b/labs/safari-dourado/index.html
@@ -206,7 +206,7 @@
 
     <script src="https://cdn.babylonjs.com/babylon.js"></script>
     <script src="https://cdn.babylonjs.com/loaders/babylonjs.loaders.min.js"></script>
-    <script src="/labs/shared.js?v=10" defer></script>
+    <script src="/labs/shared.js?v=11" defer></script>
     <script type="module" src="src/main.js"></script>
 </body>
 

--- a/labs/shared.css
+++ b/labs/shared.css
@@ -2,6 +2,15 @@
 
 :root {
     color-scheme: light;
+
+    /* Insets do notch/home indicator expostos como token: qualquer lab pode usar
+       var(--safe-top) sem repetir o fallback do env() (que é 0 fora do iOS). */
+    --safe-top: env(safe-area-inset-top, 0px);
+    --safe-right: env(safe-area-inset-right, 0px);
+    --safe-bottom: env(safe-area-inset-bottom, 0px);
+    --safe-left: env(safe-area-inset-left, 0px);
+    --touch-target: 44px;
+
     --glass-bg: rgba(255, 255, 255, 0.7);
     --glass-border: rgba(255, 255, 255, 0.5);
     --glass-shadow: 0 8px 32px 0 rgba(31, 38, 135, 0.07);
@@ -283,6 +292,58 @@ header h1 {
     transform: scale(1) rotate(0);
 }
 
+/* Botão de ícone do header (som, ajuda, fullscreen…). Compartilhado porque
+   vários labs precisam do mesmo affordance ao lado do switch de tema. */
+.lab-icon-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 40px;
+    height: 40px;
+    padding: 0;
+    font-size: 1.1rem;
+    line-height: 1;
+    border-radius: 50%;
+    border: 1px solid var(--border-subtle);
+    background: var(--bg-card);
+    color: var(--text-primary);
+    cursor: pointer;
+    font-family: inherit;
+    box-shadow: var(--shadow-sm);
+    transition: border-color 0.25s ease, transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.lab-icon-btn:hover {
+    border-color: var(--accent);
+    transform: translateY(-1px);
+    box-shadow: var(--shadow-md);
+}
+
+.lab-icon-btn:focus-visible {
+    outline: 3px solid var(--focus-ring);
+    outline-offset: 3px;
+}
+
+.lab-icon-btn[aria-pressed="true"] {
+    border-color: var(--accent);
+}
+
+/* Dicas de controle específicas de cada entrada: a instrução de swipe só faz
+   sentido no toque, o atalho de teclado só faz sentido com teclado. */
+.touch-only {
+    display: none;
+}
+
+@media (pointer: coarse) {
+    .touch-only {
+        display: revert;
+    }
+
+    .fine-only {
+        display: none;
+    }
+}
+
 /* Footer */
 footer {
     width: 100%;
@@ -304,6 +365,12 @@ footer a {
     text-decoration: none;
     font-weight: 500;
     transition: color 0.3s ease;
+    /* O link do rodapé tem ~14px de altura de texto. O padding vertical leva a
+       área tocável a 44px sem mudar o desenho da faixa. */
+    display: inline-flex;
+    align-items: center;
+    min-height: var(--touch-target);
+    padding-inline: 0.5rem;
 }
 
 footer a:hover {
@@ -369,6 +436,62 @@ footer a:hover {
         font-size: 0.8rem;
         flex-direction: column;
         gap: 0.25rem;
+    }
+}
+
+/* Landscape curto (celular deitado, ~667x375): o chrome do lab não pode comer a
+   altura útil do canvas. Encolhe header/footer e mantém os insets laterais do notch. */
+@media (max-height: 520px) and (orientation: landscape) {
+    body {
+        padding: max(0.5rem, var(--safe-top))
+            max(0.75rem, var(--safe-right))
+            max(0.5rem, var(--safe-bottom))
+            max(0.75rem, var(--safe-left));
+    }
+
+    header {
+        margin-bottom: 0.75rem;
+        gap: 0.5rem;
+    }
+
+    header h1,
+    header .app-logo {
+        font-size: clamp(0.95rem, 3.2vw, 1.15rem);
+    }
+
+    header .subtitle {
+        display: none;
+    }
+
+    footer {
+        margin-top: 1rem;
+        padding-block: 0.75rem;
+    }
+}
+
+/* Toque: qualquer controle do chrome compartilhado precisa caber o dedo.
+   O switch de tema é visualmente 64x32, então a área clicável cresce por pseudo-elemento
+   em vez de esticar o desenho. */
+@media (pointer: coarse) {
+    .back-link,
+    .header-actions button,
+    .header-actions a {
+        min-height: var(--touch-target);
+        min-width: var(--touch-target);
+    }
+
+    .theme-toggle::after {
+        content: "";
+        position: absolute;
+        inset: 50% auto auto 50%;
+        width: max(100%, var(--touch-target));
+        height: var(--touch-target);
+        transform: translate(-50%, -50%);
+    }
+
+    .back-link:hover,
+    .theme-toggle:hover {
+        transform: none;
     }
 }
 

--- a/labs/shared.css
+++ b/labs/shared.css
@@ -495,6 +495,87 @@ footer a:hover {
     }
 }
 
+/* Aviso de engine que não carregou (ver shared.js). Fica por cima de tudo
+   porque o que está embaixo é um canvas vazio. */
+.lab-engine-notice {
+    position: fixed;
+    inset: 0;
+    z-index: 9999;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: max(1rem, var(--safe-top)) max(1rem, var(--safe-right))
+        max(1rem, var(--safe-bottom)) max(1rem, var(--safe-left));
+    background: rgba(8, 10, 14, 0.82);
+    backdrop-filter: blur(6px);
+    -webkit-backdrop-filter: blur(6px);
+}
+
+.lab-engine-notice__card {
+    max-width: min(28rem, 100%);
+    max-height: min(92dvh, 100%);
+    overflow-y: auto;
+    padding: clamp(1.25rem, 5vw, 2rem);
+    border-radius: 1.25rem;
+    border: 1px solid rgba(255, 255, 255, 0.14);
+    background: #14181f;
+    color: #eef2f7;
+    text-align: center;
+    box-shadow: 0 24px 60px rgba(0, 0, 0, 0.5);
+}
+
+.lab-engine-notice__title {
+    font-size: clamp(1.1rem, 4.5vw, 1.4rem);
+    font-weight: 700;
+    margin-bottom: 0.6rem;
+}
+
+.lab-engine-notice__text {
+    font-size: 0.95rem;
+    line-height: 1.55;
+    color: rgba(238, 242, 247, 0.78);
+}
+
+.lab-engine-notice__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.6rem;
+    justify-content: center;
+    margin-top: 1.25rem;
+}
+
+.lab-engine-notice__btn,
+.lab-engine-notice__link {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: var(--touch-target);
+    padding: 0.6rem 1.4rem;
+    border-radius: 999px;
+    font: inherit;
+    font-weight: 600;
+    text-decoration: none;
+    cursor: pointer;
+}
+
+.lab-engine-notice__btn {
+    border: 0;
+    background: #4f8bf0;
+    color: #fff;
+}
+
+.lab-engine-notice__link {
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    background: transparent;
+    color: #eef2f7;
+}
+
+.lab-engine-notice__btn:focus-visible,
+.lab-engine-notice__link:focus-visible {
+    outline: 3px solid var(--focus-ring);
+    outline-offset: 3px;
+}
+
 @media (prefers-reduced-motion: reduce) {
     html {
         scroll-behavior: auto;

--- a/labs/shared.js
+++ b/labs/shared.js
@@ -422,13 +422,18 @@
         ensureFavicon();
         initChrome();
         ensureThemeCore();
-        watchModuleFailures();
         // Depois do load: até lá o script do CDN teve sua chance de definir o global.
         if (document.readyState === 'complete') setTimeout(checkEngines, 400);
         else window.addEventListener('load', () => setTimeout(checkEngines, 400), { once: true });
     }
 
     applySavedTheme();
+    /* Registrado já na avaliação do script, não no init: o `error` do
+       <script type="module"> pode disparar antes do DOMContentLoaded, e um
+       listener criado depois disso perderia o evento (foi o que acontecia no
+       Mimo, que carrega este arquivo de forma síncrona). */
+    watchModuleFailures();
+
     window.LabShell = Object.freeze({ init, buildHeader, buildFooter });
     window.LabAudio = AudioAPI;
 

--- a/labs/shared.js
+++ b/labs/shared.js
@@ -344,10 +344,88 @@
         });
     })();
 
+    /* --- Rede caiu, engine não veio ---------------------------------------
+       Metade dos labs carrega Babylon ou three.js de CDN. Quando o CDN falha
+       (rede ruim, bloqueio corporativo, offline) a página abre PRETA e sem uma
+       palavra: o canvas fica lá, vazio, e o erro só aparece no console.
+
+       Esta guarda transforma isso numa mensagem. Ela não tenta consertar nada
+       — só explica o que houve e oferece recarregar. */
+    const ENGINE_PROBES = [
+        { host: 'cdn.babylonjs.com', global: 'BABYLON', label: 'Babylon.js' },
+        { host: 'cdn.jsdelivr.net/npm/pixi.js', global: 'PIXI', label: 'PixiJS' }
+    ];
+
+    let engineNoticeShown = false;
+
+    function showEngineNotice(label) {
+        if (engineNoticeShown) return;
+        engineNoticeShown = true;
+
+        const notice = document.createElement('div');
+        notice.className = 'lab-engine-notice';
+        notice.setAttribute('role', 'alert');
+        notice.innerHTML = `
+            <div class="lab-engine-notice__card">
+                <p class="lab-engine-notice__title">Não deu para carregar o ${label}</p>
+                <p class="lab-engine-notice__text">
+                    Este lab desenha em 3D com uma biblioteca que vem de um CDN, e o
+                    navegador não conseguiu buscá-la. Costuma ser conexão instável ou
+                    uma rede que bloqueia o domínio.
+                </p>
+                <div class="lab-engine-notice__actions">
+                    <button type="button" class="lab-engine-notice__btn" data-engine-retry>Tentar de novo</button>
+                    <a class="lab-engine-notice__link" href="/labs/">Voltar aos labs</a>
+                </div>
+            </div>
+        `;
+        notice.querySelector('[data-engine-retry]').addEventListener('click', () => location.reload());
+        document.body.appendChild(notice);
+    }
+
+    /* Um lab só é cobrado pelo global se de fato pedir aquele script. */
+    function checkEngines() {
+        const html = Array.from(document.scripts).map(el => el.src || '').join(' ');
+        for (const probe of ENGINE_PROBES) {
+            if (html.includes(probe.host) && !window[probe.global]) {
+                showEngineNotice(probe.label);
+                return;
+            }
+        }
+    }
+
+    /* Scripts cuja falha realmente inviabiliza o lab. Um pacote de ícones que
+       não carrega deixa a página feia, não quebrada — avisar ali seria alarme
+       falso, então a lista é só de motores gráficos. */
+    const CRITICAL_SCRIPT = /babylonjs|pixi\.js|\bthree(\.module)?\.js|three@/;
+
+    function watchModuleFailures() {
+        /* three.js entra por importmap dentro de <script type="module">: não há
+           global para checar, e a falha de import não sobe como erro de janela.
+           O evento `error` no próprio elemento do script sobe — mas só na fase
+           de captura, porque não borbulha. */
+        window.addEventListener('error', (event) => {
+            const target = event.target;
+            if (!target || target === window || target.tagName !== 'SCRIPT') return;
+
+            const src = target.src || '';
+            // Módulo local que falhou por causa do import de CDN conta; módulo
+            // local com erro próprio, não — por isso o teste do importmap.
+            const isEngineModule = target.type === 'module' && document.querySelector('script[type="importmap"]');
+            if (isEngineModule || CRITICAL_SCRIPT.test(src)) {
+                showEngineNotice('motor 3D');
+            }
+        }, true);
+    }
+
     function init() {
         ensureFavicon();
         initChrome();
         ensureThemeCore();
+        watchModuleFailures();
+        // Depois do load: até lá o script do CDN teve sua chance de definir o global.
+        if (document.readyState === 'complete') setTimeout(checkEngines, 400);
+        else window.addEventListener('load', () => setTimeout(checkEngines, 400), { once: true });
     }
 
     applySavedTheme();

--- a/labs/shared.js
+++ b/labs/shared.js
@@ -167,6 +167,183 @@
         document.head.appendChild(icon);
     }
 
+    /* --- LabAudio ----------------------------------------------------------
+       Sintetizador mínimo compartilhado pelos labs: nenhum asset de áudio, só
+       osciladores criados na hora. Existe aqui (e não em cada lab) porque a
+       parte chata é sempre a mesma — política de autoplay, mudo persistido e o
+       botão do header.
+
+       O AudioContext só nasce no primeiro som pedido depois de um gesto do
+       usuário; antes disso os navegadores recusam ou criam um contexto suspenso
+       que nunca toca. */
+    const AudioAPI = (function () {
+        let ctx = null;
+        let master = null;
+        let storageKey = 'labs:muted';
+        let muted = false;
+        let volume = 0.5;
+        const listeners = new Set();
+
+        function readMuted() {
+            try {
+                return localStorage.getItem(storageKey) === '1';
+            } catch (err) {
+                return false;
+            }
+        }
+
+        function persist() {
+            try {
+                localStorage.setItem(storageKey, muted ? '1' : '0');
+            } catch (err) {
+                /* Storage can be unavailable in private browsing contexts. */
+            }
+        }
+
+        function ensureContext() {
+            if (muted) return null;
+            if (!ctx) {
+                const Ctx = window.AudioContext || window.webkitAudioContext;
+                if (!Ctx) return null;
+                ctx = new Ctx();
+                master = ctx.createGain();
+                master.gain.value = volume;
+                master.connect(ctx.destination);
+            }
+            if (ctx.state === 'suspended') ctx.resume();
+            return ctx;
+        }
+
+        /* Uma nota. `slideTo` faz o glissando usado em power-ups e quedas;
+           `delay` agenda sem setTimeout, então a sequência não desalinha se a
+           thread principal engasgar. */
+        function tone(options) {
+            const audio = ensureContext();
+            if (!audio) return;
+
+            const {
+                freq = 440,
+                duration = 0.12,
+                type = 'square',
+                gain = 0.18,
+                delay = 0,
+                slideTo = null,
+                attack = 0.006
+            } = options || {};
+
+            const start = audio.currentTime + delay;
+            const osc = audio.createOscillator();
+            const amp = audio.createGain();
+
+            osc.type = type;
+            osc.frequency.setValueAtTime(freq, start);
+            if (slideTo && slideTo > 0) {
+                osc.frequency.exponentialRampToValueAtTime(slideTo, start + duration);
+            }
+
+            amp.gain.setValueAtTime(0.0001, start);
+            amp.gain.linearRampToValueAtTime(gain, start + attack);
+            amp.gain.exponentialRampToValueAtTime(0.0001, start + duration);
+
+            osc.connect(amp).connect(master);
+            osc.start(start);
+            osc.stop(start + duration + 0.03);
+        }
+
+        /* Ruído branco filtrado: percussão, explosão, passo. */
+        function noise(options) {
+            const audio = ensureContext();
+            if (!audio) return;
+
+            const { duration = 0.18, gain = 0.12, delay = 0, filter = 1200, type = 'lowpass' } = options || {};
+            const start = audio.currentTime + delay;
+            const frames = Math.max(1, Math.floor(audio.sampleRate * duration));
+            const buffer = audio.createBuffer(1, frames, audio.sampleRate);
+            const data = buffer.getChannelData(0);
+            for (let i = 0; i < frames; i++) data[i] = Math.random() * 2 - 1;
+
+            const src = audio.createBufferSource();
+            src.buffer = buffer;
+
+            const biquad = audio.createBiquadFilter();
+            biquad.type = type;
+            biquad.frequency.value = filter;
+
+            const amp = audio.createGain();
+            amp.gain.setValueAtTime(gain, start);
+            amp.gain.exponentialRampToValueAtTime(0.0001, start + duration);
+
+            src.connect(biquad).connect(amp).connect(master);
+            src.start(start);
+            src.stop(start + duration + 0.02);
+        }
+
+        /* Arpejo: lista de frequências tocadas em passos regulares. */
+        function sequence(freqs, options) {
+            const { step = 0.07, duration = 0.1, type = 'square', gain = 0.16 } = options || {};
+            freqs.forEach((freq, i) => tone({ freq, duration, type, gain, delay: i * step }));
+        }
+
+        function setMuted(next) {
+            muted = Boolean(next);
+            persist();
+            if (master) master.gain.value = muted ? 0 : volume;
+            listeners.forEach(fn => fn(muted));
+        }
+
+        function configure(options) {
+            if (options && options.storageKey) {
+                storageKey = options.storageKey;
+                muted = readMuted();
+            }
+            if (options && typeof options.volume === 'number') {
+                volume = Math.max(0, Math.min(1, options.volume));
+                if (master && !muted) master.gain.value = volume;
+            }
+            return AudioAPI;
+        }
+
+        /* Botão de mudo do header. Devolve o elemento para o lab posicionar. */
+        function mountToggle(target) {
+            const host = typeof target === 'string' ? document.querySelector(target) : target;
+            if (!host) return null;
+
+            const btn = document.createElement('button');
+            btn.type = 'button';
+            btn.className = 'lab-icon-btn';
+
+            const sync = () => {
+                btn.textContent = muted ? '🔇' : '🔊';
+                btn.setAttribute('aria-pressed', String(muted));
+                btn.setAttribute('aria-label', muted ? 'Ativar som' : 'Desativar som');
+                btn.title = muted ? 'Ativar som' : 'Desativar som';
+            };
+
+            btn.addEventListener('click', () => {
+                setMuted(!muted);
+                if (!muted) tone({ freq: 880, duration: 0.07, gain: 0.14 });
+            });
+
+            listeners.add(sync);
+            sync();
+            host.appendChild(btn);
+            return btn;
+        }
+
+        muted = readMuted();
+
+        return Object.freeze({
+            configure,
+            tone,
+            noise,
+            sequence,
+            mountToggle,
+            setMuted,
+            isMuted: () => muted,
+            onChange: (fn) => { listeners.add(fn); return () => listeners.delete(fn); }
+        });
+    })();
+
     function init() {
         ensureFavicon();
         initChrome();
@@ -175,6 +352,7 @@
 
     applySavedTheme();
     window.LabShell = Object.freeze({ init, buildHeader, buildFooter });
+    window.LabAudio = AudioAPI;
 
     if (document.readyState === 'loading') {
         document.addEventListener('DOMContentLoaded', init, { once: true });

--- a/labs/snake/index.html
+++ b/labs/snake/index.html
@@ -25,8 +25,8 @@
     <meta property="og:description"
         content="Snake retrô em um console portátil 8-bit: colete frutas, ganhe velocidade e bata o seu recorde.">
     <meta property="og:url" content="https://diogopaulino.com.br/labs/snake/">
-    <link rel="stylesheet" href="/labs/shared.css?v=9">
-    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="/labs/shared.css?v=10">
+    <link rel="stylesheet" href="style.css?v=2">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
@@ -84,6 +84,10 @@
             <template data-slot="logo">
                 🐍 Retro Snake
             </template>
+            <template data-slot="actions">
+                <button type="button" id="btnMute" class="lab-icon-btn" aria-pressed="false"
+                    aria-label="Desativar som">🔊</button>
+            </template>
         </header>
 
         <main class="game-container">
@@ -92,6 +96,7 @@
                     <div class="screen-glass">
                         <div class="lcd-hud" aria-hidden="true">
                             <span class="lcd-item"><span class="lcd-key">SC</span><span id="hudScore">000</span></span>
+                            <span class="lcd-item"><span class="lcd-key">LV</span><span id="hudLevel">1</span></span>
                             <span class="lcd-item"><span class="lcd-key">HI</span><span id="hudBest">000</span></span>
                         </div>
                         <div class="screen-play">
@@ -99,7 +104,7 @@
                                 aria-label="Tabuleiro do jogo Snake"></canvas>
                             <div class="ui-overlay" id="startScreen">
                                 <h2>SNAKE</h2>
-                                <p>Pressione Start</p>
+                                <p>Toque a tela ou Start</p>
                             </div>
                             <div class="ui-overlay hidden" id="pauseScreen">
                                 <h2>PAUSA</h2>
@@ -164,6 +169,8 @@
             <p id="gameStatus" class="sr-only" role="status" aria-live="polite"></p>
 
             <div class="instructions">
+                <p class="touch-only"><strong>Deslize na tela</strong> para virar · <strong>toque</strong> para
+                    jogar/pausar</p>
                 <p>Use as <strong>Setas</strong> ou o <strong>D-Pad</strong> para mover</p>
                 <p>Pressione <strong>Enter</strong> ou <strong>Start</strong> para Jogar/Pausar</p>
             </div>
@@ -172,8 +179,8 @@
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
 
-    <script src="/labs/shared.js?v=8" defer></script>
-    <script src="script.js?v=2" defer></script>
+    <script src="/labs/shared.js?v=9" defer></script>
+    <script src="script.js?v=3" defer></script>
 </body>
 
 </html>

--- a/labs/snake/index.html
+++ b/labs/snake/index.html
@@ -25,7 +25,7 @@
     <meta property="og:description"
         content="Snake retrô em um console portátil 8-bit: colete frutas, ganhe velocidade e bata o seu recorde.">
     <meta property="og:url" content="https://diogopaulino.com.br/labs/snake/">
-    <link rel="stylesheet" href="/labs/shared.css?v=10">
+    <link rel="stylesheet" href="/labs/shared.css?v=11">
     <link rel="stylesheet" href="style.css?v=2">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -179,7 +179,7 @@
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
 
-    <script src="/labs/shared.js?v=9" defer></script>
+    <script src="/labs/shared.js?v=10" defer></script>
     <script src="script.js?v=3" defer></script>
 </body>
 

--- a/labs/snake/index.html
+++ b/labs/snake/index.html
@@ -179,7 +179,7 @@
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
 
-    <script src="/labs/shared.js?v=10" defer></script>
+    <script src="/labs/shared.js?v=11" defer></script>
     <script src="script.js?v=3" defer></script>
 </body>
 

--- a/labs/snake/script.js
+++ b/labs/snake/script.js
@@ -6,6 +6,9 @@ const gameOverScreen = document.getElementById('gameOverScreen');
 const finalScoreSpan = document.getElementById('finalScore');
 const hudScore = document.getElementById('hudScore');
 const hudBest = document.getElementById('hudBest');
+const hudLevel = document.getElementById('hudLevel');
+const muteBtn = document.getElementById('btnMute');
+const screenPlay = document.querySelector('.screen-play');
 const statusLive = document.getElementById('gameStatus');
 const powerLed = document.querySelector('.power-led');
 
@@ -48,6 +51,81 @@ function syncColors() {
     COLORS.food = COLORS.snake;
 }
 
+/* --- Áudio 8-bit -----------------------------------------------------------
+   Ondas quadradas curtas sintetizadas na hora: nenhum asset, mesmo timbre do
+   console que o aparelho imita. O contexto só nasce no primeiro gesto do
+   usuário porque navegadores bloqueiam áudio antes disso. */
+const SOUND_KEY = 'snakeMuted';
+let audioCtx = null;
+let muted = readMuted();
+
+function readMuted() {
+    try {
+        return localStorage.getItem(SOUND_KEY) === '1';
+    } catch (err) {
+        return false;
+    }
+}
+
+function saveMuted(value) {
+    try {
+        localStorage.setItem(SOUND_KEY, value ? '1' : '0');
+    } catch (err) {
+        /* Storage can be unavailable in private browsing contexts. */
+    }
+}
+
+function ensureAudio() {
+    if (muted) return null;
+    if (!audioCtx) {
+        const Ctx = window.AudioContext || window.webkitAudioContext;
+        if (!Ctx) return null;
+        audioCtx = new Ctx();
+    }
+    if (audioCtx.state === 'suspended') audioCtx.resume();
+    return audioCtx;
+}
+
+function blip(freq, duration = 0.08, type = 'square', gain = 0.05) {
+    const ctxAudio = ensureAudio();
+    if (!ctxAudio) return;
+    const now = ctxAudio.currentTime;
+    const osc = ctxAudio.createOscillator();
+    const amp = ctxAudio.createGain();
+    osc.type = type;
+    osc.frequency.setValueAtTime(freq, now);
+    amp.gain.setValueAtTime(0, now);
+    amp.gain.linearRampToValueAtTime(gain, now + 0.008);
+    amp.gain.exponentialRampToValueAtTime(0.0001, now + duration);
+    osc.connect(amp).connect(ctxAudio.destination);
+    osc.start(now);
+    osc.stop(now + duration + 0.02);
+}
+
+function sfxEat() {
+    blip(660, 0.06);
+    setTimeout(() => blip(990, 0.07), 55);
+}
+
+function sfxTurn() {
+    blip(320, 0.03, 'square', 0.022);
+}
+
+function sfxStart() {
+    [523, 659, 784, 1047].forEach((f, i) => setTimeout(() => blip(f, 0.09), i * 70));
+}
+
+function sfxDeath() {
+    [440, 349, 262, 175].forEach((f, i) => setTimeout(() => blip(f, 0.16, 'sawtooth', 0.045), i * 110));
+}
+
+function syncMuteButton() {
+    if (!muteBtn) return;
+    muteBtn.setAttribute('aria-pressed', String(muted));
+    muteBtn.setAttribute('aria-label', muted ? 'Ativar som' : 'Desativar som');
+    muteBtn.textContent = muted ? '🔇' : '🔊';
+}
+
 function readHighScore() {
     try {
         return Number(localStorage.getItem(STORAGE_KEY)) || 0;
@@ -68,9 +146,17 @@ function pad(value) {
     return String(Math.min(999, value)).padStart(3, '0');
 }
 
+// O nível é derivado da velocidade: quanto menor o intervalo entre passos,
+// mais alto o nível. Assim o HUD conta a mesma história que o jogo sente.
+function currentLevel() {
+    const ramp = (BASE_SPEED - stepInterval) / (BASE_SPEED - MIN_SPEED);
+    return 1 + Math.round(ramp * 9);
+}
+
 function updateHud() {
     hudScore.textContent = pad(score);
     hudBest.textContent = pad(highScore);
+    if (hudLevel) hudLevel.textContent = String(currentLevel());
 }
 
 function announce(message) {
@@ -99,8 +185,11 @@ function initGame() {
     pauseScreen.classList.add('hidden');
     gameOverScreen.classList.add('hidden');
     powerLed.classList.add('on');
+    eatPulse = 0;
+    deathFlash = 0;
     updateHud();
     announce('Partida iniciada.');
+    sfxStart();
 
     startLoop();
 }
@@ -139,6 +228,11 @@ function gameLoop(timestamp) {
     // Cap the delta so a backgrounded tab never replays a burst of steps.
     const delta = Math.min(timestamp - lastFrame, 250);
     lastFrame = timestamp;
+
+    // Efeitos decaem em tempo real (independente do passo fixo do jogo).
+    foodPhase += delta / 260;
+    eatPulse = Math.max(0, eatPulse - delta / 220);
+    deathFlash = Math.max(0, deathFlash - delta / 420);
 
     if (isGameRunning && !isPaused) {
         accumulator += delta;
@@ -188,70 +282,203 @@ function update() {
         // Each fruit shaves a little off the step interval for a difficulty ramp.
         stepInterval = Math.max(MIN_SPEED, BASE_SPEED - Math.floor(score / 10) * 3);
         placeFood();
+        eatPulse = 1;
+        sfxEat();
         updateHud();
     } else {
         snake.pop();
     }
 }
 
+/* --- Render ----------------------------------------------------------------
+   Efeitos de tela guardados fora do estado de jogo: decaem por frame, então
+   nunca alteram a simulação (que roda em passos fixos de `stepInterval`). */
+let eatPulse = 0;    // 1 → 0 logo depois de comer: brilho na fruta e na cabeça
+let deathFlash = 0;  // 1 → 0 na morte: inverte a tela por alguns frames
+let foodPhase = 0;   // fase da respiração da fruta
+
+// Um retângulo com cantos arredondados só onde a cobra NÃO continua. É isso que
+// transforma quadradinhos soltos em um corpo contínuo — sem sair do look 8-bit,
+// porque o raio é 1/4 da célula.
+function bodyCell(x, y, prev, next) {
+    const px = x * GRID_SIZE;
+    const py = y * GRID_SIZE;
+    const inset = 1;
+    const r = GRID_SIZE / 4;
+    const size = GRID_SIZE - inset * 2;
+
+    // Cantos: arredonda o canto quando nenhum vizinho ocupa os dois lados dele.
+    const up = (prev && prev.y === y - 1) || (next && next.y === y - 1);
+    const down = (prev && prev.y === y + 1) || (next && next.y === y + 1);
+    const left = (prev && prev.x === x - 1) || (next && next.x === x - 1);
+    const right = (prev && prev.x === x + 1) || (next && next.x === x + 1);
+
+    const tl = up || left ? 0 : r;
+    const tr = up || right ? 0 : r;
+    const br = down || right ? 0 : r;
+    const bl = down || left ? 0 : r;
+
+    ctx.beginPath();
+    ctx.moveTo(px + inset + tl, py + inset);
+    ctx.lineTo(px + inset + size - tr, py + inset);
+    ctx.quadraticCurveTo(px + inset + size, py + inset, px + inset + size, py + inset + tr);
+    ctx.lineTo(px + inset + size, py + inset + size - br);
+    ctx.quadraticCurveTo(px + inset + size, py + inset + size, px + inset + size - br, py + inset + size);
+    ctx.lineTo(px + inset + bl, py + inset + size);
+    ctx.quadraticCurveTo(px + inset, py + inset + size, px + inset, py + inset + size - bl);
+    ctx.lineTo(px + inset, py + inset + tl);
+    ctx.quadraticCurveTo(px + inset, py + inset, px + inset + tl, py + inset);
+    ctx.closePath();
+    ctx.fill();
+
+    // Preenche a junta com o vizinho: sem isso os cantos arredondados abrem
+    // fendas de 2px entre segmentos em linha reta.
+    if (right) ctx.fillRect(px + GRID_SIZE - inset - 1, py + inset, inset * 2 + 1, size);
+    if (down) ctx.fillRect(px + inset, py + GRID_SIZE - inset - 1, size, inset * 2 + 1);
+}
+
+function drawHeadEyes(segment) {
+    ctx.fillStyle = COLORS.bg;
+    const eye = 4;
+    const bx = segment.x * GRID_SIZE;
+    const by = segment.y * GRID_SIZE;
+    let e1, e2;
+
+    if (dx === 1) {
+        e1 = [bx + GRID_SIZE - 6, by + 4];
+        e2 = [bx + GRID_SIZE - 6, by + GRID_SIZE - 8];
+    } else if (dx === -1) {
+        e1 = [bx + 2, by + 4];
+        e2 = [bx + 2, by + GRID_SIZE - 8];
+    } else if (dy === -1) {
+        e1 = [bx + 4, by + 2];
+        e2 = [bx + GRID_SIZE - 8, by + 2];
+    } else {
+        e1 = [bx + 4, by + GRID_SIZE - 6];
+        e2 = [bx + GRID_SIZE - 8, by + GRID_SIZE - 6];
+    }
+
+    ctx.fillRect(e1[0], e1[1], eye, eye);
+    ctx.fillRect(e2[0], e2[1], eye, eye);
+}
+
+// Língua bifurcada saindo da cabeça — só quando a cobra está de fato andando.
+function drawTongue(head) {
+    if (!isGameRunning || isPaused) return;
+    const flick = Math.sin(foodPhase * 2.2) > 0.4;
+    if (!flick) return;
+
+    const cx = head.x * GRID_SIZE + GRID_SIZE / 2;
+    const cy = head.y * GRID_SIZE + GRID_SIZE / 2;
+    const reach = GRID_SIZE * 0.55;
+    const tipX = cx + dx * reach;
+    const tipY = cy + dy * reach;
+
+    ctx.strokeStyle = COLORS.snake;
+    ctx.lineWidth = 2;
+    ctx.beginPath();
+    ctx.moveTo(cx + dx * (GRID_SIZE / 2 - 1), cy + dy * (GRID_SIZE / 2 - 1));
+    ctx.lineTo(tipX, tipY);
+    // A forquilha abre perpendicular ao avanço.
+    ctx.moveTo(tipX, tipY);
+    ctx.lineTo(tipX + dy * 3 - dx * 0, tipY + dx * 3 - dy * 0);
+    ctx.moveTo(tipX, tipY);
+    ctx.lineTo(tipX - dy * 3, tipY - dx * 3);
+    ctx.stroke();
+}
+
+// Maçã: corpo redondo com talo e folha, respirando devagar. O pulso ao comer
+// reaproveita a mesma escala para dar o "pop" de coleta.
+function drawFood() {
+    const cx = food.x * GRID_SIZE + GRID_SIZE / 2;
+    const cy = food.y * GRID_SIZE + GRID_SIZE / 2;
+    const breathe = 1 + Math.sin(foodPhase) * 0.06;
+    const scale = breathe * (1 + eatPulse * 0.5);
+    const r = (GRID_SIZE / 2 - 2) * scale;
+
+    ctx.fillStyle = COLORS.food;
+    ctx.beginPath();
+    ctx.arc(cx, cy + 1, r, 0, Math.PI * 2);
+    ctx.fill();
+
+    // Talo e folha.
+    ctx.strokeStyle = COLORS.food;
+    ctx.lineWidth = 2;
+    ctx.beginPath();
+    ctx.moveTo(cx, cy - r);
+    ctx.lineTo(cx, cy - r - 3);
+    ctx.stroke();
+    ctx.beginPath();
+    ctx.ellipse(cx + 3, cy - r - 3, 3, 1.6, -0.5, 0, Math.PI * 2);
+    ctx.fill();
+
+    // Brilho: um furinho na cor do fundo, do jeito que um sprite 8-bit faria.
+    ctx.fillStyle = COLORS.bg;
+    ctx.fillRect(cx - r * 0.55, cy - r * 0.5, 2, 2);
+}
+
 function draw() {
-    // Clear Screen
     ctx.fillStyle = COLORS.bg;
     ctx.fillRect(0, 0, canvas.width, canvas.height);
 
-    // Draw Snake
+    // Grade fantasma: dá escala ao tabuleiro sem competir com a cobra.
+    ctx.globalAlpha = 0.07;
+    ctx.strokeStyle = COLORS.snake;
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    for (let x = GRID_SIZE; x < canvas.width; x += GRID_SIZE) {
+        ctx.moveTo(x + 0.5, 0);
+        ctx.lineTo(x + 0.5, canvas.height);
+    }
+    for (let y = GRID_SIZE; y < canvas.height; y += GRID_SIZE) {
+        ctx.moveTo(0, y + 0.5);
+        ctx.lineTo(canvas.width, y + 0.5);
+    }
+    ctx.stroke();
+    ctx.globalAlpha = 1;
+
+    drawFood();
+
     ctx.fillStyle = COLORS.snake;
     snake.forEach((segment, index) => {
-        // Draw slightly smaller rect for segment effect
-        ctx.fillRect(
-            segment.x * GRID_SIZE + 1,
-            segment.y * GRID_SIZE + 1,
-            GRID_SIZE - 2,
-            GRID_SIZE - 2
-        );
-
-        // Draw eyes on head
-        if (index === 0) {
-            ctx.fillStyle = COLORS.bg;
-            const eyeSize = 4;
-            // Position eyes based on direction
-            let ex1, ey1, ex2, ey2;
-
-            if (dx === 1) { // Right
-                ex1 = (segment.x + 1) * GRID_SIZE - 6; ey1 = segment.y * GRID_SIZE + 4;
-                ex2 = (segment.x + 1) * GRID_SIZE - 6; ey2 = (segment.y + 1) * GRID_SIZE - 8;
-            } else if (dx === -1) { // Left
-                ex1 = segment.x * GRID_SIZE + 2; ey1 = segment.y * GRID_SIZE + 4;
-                ex2 = segment.x * GRID_SIZE + 2; ey2 = (segment.y + 1) * GRID_SIZE - 8;
-            } else if (dy === -1) { // Up
-                ex1 = segment.x * GRID_SIZE + 4; ey1 = segment.y * GRID_SIZE + 2;
-                ex2 = (segment.x + 1) * GRID_SIZE - 8; ey2 = segment.y * GRID_SIZE + 2;
-            } else { // Down
-                ex1 = segment.x * GRID_SIZE + 4; ey1 = (segment.y + 1) * GRID_SIZE - 6;
-                ex2 = (segment.x + 1) * GRID_SIZE - 8; ey2 = (segment.y + 1) * GRID_SIZE - 6;
-            }
-
-            ctx.fillRect(ex1, ey1, eyeSize, eyeSize);
-            ctx.fillRect(ex2, ey2, eyeSize, eyeSize);
-            ctx.fillStyle = COLORS.snake; // Reset color
+        const prev = snake[index - 1];
+        const next = snake[index + 1];
+        // A cauda afina: as três últimas células encolhem progressivamente.
+        const fromTail = snake.length - 1 - index;
+        if (fromTail < 3 && snake.length > 4) {
+            const shrink = (3 - fromTail) * 1.6;
+            ctx.fillRect(
+                segment.x * GRID_SIZE + 1 + shrink / 2,
+                segment.y * GRID_SIZE + 1 + shrink / 2,
+                GRID_SIZE - 2 - shrink,
+                GRID_SIZE - 2 - shrink
+            );
+        } else {
+            bodyCell(segment.x, segment.y, prev, next);
         }
     });
 
-    // Draw Food
-    ctx.fillStyle = COLORS.food;
-    // Draw pixelated apple/food
-    const fx = food.x * GRID_SIZE;
-    const fy = food.y * GRID_SIZE;
-    const p = GRID_SIZE / 4;
+    if (snake.length) {
+        drawTongue(snake[0]);
+        ctx.fillStyle = COLORS.snake;
+        drawHeadEyes(snake[0]);
+        ctx.fillStyle = COLORS.snake;
+    }
 
-    // Simple cross shape for food
-    ctx.fillRect(fx + p, fy, p * 2, GRID_SIZE);
-    ctx.fillRect(fx, fy + p, GRID_SIZE, p * 2);
+    // Flash de morte: inverte o LCD por instantes, como um console de verdade.
+    if (deathFlash > 0) {
+        ctx.globalAlpha = deathFlash * 0.65;
+        ctx.fillStyle = COLORS.snake;
+        ctx.fillRect(0, 0, canvas.width, canvas.height);
+        ctx.globalAlpha = 1;
+    }
 }
 
 function gameOver() {
     isGameRunning = false;
     isPaused = false;
+    deathFlash = 1;
+    sfxDeath();
     stopLoop();
     pauseScreen.classList.add('hidden');
     finalScoreSpan.textContent = score;
@@ -291,6 +518,7 @@ function queueDirection(nextDx, nextDy) {
     if (nextDx === -currentDx && nextDy === -currentDy) return;
     if (nextDx === currentDx && nextDy === currentDy) return;
     queuedDirection = { dx: nextDx, dy: nextDy };
+    sfxTurn();
 }
 
 // Input Handling
@@ -347,6 +575,53 @@ document.querySelectorAll('.d-pad [data-key]').forEach(btn => {
     });
     btn.addEventListener('click', (e) => e.preventDefault());
 });
+
+/* Deslizar na tela: no celular o d-pad desenhado tem 30px e o polegar cobre a
+   LCD inteira. O swipe é o controle primário no toque; o d-pad continua ali
+   para quem prefere (e para o mouse). Um toque simples inicia/pausa. */
+const SWIPE_MIN = 24; // px — abaixo disso é toque, não gesto
+let touchStart = null;
+
+if (screenPlay) {
+    screenPlay.addEventListener('pointerdown', (e) => {
+        if (e.pointerType === 'mouse' && e.button !== 0) return;
+        touchStart = { x: e.clientX, y: e.clientY, moved: false };
+    });
+
+    screenPlay.addEventListener('pointermove', (e) => {
+        if (!touchStart || touchStart.moved) return;
+        const deltaX = e.clientX - touchStart.x;
+        const deltaY = e.clientY - touchStart.y;
+        if (Math.hypot(deltaX, deltaY) < SWIPE_MIN) return;
+
+        touchStart.moved = true;
+        // O eixo dominante decide: diagonais viram a direção mais forte em vez
+        // de serem descartadas.
+        if (Math.abs(deltaX) > Math.abs(deltaY)) {
+            handleInput(deltaX > 0 ? 'ArrowRight' : 'ArrowLeft');
+        } else {
+            handleInput(deltaY > 0 ? 'ArrowDown' : 'ArrowUp');
+        }
+    });
+
+    screenPlay.addEventListener('pointerup', () => {
+        if (touchStart && !touchStart.moved) handleInput('Start');
+        touchStart = null;
+    });
+
+    screenPlay.addEventListener('pointercancel', () => {
+        touchStart = null;
+    });
+}
+
+if (muteBtn) {
+    muteBtn.addEventListener('click', () => {
+        muted = !muted;
+        saveMuted(muted);
+        syncMuteButton();
+        if (!muted) blip(880, 0.06);
+    });
+}
 
 document.getElementById('btnStart').addEventListener('click', () => handleInput('Start'));
 document.getElementById('btnSelect').addEventListener('click', () => initGame());
@@ -405,6 +680,7 @@ window.visualViewport?.addEventListener('resize', fitDevice);
 
 // Initial Draw
 syncColors();
+syncMuteButton();
 updateHud();
 fitDevice();
 draw();

--- a/labs/snake/style.css
+++ b/labs/snake/style.css
@@ -111,6 +111,10 @@
     min-height: 0;
     /* Lets the overlays scale their type with the LCD instead of the viewport. */
     container-type: inline-size;
+    /* O swipe de direção é lido aqui; sem isso o navegador rola a página antes
+       de o gesto chegar ao jogo. */
+    touch-action: none;
+    cursor: pointer;
 }
 
 canvas {

--- a/labs/space-shooter/index.html
+++ b/labs/space-shooter/index.html
@@ -24,7 +24,7 @@
     <meta name="twitter:description" content="Jogo de tiro espacial estilo arcade com gráficos neon.">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="stylesheet" href="/labs/shared.css?v=10">
+    <link rel="stylesheet" href="/labs/shared.css?v=11">
     <link rel="stylesheet" href="style.css?v=3">
     <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
     <script type="application/ld+json">
@@ -194,7 +194,7 @@
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
 
-    <script src="/labs/shared.js?v=9" defer></script>
+    <script src="/labs/shared.js?v=10" defer></script>
     <script src="script.js?v=4" defer></script>
 </body>
 

--- a/labs/space-shooter/index.html
+++ b/labs/space-shooter/index.html
@@ -24,7 +24,7 @@
     <meta name="twitter:description" content="Jogo de tiro espacial estilo arcade com gráficos neon.">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="stylesheet" href="/labs/shared.css?v=9">
+    <link rel="stylesheet" href="/labs/shared.css?v=10">
     <link rel="stylesheet" href="style.css?v=3">
     <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
     <script type="application/ld+json">
@@ -194,7 +194,7 @@
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
 
-    <script src="/labs/shared.js?v=8" defer></script>
+    <script src="/labs/shared.js?v=9" defer></script>
     <script src="script.js?v=4" defer></script>
 </body>
 

--- a/labs/space-shooter/index.html
+++ b/labs/space-shooter/index.html
@@ -194,7 +194,7 @@
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
 
-    <script src="/labs/shared.js?v=10" defer></script>
+    <script src="/labs/shared.js?v=11" defer></script>
     <script src="script.js?v=4" defer></script>
 </body>
 

--- a/labs/spider-swing/index.html
+++ b/labs/spider-swing/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Outfit:wght@400;500;600;700&family=Share+Tech+Mono&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=10">
+    <link rel="stylesheet" href="/labs/shared.css?v=11">
     <link rel="stylesheet" href="style.css">
 
     <script type="importmap">
@@ -271,7 +271,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=9" defer></script>
+    <script src="/labs/shared.js?v=10" defer></script>
     <script type="module" src="src/main.js"></script>
 </body>
 

--- a/labs/spider-swing/index.html
+++ b/labs/spider-swing/index.html
@@ -271,7 +271,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=10" defer></script>
+    <script src="/labs/shared.js?v=11" defer></script>
     <script type="module" src="src/main.js"></script>
 </body>
 

--- a/labs/spider-swing/index.html
+++ b/labs/spider-swing/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Outfit:wght@400;500;600;700&family=Share+Tech+Mono&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=9">
+    <link rel="stylesheet" href="/labs/shared.css?v=10">
     <link rel="stylesheet" href="style.css">
 
     <script type="importmap">
@@ -271,7 +271,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=8" defer></script>
+    <script src="/labs/shared.js?v=9" defer></script>
     <script type="module" src="src/main.js"></script>
 </body>
 

--- a/labs/tamagotchi/index.html
+++ b/labs/tamagotchi/index.html
@@ -23,7 +23,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="RakuRaku Dinokun / Dinkie Dino (1997) | Diogo Paulino">
     <meta name="twitter:description" content="Recriação pesquisada do RakuRaku Dinokun / Dinkie Dino: carcaça, LCD, controles e ciclo de cuidado em tempo real.">
-  <link rel="stylesheet" href="/labs/shared.css?v=10">
+  <link rel="stylesheet" href="/labs/shared.css?v=11">
   <link rel="stylesheet" href="style.css?v=13">
   <script type="application/ld+json">
   {
@@ -175,7 +175,7 @@
     <footer data-lab-footer data-home-href="/"></footer>
   </div>
 
-  <script src="/labs/shared.js?v=9" defer></script>
+  <script src="/labs/shared.js?v=10" defer></script>
   <script src="script.js?v=9" defer></script>
 </body>
 

--- a/labs/tamagotchi/index.html
+++ b/labs/tamagotchi/index.html
@@ -24,7 +24,7 @@
     <meta name="twitter:title" content="RakuRaku Dinokun / Dinkie Dino (1997) | Diogo Paulino">
     <meta name="twitter:description" content="Recriação pesquisada do RakuRaku Dinokun / Dinkie Dino: carcaça, LCD, controles e ciclo de cuidado em tempo real.">
   <link rel="stylesheet" href="/labs/shared.css?v=10">
-  <link rel="stylesheet" href="style.css?v=12">
+  <link rel="stylesheet" href="style.css?v=13">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",

--- a/labs/tamagotchi/index.html
+++ b/labs/tamagotchi/index.html
@@ -23,7 +23,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="RakuRaku Dinokun / Dinkie Dino (1997) | Diogo Paulino">
     <meta name="twitter:description" content="Recriação pesquisada do RakuRaku Dinokun / Dinkie Dino: carcaça, LCD, controles e ciclo de cuidado em tempo real.">
-  <link rel="stylesheet" href="/labs/shared.css?v=9">
+  <link rel="stylesheet" href="/labs/shared.css?v=10">
   <link rel="stylesheet" href="style.css?v=12">
   <script type="application/ld+json">
   {
@@ -175,7 +175,7 @@
     <footer data-lab-footer data-home-href="/"></footer>
   </div>
 
-  <script src="/labs/shared.js?v=8" defer></script>
+  <script src="/labs/shared.js?v=9" defer></script>
   <script src="script.js?v=9" defer></script>
 </body>
 

--- a/labs/tamagotchi/index.html
+++ b/labs/tamagotchi/index.html
@@ -175,7 +175,7 @@
     <footer data-lab-footer data-home-href="/"></footer>
   </div>
 
-  <script src="/labs/shared.js?v=10" defer></script>
+  <script src="/labs/shared.js?v=11" defer></script>
   <script src="script.js?v=9" defer></script>
 </body>
 

--- a/labs/tamagotchi/style.css
+++ b/labs/tamagotchi/style.css
@@ -566,6 +566,12 @@ header {
   text-transform: inherit;
   letter-spacing: inherit;
   cursor: pointer;
+  /* O botão imita a etiqueta do verso do aparelho, então continua rasteiro; o
+     padding leva a área tocável a 44px sem engordar o desenho. */
+  display: inline-flex;
+  align-items: center;
+  min-height: var(--touch-target);
+  padding-inline: 0.4rem;
 }
 
 .reset-control span {
@@ -780,4 +786,45 @@ header {
         width: min(568px, calc(100vw - 1.5rem));
         max-width: 100%;
     }
+}
+
+/* Paisagem curta (celular deitado): o aparelho tem 568x421 e vinha com 6.8rem
+   de respiro em cima — em 375px de altura sobrava só a tampa na tela, e o LCD
+   ficava três telas abaixo.
+
+   Abaixo de 720px o layout interno já é todo percentual sobre um aspect-ratio
+   fixo, então basta limitar a LARGURA pela altura disponível: a proporção
+   568/421 converte uma na outra e o aparelho inteiro volta para a dobra. */
+@media (max-height: 540px) and (orientation: landscape) {
+  .game-container { gap: 0.6rem; }
+
+  .device-area {
+    min-height: 0;
+    padding: 0.75rem 0.75rem max(0.75rem, env(safe-area-inset-bottom, 0px));
+    border-radius: 20px;
+    gap: 0.5rem;
+  }
+
+  /* Enfeites de vitrine roubam altura que o aparelho precisa. */
+  .exhibit-label,
+  .device-area::before,
+  .device-area::after {
+    display: none;
+  }
+
+  .tama-shell {
+    width: min(568px, calc(100vw - 2.5rem), calc((100dvh - 5.5rem) * 568 / 421));
+    max-width: none;
+    height: auto;
+    aspect-ratio: 568 / 421;
+  }
+
+  .device-actions {
+    font-size: 0.56rem;
+    gap: 0.5rem;
+  }
+
+  footer {
+    display: none;
+  }
 }

--- a/labs/tatu-bola/index.html
+++ b/labs/tatu-bola/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Press+Start+2P&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=9">
+    <link rel="stylesheet" href="/labs/shared.css?v=10">
     <link rel="stylesheet" href="style.css">
 
     <script type="importmap">
@@ -276,7 +276,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=8" defer></script>
+    <script src="/labs/shared.js?v=9" defer></script>
     <script type="module" src="src/main.js"></script>
 </body>
 

--- a/labs/tatu-bola/index.html
+++ b/labs/tatu-bola/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Press+Start+2P&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=10">
+    <link rel="stylesheet" href="/labs/shared.css?v=11">
     <link rel="stylesheet" href="style.css">
 
     <script type="importmap">
@@ -276,7 +276,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=9" defer></script>
+    <script src="/labs/shared.js?v=10" defer></script>
     <script type="module" src="src/main.js"></script>
 </body>
 

--- a/labs/tatu-bola/index.html
+++ b/labs/tatu-bola/index.html
@@ -276,7 +276,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=10" defer></script>
+    <script src="/labs/shared.js?v=11" defer></script>
     <script type="module" src="src/main.js"></script>
 </body>
 

--- a/labs/tetris/index.html
+++ b/labs/tetris/index.html
@@ -22,7 +22,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Tetris 90s | Diogo Paulino">
     <meta name="twitter:description" content="Jogue Tetris clássico estilo anos 90 no seu navegador.">
-    <link rel="stylesheet" href="/labs/shared.css?v=10">
+    <link rel="stylesheet" href="/labs/shared.css?v=11">
     <link rel="stylesheet" href="style.css?v=2">
     <script type="application/ld+json">
     {
@@ -172,7 +172,7 @@
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
 
-    <script src="/labs/shared.js?v=9" defer></script>
+    <script src="/labs/shared.js?v=10" defer></script>
     <script src="script.js?v=2" defer></script>
 </body>
 

--- a/labs/tetris/index.html
+++ b/labs/tetris/index.html
@@ -22,8 +22,8 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Tetris 90s | Diogo Paulino">
     <meta name="twitter:description" content="Jogue Tetris clássico estilo anos 90 no seu navegador.">
-    <link rel="stylesheet" href="/labs/shared.css?v=9">
-    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="/labs/shared.css?v=10">
+    <link rel="stylesheet" href="style.css?v=2">
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
@@ -163,6 +163,8 @@
         <p id="gameStatus" class="sr-only" role="status" aria-live="polite"></p>
 
         <div class="instructions">
+            <p class="touch-only"><strong>Arraste</strong> na tela para mover • <strong>para cima</strong> derruba •
+                <strong>toque</strong> gira</p>
             <p><strong>Setas</strong> mover • <strong>Cima</strong> girar • <strong>Espaço</strong> queda rápida</p>
             <p><strong>Enter</strong> ou <strong>Start</strong> jogar/pausar • <strong>R</strong> reiniciar</p>
         </div>
@@ -170,8 +172,8 @@
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
 
-    <script src="/labs/shared.js?v=8" defer></script>
-    <script src="script.js" defer></script>
+    <script src="/labs/shared.js?v=9" defer></script>
+    <script src="script.js?v=2" defer></script>
 </body>
 
 </html>

--- a/labs/tetris/index.html
+++ b/labs/tetris/index.html
@@ -172,7 +172,7 @@
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
 
-    <script src="/labs/shared.js?v=10" defer></script>
+    <script src="/labs/shared.js?v=11" defer></script>
     <script src="script.js?v=2" defer></script>
 </body>
 

--- a/labs/tetris/script.js
+++ b/labs/tetris/script.js
@@ -20,6 +20,46 @@ const colors = [
     '#9bbc0f', // Lightest (Highlight)
 ];
 
+/* --- Som -------------------------------------------------------------------
+   Timbre de chip: quadrada curta para os controles, arpejo para as linhas.
+   O motor vem do LabAudio (labs/shared.js), então o mudo é persistido e
+   compartilhado com os outros labs. */
+const audio = window.LabAudio;
+
+function sfx(name) {
+    if (!audio) return;
+    switch (name) {
+        case 'move':
+            audio.tone({ freq: 220, duration: 0.03, gain: 0.06 });
+            break;
+        case 'rotate':
+            audio.tone({ freq: 440, duration: 0.05, gain: 0.08 });
+            break;
+        case 'lock':
+            audio.noise({ duration: 0.07, gain: 0.09, filter: 900 });
+            break;
+        case 'drop':
+            audio.tone({ freq: 520, duration: 0.12, gain: 0.1, slideTo: 120, type: 'square' });
+            break;
+        case 'line':
+            audio.sequence([523, 659, 784], { step: 0.05, duration: 0.09, gain: 0.12 });
+            break;
+        case 'tetris':
+            // Quatro linhas de uma vez merecem a fanfarra completa.
+            audio.sequence([523, 659, 784, 1047, 1319], { step: 0.06, duration: 0.14, gain: 0.14 });
+            break;
+        case 'level':
+            audio.sequence([784, 988, 1175], { step: 0.05, duration: 0.1, gain: 0.11 });
+            break;
+        case 'over':
+            audio.tone({ freq: 330, duration: 0.9, gain: 0.14, slideTo: 60, type: 'sawtooth' });
+            break;
+        case 'start':
+            audio.sequence([392, 523, 659, 784], { step: 0.08, duration: 0.12, gain: 0.13 });
+            break;
+    }
+}
+
 // Tetromino definitions
 const pieces = 'ILJOTSZ';
 const piecesMap = {
@@ -90,10 +130,18 @@ function arenaSweep() {
     }
 
     if (cleared > 0) {
+        const previousLevel = player.level;
         player.lines += cleared;
         player.score += LINE_SCORE[cleared] * player.level;
         player.level = Math.floor(player.lines / 10) + 1;
+        // Flash das linhas: decai por frame em `draw`, fora da simulação.
+        clearFlash = 1;
+        clearFlashRows = cleared;
+        sfx(cleared === 4 ? 'tetris' : 'line');
+        if (player.level > previousLevel) sfx('level');
         updateScore();
+    } else {
+        sfx('lock');
     }
 }
 
@@ -139,6 +187,11 @@ function drawMatrix(matrix, offset, ctx = context) {
     });
 }
 
+/* Feedback visual de linha completa: um clarão que decai por frame. Vive fora
+   do estado do jogo, então nunca muda a simulação. */
+let clearFlash = 0;
+let clearFlashRows = 0;
+
 function draw() {
     // Clear screen with "screen bg" color
     context.fillStyle = colors[3];
@@ -148,6 +201,15 @@ function draw() {
     if (player.matrix) {
         drawGhost();
         drawMatrix(player.matrix, player.pos);
+    }
+
+    if (clearFlash > 0) {
+        // Quatro linhas piscam mais forte que uma: o clarão conta quanto valeu.
+        const intensity = clearFlash * (0.35 + clearFlashRows * 0.12);
+        context.globalAlpha = Math.min(0.85, intensity);
+        context.fillStyle = colors[4];
+        context.fillRect(0, 0, COLS, ROWS);
+        context.globalAlpha = 1;
     }
 }
 
@@ -247,6 +309,7 @@ function playerHardDrop() {
 
     if (distance > 0) {
         player.score += distance * 2;
+        sfx('drop');
     }
     lockPiece();
     dropCounter = 0;
@@ -265,6 +328,8 @@ function playerMove(offset) {
     player.pos.x += offset;
     if (collide(arena, player)) {
         player.pos.x -= offset;
+    } else {
+        sfx('move');
     }
 }
 
@@ -302,6 +367,7 @@ function playerRotate(dir) {
             return;
         }
     }
+    sfx('rotate');
 }
 
 let dropCounter = 0;
@@ -320,6 +386,8 @@ function update(time = 0) {
         }
         handleAutoRepeat(deltaTime);
     }
+
+    clearFlash = Math.max(0, clearFlash - deltaTime / 260);
 
     draw();
     requestAnimationFrame(update);
@@ -415,11 +483,14 @@ function resetGame() {
 
 function startGame() {
     resetGame();
+    clearFlash = 0;
+    sfx('start');
     setState('playing');
 }
 
 function gameOver() {
     player.matrix = null;
+    sfx('over');
     setState('over');
 }
 
@@ -557,6 +628,73 @@ bindHold('.d-pad .down', 'down');
 bindHold('.d-pad .up', 'rotate');
 bindHold('.btn-a', 'rotate');
 bindHold('.btn-b', 'hard-drop');
+
+/* --- Gestos na tela --------------------------------------------------------
+   No celular o d-pad desenhado tem ~34px e o polegar cobre metade do console.
+   Arrastar na própria tela vira o controle principal:
+     · horizontal  → move coluna a coluna, acompanhando o dedo
+     · para baixo  → soft drop contínuo
+     · para cima   → hard drop
+     · toque curto → gira
+   O d-pad continua funcionando para quem prefere (e para o mouse). */
+const screenEl = document.querySelector('.screen');
+const SWIPE_STEP = 22;   // px de arrasto que valem uma coluna
+const SWIPE_FLICK = 46;  // px verticais que disparam hard drop / soft drop
+let gesture = null;
+
+if (screenEl) {
+    screenEl.addEventListener('pointerdown', event => {
+        if (event.pointerType === 'mouse' && event.button !== 0) return;
+        screenEl.setPointerCapture?.(event.pointerId);
+        gesture = { x: event.clientX, y: event.clientY, movedCols: 0, dropped: false, acted: false };
+    });
+
+    screenEl.addEventListener('pointermove', event => {
+        if (!gesture || state !== 'playing') return;
+
+        const deltaX = event.clientX - gesture.x;
+        const deltaY = event.clientY - gesture.y;
+
+        // Colunas ainda não consumidas deste arrasto.
+        const wantCols = Math.trunc(deltaX / SWIPE_STEP);
+        if (wantCols !== gesture.movedCols) {
+            const steps = wantCols - gesture.movedCols;
+            for (let i = 0; i < Math.abs(steps); i++) playerMove(Math.sign(steps));
+            gesture.movedCols = wantCols;
+            gesture.acted = true;
+        }
+
+        // O vertical só age quando é claramente o eixo dominante.
+        if (Math.abs(deltaY) > SWIPE_FLICK && Math.abs(deltaY) > Math.abs(deltaX) && !gesture.dropped) {
+            if (deltaY < 0) {
+                playerHardDrop();
+                gesture.dropped = true;
+            } else {
+                playerDrop(true);
+                // Reancora para o próximo passo do soft drop.
+                gesture.y = event.clientY;
+            }
+            gesture.acted = true;
+        }
+    });
+
+    const endGesture = () => {
+        if (gesture && !gesture.acted) {
+            // Toque curto: gira se estiver jogando, senão faz o papel do Start.
+            if (state === 'playing') playerRotate(1);
+            else toggleStartPause();
+        }
+        gesture = null;
+    };
+
+    screenEl.addEventListener('pointerup', endGesture);
+    screenEl.addEventListener('pointercancel', () => { gesture = null; });
+}
+
+if (window.LabAudio) {
+    window.LabAudio.configure({ storageKey: 'tetris90s:muted', volume: 0.45 });
+    window.LabAudio.mountToggle('[data-lab-header] .header-actions');
+}
 
 document.querySelector('.btn-start').addEventListener('click', toggleStartPause);
 document.querySelector('.btn-select').addEventListener('click', startGame);

--- a/labs/tetris/style.css
+++ b/labs/tetris/style.css
@@ -97,7 +97,11 @@ body {
     align-items: center;
 }
 
+/* A tela é a superfície dos gestos (arrastar move/derruba, tocar gira), então
+   o navegador não pode roubar o gesto para rolar a página antes. */
 .screen {
+    touch-action: none;
+    cursor: pointer;
     background-color: var(--gb-screen-bg);
     width: 90%;
     height: 90%;

--- a/labs/ultimo-bastiao/index.html
+++ b/labs/ultimo-bastiao/index.html
@@ -192,7 +192,7 @@
 
     <section id="errorOverlay" class="overlay compact-overlay" hidden>
       <div class="compact-card">
-        <p class="eyebrow danger">WEBGL INDISPONÍVEL</p>
+        <p class="eyebrow danger">NÃO FOI POSSÍVEL COMEÇAR</p>
         <h2>A batalha não pôde começar.</h2>
         <p id="errorText">Use um navegador atualizado com aceleração gráfica habilitada.</p>
       </div>
@@ -203,7 +203,7 @@
 
   <script src="https://cdn.babylonjs.com/babylon.js"></script>
   <script src="https://cdn.babylonjs.com/loaders/babylonjs.loaders.min.js"></script>
-  <script type="module" src="src/game.js?v=3"></script>
+  <script type="module" src="src/game.js?v=4"></script>
 </body>
 
 </html>

--- a/labs/ultimo-bastiao/src/game.js
+++ b/labs/ultimo-bastiao/src/game.js
@@ -457,7 +457,14 @@ class Game {
   }
 
   async init() {
-    if (!B || !B.Engine?.isSupported()) {
+    // Duas falhas diferentes davam a mesma mensagem ("WebGL indisponível"),
+    // e a mais comum das duas — o CDN do Babylon não responder — não tem nada
+    // a ver com o navegador do jogador.
+    if (!B) {
+      this.showError('O motor 3D (Babylon.js) não pôde ser baixado. Verifique a conexão e recarregue a página.');
+      return;
+    }
+    if (!B.Engine?.isSupported()) {
       this.showError('Este navegador não oferece o WebGL necessário para abrir o campo de batalha.');
       return;
     }

--- a/labs/ultimo-bastiao/style.css
+++ b/labs/ultimo-bastiao/style.css
@@ -33,7 +33,7 @@ button { color: inherit; }
 }
 
 .back-link, .top-actions, .brand { pointer-events: auto; }
-.back-link { width: max-content; display: flex; gap: 9px; align-items: center; color: #ddd5c3; text-decoration: none; font-size: 12px; letter-spacing: .12em; text-transform: uppercase; }
+.back-link { width: max-content; display: flex; gap: 9px; align-items: center; color: #ddd5c3; text-decoration: none; font-size: 12px; letter-spacing: .12em; text-transform: uppercase; min-height: 44px; min-width: 44px; justify-content: center; padding-inline: 6px; }
 .back-link span:first-child { font-size: 20px; font-weight: 300; transform: translateY(-1px); }
 .brand { display: flex; align-items: center; gap: 10px; font: 600 13px/1 "Cinzel", serif; letter-spacing: .12em; text-transform: uppercase; text-shadow: 0 2px 12px #000; }
 .brand i { display: block; width: 7px; height: 7px; background: var(--gold); transform: rotate(45deg); box-shadow: 0 0 14px rgba(201, 164, 91, .75); }
@@ -176,7 +176,8 @@ kbd { display: inline-block; min-width: 26px; margin-right: 5px; padding: 4px 6p
 @media (max-height: 520px) and (orientation: landscape) {
   .topbar { min-height: 42px; padding-top: max(5px, env(safe-area-inset-top)); }
   .brand { display: none; }
-  .icon-button { width: 38px; height: 38px; }
+  /* 44px vale também no celular: são som e pausa, tocados em pleno combate. */
+  .icon-button { width: 44px; height: 44px; }
   .vitals { top: max(46px, calc(env(safe-area-inset-top) + 40px)); left: max(10px, env(safe-area-inset-left)); width: 245px; padding-block: 6px; }
   .portrait { width: 32px; height: 32px; }
   .combo { top: max(46px, calc(env(safe-area-inset-top) + 40px)); }

--- a/labs/videogame/index.html
+++ b/labs/videogame/index.html
@@ -29,7 +29,7 @@
     <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="mobile.css">
     <script src="/labs/videogame/lib/nostalgist.umd.js" defer></script>
-    <script src="/labs/shared.js?v=10" defer></script>
+    <script src="/labs/shared.js?v=11" defer></script>
     <script src="games.js" defer></script>
     <script src="script.js" defer></script>
     <script type="application/ld+json">

--- a/labs/videogame/index.html
+++ b/labs/videogame/index.html
@@ -25,11 +25,11 @@
 
 
 
-    <link rel="stylesheet" href="/labs/shared.css?v=10">
+    <link rel="stylesheet" href="/labs/shared.css?v=11">
     <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="mobile.css">
     <script src="/labs/videogame/lib/nostalgist.umd.js" defer></script>
-    <script src="/labs/shared.js?v=9" defer></script>
+    <script src="/labs/shared.js?v=10" defer></script>
     <script src="games.js" defer></script>
     <script src="script.js" defer></script>
     <script type="application/ld+json">

--- a/labs/videogame/index.html
+++ b/labs/videogame/index.html
@@ -25,11 +25,11 @@
 
 
 
-    <link rel="stylesheet" href="/labs/shared.css?v=9">
+    <link rel="stylesheet" href="/labs/shared.css?v=10">
     <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="mobile.css">
     <script src="/labs/videogame/lib/nostalgist.umd.js" defer></script>
-    <script src="/labs/shared.js?v=8" defer></script>
+    <script src="/labs/shared.js?v=9" defer></script>
     <script src="games.js" defer></script>
     <script src="script.js" defer></script>
     <script type="application/ld+json">

--- a/labs/videogame/style.css
+++ b/labs/videogame/style.css
@@ -254,6 +254,7 @@ main {
 }
 
 .btn-group button {
+    min-height: var(--touch-target);
     padding: .5rem 1rem;
     background: 0 0;
     border: none;

--- a/labs/winamp/index.html
+++ b/labs/winamp/index.html
@@ -26,7 +26,7 @@
     <meta name="twitter:title" content="Winamp JS | Diogo Paulino">
     <meta name="twitter:description" content="Player retrô 100% vanilla: playlist, equalizador, visualizador e músicas chiptune sintetizadas no navegador.">
     <meta name="twitter:image" content="https://diogopaulino.com.br/assets/img/diogo.jpeg">
-    <link rel="stylesheet" href="/labs/shared.css?v=9">
+    <link rel="stylesheet" href="/labs/shared.css?v=10">
     <link rel="stylesheet" href="style.css?v=5">
     <script type="application/ld+json">
     {
@@ -416,7 +416,7 @@
 
     <noscript>Ative o JavaScript para usar o player.</noscript>
     <script type="module" src="script.js?v=5"></script>
-    <script src="/labs/shared.js?v=8" defer></script>
+    <script src="/labs/shared.js?v=9" defer></script>
 </body>
 
 </html>

--- a/labs/winamp/index.html
+++ b/labs/winamp/index.html
@@ -416,7 +416,7 @@
 
     <noscript>Ative o JavaScript para usar o player.</noscript>
     <script type="module" src="script.js?v=5"></script>
-    <script src="/labs/shared.js?v=10" defer></script>
+    <script src="/labs/shared.js?v=11" defer></script>
 </body>
 
 </html>

--- a/labs/winamp/index.html
+++ b/labs/winamp/index.html
@@ -26,7 +26,7 @@
     <meta name="twitter:title" content="Winamp JS | Diogo Paulino">
     <meta name="twitter:description" content="Player retrô 100% vanilla: playlist, equalizador, visualizador e músicas chiptune sintetizadas no navegador.">
     <meta name="twitter:image" content="https://diogopaulino.com.br/assets/img/diogo.jpeg">
-    <link rel="stylesheet" href="/labs/shared.css?v=10">
+    <link rel="stylesheet" href="/labs/shared.css?v=11">
     <link rel="stylesheet" href="style.css?v=5">
     <script type="application/ld+json">
     {
@@ -416,7 +416,7 @@
 
     <noscript>Ative o JavaScript para usar o player.</noscript>
     <script type="module" src="script.js?v=5"></script>
-    <script src="/labs/shared.js?v=9" defer></script>
+    <script src="/labs/shared.js?v=10" defer></script>
 </body>
 
 </html>

--- a/labs/xadrez/index.html
+++ b/labs/xadrez/index.html
@@ -32,7 +32,7 @@
     <link rel="preconnect" href="https://cdn.babylonjs.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;600;700&family=Outfit:wght@300;400;500;600;700&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=8">
+    <link rel="stylesheet" href="/labs/shared.css?v=10">
     <link rel="stylesheet" href="style.css">
     <script type="application/ld+json">
     {
@@ -241,7 +241,7 @@
 
     <script src="https://cdn.babylonjs.com/babylon.js"></script>
     <script src="https://cdn.babylonjs.com/loaders/babylonjs.loaders.min.js"></script>
-    <script src="/labs/shared.js?v=7" defer></script>
+    <script src="/labs/shared.js?v=9" defer></script>
     <script type="module" src="src/main.js"></script>
 </body>
 

--- a/labs/xadrez/index.html
+++ b/labs/xadrez/index.html
@@ -241,7 +241,7 @@
 
     <script src="https://cdn.babylonjs.com/babylon.js"></script>
     <script src="https://cdn.babylonjs.com/loaders/babylonjs.loaders.min.js"></script>
-    <script src="/labs/shared.js?v=10" defer></script>
+    <script src="/labs/shared.js?v=11" defer></script>
     <script type="module" src="src/main.js"></script>
 </body>
 

--- a/labs/xadrez/index.html
+++ b/labs/xadrez/index.html
@@ -32,7 +32,7 @@
     <link rel="preconnect" href="https://cdn.babylonjs.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;600;700&family=Outfit:wght@300;400;500;600;700&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=10">
+    <link rel="stylesheet" href="/labs/shared.css?v=11">
     <link rel="stylesheet" href="style.css">
     <script type="application/ld+json">
     {
@@ -241,7 +241,7 @@
 
     <script src="https://cdn.babylonjs.com/babylon.js"></script>
     <script src="https://cdn.babylonjs.com/loaders/babylonjs.loaders.min.js"></script>
-    <script src="/labs/shared.js?v=9" defer></script>
+    <script src="/labs/shared.js?v=10" defer></script>
     <script type="module" src="src/main.js"></script>
 </body>
 


### PR DESCRIPTION
## 🎯 Objetivo

Passar os 54 labs no detalhe procurando o que está de fato quebrado antes do que está feio — quatro labs não abriam de jeito nenhum, 26 mostravam tela preta sem explicação quando o CDN caía, e dezenas de controles eram pequenos demais para o dedo.

## ✨ O que mudou

**Quatro labs que não abriam**

- **guerreiro-castelo** — `Environment.js` importava `barkTexture` e `leafTexture` de `Textures.js`, que nunca os exportou. O módulo morria no import e a aventura inteira ficava fora do ar. Adicionadas as duas texturas procedurais no mesmo estilo do arquivo (casca com sulcos e nós; folhagem em quatro tons com furos de luz).
- **honor-front** — `main.js` importava `CombatAudio` de `audio.js`, que só exporta `GameAudio`, e chamava uma API inexistente (`init`, `shoot`, `empty`, `enemyShoot`, `playerHurt`, `toggleMute`). Adicionada a fachada `CombatAudio` traduzindo os termos de ação do jogo para os de síntese do motor.
- **f1-racing** — `src/utils.js` era importado por `main.js` mas não existia (404), derrubando o módulo do jogo. Arquivo criado com `clamp`/`lerp`/`damp`/`sign`/`mapRange`.
- **joao-e-o-pe-de-feijao** — `const LOOK = new B.Vector3()` no topo de `main.js` derrubava o módulo antes de qualquer guarda rodar; nem a tela de erro do próprio lab aparecia. Os scratch vectors passam a nascer no primeiro frame que os usa.

**Tela preta quando o CDN cai**

29 labs carregam Babylon.js ou three.js de CDN. Sem rede, a página abria preta e muda — o erro só existia no console. `shared.js` ganha uma guarda automática, sem editar lab por lab: checa o global depois do `load` para scripts clássicos, e escuta o evento `error` do `<script type="module">` na fase de captura para o caso do importmap (three.js não deixa global para checar). A lista de scripts críticos é só de motores gráficos — um pacote de ícones que falha deixa a página feia, não quebrada. **Conferido: o aviso aparece nos 26 labs cujo motor vem de CDN e em nenhum dos outros 28.**

**Claude Bros reescrito em canvas puro**

Dependia do PixiJS via cdnjs — contra a regra vanilla do repositório e um ponto único de falha. Agora é Canvas 2D autocontido: passo fixo de 1/120s, colisão eixo a eixo, coyote time, jump buffer e pulo variável; fase de 88 tiles com blocos de bônus, espinhos e bandeira; céu, sol, nuvens e dois planos de morros em parallax; controles de toque em pointer events (antes só `touchstart`, então nem funcionavam no desktop). Também ganhou o card que faltava na galeria.

**Som, gestos e gráficos nos clássicos 2D**

`shared.js` ganha o `LabAudio` (sintetizador mínimo, mudo persistido, botão de header pronto) para os labs pararem de reimplementar a mesma parte chata do Web Audio.

- **Snake** — deslizar na tela vira o controle principal; corpo contínuo com cantos arredondados só onde a cobra não segue, cauda que afina, língua, maçã com talo e folha, flash invertido na morte; sons 8-bit e nível no LCD.
- **Tetris** — arrastar move coluna a coluna acompanhando o dedo, para cima derruba, toque gira; sons por evento e clarão proporcional às linhas limpas.
- **Campo Minado** — botão de modo escavar/bandeira (tecla F) no lugar de depender de segurar 500ms; duplo clique faz *chord*; entrada unificada em pointer events (antes `mouse*` e `touch*` podiam disparar a mesma jogada duas vezes); célula com piso de 26px no toque; sons, vibração e recorde por dificuldade.
- **Lunar Lander** — propulsor contínuo (ruído filtrado que segue o acelerador, com grafo próprio por ser contínuo), pouso, colisão, reabastecimento e bipe único ao cruzar 15% de combustível.

**Alvos de toque abaixo de 44px**

`shared.css` ganha tokens `--safe-*`/`--touch-target`, media query de paisagem curta e alvos de 44px no chrome em `pointer: coarse`. Nos labs: sliders de aurora-flow, gravity, image-editor, image-optimizer, matrix, orbis, paint e river-knight (o trilho de 3–6px era o alvo inteiro — o input vai a 44px e o trilho visível migra para os pseudo-elementos, sem mudar o desenho), mais calculator, cyberos, grao, partitura, piano, pomodoro, quimera, lander, orbis, videogame, tamagotchi, ultimo-bastiao e minesweeper.

No **Paint** a solução foi outra: numa grade densa, áreas de 44px sobre amostras de 24px se sobrepõem e o toque perto da borda escolhe a cor vizinha — pior que o alvo pequeno. A grade passa a preencher a largura com células de no mínimo 40px.

**Paisagem curta**

- **tamagotchi** — com 6.8rem de respiro acima de um aparelho de 568×421, em 667×375 aparecia só a tampa e o LCD ficava fora da dobra. A largura passa a ser limitada pela altura livre pela proporção 568/421.
- **cyberos** — a regra de ≤820px virava o dock em faixa horizontal no rodapé, mas deitado sobra largura e não altura: a janela do terminal cobria os quatro ícones, inalcançáveis. Em paisagem o dock volta a ser coluna à esquerda.

**Outros**

- **calculator** — os oito ícones vinham de `@phosphor-icons/web` via jsdelivr; com o CDN fora o botão de apagar virava um quadrado vazio sem rótulo. Agora são SVG inline e o lab não depende de rede.
- **minesweeper** — os três botões da moldura Win95 não fazem nada e viraram `<span aria-hidden>`; como `<button>` entravam na navegação por Tab.
- **ultimo-bastiao** — CDN fora do ar e WebGL ausente davam a mesma mensagem ("WEBGL INDISPONÍVEL"); agora são distintas.

## 🧪 Como testar

1. Na raiz do repo: `python3 -m http.server 8000`
2. Abrir [http://localhost:8000/](http://localhost:8000/) (home) e [http://localhost:8000/labs/](http://localhost:8000/labs/) (galeria)
3. Abrir o lab ou a página alterada e confirmar que CSS, JS e o voltar funcionam
4. Responsivo: DevTools em **375×667**, **390×844** e landscape curto (~667×375) — sem overflow horizontal, HUD/controles utilizáveis, alvos ≥ 44px
5. Se o lab for novo, renomeado ou removido: conferir pasta ↔ card da galeria ↔ README ↔ `sitemap.xml` ↔ canonical/OG

Além do roteiro acima, o que foi verificado por automação (Chromium, 375×667 e 667×375, todas as 55 páginas):

- **0** casos de overflow horizontal
- **0** referências locais quebradas (todos os `src`/`href` do repositório resolvem)
- **0** erros de JS próprios do site — o único restante era o do João, corrigido nesta PR
- **0** imports ES apontando para exports inexistentes
- **54/54** labs com o bloco de SEO completo (title, description, author, robots, canonical, OG, Twitter, JSON-LD, favicon, `viewport-fit`)
- galeria com 54 cards, 54 links respondendo 200
- jogabilidade conferida à mão no Snake (swipe → morte → fim de jogo), Tetris (arrasto move, swipe para cima derruba, score 34), Claude Bros (corrida, moeda coletada, vida perdida), Campo Minado (modo bandeira marca e o contador cai) e Calculadora (12+7=19, backspace, troca de aba)

**Limite deste ambiente:** a rede externa é bloqueada aqui, então os 26 labs que carregam Babylon/three de CDN não puderam ser vistos renderizando em 3D. Para eles a verificação foi estática (imports, CSS, HUD, alvos) mais o caminho de falha — que é justamente o que esta PR passou a tratar. **Vale abrir um punhado deles com rede antes de mergear**, sobretudo guerreiro-castelo, honor-front e f1-racing, que voltaram do zero.

## ✅ Checklist

- [x] Links conferidos: pasta do lab ↔ card da galeria ↔ README ↔ sitemap (e corrigidos se quebravam) — o **claude-bros** não tinha card na galeria, que já anunciava 54 experimentos e listava 53
- [x] README atualizado (linha na tabela + URL + contagem no badge/texto) — a linha do claude-bros ainda dizia PixiJS; contagens já estavam corretas em 54
- [x] SEO consistente: title, description, canonical, author, robots, OG, Twitter, JSON-LD (e contagem nos metas da galeria)
- [x] Testado via HTTP na raiz, não via `file://`
- [x] Responsivo: 375px / 390px / landscape — overflow, HUD, toque, safe-area (`viewport-fit=cover`)
- [x] Nada fora do escopo foi quebrado — regressão nas 55 páginas nos dois viewports, sem 404, sem erro de JS e sem overflow


---
_Generated by [Claude Code](https://claude.ai/code/session_017VGrsfskquvGeyDXtww9fu)_