### PR TITLE
🎨 UI: revisão dos 54 labs — alvos de toque, jogabilidade e robustez

### DIFF
--- a/labs/aurora-flow/script.js
+++ b/labs/aurora-flow/script.js
@@ -1001,9 +1001,23 @@ function drawKp() {
     if (el) el.textContent = kp.toFixed(1);
 }
 
-function animate() {
+/* A cena avança por frame (partículas somam `vx` direto, `time` soma 0.016),
+   e isso amarra a velocidade ao refresh: num painel de 120Hz a aurora corria em
+   dobro. Em vez de reescrever toda a simulação para delta-time — o que mudaria
+   a calibragem visual — o laço mantém a cadência de 60fps e devolve os frames
+   extras ao aparelho (metade do trabalho num celular de 120Hz). */
+const FRAME_MS = 1000 / 60;
+let lastFrameAt = -Infinity;
+
+function animate(frameNow) {
     requestAnimationFrame(animate);
     if (paused) return;
+
+    const stamp = frameNow === undefined ? performance.now() : frameNow;
+    // Meio milissegundo de folga: a 60Hz o intervalo oscila em torno de 16,67ms
+    // e um teste rígido descartaria um frame sim, outro não.
+    if (stamp - lastFrameAt < FRAME_MS - 0.5) return;
+    lastFrameAt = stamp;
 
     time += 0.016 * flowSpeed;
     flash *= 0.9;

--- a/labs/f1-racing/style.css
+++ b/labs/f1-racing/style.css
@@ -804,6 +804,7 @@ kbd {
     justify-content: center;
     gap: 0.6rem;
     padding: 0.85rem 1.6rem;
+    min-height: var(--touch-target, 44px);
     border-radius: 999px;
     background: linear-gradient(120deg, var(--f1-red), oklch(60% 0.23 20));
     color: oklch(99% 0 0);

--- a/labs/image-editor/style.css
+++ b/labs/image-editor/style.css
@@ -381,6 +381,9 @@ input[type="range"]:focus-visible::-moz-range-thumb {
 .btn {
     flex: 1;
     padding: 0.75rem;
+    /* Salvar/Copiar/Resetar ficavam com 36-40px de altura: o padding sozinho
+       não garante o alvo mínimo quando a fonte é pequena. */
+    min-height: var(--touch-target, 44px);
     border-radius: 0.5rem;
     font-weight: 600;
     font-size: 0.875rem;

--- a/labs/index.html
+++ b/labs/index.html
@@ -61,144 +61,156 @@
           {
             "@type": "ListItem",
             "position": 1,
+            "url": "https://diogopaulino.com.br/labs/ultimo-bastiao/",
+            "name": "O Último Bastião"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
             "url": "https://diogopaulino.com.br/labs/xadrez/",
             "name": "Xadrez"
           },
           {
             "@type": "ListItem",
-            "position": 2,
+            "position": 3,
             "url": "https://diogopaulino.com.br/labs/rastro-vermelho/",
             "name": "Rastro Vermelho"
           },
           {
             "@type": "ListItem",
-            "position": 3,
+            "position": 4,
             "url": "https://diogopaulino.com.br/labs/tatu-bola/",
             "name": "Tatu Bola"
           },
           {
             "@type": "ListItem",
-            "position": 4,
+            "position": 5,
             "url": "https://diogopaulino.com.br/labs/cupola-64/",
             "name": "Cúpola 64"
           },
           {
             "@type": "ListItem",
-            "position": 5,
+            "position": 6,
             "url": "https://diogopaulino.com.br/labs/menina-da-lanterna/",
             "name": "A Menina da Lanterna"
           },
           {
             "@type": "ListItem",
-            "position": 6,
+            "position": 7,
             "url": "https://diogopaulino.com.br/labs/forrest-run/",
             "name": "Forrest Run"
           },
           {
             "@type": "ListItem",
-            "position": 7,
+            "position": 8,
             "url": "https://diogopaulino.com.br/labs/nina/",
             "name": "Nina"
           },
           {
             "@type": "ListItem",
-            "position": 8,
+            "position": 9,
+            "url": "https://diogopaulino.com.br/labs/mimo/",
+            "name": "Mimo"
+          },
+          {
+            "@type": "ListItem",
+            "position": 10,
             "url": "https://diogopaulino.com.br/labs/quimera/",
             "name": "Quimera"
           },
           {
             "@type": "ListItem",
-            "position": 9,
+            "position": 11,
             "url": "https://diogopaulino.com.br/labs/castelo-estelar/",
             "name": "Castelo Estelar"
           },
           {
             "@type": "ListItem",
-            "position": 10,
+            "position": 12,
             "url": "https://diogopaulino.com.br/labs/eyra/",
             "name": "Eyra"
           },
           {
             "@type": "ListItem",
-            "position": 11,
+            "position": 13,
             "url": "https://diogopaulino.com.br/labs/lavandula/",
             "name": "Lavandula"
           },
           {
             "@type": "ListItem",
-            "position": 12,
+            "position": 14,
             "url": "https://diogopaulino.com.br/labs/nereida/",
             "name": "Nereida"
           },
           {
             "@type": "ListItem",
-            "position": 13,
+            "position": 15,
             "url": "https://diogopaulino.com.br/labs/riftball/",
             "name": "Riftball"
           },
           {
             "@type": "ListItem",
-            "position": 15,
+            "position": 16,
             "url": "https://diogopaulino.com.br/labs/jurassic/",
             "name": "Jurassic"
           },
           {
             "@type": "ListItem",
-            "position": 16,
+            "position": 17,
             "url": "https://diogopaulino.com.br/labs/spider-swing/",
             "name": "Spider Swing"
           },
           {
             "@type": "ListItem",
-            "position": 17,
+            "position": 18,
             "url": "https://diogopaulino.com.br/labs/honor-front/",
             "name": "Honor Front"
           },
           {
             "@type": "ListItem",
-            "position": 18,
+            "position": 19,
             "url": "https://diogopaulino.com.br/labs/safari-dourado/",
             "name": "Safari Dourado"
           },
           {
             "@type": "ListItem",
-            "position": 19,
+            "position": 20,
             "url": "https://diogopaulino.com.br/labs/grao/",
             "name": "Grão"
           },
           {
             "@type": "ListItem",
-            "position": 20,
+            "position": 21,
             "url": "https://diogopaulino.com.br/labs/orbis/",
             "name": "Orbis"
           },
           {
             "@type": "ListItem",
-            "position": 21,
+            "position": 22,
             "url": "https://diogopaulino.com.br/labs/neon-rider/",
             "name": "Neon Rider"
           },
           {
             "@type": "ListItem",
-            "position": 22,
+            "position": 23,
             "url": "https://diogopaulino.com.br/labs/guerreiro-castelo/",
             "name": "O Guerreiro e o Castelo"
           },
           {
             "@type": "ListItem",
-            "position": 23,
+            "position": 24,
             "url": "https://diogopaulino.com.br/labs/river-knight/",
             "name": "River Knight"
           },
           {
             "@type": "ListItem",
-            "position": 24,
+            "position": 25,
             "url": "https://diogopaulino.com.br/labs/jornada-do-anel/",
             "name": "A Jornada do Anel"
           },
           {
             "@type": "ListItem",
-            "position": 25,
+            "position": 26,
             "url": "https://diogopaulino.com.br/labs/joao-e-o-pe-de-feijao/",
             "name": "João e o Pé de Feijão"
           },
@@ -216,165 +228,159 @@
           },
           {
             "@type": "ListItem",
-            "position": 30,
+            "position": 29,
             "url": "https://diogopaulino.com.br/labs/ravi-123/",
             "name": "Ravi 1·2·3"
           },
           {
             "@type": "ListItem",
-            "position": 31,
+            "position": 30,
             "url": "https://diogopaulino.com.br/labs/rock-kombat/",
             "name": "Rock Kombat"
           },
           {
             "@type": "ListItem",
-            "position": 33,
+            "position": 31,
             "url": "https://diogopaulino.com.br/labs/videogame/",
             "name": "Videogame"
           },
           {
             "@type": "ListItem",
-            "position": 34,
+            "position": 32,
             "url": "https://diogopaulino.com.br/labs/lander/",
             "name": "Lunar Lander"
           },
           {
             "@type": "ListItem",
-            "position": 35,
+            "position": 33,
             "url": "https://diogopaulino.com.br/labs/kong-kong/",
             "name": "Kong Kong"
           },
           {
             "@type": "ListItem",
-            "position": 36,
+            "position": 34,
             "url": "https://diogopaulino.com.br/labs/jungle-run/",
             "name": "Jungle Run"
           },
           {
             "@type": "ListItem",
-            "position": 37,
+            "position": 35,
             "url": "https://diogopaulino.com.br/labs/space-shooter/",
             "name": "Neon Invaders"
           },
           {
             "@type": "ListItem",
-            "position": 38,
+            "position": 36,
             "url": "https://diogopaulino.com.br/labs/tetris/",
             "name": "Tetris 90s"
           },
           {
             "@type": "ListItem",
-            "position": 39,
+            "position": 37,
+            "url": "https://diogopaulino.com.br/labs/claude-bros/",
+            "name": "Claude Bros"
+          },
+          {
+            "@type": "ListItem",
+            "position": 38,
             "url": "https://diogopaulino.com.br/labs/snake/",
             "name": "Retro Snake"
           },
           {
             "@type": "ListItem",
-            "position": 40,
+            "position": 39,
             "url": "https://diogopaulino.com.br/labs/minesweeper/",
             "name": "Campo Minado 95"
           },
           {
             "@type": "ListItem",
-            "position": 41,
+            "position": 40,
             "url": "https://diogopaulino.com.br/labs/tamagotchi/",
             "name": "RakuRaku Dinokun"
           },
           {
             "@type": "ListItem",
-            "position": 42,
+            "position": 41,
             "url": "https://diogopaulino.com.br/labs/cyberos/",
             "name": "CyberOS Terminal"
           },
           {
             "@type": "ListItem",
-            "position": 43,
+            "position": 42,
             "url": "https://diogopaulino.com.br/labs/matrix/",
             "name": "Matrix"
           },
           {
             "@type": "ListItem",
-            "position": 44,
+            "position": 43,
             "url": "https://diogopaulino.com.br/labs/aurora-flow/",
             "name": "Aurora Flow"
           },
           {
             "@type": "ListItem",
-            "position": 45,
+            "position": 44,
             "url": "https://diogopaulino.com.br/labs/paint/",
             "name": "Paint Lab"
           },
           {
             "@type": "ListItem",
-            "position": 46,
+            "position": 45,
             "url": "https://diogopaulino.com.br/labs/gravity/",
             "name": "Gravity"
           },
           {
             "@type": "ListItem",
-            "position": 47,
+            "position": 46,
             "url": "https://diogopaulino.com.br/labs/image-optimizer/",
             "name": "Image Optimizer"
           },
           {
             "@type": "ListItem",
-            "position": 48,
+            "position": 47,
             "url": "https://diogopaulino.com.br/labs/image-editor/",
             "name": "Image Editor"
           },
           {
             "@type": "ListItem",
-            "position": 49,
+            "position": 48,
             "url": "https://diogopaulino.com.br/labs/pomodoro/",
             "name": "Pomodoro"
           },
           {
             "@type": "ListItem",
-            "position": 50,
+            "position": 49,
             "url": "https://diogopaulino.com.br/labs/english-duo/",
             "name": "Talk"
           },
           {
             "@type": "ListItem",
-            "position": 51,
+            "position": 50,
             "url": "https://diogopaulino.com.br/labs/calculator/",
             "name": "Calculator"
           },
           {
             "@type": "ListItem",
-            "position": 52,
+            "position": 51,
             "url": "https://diogopaulino.com.br/labs/partitura/",
             "name": "Partitura: Maestro Quest"
           },
           {
             "@type": "ListItem",
-            "position": 53,
+            "position": 52,
             "url": "https://diogopaulino.com.br/labs/piano/",
             "name": "Piano"
           },
           {
             "@type": "ListItem",
-            "position": 54,
+            "position": 53,
             "url": "https://diogopaulino.com.br/labs/winamp/",
             "name": "Winamp JS"
           },
           {
             "@type": "ListItem",
-            "position": 55,
+            "position": 54,
             "url": "https://diogopaulino.com.br/labs/pulsar/",
             "name": "Pulsar"
-          },
-          {
-            "@type": "ListItem",
-            "position": 56,
-            "url": "https://diogopaulino.com.br/labs/ultimo-bastiao/",
-            "name": "O Último Bastião"
-          },
-          {
-            "@type": "ListItem",
-            "position": 57,
-            "url": "https://diogopaulino.com.br/labs/mimo/",
-            "name": "Mimo"
           }
         ]
       },

--- a/labs/jungle-run/style.css
+++ b/labs/jungle-run/style.css
@@ -854,9 +854,14 @@ button:focus-visible {
         font-size: 0.48rem;
     }
 
-    .stat-box,
-    .icon-btn {
+    .stat-box {
         min-height: 39px;
+    }
+
+    /* O pause é apertado no meio da corrida: mantém o alvo cheio mesmo com o
+       HUD compacto (o resto do espaço vem de .distance-box/.sound-btn ocultos). */
+    .icon-btn {
+        min-height: var(--touch-target, 44px);
     }
 
     .stat-box {
@@ -885,7 +890,7 @@ button:focus-visible {
     }
 
     .icon-btn {
-        width: 39px;
+        width: var(--touch-target, 44px);
     }
 
     .sound-btn {

--- a/labs/lander/style.css
+++ b/labs/lander/style.css
@@ -85,8 +85,11 @@ body {
     padding: 1px 4px;
     cursor: pointer;
     /* A barra de menu imita o Windows 95, então o item continua raso; o alvo
-       tocável cresce por pseudo-elemento sem engordar a barra. */
+       tocável cresce por pseudo-elemento sem engordar a barra. O z-index é o
+       que faz esse alvo valer: sem ele o conteúdo que vem depois no DOM ficava
+       por cima da parte que transborda da barra e comia 10px do toque. */
     position: relative;
+    z-index: 3;
 }
 
 .menu-item::after {
@@ -322,6 +325,8 @@ canvas {
     pointer-events: auto;
     text-shadow: inherit;
     width: 100%;
+    /* A linha de texto dava 42px de altura: 2px abaixo do alvo mínimo. */
+    min-height: var(--touch-target, 44px);
 }
 
 .start-button:focus-visible {

--- a/labs/matrix/script.js
+++ b/labs/matrix/script.js
@@ -204,7 +204,12 @@
     }
 
     function seedStreams(layer) {
-        const count = Math.max(1, Math.round(layer.cols * (settings.density / 100) * 1.2));
+        /* As camadas de fundo usam células menores, então têm mais colunas — e
+           com a mesma densidade por coluna acabavam gerando 1,6x mais streams
+           que a camada da frente. Medido a 375px: a camada de trás (alpha 0,32)
+           respondia por 73% dos glifos do frame. O fator `scale` iguala a
+           contagem à da frente: a névoa de parallax continua lá, o custo não. */
+        const count = Math.max(1, Math.round(layer.cols * layer.scale * (settings.density / 100) * 1.2));
         layer.streams = new Array(count);
         for (let i = 0; i < count; i++) {
             layer.streams[i] = newStream(layer, true);

--- a/labs/matrix/style.css
+++ b/labs/matrix/style.css
@@ -664,6 +664,7 @@ input[type="range"]:focus-visible {
     gap: 8px;
     width: 100%;
     padding: 10px;
+    min-height: var(--touch-target, 44px);
     background: rgba(255, 255, 255, 0.04);
     border: 1px solid var(--panel-border);
     border-radius: 8px;
@@ -704,6 +705,7 @@ input[type="range"]:focus-visible {
     justify-content: center;
     gap: 6px;
     padding: 9px 10px;
+    min-height: var(--touch-target, 44px);
     border-radius: 8px;
     border: 1px solid;
     cursor: pointer;
@@ -1058,4 +1060,9 @@ body.cinema.pointer-idle .cinema-exit {
     }
     .icon-btn,
     .close-btn { min-width: 44px; min-height: 44px; }
+
+    /* Painel de controles: no toque cada botão precisa dos 44px, mesmo os
+       compactos desenhados para o mouse. */
+    .glyph-btn { min-height: var(--touch-target, 44px); }
+    .mini-btn { width: var(--touch-target, 44px); min-height: var(--touch-target, 44px); }
 }

--- a/labs/paint/style.css
+++ b/labs/paint/style.css
@@ -532,11 +532,13 @@ kbd {
         max-width: 100%;
     }
 
+    /* Antes este bloco encolhia os botões para 40px — justamente no tamanho de
+       tela onde eles são tocados com o dedo. Mantém os 44px do padrão. */
     .header-tools button {
-        width: 40px;
-        height: 40px;
-        min-width: 40px;
-        min-height: 40px;
+        width: var(--touch-target, 44px);
+        height: var(--touch-target, 44px);
+        min-width: var(--touch-target, 44px);
+        min-height: var(--touch-target, 44px);
     }
 
     footer[data-lab-footer] {
@@ -639,9 +641,9 @@ kbd {
     /* Amostras de 24px são impossíveis de acertar com o dedo, e alargar o alvo
        por pseudo-elemento não resolve numa grade densa (as áreas se sobrepõem e
        o toque escolhe a cor vizinha). A grade passa a preencher a largura
-       disponível com células de no mínimo 40px. */
+       disponível com células de no mínimo 44px. */
     .side-bar.right .color-palette {
-        grid-template-columns: repeat(auto-fill, minmax(40px, 1fr));
+        grid-template-columns: repeat(auto-fill, minmax(var(--touch-target, 44px), 1fr));
         justify-content: stretch;
         gap: 6px;
     }
@@ -649,8 +651,8 @@ kbd {
     .side-bar.right .color-palette .color-swatch {
         width: 100%;
         height: auto;
-        min-width: 40px;
-        min-height: 40px;
+        min-width: var(--touch-target, 44px);
+        min-height: var(--touch-target, 44px);
         aspect-ratio: 1;
     }
 

--- a/labs/pomodoro/script.js
+++ b/labs/pomodoro/script.js
@@ -38,6 +38,9 @@
         interval: [2, 12]
     };
 
+    /* Título estático da página, preservado em toda atualização da aba. */
+    const BASE_TITLE = document.title;
+
     const MODES = {
         focus: { label: 'Foco', badge: 'Foco', title: 'Foco' },
         short: { label: 'Pausa curta', badge: 'Pausa curta', title: 'Pausa' },
@@ -1088,9 +1091,13 @@
 
         renderTitle(text) {
             const suffix = MODES[this.mode].title;
+            /* A contagem na aba é útil com o timer em outra janela, mas o nome
+               precisa continuar no título (é assim que o site é achado por
+               busca). BASE_TITLE vem do próprio <title>, então os dois nunca
+               divergem. */
             const title = this.running || this.remaining < this.durationFor(this.mode)
-                ? `${text} · ${suffix} — Pomodoro`
-                : 'Pomodoro - Labs';
+                ? `${text} · ${suffix} — ${BASE_TITLE}`
+                : BASE_TITLE;
 
             if (title !== this.lastTitle) {
                 this.lastTitle = title;

--- a/labs/quimera/style.css
+++ b/labs/quimera/style.css
@@ -271,7 +271,9 @@ header[data-lab-header] {
 
 .slot-row {
     display: grid;
-    grid-template-columns: 2.2rem 1fr 2.2rem;
+    /* As colunas das setas seguem o alvo de toque: 2.2rem deixava ‹ › com 35px
+       de largura, curto demais para o dedo. */
+    grid-template-columns: var(--touch-target) 1fr var(--touch-target);
     gap: 0.25rem;
     align-items: center;
 }
@@ -328,6 +330,8 @@ header[data-lab-header] {
 
 .btn {
     padding: 0.55rem 0.9rem;
+    /* O padding sozinho parava em 36px de altura. */
+    min-height: var(--touch-target, 44px);
     border-radius: 12px;
     background: linear-gradient(180deg, color-mix(in oklab, var(--gold) 78%, white), var(--gold));
     color: #2a1a10;

--- a/labs/rastro-vermelho/src/main.js
+++ b/labs/rastro-vermelho/src/main.js
@@ -165,10 +165,23 @@ async function loadHorse(scene, shadow) {
     return { root, animations: result.animationGroups };
 }
 
+const SETTINGS_KEY = 'rastro-vermelho:babylon';
+const SETTINGS_DEFAULT = { quality: 'auto', volume: 70, muted: false, best: 0 };
+
+/* Duas falhas reais aqui: o modo privado do Safari estoura na gravação, e um
+   valor corrompido derrubava o lab já no construtor, antes de qualquer tela. */
+function loadSettings() {
+    try {
+        return Object.assign({}, SETTINGS_DEFAULT, JSON.parse(localStorage.getItem(SETTINGS_KEY) || '{}'));
+    } catch (err) {
+        return Object.assign({}, SETTINGS_DEFAULT);
+    }
+}
+
 class RastroVermelho {
     constructor() {
         this.canvas = canvas;
-        this.settings = JSON.parse(localStorage.getItem('rastro-vermelho:babylon') || '{"quality":"auto","volume":70,"muted":false,"best":0}');
+        this.settings = loadSettings();
         this.profile = this.pickQuality();
         this.engine = new B.Engine(canvas, true, { preserveDrawingBuffer: false, stencil: true, adaptToDeviceRatio: false });
         this.engine.setHardwareScalingLevel(1 / this.profile.scale);
@@ -336,7 +349,7 @@ class RastroVermelho {
     }
 
     setLoading(progress, text) { $('#loadingFill').style.width = `${progress * 100}%`; $('#loadingText').textContent = text; }
-    persist() { localStorage.setItem('rastro-vermelho:babylon', JSON.stringify(this.settings)); }
+    persist() { try { localStorage.setItem(SETTINGS_KEY, JSON.stringify(this.settings)); } catch (err) { /* armazenamento indisponível */ } }
     say(text, duration = 2.8) { const message = $('#message'); message.textContent = text; message.dataset.show = 'true'; clearTimeout(this.messageTimer); this.messageTimer = setTimeout(() => { message.dataset.show = 'false'; }, duration * 1000); }
 
     frame() {

--- a/labs/rock-kombat/audio.js
+++ b/labs/rock-kombat/audio.js
@@ -1,6 +1,11 @@
 let context = null;
 let master = null;
-let muted = localStorage.getItem('rk-muted') === '1';
+/* Mesma proteção do main.js: mutar não pode derrubar o jogo. */
+function readStored(key) {
+  try { return localStorage.getItem(key); } catch { return null; }
+}
+
+let muted = readStored('rk-muted') === '1';
 let musicTimer = null;
 let musicStep = 0;
 
@@ -101,7 +106,7 @@ function stopMusic() {
 
 function setMuted(value) {
   muted = value;
-  localStorage.setItem('rk-muted', value ? '1' : '0');
+  try { localStorage.setItem('rk-muted', value ? '1' : '0'); } catch { /* armazenamento indisponível */ }
   if (master) master.gain.setTargetAtTime(value ? 0 : .58, context.currentTime, .02);
 }
 

--- a/labs/rock-kombat/main.js
+++ b/labs/rock-kombat/main.js
@@ -13,7 +13,17 @@ let paused = false;
 let selected = null;
 let selectedCpu = null;
 let stageId = 'seattle';
-let difficulty = localStorage.getItem('rk-difficulty') || 'normal';
+/* Safari no modo privado deixa ler mas estoura ao gravar: sem esta proteção,
+   trocar a dificuldade derrubava o jogo com QuotaExceededError. */
+function readStored(key, fallback) {
+  try { return localStorage.getItem(key) ?? fallback; } catch { return fallback; }
+}
+
+function writeStored(key, value) {
+  try { localStorage.setItem(key, value); } catch { /* armazenamento indisponível */ }
+}
+
+let difficulty = readStored('rk-difficulty', 'normal') || 'normal';
 const images = new Map();
 let assetsReady = false;
 let frameNumber = 0;
@@ -407,7 +417,7 @@ $$('#difficulty-options button').forEach(button => {
   button.classList.toggle('is-active', button.dataset.difficulty === difficulty);
   button.addEventListener('click', () => {
     difficulty = button.dataset.difficulty;
-    localStorage.setItem('rk-difficulty', difficulty);
+    writeStored('rk-difficulty', difficulty);
     $$('#difficulty-options button').forEach(item => item.classList.toggle('is-active', item === button));
     audio.sfx('ui');
   });

--- a/labs/snake/style.css
+++ b/labs/snake/style.css
@@ -272,27 +272,40 @@ canvas {
 }
 
 /* Área de toque: as setas continuam com 30px de desenho (o d-pad precisa caber
-   no aparelho), mas o alvo real cresce para fora até ~44px. */
+   no aparelho), mas o alvo real cresce para fora até 44px.
+
+   O aparelho inteiro é escalado por `--device-scale` (0,79 num iPhone SE), e o
+   `transform` encolhe o alvo junto: 44px de CSS viravam ~35px de dedo. Dividir
+   pelo fator devolve os 44px físicos. Com scale 1 a conta dá exatamente os -7px
+   e -14px de antes. */
+.d-pad {
+    --hit: calc((var(--touch-target, 44px) / var(--device-scale, 1) - 30px) / 2);
+}
+
 .d-pad > button::after {
     content: '';
     position: absolute;
-    inset: -7px;
+    inset: calc(var(--hit) * -1);
 }
 
 .d-pad-up::after {
-    inset: -14px -7px 0 -7px;
+    inset: calc(var(--hit) * -2) calc(var(--hit) * -1) 0 calc(var(--hit) * -1);
+    /* Cima e baixo vêm antes de esquerda/direita no DOM, então perdiam os
+       cantos da própria área ampliada. O z-index devolve a faixa inteira. */
+    z-index: 1;
 }
 
 .d-pad-down::after {
-    inset: 0 -7px -14px -7px;
+    inset: 0 calc(var(--hit) * -1) calc(var(--hit) * -2) calc(var(--hit) * -1);
+    z-index: 1;
 }
 
 .d-pad-left::after {
-    inset: -7px 0 -7px -14px;
+    inset: calc(var(--hit) * -1) 0 calc(var(--hit) * -1) calc(var(--hit) * -2);
 }
 
 .d-pad-right::after {
-    inset: -7px -14px -7px 0;
+    inset: calc(var(--hit) * -1) calc(var(--hit) * -2) calc(var(--hit) * -1) 0;
 }
 
 .d-pad-center {
@@ -356,6 +369,8 @@ canvas {
 .btn-b {
     width: 35px;
     height: 35px;
+    /* Ancora o ::after que amplia o alvo sem engordar o botão desenhado. */
+    position: relative;
     border-radius: 50%;
     background-color: var(--gb-btn-action);
     border: none;
@@ -365,6 +380,14 @@ canvas {
     cursor: pointer;
     touch-action: manipulation;
     transition: filter 0.15s ease;
+}
+
+.btn-a::after,
+.btn-b::after {
+    content: '';
+    position: absolute;
+    inset: calc((var(--touch-target, 44px) / var(--device-scale, 1) - 35px) / -2);
+    border-radius: 50%;
 }
 
 .btn-a:hover,
@@ -406,6 +429,8 @@ canvas {
 .btn-start {
     width: 50px;
     height: 12px;
+    /* Ancora o ::after: a barrinha de 12px é fina demais para o dedo. */
+    position: relative;
     border-radius: 10px;
     background-color: var(--gb-btn-meta);
     border: none;
@@ -414,6 +439,13 @@ canvas {
     cursor: pointer;
     touch-action: manipulation;
     transition: filter 0.15s ease;
+}
+
+.btn-select::after,
+.btn-start::after {
+    content: '';
+    position: absolute;
+    inset: calc((var(--touch-target, 44px) / var(--device-scale, 1) - 12px) / -2) 0;
 }
 
 .btn-select:hover,

--- a/labs/space-shooter/script.js
+++ b/labs/space-shooter/script.js
@@ -13,6 +13,11 @@ let gameWidth = 0;
 let gameHeight = 0;
 let soundEnabled = true;
 let highScore = Number(localStorage.getItem('neonInvadersHighScore') || 0);
+// Tiro contínuo: segurar espaço ou o botão dispara em cadência fixa, em vez de
+// exigir um toque por tiro (no celular isso virava tapinha frenético).
+const FIRE_INTERVAL = 0.14; // segundos entre disparos com o gatilho preso
+let fireHeld = false;
+let fireCooldown = 0;
 
 // Entities
 const player = {
@@ -89,7 +94,8 @@ function resize() {
     gameWidth = parent.clientWidth;
     gameHeight = parent.clientHeight;
 
-    const dpr = window.devicePixelRatio || 1;
+    /* Cap em 2: acima disso o ganho visual some e o fill-rate no celular dobra. */
+    const dpr = Math.min(window.devicePixelRatio || 1, 2);
 
     canvas.style.width = `${gameWidth}px`;
     canvas.style.height = `${gameHeight}px`;
@@ -165,17 +171,25 @@ window.addEventListener('keydown', e => {
         return;
     }
     if (keys.hasOwnProperty(e.key) || e.key === ' ') keys[e.key === ' ' ? 'Space' : e.key] = true;
-    if (e.key === ' ' && gameRunning) fireBullet();
+    if (e.key === ' ' && gameRunning && !e.repeat) {
+        fireHeld = true;
+        fireCooldown = 0;
+    }
 });
 
 window.addEventListener('keyup', e => {
     if (keys.hasOwnProperty(e.key) || e.key === ' ') keys[e.key === ' ' ? 'Space' : e.key] = false;
+    if (e.key === ' ') fireHeld = false;
 });
 
 // Touch/Mouse support for shooting
-canvas.addEventListener('mousedown', () => {
-    if (gameRunning) fireBullet();
+canvas.addEventListener('pointerdown', () => {
+    if (!gameRunning) return;
+    fireHeld = true;
+    fireCooldown = 0;
 });
+window.addEventListener('pointerup', () => { fireHeld = false; });
+window.addEventListener('pointercancel', () => { fireHeld = false; });
 
 canvas.addEventListener('pointermove', e => {
     if (!gameRunning || e.pointerType === 'mouse') return;
@@ -244,6 +258,13 @@ function fireBullet() {
 
 // Game Loop
 function update(dt) {
+    // Gatilho preso: dispara na cadência de FIRE_INTERVAL enquanto estiver ativo.
+    fireCooldown -= dt;
+    if (fireHeld && fireCooldown <= 0) {
+        fireBullet();
+        fireCooldown = FIRE_INTERVAL;
+    }
+
     // Player Movement
     if (keys.ArrowLeft || keys.a) player.dx = -player.speed;
     else if (keys.ArrowRight || keys.d) player.dx = player.speed;
@@ -434,7 +455,9 @@ function draw() {
 
 function loop(timestamp) {
     if (!gameRunning) return;
-    const dt = (timestamp - lastTime) / 1000;
+    // Teto de 1/30s: sem ele, um frame longo (troca de aba, GC) fazia os
+    // inimigos pularem várias linhas e os tiros atravessarem a nave.
+    const dt = Math.min((timestamp - lastTime) / 1000, 1 / 30);
     lastTime = timestamp;
 
     update(dt);
@@ -505,15 +528,37 @@ function bindHoldControl(element, keyName) {
 bindHoldControl(document.getElementById('moveLeft'), 'ArrowLeft');
 bindHoldControl(document.getElementById('moveRight'), 'ArrowRight');
 
-document.getElementById('shootBtn').addEventListener('pointerdown', e => {
+const shootBtn = document.getElementById('shootBtn');
+shootBtn.addEventListener('pointerdown', e => {
     e.preventDefault();
-    if (gameRunning) fireBullet();
+    if (!gameRunning) return;
+    fireHeld = true;
+    fireCooldown = 0;
+});
+['pointerup', 'pointercancel', 'pointerleave'].forEach(evt => {
+    shootBtn.addEventListener(evt, e => {
+        e.preventDefault();
+        fireHeld = false;
+    });
 });
 
 document.getElementById('soundToggle').addEventListener('click', e => {
     soundEnabled = !soundEnabled;
     e.currentTarget.setAttribute('aria-pressed', String(soundEnabled));
     e.currentTarget.lastElementChild.textContent = soundEnabled ? 'Som ativado' : 'Som desativado';
+});
+
+// Aba escondida: congela o jogo em vez de deixar a horda avançar sozinha.
+document.addEventListener('visibilitychange', () => {
+    if (!gameRunning) return;
+    if (document.hidden) {
+        cancelAnimationFrame(animationId);
+        fireHeld = false;
+        keys.ArrowLeft = keys.ArrowRight = keys.a = keys.d = false;
+    } else {
+        lastTime = performance.now();
+        animationId = requestAnimationFrame(loop);
+    }
 });
 
 // Initial Resize

--- a/labs/space-shooter/script.js
+++ b/labs/space-shooter/script.js
@@ -12,7 +12,17 @@ let lastTime = 0;
 let gameWidth = 0;
 let gameHeight = 0;
 let soundEnabled = true;
-let highScore = Number(localStorage.getItem('neonInvadersHighScore') || 0);
+/* Modo privado do Safari estoura ao gravar; o recorde é bônus, não pode
+   interromper a tela de fim de jogo. */
+function readHighScore() {
+    try { return Number(localStorage.getItem('neonInvadersHighScore') || 0); } catch (err) { return 0; }
+}
+
+function saveHighScore(value) {
+    try { localStorage.setItem('neonInvadersHighScore', String(value)); } catch (err) { /* armazenamento indisponível */ }
+}
+
+let highScore = readHighScore();
 // Tiro contínuo: segurar espaço ou o botão dispara em cadência fixa, em vez de
 // exigir um toque por tiro (no celular isso virava tapinha frenético).
 const FIRE_INTERVAL = 0.14; // segundos entre disparos com o gatilho preso
@@ -487,7 +497,7 @@ function gameOver() {
     cancelAnimationFrame(animationId);
     if (score > highScore) {
         highScore = score;
-        localStorage.setItem('neonInvadersHighScore', String(highScore));
+        saveHighScore(highScore);
     }
     updateHud();
     document.getElementById('finalScore').innerText = formatScore(score);

--- a/labs/tatu-bola/src/config.js
+++ b/labs/tatu-bola/src/config.js
@@ -50,10 +50,10 @@ export const QUEST = {
 };
 
 export const QUALITY = {
-    auto: { pixel: 1.0, shadows: true, particles: 1.0 },
+    auto: { pixel: 1.5, shadows: true, particles: 1.0 },
     low: { pixel: 1.0, shadows: false, particles: 0.5 },
-    medium: { pixel: 1.0, shadows: true, particles: 0.8 },
-    high: { pixel: 1.0, shadows: true, particles: 1.2 }
+    medium: { pixel: 1.5, shadows: true, particles: 0.8 },
+    high: { pixel: 2.0, shadows: true, particles: 1.2 }
 };
 
 /** Cristais — (x, z). Y é amostrado do terreno + offset. */

--- a/labs/tatu-bola/src/main.js
+++ b/labs/tatu-bola/src/main.js
@@ -163,7 +163,8 @@ class Game {
 
     applyQuality() {
         const q = this.qualityPreset();
-        this.renderer.setPixelRatio(window.devicePixelRatio || 1);
+        /* Retina sem cap custa 4-9x de fill-rate no celular: o preset limita. */
+        this.renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, q.pixel));
         this.renderer.shadowMap.enabled = q.shadows;
         this.world.setShadows(q.shadows);
         setSnap(q.snap);

--- a/labs/tetris/style.css
+++ b/labs/tetris/style.css
@@ -276,35 +276,57 @@ body {
 
 /* Área de toque: as setas mantêm os 30px de desenho (o d-pad precisa caber no
    console), mas o alvo real cresce para fora, longe do centro. */
+/* O console inteiro é escalado por `--device-scale` (0,8 num iPhone SE) e o
+   `transform` encolhe o alvo junto: 44px de CSS viravam ~35px de dedo. Dividir
+   pelo fator devolve os 44px físicos — com escala 1 a conta dá os mesmos -7px
+   e -14px de antes. */
+.d-pad {
+    --hit: calc((var(--touch-target, 44px) / var(--device-scale, 1) - 30px) / 2);
+}
+
 .d-pad > button::after {
     content: '';
     position: absolute;
-    inset: -7px;
+    inset: calc(var(--hit) * -1);
 }
 
 .d-pad .up::after {
-    inset: -14px -7px 0 -7px;
+    inset: calc(var(--hit) * -2) calc(var(--hit) * -1) 0 calc(var(--hit) * -1);
+    /* Cima e baixo vêm antes de esquerda/direita no DOM, então perdiam os
+       cantos da própria área ampliada. O z-index devolve a faixa inteira. */
+    z-index: 1;
 }
 
 .d-pad .down::after {
-    inset: 0 -7px -14px -7px;
+    inset: 0 calc(var(--hit) * -1) calc(var(--hit) * -2) calc(var(--hit) * -1);
+    z-index: 1;
 }
 
 .d-pad .left::after {
-    inset: -7px 0 -7px -14px;
+    inset: calc(var(--hit) * -1) 0 calc(var(--hit) * -1) calc(var(--hit) * -2);
 }
 
 .d-pad .right::after {
-    inset: -7px -14px -7px 0;
+    inset: calc(var(--hit) * -1) calc(var(--hit) * -2) calc(var(--hit) * -1) 0;
 }
 
+/* A/B são redondos de 35px; Select/Start são barras de 14px de altura. Cada um
+   cresce até o alvo mínimo, também compensando a escala do console. */
 .btn-a::after,
-.btn-b::after,
+.btn-b::after {
+    content: '';
+    position: absolute;
+    inset: calc((var(--touch-target, 44px) / var(--device-scale, 1) - 35px) / -2);
+    border-radius: inherit;
+}
+
 .btn-select::after,
 .btn-start::after {
     content: '';
     position: absolute;
-    inset: -6px;
+    /* Só na vertical: Select e Start ficam a 5px um do outro, então crescer na
+       horizontal fazia um roubar o toque do outro. */
+    inset: calc((var(--touch-target, 44px) / var(--device-scale, 1) - 14px) / -2) 0;
     border-radius: inherit;
 }
 

--- a/labs/winamp/script.js
+++ b/labs/winamp/script.js
@@ -1085,8 +1085,13 @@ function applySkin(key) {
 function fitPlayer() {
     const stageWidth = isCompact ? 550 : 1100;
     const stageHeight = isCompact ? 783 : 464;
-    const iconRail = isCompact ? 84 : 132;
-    const horizontalRoom = Math.max(260, window.innerWidth - iconRail - 18);
+    /* Precisa bater com os insets de `.player-workspace` no CSS: a conta antiga
+       descontava a trilha de ícones e mais 18px de folga que o layout já não
+       reservava, e o player saía menor do que cabia. Com o player a 0,5x cada
+       botão do transporte tem 20px de dedo, então cada ponto de escala conta. */
+    const iconRail = isCompact ? 77 : 132;
+    const gutter = isCompact ? 7 : 18;
+    const horizontalRoom = Math.max(260, window.innerWidth - iconRail - gutter);
     const verticalRoom = Math.max(250, window.innerHeight - 58);
     const scale = Math.min(1, horizontalRoom / stageWidth, verticalRoom / stageHeight);
     document.documentElement.style.setProperty("--player-scale", String(Math.max(0.36, scale)));

--- a/labs/winamp/style.css
+++ b/labs/winamp/style.css
@@ -188,6 +188,11 @@ a:focus-visible {
     left: 8px;
     z-index: 1000001;
     padding: 8px 12px;
+    /* Atalho de teclado, mas quem navega por leitor de tela no celular também
+       o aciona com o dedo: 34px de altura era curto. */
+    display: flex;
+    align-items: center;
+    min-height: var(--touch-target, 44px);
     border: 2px outset var(--win-light);
     background: var(--win-gray);
     color: #000;


### PR DESCRIPTION
## 🎯 Objetivo

Passar os 54 labs por uma auditoria automatizada (Playwright em 375×667, 667×375 e desktop) e corrigir o que ela encontrou: alvos de toque abaixo de 44px, um lab que quebrava no modo privado do Safari, o catálogo estruturado da galeria defasado e dois gargalos de desempenho.

## ✨ O que mudou

**Alvos de toque (o achado mais recorrente)**

- **Snake e Tetris** desenham o console numa base fixa e o escalam com `transform`. A área ampliada por pseudo-elemento escalava junto, então 44px de CSS viravam ~35px de dedo. O raio agora divide por `--device-scale` — com escala 1 a conta dá exatamente os `-7px`/`-14px` de antes. Cima e baixo ganharam `z-index`: vinham antes de esquerda/direita no DOM e perdiam os cantos da própria área. No Snake, A/B e Select/Start não tinham área ampliada; agora têm.
- **Paint**: o bloco de `≤768px` encolhia os botões do header para 40px — justamente no tamanho de tela onde são tocados com o dedo. Paleta com piso de 44px.
- **Matrix**: `.glyph-btn`, `.mini-btn` e os botões do painel de controles.
- **Quimera**: as setas ‹ › do seletor (35px numa linha de 3 colunas com espaço de sobra) e os botões de ação.
- **Lander**: o `::after` do menu não tinha `z-index`, e o conteúdo seguinte no DOM comia 10px do alvo.
- **jungle-run** (pause no meio da corrida), **f1-racing**, **image-editor**, **winamp**.

**Jogabilidade**

- **Space Shooter**: segurar o gatilho — espaço, tela ou botão — dispara em cadência, em vez de exigir um toque por tiro (no celular virava tapinha frenético). O `dt` ganhou teto de 1/30s: sem ele, um frame longo fazia a horda pular várias linhas de uma vez. E o jogo congela com a aba escondida, em vez de deixar os inimigos avançarem sozinhos.

**Performance**

- **Matrix**: as camadas de fundo têm células menores, logo mais colunas — com a mesma densidade por coluna, geravam 1,6× mais streams que a camada da frente. Medido a 375px: 73% dos glifos do frame estavam numa camada de alpha 0,32. De 735 para 531 `drawImage` por frame, 35 → 43 fps.
- **Tatu Bola**: o renderer usava o `devicePixelRatio` cru (9× de fill-rate num celular de DPR 3) e ignorava o campo `pixel` do próprio preset de qualidade. **Space Shooter**: DPR limitado a 2.
- **Aurora Flow**: a cena avança por frame (partículas somam `vx`, `time` soma 0.016), então num painel de 120Hz ela corria em dobro. Em vez de reescrever a simulação para delta-time — o que mudaria a calibragem visual — o laço mantém a cadência de 60fps: mesma imagem, metade do trabalho num celular de 120Hz.
- **Winamp**: `fitPlayer` descontava 18px que o layout já não reservava, e o player saía menor do que cabia.

**Robustez e catálogo**

- Safari em navegação privada deixa ler o `localStorage` mas estoura ao gravar. Com um stub que reproduz isso, o **Rock Kombat** morria com `QuotaExceededError` ao trocar a dificuldade ou o som. Blindados também **space-shooter** (recorde) e **rastro-vermelho** — neste, o `JSON.parse` das preferências rodava no construtor, e um valor corrompido derrubava o lab antes da primeira tela.
- **Galeria**: o `ItemList` declarava `numberOfItems: 54` mas carregava 53 — o Claude Bros entrou como card e nunca entrou na lista estruturada. As posições tinham buraco (iam a 57, com 14, 26, 29 e 32 vagos, herdados de labs que saíram) e a ordem já não acompanhava a dos cards. Regenerada a partir da ordem real, 1 a 54.
- **Pomodoro**: o `<title>` do HTML está certo, mas o JS o reescrevia a cada segundo e trocava por "Pomodoro - Labs", derrubando o nome. A contagem na aba continua — agora o sufixo vem do próprio `<title>`, então os dois nunca divergem.

## 🧪 Como testar

1. Na raiz do repo: `python3 -m http.server 8000`
2. Abrir [http://localhost:8000/](http://localhost:8000/) (home) e [http://localhost:8000/labs/](http://localhost:8000/labs/) (galeria)
3. Abrir o lab ou a página alterada e confirmar que CSS, JS e o voltar funcionam
4. Responsivo: DevTools em **375×667**, **390×844** e landscape curto (~667×375) — sem overflow horizontal, HUD/controles utilizáveis, alvos ≥ 44px
5. Se o lab for novo, renomeado ou removido: conferir pasta ↔ card da galeria ↔ README ↔ `sitemap.xml` ↔ canonical/OG

Roteiros específicos desta PR:

- **Space Shooter**: segurar o botão de tiro derruba vários inimigos sem soltar; trocar de aba e voltar não avança a horda.
- **Snake / Tetris**: no iPhone SE, o D-pad e os botões A/B respondem na borda, não só no pixel do desenho.
- **Pomodoro**: iniciar o timer e olhar a aba — `24:58 · Foco — Pomodoro | Diogo Paulino`.
- **Rock Kombat**: abrir em janela privada, trocar a dificuldade e o som — sem erro no console.

### O que a auditoria automatizada mediu (54 labs × 3 viewports)

| Verificação | Resultado |
| --- | --- |
| Overflow horizontal | nenhum |
| Erros de console / página | nenhum (fora o CDN bloqueado no ambiente de teste) |
| Requests 404 do próprio site | nenhum |
| Modo privado (gravação estourando) | nenhum lab quebra |
| Home e galeria | limpas nos 3 viewports |
| Catálogo | 54 slugs iguais em pasta ↔ galeria ↔ README ↔ sitemap |
| JSON-LD | 56 arquivos, todos JSON válido |

Os labs 3D (three.js/Babylon/Pixi) não puderam ser jogados aqui — o ambiente bloqueia os CDNs. Em compensação isso exercitou o caminho de falha: o guard do `shared.js` mostra o aviso "Não deu para carregar o motor 3D" em todos eles, sem tela preta.

**Uma limitação assumida:** o Winamp é uma réplica fiel do 2.91 e, a 0,5×, está no tamanho original do player — os botões de transporte ficam com ~21px de dedo. Forçar 44px ali ou deforma a réplica ou faz botões vizinhos roubarem o toque um do outro (a 5px de distância, foi o que aconteceu num teste). Ficou como está, com o ganho de escala do `fitPlayer`. Mesma leitura para o Select do Tetris (38px é o máximo com 5px de folga até o Start) e para o d-pad esquerdo do Snake em paisagem (41px, limitado pelo miolo do próprio d-pad).

## ✅ Checklist

- [x] Links conferidos: pasta do lab ↔ card da galeria ↔ README ↔ sitemap (e corrigidos se quebravam)
- [x] README atualizado (linha na tabela + URL + contagem no badge/texto) — obrigatório em lab novo, renomeado ou removido — *sem lab novo/renomeado/removido nesta PR; as 54 linhas e a contagem foram conferidas e já estavam certas*
- [x] SEO consistente: title, description, canonical, author, robots, OG, Twitter, JSON-LD (e contagem nos metas da galeria)
- [x] Testado via HTTP na raiz, não via `file://`
- [x] Responsivo: 375px / 390px / landscape — overflow, HUD, toque, safe-area (`viewport-fit=cover`)
- [x] Nada fora do escopo foi quebrado

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CxLrSBLr6NjuxEYnTy3PqD

---
_Generated by [Claude Code](https://claude.ai/code/session_01CxLrSBLr6NjuxEYnTy3PqD)_