### PR TITLE
⚡️ perf: otimização global dos 54 labs — visibilidade, performance e UX

### DIFF
--- a/labs/aurora-flow/index.html
+++ b/labs/aurora-flow/index.html
@@ -29,7 +29,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600;700;800&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=11">
+    <link rel="stylesheet" href="/labs/shared.css?v=12">
     <link rel="stylesheet" href="style.css">
     <script type="application/ld+json">
     {
@@ -239,7 +239,7 @@
 
     <footer data-lab-footer data-home-href="/"></footer>
 
-    <script src="/labs/shared.js?v=11" defer></script>
+    <script src="/labs/shared.js?v=12" defer></script>
     <script src="script.js" defer></script>
 </body>
 

--- a/labs/aurora-flow/script.js
+++ b/labs/aurora-flow/script.js
@@ -1010,6 +1010,7 @@ const FRAME_MS = 1000 / 60;
 let lastFrameAt = -Infinity;
 
 function animate(frameNow) {
+    if (document.hidden) return;
     requestAnimationFrame(animate);
     if (paused) return;
 
@@ -1402,3 +1403,4 @@ buildSceneRail();
 resize();
 applyScene(currentKey, true);
 animate();
+window.LabVisibility?.whenVisible(() => animate());

--- a/labs/beige-box/index.html
+++ b/labs/beige-box/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=Outfit:wght@300;400;500;600;700&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=11">
+    <link rel="stylesheet" href="/labs/shared.css?v=12">
     <link rel="stylesheet" href="style.css?v=1">
 
     <script type="importmap">
@@ -146,7 +146,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=11" defer></script>
+    <script src="/labs/shared.js?v=12" defer></script>
     <script type="module" src="src/main.js?v=3"></script>
 </body>
 

--- a/labs/beige-box/src/main.js
+++ b/labs/beige-box/src/main.js
@@ -166,7 +166,9 @@ class BeigeBox {
         }, 420);
 
         this._clock.start();
-        this.renderer.setAnimationLoop(() => this.frame());
+        this._renderLoop = () => this.frame();
+        if (window.LabRuntime) LabRuntime.bindThreeLoop(this.renderer, this._renderLoop);
+        else this.renderer.setAnimationLoop(this._renderLoop);
         window.addEventListener('resize', () => this.resize());
     }
 

--- a/labs/calculator/index.html
+++ b/labs/calculator/index.html
@@ -23,7 +23,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Calculator | Diogo Paulino">
     <meta name="twitter:description" content="Calculadora online com modos simples, científico e conversor de moedas em tempo real.">
-    <link rel="stylesheet" href="/labs/shared.css?v=11">
+    <link rel="stylesheet" href="/labs/shared.css?v=12">
     <link rel="stylesheet" href="style.css?v=6">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -239,7 +239,7 @@
 
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
-    <script src="/labs/shared.js?v=11" defer></script>
+    <script src="/labs/shared.js?v=12" defer></script>
     <script src="script.js" defer></script>
 </body>
 

--- a/labs/castelo-estelar/index.html
+++ b/labs/castelo-estelar/index.html
@@ -34,7 +34,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;600;700&family=Outfit:wght@300;400;500;600;700&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=11">
+    <link rel="stylesheet" href="/labs/shared.css?v=12">
     <link rel="stylesheet" href="style.css">
 
     <script type="importmap">
@@ -186,7 +186,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=11" defer></script>
+    <script src="/labs/shared.js?v=12" defer></script>
     <script>
         (function () {
             function hasGpu() {

--- a/labs/castelo-estelar/src/main.js
+++ b/labs/castelo-estelar/src/main.js
@@ -147,7 +147,9 @@ class CasteloEstelar {
         this.show('#intro');
         document.body.dataset.state = 'menu';
         this.clock.start();
-        this.renderer.setAnimationLoop(() => this.frame());
+        this._renderLoop = () => this.frame();
+        if (window.LabRuntime) LabRuntime.bindThreeLoop(this.renderer, this._renderLoop);
+        else this.renderer.setAnimationLoop(this._renderLoop);
     }
 
     fail(err) {

--- a/labs/claude-bros/index.html
+++ b/labs/claude-bros/index.html
@@ -65,7 +65,7 @@
   }
   </script>
 
-  <link rel="stylesheet" href="/labs/shared.css?v=11">
+  <link rel="stylesheet" href="/labs/shared.css?v=12">
   <link rel="stylesheet" href="style.css?v=2">
 </head>
 
@@ -117,7 +117,7 @@
     <footer data-lab-footer data-home-href="/"></footer>
   </main>
 
-  <script src="/labs/shared.js?v=11" defer></script>
+  <script src="/labs/shared.js?v=12" defer></script>
   <script src="main.js?v=2" defer></script>
 </body>
 

--- a/labs/cupola-64/index.html
+++ b/labs/cupola-64/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600;700;800&family=Press+Start+2P&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=11">
+    <link rel="stylesheet" href="/labs/shared.css?v=12">
     <link rel="stylesheet" href="style.css">
 
     <script type="importmap">
@@ -271,7 +271,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=11" defer></script>
+    <script src="/labs/shared.js?v=12" defer></script>
     <script>
         (function () {
             function hasGpu() {

--- a/labs/cyberos/index.html
+++ b/labs/cyberos/index.html
@@ -29,7 +29,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=VT323&display=swap"
     rel="stylesheet">
-  <link rel="stylesheet" href="/labs/shared.css?v=11">
+  <link rel="stylesheet" href="/labs/shared.css?v=12">
   <link rel="stylesheet" href="style.css?v=3">
   <script type="application/ld+json">
   {
@@ -246,7 +246,7 @@
 
   <footer data-lab-footer data-home-href="/" class="cyber-lab-footer"></footer>
 
-  <script src="/labs/shared.js?v=11" defer></script>
+  <script src="/labs/shared.js?v=12" defer></script>
   <script src="script.js?v=2" defer></script>
 </body>
 

--- a/labs/english-duo/index.html
+++ b/labs/english-duo/index.html
@@ -22,7 +22,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Talk | Diogo Paulino">
     <meta name="twitter:description" content="Aprenda idiomas de forma divertida e interativa com o Talk.">
-    <link rel="stylesheet" href="/labs/shared.css?v=11">
+    <link rel="stylesheet" href="/labs/shared.css?v=12">
     <link rel="stylesheet" href="style.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -417,7 +417,7 @@
     </div>
 
     <div id="toast-container" class="toast-container"></div>
-    <script src="/labs/shared.js?v=11" defer></script>
+    <script src="/labs/shared.js?v=12" defer></script>
     <script src="script.js" defer></script>
 </body>
 

--- a/labs/eyra/index.html
+++ b/labs/eyra/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;600;700;800&family=Outfit:wght@400;500;600;700;800&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=11">
+    <link rel="stylesheet" href="/labs/shared.css?v=12">
     <link rel="stylesheet" href="style.css">
 
     <script type="importmap">
@@ -261,7 +261,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=11" defer></script>
+    <script src="/labs/shared.js?v=12" defer></script>
     <script>
         (function () {
             function hasGpu() {

--- a/labs/f1-racing/index.html
+++ b/labs/f1-racing/index.html
@@ -28,7 +28,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="preconnect" href="https://cdn.babylonjs.com" crossorigin>
-    <link rel="stylesheet" href="/labs/shared.css?v=11">
+    <link rel="stylesheet" href="/labs/shared.css?v=12">
     <link rel="stylesheet" href="style.css?v=13">
     <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700&family=Orbitron:wght@500;600;700;800;900&display=swap"
         rel="stylesheet">
@@ -180,7 +180,7 @@
 
     <script src="https://cdn.babylonjs.com/babylon.js"></script>
     <script src="https://cdn.babylonjs.com/loaders/babylonjs.loaders.min.js"></script>
-    <script src="/labs/shared.js?v=11" defer></script>
+    <script src="/labs/shared.js?v=12" defer></script>
     <script type="module" src="src/main.js"></script>
 </body>
 

--- a/labs/f1-racing/src/main.js
+++ b/labs/f1-racing/src/main.js
@@ -9,6 +9,7 @@ import { buildF1Car, updateCarVisuals } from './carModel.js';
 import { Vehicle } from './vehicle.js';
 import { RaceEffects } from './effects.js';
 import { AudioEngine } from './audio.js';
+import { TEAMS } from './config.js';
 import { clamp, lerp } from './utils.js';
 
 class F1GrandPrix {
@@ -93,7 +94,11 @@ class F1GrandPrix {
 
         // Carro do Jogador
         this.playerCar = buildF1Car(BABYLON, this.scene, '#e10600');
-        this.vehicle = new Vehicle(this.circuit);
+        this.vehicle = new Vehicle({
+            circuit: this.circuit,
+            team: TEAMS[0],
+            isPlayer: true
+        });
 
         // Efeitos
         this.effects = new RaceEffects(BABYLON, this.scene);

--- a/labs/f1-racing/src/main.js
+++ b/labs/f1-racing/src/main.js
@@ -119,10 +119,12 @@ class F1GrandPrix {
         if (menu) menu.classList.add('is-visible');
         document.body.dataset.state = 'menu';
 
-        this.engine.runRenderLoop(() => {
+        this._renderLoop = () => {
             this.frame();
             this.scene.render();
-        });
+        };
+        if (window.LabRuntime) LabRuntime.bindBabylonLoop(this.engine, this._renderLoop);
+        else this.engine.runRenderLoop(this._renderLoop);
 
         window.addEventListener('resize', () => this.engine.resize());
     }

--- a/labs/f1-racing/src/vehicle.js
+++ b/labs/f1-racing/src/vehicle.js
@@ -58,7 +58,7 @@ export class Vehicle {
     constructor({ circuit, team, driver, compound = 'soft', weather, isPlayer = false, skill = 1 }) {
         this.circuit = circuit;
         this.team = team;
-        this.driver = driver || team.name;
+        this.driver = driver || team?.name || 'Pilot';
         this.isPlayer = isPlayer;
         this.skill = skill;
         this.weather = weather;

--- a/labs/forrest-run/index.html
+++ b/labs/forrest-run/index.html
@@ -34,7 +34,7 @@
     <link rel="preconnect" href="https://cdn.babylonjs.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,500;0,700;1,500&family=Outfit:wght@400;500;600;700&family=Share+Tech+Mono&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=11">
+    <link rel="stylesheet" href="/labs/shared.css?v=12">
     <link rel="stylesheet" href="style.css">
 
     <script type="application/ld+json">
@@ -260,7 +260,7 @@
 
     <script src="https://cdn.babylonjs.com/babylon.js"></script>
     <script src="https://cdn.babylonjs.com/loaders/babylonjs.loaders.min.js"></script>
-    <script src="/labs/shared.js?v=11" defer></script>
+    <script src="/labs/shared.js?v=12" defer></script>
     <script type="module" src="src/main.js"></script>
 </body>
 

--- a/labs/grao/index.html
+++ b/labs/grao/index.html
@@ -29,7 +29,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=11">
+    <link rel="stylesheet" href="/labs/shared.css?v=12">
     <link rel="stylesheet" href="style.css">
     <script type="application/ld+json">
     {
@@ -273,7 +273,7 @@
     <div class="toast-region" id="toast-region" aria-live="polite"></div>
     <p class="sr-only" id="live-region" role="status" aria-live="polite"></p>
 
-    <script src="/labs/shared.js?v=11" defer></script>
+    <script src="/labs/shared.js?v=12" defer></script>
     <script type="module" src="script.js"></script>
 </body>
 

--- a/labs/gravity/index.html
+++ b/labs/gravity/index.html
@@ -26,7 +26,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=11">
+    <link rel="stylesheet" href="/labs/shared.css?v=12">
     <link rel="stylesheet" href="style.css">
     <script type="application/ld+json">
     {
@@ -270,7 +270,7 @@
 
     <footer data-lab-footer data-home-href="/"></footer>
 
-    <script src="/labs/shared.js?v=11" defer></script>
+    <script src="/labs/shared.js?v=12" defer></script>
     <script src="script.js" defer></script>
 </body>
 

--- a/labs/gravity/script.js
+++ b/labs/gravity/script.js
@@ -1387,6 +1387,7 @@
     }
 
     function animate(now) {
+        if (document.hidden) return;
         requestAnimationFrame(animate);
         now = now || performance.now();
         updateFps(now);
@@ -1656,4 +1657,5 @@
 
     resize();
     requestAnimationFrame(animate);
+    window.LabVisibility?.whenVisible(() => requestAnimationFrame(animate));
 })();

--- a/labs/guerreiro-castelo/index.html
+++ b/labs/guerreiro-castelo/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.babylonjs.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;600;700;800&family=Outfit:wght@300;400;500;600;700&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=11">
+    <link rel="stylesheet" href="/labs/shared.css?v=12">
     <link rel="stylesheet" href="css/style.css">
 
     <script type="application/ld+json">
@@ -256,7 +256,7 @@
     <script src="https://cdn.babylonjs.com/babylon.js"></script>
     <script src="https://cdn.babylonjs.com/loaders/babylonjs.loaders.min.js"></script>
     <script src="https://cdn.babylonjs.com/materialsLibrary/babylonjs.materials.min.js"></script>
-    <script src="/labs/shared.js?v=11" defer></script>
+    <script src="/labs/shared.js?v=12" defer></script>
     <script type="module" src="js/main.js"></script>
 </body>
 

--- a/labs/guerreiro-castelo/js/core/Game.js
+++ b/labs/guerreiro-castelo/js/core/Game.js
@@ -247,9 +247,11 @@ export class Game {
     }
 
     start() {
-        this.engine.runRenderLoop(() => {
+        this._renderLoop = () => {
             this.tick();
             this.scene.render();
-        });
+        };
+        if (window.LabRuntime) LabRuntime.bindBabylonLoop(this.engine, this._renderLoop);
+        else this.engine.runRenderLoop(this._renderLoop);
     }
 }

--- a/labs/honor-front/index.html
+++ b/labs/honor-front/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.babylonjs.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@600;700;800&family=Oswald:wght@400;500;600;700&family=Outfit:wght@300;400;500;600;700&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=11">
+    <link rel="stylesheet" href="/labs/shared.css?v=12">
     <link rel="stylesheet" href="style.css?v=1">
 
     <script type="application/ld+json">
@@ -216,7 +216,7 @@
 
     <script src="https://cdn.babylonjs.com/babylon.js"></script>
     <script src="https://cdn.babylonjs.com/loaders/babylonjs.loaders.min.js"></script>
-    <script src="/labs/shared.js?v=11" defer></script>
+    <script src="/labs/shared.js?v=12" defer></script>
     <script type="module" src="src/main.js"></script>
 </body>
 

--- a/labs/honor-front/src/main.js
+++ b/labs/honor-front/src/main.js
@@ -199,10 +199,12 @@ class HonorFront {
         document.getElementById('menuOverlay').hidden = false;
         document.body.dataset.state = 'intro';
 
-        this.engine.runRenderLoop(() => {
+        this._renderLoop = () => {
             this.frame();
             this.scene.render();
-        });
+        };
+        if (window.LabRuntime) LabRuntime.bindBabylonLoop(this.engine, this._renderLoop);
+        else this.engine.runRenderLoop(this._renderLoop);
 
         window.addEventListener('resize', () => this.engine.resize());
     }

--- a/labs/image-editor/index.html
+++ b/labs/image-editor/index.html
@@ -24,7 +24,7 @@
     <meta name="twitter:description" content="Editor de imagens no navegador: recorte, filtros, ajustes de brilho, contraste e saturação, tudo processado localmente sem enviar nada para servidor.">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="stylesheet" href="/labs/shared.css?v=11">
+    <link rel="stylesheet" href="/labs/shared.css?v=12">
     <link rel="stylesheet" href="style.css">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <script type="application/ld+json">
@@ -218,7 +218,7 @@
 
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
-    <script src="/labs/shared.js?v=11" defer></script>
+    <script src="/labs/shared.js?v=12" defer></script>
     <script src="script.js" defer></script>
 </body>
 

--- a/labs/image-optimizer/index.html
+++ b/labs/image-optimizer/index.html
@@ -24,7 +24,7 @@
     <meta name="twitter:description" content="Otimize e converta suas imagens para JPG, PNG ou WEBP diretamente no navegador.">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="stylesheet" href="/labs/shared.css?v=11">
+    <link rel="stylesheet" href="/labs/shared.css?v=12">
     <link rel="stylesheet" href="style.css">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <script type="application/ld+json">
@@ -130,7 +130,7 @@
 
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
-    <script src="/labs/shared.js?v=11" defer></script>
+    <script src="/labs/shared.js?v=12" defer></script>
     <script src="script.js" defer></script>
 </body>
 

--- a/labs/index.html
+++ b/labs/index.html
@@ -28,7 +28,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@100..900&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="/labs/shared.css?v=9">
+  <link rel="stylesheet" href="/labs/shared.css?v=12">
   <link rel="stylesheet" href="/labs/style.css">
   <script type="application/ld+json">
   {
@@ -1549,7 +1549,7 @@
     </div>
     <footer data-lab-footer data-home-href="/"></footer>
   </div>
-  <script src="/labs/shared.js?v=8"></script>
+  <script src="/labs/shared.js?v=12"></script>
   <script src="/labs/index.js"></script>
 </body>
 

--- a/labs/joao-e-o-pe-de-feijao/index.html
+++ b/labs/joao-e-o-pe-de-feijao/index.html
@@ -35,7 +35,7 @@
     <link rel="preconnect" href="https://assets.babylonjs.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;600;700;800&family=Nunito:wght@400;600;700;800&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=11">
+    <link rel="stylesheet" href="/labs/shared.css?v=12">
     <link rel="stylesheet" href="style.css?v=2">
 
     <script type="application/ld+json">
@@ -292,7 +292,7 @@
 
     <script src="https://cdn.babylonjs.com/babylon.js"></script>
     <script src="https://cdn.babylonjs.com/loaders/babylonjs.loaders.min.js"></script>
-    <script src="/labs/shared.js?v=11" defer></script>
+    <script src="/labs/shared.js?v=12" defer></script>
     <script>
         (function () {
             function hasGpu() {

--- a/labs/joao-e-o-pe-de-feijao/src/main.js
+++ b/labs/joao-e-o-pe-de-feijao/src/main.js
@@ -126,7 +126,9 @@ class Game {
         this.hud.setState('menu');
 
         this.lastTime = performance.now();
-        this.engine.runRenderLoop(() => this._loop());
+        this._renderLoop = () => this._loop();
+        if (window.LabRuntime) LabRuntime.bindBabylonLoop(this.engine, this._renderLoop);
+        else this.engine.runRenderLoop(this._renderLoop);
     }
 
     _refreshChapterList() {

--- a/labs/jornada-do-anel/index.html
+++ b/labs/jornada-do-anel/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;600;700;800&family=Outfit:wght@300;400;500;600;700&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=11">
+    <link rel="stylesheet" href="/labs/shared.css?v=12">
     <link rel="stylesheet" href="style.css?v=1">
 
     <script type="importmap">
@@ -294,7 +294,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=11" defer></script>
+    <script src="/labs/shared.js?v=12" defer></script>
     <script>
         (function () {
             function hasGpu() {

--- a/labs/jornada-do-anel/src/main.js
+++ b/labs/jornada-do-anel/src/main.js
@@ -138,6 +138,7 @@ class Game {
         this.state = 'menu';
         this.hud.setState('menu');
         this._loop();
+        window.LabVisibility?.whenVisible(() => this._loop(performance.now()));
     }
 
     _refreshChapterList() {
@@ -401,6 +402,7 @@ class Game {
     }
 
     _loop(timestamp) {
+        if (document.hidden) return;
         requestAnimationFrame((t) => this._loop(t));
         this.timer.update(timestamp);
         const dt = Math.min(0.05, this.timer.getDelta());

--- a/labs/jungle-run/index.html
+++ b/labs/jungle-run/index.html
@@ -28,7 +28,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@600;900&family=Plus+Jakarta+Sans:wght@400;500;700;800&display=swap" rel="stylesheet">
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
-    <link rel="stylesheet" href="/labs/shared.css?v=11">
+    <link rel="stylesheet" href="/labs/shared.css?v=12">
     <link rel="stylesheet" href="style.css?v=3">
     <script src="https://cdn.jsdelivr.net/npm/pixi.js@8.6.6/dist/pixi.min.js" defer></script>
     <script type="application/ld+json">
@@ -305,7 +305,7 @@
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
 
-    <script src="/labs/shared.js?v=11" defer></script>
+    <script src="/labs/shared.js?v=12" defer></script>
     <script src="script.js?v=5" defer></script>
 </body>
 

--- a/labs/jurassic/index.html
+++ b/labs/jurassic/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,500;0,600;0,700;1,500&family=Barlow:wght@400;500;600;700&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=11">
+    <link rel="stylesheet" href="/labs/shared.css?v=12">
     <link rel="stylesheet" href="style.css?v=1">
 
     <script type="importmap">
@@ -285,7 +285,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=11" defer></script>
+    <script src="/labs/shared.js?v=12" defer></script>
     <script>
         (function () {
             function hasGpu() {

--- a/labs/jurassic/src/main.js
+++ b/labs/jurassic/src/main.js
@@ -149,6 +149,7 @@ class Game {
         this._applyAtmosphere();
         this._heroCamera();
         this._loop();
+        window.LabVisibility?.whenVisible(() => this._loop());
     }
 
     async _bloom() {
@@ -527,6 +528,7 @@ class Game {
     }
 
     _loop = () => {
+        if (document.hidden) return;
         requestAnimationFrame(this._loop);
         const dt = Math.min(0.05, this.clock.getDelta());
         this.time += dt;

--- a/labs/kong-kong/index.html
+++ b/labs/kong-kong/index.html
@@ -29,7 +29,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@500;700;800&family=Titan+One&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="/labs/shared.css?v=11">
+  <link rel="stylesheet" href="/labs/shared.css?v=12">
   <link rel="stylesheet" href="style.css">
   <script type="application/ld+json">
   {
@@ -147,7 +147,7 @@
   </div>
 
   <p class="sr-only" id="announcer" aria-live="assertive"></p>
-  <script src="/labs/shared.js?v=11" defer></script>
+  <script src="/labs/shared.js?v=12" defer></script>
   <script type="module" src="src/main.js"></script>
 </body>
 

--- a/labs/kong-kong/src/main.js
+++ b/labs/kong-kong/src/main.js
@@ -60,6 +60,7 @@ let lastAnnounce = '';
 let last = performance.now();
 
 function frame(now) {
+  if (document.hidden) return;
   const dt = Math.min(0.033, (now - last) / 1000);
   last = now;
   game.update(dt);
@@ -82,3 +83,4 @@ function frame(now) {
 
 syncMute();
 requestAnimationFrame(frame);
+window.LabVisibility?.whenVisible(() => requestAnimationFrame(frame));

--- a/labs/lander/index.html
+++ b/labs/lander/index.html
@@ -24,7 +24,7 @@
     <meta name="twitter:description" content="Pouso lunar com física realista: gravidade, inércia, consumo de combustível e terreno gerado por procedimento. Desça devagar e no ângulo certo.">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="stylesheet" href="/labs/shared.css?v=11">
+    <link rel="stylesheet" href="/labs/shared.css?v=12">
     <link rel="stylesheet" href="style.css?v=4">
     <link href="https://fonts.googleapis.com/css2?family=VT323&display=swap" rel="stylesheet">
     <script type="application/ld+json">
@@ -184,7 +184,7 @@
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
 
-    <script src="/labs/shared.js?v=11" defer></script>
+    <script src="/labs/shared.js?v=12" defer></script>
     <script src="script.js?v=4" defer></script>
 </body>
 

--- a/labs/lavandula/index.html
+++ b/labs/lavandula/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;600;700;800&family=Outfit:wght@300;400;500;600;700&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=11">
+    <link rel="stylesheet" href="/labs/shared.css?v=12">
     <link rel="stylesheet" href="style.css?v=1">
 
     <script type="importmap">
@@ -264,7 +264,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=11" defer></script>
+    <script src="/labs/shared.js?v=12" defer></script>
     <script>
         (function () {
             function hasGpu() {

--- a/labs/lavandula/src/main.js
+++ b/labs/lavandula/src/main.js
@@ -128,6 +128,7 @@ class Game {
         this.hud.setState('menu');
         this._placeMenuCamera();
         this._loop();
+        window.LabVisibility?.whenVisible(() => this._loop());
     }
 
     _placeMenuCamera() {
@@ -405,6 +406,7 @@ class Game {
     }
 
     _loop = () => {
+        if (document.hidden) return;
         requestAnimationFrame(this._loop);
         this.timer.update();
         const dt = clamp(this.timer.getDelta(), 0, 0.05);

--- a/labs/matrix/index.html
+++ b/labs/matrix/index.html
@@ -27,7 +27,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Share+Tech+Mono&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=11">
+    <link rel="stylesheet" href="/labs/shared.css?v=12">
     <link rel="stylesheet" href="style.css?v=4">
     <script type="application/ld+json">
     {
@@ -336,7 +336,7 @@
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
 
-    <script src="/labs/shared.js?v=11" defer></script>
+    <script src="/labs/shared.js?v=12" defer></script>
     <script src="script.js" defer></script>
 </body>
 

--- a/labs/menina-da-lanterna/index.html
+++ b/labs/menina-da-lanterna/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@500;600;700&family=Nunito:wght@400;600;700;800&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=11">
+    <link rel="stylesheet" href="/labs/shared.css?v=12">
     <link rel="stylesheet" href="style.css?v=2">
 
     <script type="importmap">
@@ -312,7 +312,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=11" defer></script>
+    <script src="/labs/shared.js?v=12" defer></script>
     <script>
         (function () {
             function hasGpu() {

--- a/labs/menina-da-lanterna/src/main.js
+++ b/labs/menina-da-lanterna/src/main.js
@@ -137,6 +137,7 @@ class Game {
         this.state = 'menu';
         this.hud.setState('menu');
         this._loop();
+        window.LabVisibility?.whenVisible(() => this._loop(performance.now()));
     }
 
     _refreshChapterList() {
@@ -418,6 +419,7 @@ class Game {
     }
 
     _loop(timestamp) {
+        if (document.hidden) return;
         requestAnimationFrame((t) => this._loop(t));
         this.timer.update(timestamp);
         const dt = Math.min(0.05, this.timer.getDelta());

--- a/labs/mimo/index.html
+++ b/labs/mimo/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;600;700&family=Outfit:wght@400;500;600;700&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=11">
+    <link rel="stylesheet" href="/labs/shared.css?v=12">
     <link rel="stylesheet" href="style.css">
 
     <script type="importmap">
@@ -275,7 +275,7 @@
         </div>
     </main>
 
-    <script src="/labs/shared.js?v=11"></script>
+    <script src="/labs/shared.js?v=12"></script>
     <script type="module" src="src/main.js"></script>
 </body>
 

--- a/labs/mimo/src/main.js
+++ b/labs/mimo/src/main.js
@@ -162,7 +162,9 @@ class Mimo {
         }, 420);
 
         this.clock = new THREE.Clock();
-        this.renderer.setAnimationLoop(() => this.frame());
+        this._renderLoop = () => this.frame();
+        if (window.LabRuntime) LabRuntime.bindThreeLoop(this.renderer, this._renderLoop);
+        else this.renderer.setAnimationLoop(this._renderLoop);
         window.addEventListener('resize', () => this.resize());
     }
 

--- a/labs/minesweeper/index.html
+++ b/labs/minesweeper/index.html
@@ -22,7 +22,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Campo Minado 95 | Diogo Paulino">
     <meta name="twitter:description" content="Clássico jogo de Campo Minado estilo Windows 95.">
-    <link rel="stylesheet" href="/labs/shared.css?v=11">
+    <link rel="stylesheet" href="/labs/shared.css?v=12">
     <link rel="stylesheet" href="style.css?v=2">
     <script type="application/ld+json">
     {
@@ -145,7 +145,7 @@
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
 
-    <script src="/labs/shared.js?v=11" defer></script>
+    <script src="/labs/shared.js?v=12" defer></script>
     <script src="script.js?v=2" defer></script>
 </body>
 

--- a/labs/minesweeper/script.js
+++ b/labs/minesweeper/script.js
@@ -469,6 +469,17 @@ document.addEventListener('DOMContentLoaded', () => {
     window.addEventListener('resize', updateCellSize);
     window.addEventListener('orientationchange', () => setTimeout(updateCellSize, 120));
 
+    let timerPausedByTab = false;
+    document.addEventListener('visibilitychange', () => {
+        if (document.hidden) {
+            timerPausedByTab = timerInterval !== null;
+            stopTimer();
+        } else if (timerPausedByTab && !gameOver && !firstClick) {
+            startTimer();
+            timerPausedByTab = false;
+        }
+    });
+
     flagToggle?.addEventListener('click', () => setFlagMode(!flagMode));
 
     /* F alterna o modo pelo teclado — o equivalente do botão direito para quem

--- a/labs/neon-rider/index.html
+++ b/labs/neon-rider/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Audiowide&family=Outfit:wght@400;500;600;700&family=Share+Tech+Mono&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=11">
+    <link rel="stylesheet" href="/labs/shared.css?v=12">
     <link rel="stylesheet" href="style.css?v=2">
 
     <script type="importmap">
@@ -268,7 +268,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=11" defer></script>
+    <script src="/labs/shared.js?v=12" defer></script>
     <script type="module" src="src/main.js?v=4"></script>
 </body>
 

--- a/labs/nereida/index.html
+++ b/labs/nereida/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,500;0,600;0,700;1,500&family=Figtree:wght@400;600;700;800&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=11">
+    <link rel="stylesheet" href="/labs/shared.css?v=12">
     <link rel="stylesheet" href="style.css">
 
     <script type="importmap">
@@ -248,7 +248,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=11" defer></script>
+    <script src="/labs/shared.js?v=12" defer></script>
     <script>
         (function () {
             function hasGpu() {

--- a/labs/nina/index.html
+++ b/labs/nina/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Fredoka:wght@500;600;700&family=Nunito:wght@400;600;700;800&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=11">
+    <link rel="stylesheet" href="/labs/shared.css?v=12">
     <link rel="stylesheet" href="style.css">
 
     <script type="importmap">
@@ -248,7 +248,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=11" defer></script>
+    <script src="/labs/shared.js?v=12" defer></script>
     <script>
         (function () {
             function hasGpu() {

--- a/labs/orbis/index.html
+++ b/labs/orbis/index.html
@@ -34,7 +34,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;600;700&family=Syne:wght@400;500;600;700;800&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=11">
+    <link rel="stylesheet" href="/labs/shared.css?v=12">
     <link rel="stylesheet" href="style.css">
 
     <script type="importmap">
@@ -175,7 +175,7 @@
         <p class="fps-badge" aria-hidden="true"><span id="fps">60</span> fps</p>
     </main>
 
-    <script src="/labs/shared.js?v=11" defer></script>
+    <script src="/labs/shared.js?v=12" defer></script>
     <script type="module" src="./src/main.js"></script>
 </body>
 

--- a/labs/orbis/src/main.js
+++ b/labs/orbis/src/main.js
@@ -103,7 +103,9 @@ class Orbis {
         this.hideLoading();
 
         window.addEventListener('resize', () => this.resize());
-        this.renderer.setAnimationLoop(() => this.frame());
+        this._renderLoop = () => this.frame();
+        if (window.LabRuntime) LabRuntime.bindThreeLoop(this.renderer, this._renderLoop);
+        else this.renderer.setAnimationLoop(this._renderLoop);
     }
 
     async setupBloom() {

--- a/labs/paint/index.html
+++ b/labs/paint/index.html
@@ -28,7 +28,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@100..900&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=11">
+    <link rel="stylesheet" href="/labs/shared.css?v=12">
     <link rel="stylesheet" href="style.css?v=5">
     <script type="application/ld+json">
     {
@@ -305,7 +305,7 @@
 
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
-    <script src="/labs/shared.js?v=11" defer></script>
+    <script src="/labs/shared.js?v=12" defer></script>
     <script src="script.js?v=3" defer></script>
 </body>
 

--- a/labs/partitura/index.html
+++ b/labs/partitura/index.html
@@ -27,7 +27,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;500;700;800&family=Space+Mono:wght@400;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="/labs/shared.css?v=11">
+  <link rel="stylesheet" href="/labs/shared.css?v=12">
   <link rel="stylesheet" href="style.css">
   <script type="application/ld+json">
   {
@@ -275,7 +275,7 @@
     <footer data-lab-footer data-home-href="/" class="compact-footer"></footer>
   </div>
 
-  <script src="/labs/shared.js?v=11" defer></script>
+  <script src="/labs/shared.js?v=12" defer></script>
   <script src="script.js" defer></script>
 </body>
 

--- a/labs/partitura/script.js
+++ b/labs/partitura/script.js
@@ -1000,6 +1000,7 @@ function startArcadeMode() {
 
   clearInterval(arcadeTimerInterval);
   arcadeTimerInterval = setInterval(() => {
+    if (document.hidden) return;
     arcadeTimeRemaining--;
     if (timerEl) timerEl.textContent = `${arcadeTimeRemaining}s`;
 

--- a/labs/piano/index.html
+++ b/labs/piano/index.html
@@ -24,7 +24,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Piano | Diogo Paulino">
     <meta name="twitter:description" content="Piano minimalista com sons ultra realistas. 4 oitavas completas.">
-  <link rel="stylesheet" href="/labs/shared.css?v=11">
+  <link rel="stylesheet" href="/labs/shared.css?v=12">
   <link rel="stylesheet" href="style.css">
   <script type="application/ld+json">
   {
@@ -133,7 +133,7 @@
     <footer data-lab-footer data-home-href="/"></footer>
   </div>
 
-  <script src="/labs/shared.js?v=11" defer></script>
+  <script src="/labs/shared.js?v=12" defer></script>
   <script src="script.js" defer></script>
 </body>
 

--- a/labs/pomodoro/index.html
+++ b/labs/pomodoro/index.html
@@ -26,7 +26,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=11">
+    <link rel="stylesheet" href="/labs/shared.css?v=12">
     <link rel="stylesheet" href="style.css?v=4">
     <script type="application/ld+json">
     {
@@ -357,7 +357,7 @@
     <div class="toast-region" id="toast-region" aria-live="polite" aria-atomic="false"></div>
     <p class="sr-only" id="live-region" role="status" aria-live="polite"></p>
 
-    <script src="/labs/shared.js?v=11" defer></script>
+    <script src="/labs/shared.js?v=12" defer></script>
     <script src="script.js?v=3" defer></script>
 </body>
 

--- a/labs/pulsar/index.html
+++ b/labs/pulsar/index.html
@@ -29,7 +29,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Oxanium:wght@400;600;700;800&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=11">
+    <link rel="stylesheet" href="/labs/shared.css?v=12">
     <link rel="stylesheet" href="style.css">
     <script type="application/ld+json">
     {
@@ -182,7 +182,7 @@
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
 
-    <script src="/labs/shared.js?v=11" defer></script>
+    <script src="/labs/shared.js?v=12" defer></script>
     <script src="script.js" defer></script>
 </body>
 

--- a/labs/quimera/index.html
+++ b/labs/quimera/index.html
@@ -34,7 +34,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,500;0,9..144,650;1,9..144,500&family=Outfit:wght@300;400;500;600;700&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=11">
+    <link rel="stylesheet" href="/labs/shared.css?v=12">
     <link rel="stylesheet" href="style.css">
 
     <script type="importmap">
@@ -194,7 +194,7 @@
         <footer data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=11" defer></script>
+    <script src="/labs/shared.js?v=12" defer></script>
     <script type="module" src="./src/main.js"></script>
 </body>
 

--- a/labs/quimera/src/main.js
+++ b/labs/quimera/src/main.js
@@ -56,6 +56,7 @@ class Quimera {
         this.applyMix(this.ids, { bounce: false, silent: true });
         $('#loading')?.classList.add('is-done');
         this.loop();
+        window.LabVisibility?.whenVisible(() => this.loop());
     }
 
     _restore() {
@@ -287,6 +288,7 @@ class Quimera {
     }
 
     loop() {
+        if (document.hidden) return;
         const now = performance.now();
         const dt = Math.min(0.05, (now - this.lastT) / 1000);
         this.lastT = now;

--- a/labs/rastro-vermelho/index.html
+++ b/labs/rastro-vermelho/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.babylonjs.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;600;700;800&family=Outfit:wght@300;400;500;600;700&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=11">
+    <link rel="stylesheet" href="/labs/shared.css?v=12">
     <link rel="stylesheet" href="style.css?v=1">
 
     <script type="application/ld+json">
@@ -257,7 +257,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=11" defer></script>
+    <script src="/labs/shared.js?v=12" defer></script>
     <script>
         (function () {
             function hasGpu() {

--- a/labs/rastro-vermelho/src/main.js
+++ b/labs/rastro-vermelho/src/main.js
@@ -276,7 +276,9 @@ class RastroVermelho {
         this.updateChunks();
         this.setLoading(1, 'O oeste está pronto.');
         setTimeout(() => { $('#loadingOverlay').hidden = true; $('#menuOverlay').hidden = false; this.state = 'menu'; document.body.dataset.state = 'menu'; }, 450);
-        this.engine.runRenderLoop(() => this.frame());
+        this._renderLoop = () => this.frame();
+        if (window.LabRuntime) LabRuntime.bindBabylonLoop(this.engine, this._renderLoop);
+        else this.engine.runRenderLoop(this._renderLoop);
         addEventListener('resize', () => this.engine.resize());
     }
 

--- a/labs/ravi-123/index.html
+++ b/labs/ravi-123/index.html
@@ -27,7 +27,7 @@
     content="Conte de 1 a 9 e ajude o Ravi a convidar heróis para a maior festa surpresa do reino. Pixel art 320×200, tudo em vanilla.">
   <meta property="og:locale" content="pt_BR">
 
-  <link rel="stylesheet" href="/labs/shared.css?v=11">
+  <link rel="stylesheet" href="/labs/shared.css?v=12">
   <link rel="stylesheet" href="style.css?v=23">
   <script type="application/ld+json">
   {
@@ -104,7 +104,7 @@
   </noscript>
 
   <script type="module" src="main.js?v=23"></script>
-  <script src="/labs/shared.js?v=11" defer></script>
+  <script src="/labs/shared.js?v=12" defer></script>
 </body>
 
 </html>

--- a/labs/riftball/index.html
+++ b/labs/riftball/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600;700;800&family=Syne:wght@700;800&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=11">
+    <link rel="stylesheet" href="/labs/shared.css?v=12">
     <link rel="stylesheet" href="style.css">
 
     <script type="importmap">
@@ -284,7 +284,7 @@
     </main>
 
     <script src="https://cdn.jsdelivr.net/npm/peerjs@1.5.4/dist/peerjs.min.js" defer></script>
-    <script src="/labs/shared.js?v=11" defer></script>
+    <script src="/labs/shared.js?v=12" defer></script>
     <script type="module" src="src/main.js"></script>
 </body>
 

--- a/labs/riftball/src/main.js
+++ b/labs/riftball/src/main.js
@@ -137,6 +137,7 @@ class Game {
         this.hud.hideLoading();
         this.enterAttract();
         this.loop();
+        window.LabVisibility?.whenVisible(() => this.loop());
 
         const sala = new URLSearchParams(window.location.search).get('sala');
         if (sala) {
@@ -526,6 +527,7 @@ class Game {
     }
 
     loop = () => {
+        if (document.hidden) return;
         requestAnimationFrame(this.loop);
         const now = performance.now();
         let dt = (now - this.last) / 1000;

--- a/labs/river-knight/index.html
+++ b/labs/river-knight/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;600;700;800&family=Outfit:wght@300;400;500;600;700&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=11">
+    <link rel="stylesheet" href="/labs/shared.css?v=12">
     <link rel="stylesheet" href="style.css?v=5">
 
     <script type="importmap">
@@ -300,7 +300,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=11" defer></script>
+    <script src="/labs/shared.js?v=12" defer></script>
     <script type="module" src="src/main.js?v=16"></script>
 </body>
 

--- a/labs/rock-kombat/index.html
+++ b/labs/rock-kombat/index.html
@@ -22,7 +22,7 @@
   <meta property="og:title" content="Rock Kombat — 2D Arcade Fight | Diogo Paulino">
   <meta property="og:description" content="Escolha sua lenda. Leia a distância. Domine o palco.">
   <meta property="og:url" content="https://diogopaulino.com.br/labs/rock-kombat/">
-  <link rel="stylesheet" href="/labs/shared.css?v=11">
+  <link rel="stylesheet" href="/labs/shared.css?v=12">
   <link rel="stylesheet" href="style.css?v=6">
   <script type="application/ld+json">
   {
@@ -264,7 +264,7 @@
 
   <footer data-lab-footer data-home-href="/"></footer>
 
-  <script src="/labs/shared.js?v=11" defer></script>
+  <script src="/labs/shared.js?v=12" defer></script>
   <script type="module" src="main.js?v=4"></script>
 </body>
 </html>

--- a/labs/safari-dourado/index.html
+++ b/labs/safari-dourado/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.babylonjs.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@500;600;700;800&family=Outfit:wght@300;400;500;600;700&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=11">
+    <link rel="stylesheet" href="/labs/shared.css?v=12">
     <link rel="stylesheet" href="style.css?v=1">
 
     <script type="application/ld+json">
@@ -206,7 +206,7 @@
 
     <script src="https://cdn.babylonjs.com/babylon.js"></script>
     <script src="https://cdn.babylonjs.com/loaders/babylonjs.loaders.min.js"></script>
-    <script src="/labs/shared.js?v=11" defer></script>
+    <script src="/labs/shared.js?v=12" defer></script>
     <script type="module" src="src/main.js"></script>
 </body>
 

--- a/labs/safari-dourado/src/main.js
+++ b/labs/safari-dourado/src/main.js
@@ -126,10 +126,12 @@ class SafariDourado {
         document.getElementById('menuOverlay').hidden = false;
         document.body.dataset.state = 'menu';
 
-        this.engine.runRenderLoop(() => {
+        this._renderLoop = () => {
             this.frame();
             this.scene.render();
-        });
+        };
+        if (window.LabRuntime) LabRuntime.bindBabylonLoop(this.engine, this._renderLoop);
+        else this.engine.runRenderLoop(this._renderLoop);
 
         window.addEventListener('resize', () => this.engine.resize());
     }

--- a/labs/shared.css
+++ b/labs/shared.css
@@ -298,8 +298,10 @@ header h1 {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    width: 40px;
-    height: 40px;
+    width: var(--touch-target);
+    height: var(--touch-target);
+    min-width: var(--touch-target);
+    min-height: var(--touch-target);
     padding: 0;
     font-size: 1.1rem;
     line-height: 1;
@@ -574,6 +576,78 @@ footer a:hover {
 .lab-engine-notice__link:focus-visible {
     outline: 3px solid var(--focus-ring);
     outline-offset: 3px;
+}
+
+/* Shell fullscreen para jogos/simulações: ocupa a viewport útil com safe-area. */
+.lab-game-shell {
+    position: relative;
+    width: min(100%, 100vw);
+    max-width: 100%;
+    min-width: 0;
+    margin-inline: auto;
+}
+
+.lab-game-shell canvas,
+.lab-game-shell .game-stage {
+    display: block;
+    width: 100%;
+    max-width: 100%;
+    height: auto;
+    touch-action: none;
+}
+
+.lab-hud-dock {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.5rem;
+    padding: max(0.5rem, var(--safe-top)) max(0.75rem, var(--safe-right))
+        max(0.5rem, var(--safe-bottom)) max(0.75rem, var(--safe-left));
+}
+
+.lab-touch-controls {
+    position: fixed;
+    inset: auto 0 max(0.75rem, var(--safe-bottom)) 0;
+    display: none;
+    justify-content: space-between;
+    align-items: flex-end;
+    gap: 0.75rem;
+    padding: 0 max(0.75rem, var(--safe-right)) 0 max(0.75rem, var(--safe-left));
+    pointer-events: none;
+    z-index: 40;
+}
+
+.lab-touch-controls > * {
+    pointer-events: auto;
+}
+
+@media (pointer: coarse) {
+    .lab-touch-controls {
+        display: flex;
+    }
+}
+
+@media (max-width: 768px) {
+    .lab-hud-dock {
+        flex-direction: column;
+        align-items: stretch;
+        max-height: min(92dvh, 100%);
+        overflow-y: auto;
+    }
+}
+
+@media (max-height: 520px) and (orientation: landscape) {
+    .lab-hud-dock {
+        flex-direction: row;
+        flex-wrap: nowrap;
+        max-height: none;
+        overflow: visible;
+        gap: 0.35rem;
+    }
+
+    .lab-touch-controls {
+        padding-bottom: max(0.35rem, var(--safe-bottom));
+    }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/labs/shared.js
+++ b/labs/shared.js
@@ -418,6 +418,170 @@
         }, true);
     }
 
+    /* --- LabVisibility / LabRuntime ----------------------------------------
+       Pausa loops e timers quando a aba fica oculta — evita GPU/CPU em
+       background. Vários labs repetiam o mesmo visibilitychange; centralizar
+       aqui deixa a adoção de uma linha. */
+    const VisibilityAPI = (function () {
+        const listeners = new Set();
+
+        function notify() {
+            listeners.forEach((fn) => {
+                try {
+                    fn(document.hidden);
+                } catch (err) {
+                    console.error(err);
+                }
+            });
+        }
+
+        document.addEventListener('visibilitychange', notify);
+
+        function onChange(fn) {
+            listeners.add(fn);
+            return () => listeners.delete(fn);
+        }
+
+        return Object.freeze({
+            isHidden: () => document.hidden,
+            onChange,
+            whenHidden: (fn) => onChange((hidden) => { if (hidden) fn(); }),
+            whenVisible: (fn) => onChange((hidden) => { if (!hidden) fn(); })
+        });
+    })();
+
+    const RuntimeAPI = (function () {
+        /* Loop rAF com auto-pausa: wantsRun mantém intenção entre hide/show. */
+        function createLoop(onFrame, options) {
+            const autoPause = !options || options.autoPause !== false;
+            let id = null;
+            let wantsRun = false;
+
+            function tick(now) {
+                if (!wantsRun || document.hidden) return;
+                onFrame(now);
+                id = requestAnimationFrame(tick);
+            }
+
+            function start() {
+                wantsRun = true;
+                if (document.hidden || id !== null) return;
+                id = requestAnimationFrame(tick);
+            }
+
+            function stop() {
+                wantsRun = false;
+                if (id !== null) {
+                    cancelAnimationFrame(id);
+                    id = null;
+                }
+            }
+
+            let unbind = null;
+            if (autoPause) {
+                unbind = VisibilityAPI.onChange((hidden) => {
+                    if (hidden) {
+                        if (id !== null) {
+                            cancelAnimationFrame(id);
+                            id = null;
+                        }
+                    } else if (wantsRun) {
+                        id = requestAnimationFrame(tick);
+                    }
+                });
+            }
+
+            return Object.freeze({
+                start,
+                stop,
+                isRunning: () => wantsRun,
+                destroy: () => {
+                    stop();
+                    if (unbind) unbind();
+                }
+            });
+        }
+
+        function bindBabylonLoop(engine, loopFn) {
+            if (!engine || typeof loopFn !== 'function') return () => {};
+            engine.runRenderLoop(loopFn);
+            return VisibilityAPI.onChange((hidden) => {
+                if (hidden) engine.stopRenderLoop();
+                else engine.runRenderLoop(loopFn);
+            });
+        }
+
+        function bindThreeLoop(renderer, loopFn) {
+            if (!renderer || typeof loopFn !== 'function') return () => {};
+            renderer.setAnimationLoop(loopFn);
+            return VisibilityAPI.onChange((hidden) => {
+                if (hidden) renderer.setAnimationLoop(null);
+                else renderer.setAnimationLoop(loopFn);
+            });
+        }
+
+        function debounceResize(fn, ms) {
+            const delay = typeof ms === 'number' ? ms : 150;
+            let timer = null;
+            const run = () => {
+                clearTimeout(timer);
+                timer = setTimeout(fn, delay);
+            };
+            window.addEventListener('resize', run);
+            if (window.visualViewport) window.visualViewport.addEventListener('resize', run);
+            return () => {
+                clearTimeout(timer);
+                window.removeEventListener('resize', run);
+                if (window.visualViewport) window.visualViewport.removeEventListener('resize', run);
+            };
+        }
+
+        /* Intervalo que congela o relógio enquanto a aba está oculta. */
+        function createInterval(fn, ms) {
+            let id = null;
+            let hiddenAt = 0;
+
+            function start() {
+                stop();
+                id = setInterval(fn, ms);
+            }
+
+            function stop() {
+                if (id !== null) {
+                    clearInterval(id);
+                    id = null;
+                }
+            }
+
+            const unbind = VisibilityAPI.onChange((hidden) => {
+                if (hidden) {
+                    hiddenAt = Date.now();
+                    stop();
+                } else if (hiddenAt) {
+                    hiddenAt = 0;
+                    start();
+                }
+            });
+
+            return Object.freeze({
+                start,
+                stop,
+                destroy: () => {
+                    stop();
+                    unbind();
+                }
+            });
+        }
+
+        return Object.freeze({
+            createLoop,
+            bindBabylonLoop,
+            bindThreeLoop,
+            debounceResize,
+            createInterval
+        });
+    })();
+
     function init() {
         ensureFavicon();
         initChrome();
@@ -436,6 +600,8 @@
 
     window.LabShell = Object.freeze({ init, buildHeader, buildFooter });
     window.LabAudio = AudioAPI;
+    window.LabVisibility = VisibilityAPI;
+    window.LabRuntime = RuntimeAPI;
 
     if (document.readyState === 'loading') {
         document.addEventListener('DOMContentLoaded', init, { once: true });

--- a/labs/snake/index.html
+++ b/labs/snake/index.html
@@ -25,7 +25,7 @@
     <meta property="og:description"
         content="Snake retrô em um console portátil 8-bit: colete frutas, ganhe velocidade e bata o seu recorde.">
     <meta property="og:url" content="https://diogopaulino.com.br/labs/snake/">
-    <link rel="stylesheet" href="/labs/shared.css?v=11">
+    <link rel="stylesheet" href="/labs/shared.css?v=12">
     <link rel="stylesheet" href="style.css?v=2">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -179,7 +179,7 @@
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
 
-    <script src="/labs/shared.js?v=11" defer></script>
+    <script src="/labs/shared.js?v=12" defer></script>
     <script src="script.js?v=3" defer></script>
 </body>
 

--- a/labs/space-shooter/index.html
+++ b/labs/space-shooter/index.html
@@ -24,7 +24,7 @@
     <meta name="twitter:description" content="Jogo de tiro espacial estilo arcade com gráficos neon.">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="stylesheet" href="/labs/shared.css?v=11">
+    <link rel="stylesheet" href="/labs/shared.css?v=12">
     <link rel="stylesheet" href="style.css?v=3">
     <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
     <script type="application/ld+json">
@@ -194,7 +194,7 @@
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
 
-    <script src="/labs/shared.js?v=11" defer></script>
+    <script src="/labs/shared.js?v=12" defer></script>
     <script src="script.js?v=4" defer></script>
 </body>
 

--- a/labs/spider-swing/index.html
+++ b/labs/spider-swing/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Outfit:wght@400;500;600;700&family=Share+Tech+Mono&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=11">
+    <link rel="stylesheet" href="/labs/shared.css?v=12">
     <link rel="stylesheet" href="style.css">
 
     <script type="importmap">
@@ -271,7 +271,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=11" defer></script>
+    <script src="/labs/shared.js?v=12" defer></script>
     <script type="module" src="src/main.js"></script>
 </body>
 

--- a/labs/tamagotchi/index.html
+++ b/labs/tamagotchi/index.html
@@ -23,7 +23,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="RakuRaku Dinokun / Dinkie Dino (1997) | Diogo Paulino">
     <meta name="twitter:description" content="Recriação pesquisada do RakuRaku Dinokun / Dinkie Dino: carcaça, LCD, controles e ciclo de cuidado em tempo real.">
-  <link rel="stylesheet" href="/labs/shared.css?v=11">
+  <link rel="stylesheet" href="/labs/shared.css?v=12">
   <link rel="stylesheet" href="style.css?v=13">
   <script type="application/ld+json">
   {
@@ -175,7 +175,7 @@
     <footer data-lab-footer data-home-href="/"></footer>
   </div>
 
-  <script src="/labs/shared.js?v=11" defer></script>
+  <script src="/labs/shared.js?v=12" defer></script>
   <script src="script.js?v=9" defer></script>
 </body>
 

--- a/labs/tamagotchi/script.js
+++ b/labs/tamagotchi/script.js
@@ -1615,6 +1615,7 @@
   }
 
   function render(timestamp) {
+    if (document.hidden) return;
     requestAnimationFrame(render);
     if (timestamp - lastFrameAt < 430) return;
     lastFrameAt = timestamp;
@@ -1698,5 +1699,10 @@
   catchUp();
   maybeAlert();
   requestAnimationFrame(render);
-  setInterval(() => { catchUp(); maybeAlert(); }, 30 * 1000);
+  window.LabVisibility?.whenVisible(() => requestAnimationFrame(render));
+  setInterval(() => {
+    if (document.hidden) return;
+    catchUp();
+    maybeAlert();
+  }, 30 * 1000);
 })();

--- a/labs/tatu-bola/index.html
+++ b/labs/tatu-bola/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Press+Start+2P&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=11">
+    <link rel="stylesheet" href="/labs/shared.css?v=12">
     <link rel="stylesheet" href="style.css">
 
     <script type="importmap">
@@ -276,7 +276,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=11" defer></script>
+    <script src="/labs/shared.js?v=12" defer></script>
     <script type="module" src="src/main.js"></script>
 </body>
 

--- a/labs/tatu-bola/src/main.js
+++ b/labs/tatu-bola/src/main.js
@@ -110,6 +110,7 @@ class Game {
         this.hud.hideLoading();
         this.gotoMenu();
         this.loop();
+        window.LabVisibility?.whenVisible(() => this.loop());
     }
 
     bindUi() {
@@ -377,6 +378,7 @@ class Game {
     }
 
     loop = () => {
+        if (document.hidden) return;
         requestAnimationFrame(this.loop);
         const dt = Math.min(0.033, this.clock.getDelta());
         this.time += dt;

--- a/labs/tetris/index.html
+++ b/labs/tetris/index.html
@@ -22,7 +22,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Tetris 90s | Diogo Paulino">
     <meta name="twitter:description" content="Jogue Tetris clássico estilo anos 90 no seu navegador.">
-    <link rel="stylesheet" href="/labs/shared.css?v=11">
+    <link rel="stylesheet" href="/labs/shared.css?v=12">
     <link rel="stylesheet" href="style.css?v=2">
     <script type="application/ld+json">
     {
@@ -172,7 +172,7 @@
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
 
-    <script src="/labs/shared.js?v=11" defer></script>
+    <script src="/labs/shared.js?v=12" defer></script>
     <script src="script.js?v=2" defer></script>
 </body>
 

--- a/labs/videogame/index.html
+++ b/labs/videogame/index.html
@@ -25,11 +25,11 @@
 
 
 
-    <link rel="stylesheet" href="/labs/shared.css?v=11">
+    <link rel="stylesheet" href="/labs/shared.css?v=12">
     <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="mobile.css">
     <script src="/labs/videogame/lib/nostalgist.umd.js" defer></script>
-    <script src="/labs/shared.js?v=11" defer></script>
+    <script src="/labs/shared.js?v=12" defer></script>
     <script src="games.js" defer></script>
     <script src="script.js" defer></script>
     <script type="application/ld+json">

--- a/labs/videogame/script.js
+++ b/labs/videogame/script.js
@@ -89,6 +89,20 @@ const App = {
                 this.renderGames(this.allGames.filter(g => g.title.toLowerCase().includes(term)));
             }, 300);
         });
+
+        document.addEventListener('visibilitychange', () => {
+            if (!this.emulator) return;
+            try {
+                if (document.hidden && typeof this.emulator.pause === 'function') {
+                    this.emulator.pause();
+                } else if (!document.hidden && typeof this.emulator.resume === 'function') {
+                    this.emulator.resume();
+                }
+            } catch (err) {
+                console.warn('Emulador: pausa por visibilidade indisponível.', err);
+            }
+        });
+
         romInput?.addEventListener('change', e => {
             const file = e.target.files[0];
             if (file) this.startGame(file, file.name.replace(/\.[^/.]+$/, ''))

--- a/labs/winamp/index.html
+++ b/labs/winamp/index.html
@@ -26,7 +26,7 @@
     <meta name="twitter:title" content="Winamp JS | Diogo Paulino">
     <meta name="twitter:description" content="Player retrô 100% vanilla: playlist, equalizador, visualizador e músicas chiptune sintetizadas no navegador.">
     <meta name="twitter:image" content="https://diogopaulino.com.br/assets/img/diogo.jpeg">
-    <link rel="stylesheet" href="/labs/shared.css?v=11">
+    <link rel="stylesheet" href="/labs/shared.css?v=12">
     <link rel="stylesheet" href="style.css?v=5">
     <script type="application/ld+json">
     {
@@ -416,7 +416,7 @@
 
     <noscript>Ative o JavaScript para usar o player.</noscript>
     <script type="module" src="script.js?v=5"></script>
-    <script src="/labs/shared.js?v=11" defer></script>
+    <script src="/labs/shared.js?v=12" defer></script>
 </body>
 
 </html>

--- a/labs/xadrez/index.html
+++ b/labs/xadrez/index.html
@@ -32,7 +32,7 @@
     <link rel="preconnect" href="https://cdn.babylonjs.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;600;700&family=Outfit:wght@300;400;500;600;700&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=11">
+    <link rel="stylesheet" href="/labs/shared.css?v=12">
     <link rel="stylesheet" href="style.css">
     <script type="application/ld+json">
     {
@@ -241,7 +241,7 @@
 
     <script src="https://cdn.babylonjs.com/babylon.js"></script>
     <script src="https://cdn.babylonjs.com/loaders/babylonjs.loaders.min.js"></script>
-    <script src="/labs/shared.js?v=11" defer></script>
+    <script src="/labs/shared.js?v=12" defer></script>
     <script type="module" src="src/main.js"></script>
 </body>
 

--- a/labs/xadrez/src/main.js
+++ b/labs/xadrez/src/main.js
@@ -226,10 +226,12 @@ class Atelier {
         document.getElementById('intro').hidden = false;
         document.body.dataset.state = 'intro';
 
-        this.engine.runRenderLoop(() => {
+        this._renderLoop = () => {
             this.frame();
             this.scene.render();
-        });
+        };
+        if (window.LabRuntime) LabRuntime.bindBabylonLoop(this.engine, this._renderLoop);
+        else this.engine.runRenderLoop(this._renderLoop);
 
         window.addEventListener('resize', () => {
             this.engine.resize();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 🎯 Objetivo

Otimizar todos os labs do playground em performance, usabilidade e consistência de UI — parando loops e timers quando a aba fica oculta e centralizando utilitários que estavam duplicados em dezenas de arquivos.

## ✨ O que mudou

- **`shared.js` v12** — novos `LabVisibility` e `LabRuntime`:
  - `bindBabylonLoop` / `bindThreeLoop` — pausa render automática em aba oculta
  - `createLoop` — rAF com auto-pausa
  - `debounceResize` — resize + visualViewport
  - `createInterval` — timers que congelam fora de foco
- **`shared.css` v12** — `.lab-icon-btn` corrigido para 44×44px; utilitários `.lab-game-shell`, `.lab-hud-dock`, `.lab-touch-controls`
- **~25 labs** passaram a pausar GPU/CPU em background (Babylon, Three.js, canvas rAF)
- **Timers** pausam em aba oculta: Campo Minado, Partitura (modo arcade), Tamagotchi
- **Videogame** — tenta `pause()`/`resume()` do emulador Nostalgist ao trocar de aba
- **Cache bump** — galeria e todos os labs em `shared.js?v=12` / `shared.css?v=12`
- **🐛 F1 Racing** — corrige `new Vehicle(this.circuit)` → objeto com `{ circuit, team, isPlayer }` (bug pré-existente que impedia o menu de carregar)

## 🧪 Como testar

1. Na raiz: `python3 -m http.server 8000`
2. Abrir [http://localhost:8000/labs/](http://localhost:8000/labs/)
3. Testar labs pesados (F1 Racing, Gravity, Guerreiro do Castelo, Mimo, Jurassic) — trocar de aba: FPS deve cair a ~0
4. F1 Racing: menu aparece (não fica preso em "CARREGANDO PISTA E MOTORES...")
5. Campo Minado: timer para ao mudar de aba
6. Responsivo: 375×667, 390×844, landscape ~667×375 — botões do header ≥ 44px

## ✅ Verificação no browser (Cloud Agent)

| Teste | Resultado |
|-------|-----------|
| Galeria `/labs/` | ✅ PASS — cards, `shared.js?v=12`, zero erros |
| F1 Racing | ✅ PASS (após fix) — menu carrega, sem TypeError |
| Gravity | ✅ PASS — canvas, controles, zero erros |
| Campo Minado | ✅ PASS — tabuleiro, timer, zero erros |
| Snake | ✅ PASS — interface Game Boy, zero erros |
| Mobile ~375px | ✅ PASS — sem overflow horizontal |

## ✅ Checklist

- [x] Links conferidos: pasta do lab ↔ card da galeria ↔ README ↔ sitemap (sem mudança de catálogo)
- [x] README atualizado — N/A (nenhum lab novo/renomeado)
- [x] SEO consistente — N/A (metadados inalterados)
- [x] Testado via HTTP na raiz
- [x] Responsivo: melhoria nos alvos de toque compartilhados
- [x] Nada fora do escopo foi quebrado

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a01ca5-aff8-7692-adae-fc4560e861e1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a01ca5-aff8-7692-adae-fc4560e861e1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

