### PR TITLE
🎨 UI: melhora hierarquia do subtítulo da home

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -376,16 +376,19 @@ body {
 }
 
 .subtitle {
-  font-size: 1.125rem;
-  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  min-height: 28px;
+  padding: 0.375rem 0.75rem;
+  border-radius: 999px;
+  background: var(--accent-muted);
+  font-size: 0.8125rem;
+  font-weight: 700;
   color: var(--accent);
   margin: 0;
-  letter-spacing: -0.01em;
-  transition: all 0.3s ease;
-}
-
-.subtitle:hover {
-  color: var(--accent-hover);
+  letter-spacing: 0.035em;
+  line-height: 1;
+  transition: color 0.3s ease, background-color 0.3s ease;
 }
 
 .subdesc {
@@ -529,7 +532,7 @@ body {
   }
 
   .subtitle {
-    font-size: 1.125rem;
+    font-size: 0.8125rem;
   }
 
   .subdesc {
@@ -616,7 +619,7 @@ body {
   }
 
   .subtitle {
-    font-size: 1.0625rem;
+    font-size: 0.75rem;
   }
 
   .subdesc {


### PR DESCRIPTION
## 🎯 Objetivo

Dar mais intenção visual ao cargo “Tech Manager” na home, evitando que ele dispute hierarquia com o nome.

## ✨ O que mudou

- Transforma o subtítulo em uma credencial visual discreta com fundo suave e formato de pílula.
- Ajusta tipografia, espaçamento e escala nos breakpoints mobile.
- Remove o hover isolado que fazia o texto parecer um elemento interativo.

## 🧪 Como testar

1. Na raiz do repo: `python3 -m http.server 8000`
2. Abrir [http://localhost:8000/](http://localhost:8000/)
3. Confirmar a hierarquia entre “Diogo Paulino”, “Tech Manager” e “Design & Code lover” nos temas claro e escuro
4. Testar em **375×667**, **390×844** e landscape curto (~667×375), confirmando ausência de overflow horizontal

## ✅ Checklist

- [x] Links conferidos — não aplicável a mudança de catálogo
- [x] README atualizado — não aplicável a mudança de catálogo
- [x] SEO consistente — metadados não foram alterados
- [x] Testado via HTTP na raiz, não via `file://`
- [x] Responsivo: 375px / 390px / landscape — sem overflow horizontal
- [x] Nada fora do escopo foi quebrado