### PR TITLE
🐛 fix: PS5 Controller no filtro Games e fallback WebGL2

### DIFF
--- a/labs/index.html
+++ b/labs/index.html
@@ -770,7 +770,7 @@
           </div>
         </div>
       </a>
-      <a href="/labs/ps5-controller/" class="project-card" data-groups="creative">
+      <a href="/labs/ps5-controller/" class="project-card" data-groups="game,creative">
         <div class="project-icon">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
             stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">

--- a/labs/ps5-controller/index.html
+++ b/labs/ps5-controller/index.html
@@ -102,7 +102,7 @@
     <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
 
     <script src="/labs/shared.js?v=12" defer></script>
-    <script type="module" src="src/main.js?v=1"></script>
+    <script type="module" src="src/main.js?v=2"></script>
 </body>
 
 </html>

--- a/labs/ps5-controller/src/main.js
+++ b/labs/ps5-controller/src/main.js
@@ -1045,12 +1045,26 @@ var init_ProductScene = __esm({
       bandOverride = null;
       /** Resolves once the renderer, environment and first model are ready. */
       async init(container, onProgress) {
-        this.renderer = new WebGPURenderer({
+        const rendererOptions = {
           antialias: true,
           alpha: false,
           powerPreference: "high-performance"
-        });
-        await this.renderer.init();
+        };
+        const backends = navigator.gpu ? [false, true] : [true];
+        let lastError = null;
+        for (const forceWebGL of backends) {
+          try {
+            this.renderer = new WebGPURenderer({ ...rendererOptions, forceWebGL });
+            await this.renderer.init();
+            lastError = null;
+            break;
+          } catch (error) {
+            lastError = error;
+            this.renderer?.dispose?.();
+            this.renderer = void 0;
+          }
+        }
+        if (!this.renderer) throw lastError ?? new Error("Renderer unavailable");
         const capabilities = this.renderer;
         this.maxAnisotropy = Math.min(16, capabilities.getMaxAnisotropy?.() ?? 16);
         this.renderer.toneMapping = NeutralToneMapping;
@@ -2761,7 +2775,7 @@ var App = class {
     const notice = el(
       "p",
       "webgl-notice",
-      "This showcase needs WebGL to render the DualSense in 3D. Enable hardware acceleration or try a different browser."
+      "Este lab precisa de WebGL para renderizar o DualSense em 3D. Ative a aceleração de hardware ou tente outro navegador."
     );
     qs(this.shell, ".hero").append(notice);
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 🎯 Objetivo

Corrigir dois pontos que impediam o lab PS5 Controller de aparecer ou funcionar para parte dos visitantes.

## ✨ O que mudou

- Card na galeria passa a ter `data-groups="game,creative"` — antes só `creative`, então sumia no filtro **Games**
- Inicialização do renderer tenta WebGPU e, se falhar, refaz com `forceWebGL: true` (WebGL2)
- Mensagem de erro traduzida para português

## 🧪 Como testar

1. `python3 -m http.server 8000` na raiz
2. Abrir [http://localhost:8000/labs/](http://localhost:8000/labs/) → filtro **Games** → card **PS5 Controller** visível
3. Abrir [http://localhost:8000/labs/ps5-controller/](http://localhost:8000/labs/ps5-controller/) → controle 3D carrega após o loader

## ✅ Checklist

- [x] Links conferidos: pasta do lab ↔ card da galeria ↔ README ↔ sitemap
- [x] Testado via HTTP na raiz
- [x] Responsivo mantido
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a045ce-5f07-7bab-a758-62f4055550aa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a045ce-5f07-7bab-a758-62f4055550aa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

