### PR TITLE
⚡️ perf + 🎨 UI: padroniza chrome e pausa loops em todos os labs

### DIFF
--- a/labs/aurora-flow/index.html
+++ b/labs/aurora-flow/index.html
@@ -29,7 +29,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600;700;800&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=12">
+    <link rel="stylesheet" href="/labs/shared.css?v=13">
     <link rel="stylesheet" href="style.css">
     <script type="application/ld+json">
     {
@@ -239,7 +239,7 @@
 
     <footer data-lab-footer data-home-href="/"></footer>
 
-    <script src="/labs/shared.js?v=12" defer></script>
+    <script src="/labs/shared.js?v=13" defer></script>
     <script src="script.js" defer></script>
 </body>
 

--- a/labs/beige-box/index.html
+++ b/labs/beige-box/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=Outfit:wght@300;400;500;600;700&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=12">
+    <link rel="stylesheet" href="/labs/shared.css?v=13">
     <link rel="stylesheet" href="style.css?v=1">
 
     <script type="importmap">
@@ -146,7 +146,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=12" defer></script>
+    <script src="/labs/shared.js?v=13" defer></script>
     <script type="module" src="src/main.js?v=3"></script>
 </body>
 

--- a/labs/beige-box/src/main.js
+++ b/labs/beige-box/src/main.js
@@ -169,7 +169,8 @@ class BeigeBox {
         this._renderLoop = () => this.frame();
         if (window.LabRuntime) LabRuntime.bindThreeLoop(this.renderer, this._renderLoop);
         else this.renderer.setAnimationLoop(this._renderLoop);
-        window.addEventListener('resize', () => this.resize());
+        if (window.LabRuntime) LabRuntime.debounceResize(() => this.resize());
+        else window.addEventListener('resize', () => this.resize());
     }
 
     setupLights() {

--- a/labs/calculator/index.html
+++ b/labs/calculator/index.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
-    <title>Calculator | Diogo Paulino</title>
+    <title>Calculator — simples, científico e moedas | Diogo Paulino</title>
     <meta name="description"
         content="Calculadora online com modos simples, científico e conversor de moedas em tempo real.">
     <link rel="canonical" href="https://diogopaulino.com.br/labs/calculator/">
@@ -18,12 +18,12 @@
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="Diogo Paulino · Labs">
     <meta property="og:url" content="https://diogopaulino.com.br/labs/calculator/">
-    <meta property="og:title" content="Calculator | Diogo Paulino">
+    <meta property="og:title" content="Calculator — simples, científico e moedas | Diogo Paulino">
     <meta property="og:description" content="Calculadora online com modos simples, científico e conversor de moedas em tempo real.">
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Calculator | Diogo Paulino">
+    <meta name="twitter:title" content="Calculator — simples, científico e moedas | Diogo Paulino">
     <meta name="twitter:description" content="Calculadora online com modos simples, científico e conversor de moedas em tempo real.">
-    <link rel="stylesheet" href="/labs/shared.css?v=12">
+    <link rel="stylesheet" href="/labs/shared.css?v=13">
     <link rel="stylesheet" href="style.css?v=6">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -239,7 +239,7 @@
 
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
-    <script src="/labs/shared.js?v=12" defer></script>
+    <script src="/labs/shared.js?v=13" defer></script>
     <script src="script.js" defer></script>
 </body>
 

--- a/labs/castelo-estelar/index.html
+++ b/labs/castelo-estelar/index.html
@@ -34,7 +34,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;600;700&family=Outfit:wght@300;400;500;600;700&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=12">
+    <link rel="stylesheet" href="/labs/shared.css?v=13">
     <link rel="stylesheet" href="style.css">
 
     <script type="importmap">
@@ -186,7 +186,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=12" defer></script>
+    <script src="/labs/shared.js?v=13" defer></script>
     <script>
         (function () {
             function hasGpu() {

--- a/labs/claude-bros/index.html
+++ b/labs/claude-bros/index.html
@@ -65,7 +65,7 @@
   }
   </script>
 
-  <link rel="stylesheet" href="/labs/shared.css?v=12">
+  <link rel="stylesheet" href="/labs/shared.css?v=13">
   <link rel="stylesheet" href="style.css?v=2">
 </head>
 
@@ -117,7 +117,7 @@
     <footer data-lab-footer data-home-href="/"></footer>
   </main>
 
-  <script src="/labs/shared.js?v=12" defer></script>
+  <script src="/labs/shared.js?v=13" defer></script>
   <script src="main.js?v=2" defer></script>
 </body>
 

--- a/labs/claude-bros/main.js
+++ b/labs/claude-bros/main.js
@@ -845,9 +845,11 @@ function render() {
 
 let lastTime = 0;
 let accumulator = 0;
+let rafId = 0;
 
 function frame(now) {
-    requestAnimationFrame(frame);
+    if (!document.hidden) rafId = requestAnimationFrame(frame);
+    else rafId = 0;
 
     if (!lastTime) lastTime = now;
     // Trava a 250ms: uma aba que voltou do background não replica meio segundo
@@ -1000,9 +1002,19 @@ bindHold('btnJump', () => {
 
 document.getElementById('btnPause')?.addEventListener('click', togglePause);
 
-// Sair da aba pausa em vez de deixar o jogador morrer sozinho.
+// Sair da aba pausa em vez de deixar o jogador morrer sozinho; cancela o rAF.
 document.addEventListener('visibilitychange', () => {
-    if (document.hidden && state === 'playing') togglePause();
+    if (document.hidden) {
+        if (state === 'playing') togglePause();
+        if (rafId) {
+            const id = rafId;
+            rafId = 0;
+            cancelAnimationFrame(id);
+        }
+    } else if (!rafId) {
+        lastTime = 0;
+        rafId = requestAnimationFrame(frame);
+    }
 });
 
 /* ---------------------------------------------------------------- layout --- */
@@ -1053,4 +1065,4 @@ if (touchLayer && !window.matchMedia('(pointer: fine)').matches) touchLayer.hidd
 resetGame();
 resize();
 showOverlay('Claude Bros', 'Colete as estrelas, pule nos rivais e chegue à bandeira.', 'Começar');
-requestAnimationFrame(frame);
+rafId = requestAnimationFrame(frame);

--- a/labs/cupola-64/index.html
+++ b/labs/cupola-64/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600;700;800&family=Press+Start+2P&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=12">
+    <link rel="stylesheet" href="/labs/shared.css?v=13">
     <link rel="stylesheet" href="style.css">
 
     <script type="importmap">
@@ -271,7 +271,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=12" defer></script>
+    <script src="/labs/shared.js?v=13" defer></script>
     <script>
         (function () {
             function hasGpu() {

--- a/labs/cupola-64/src/main.js
+++ b/labs/cupola-64/src/main.js
@@ -102,7 +102,8 @@ class Game {
             camR: document.getElementById('btnCamR')
         });
 
-        window.addEventListener('resize', () => this.resize());
+        if (window.LabRuntime) LabRuntime.debounceResize(() => this.resize());
+        else window.addEventListener('resize', () => this.resize());
         document.addEventListener('visibilitychange', () => {
             if (document.hidden && this.state === 'play') this.pause();
         });
@@ -214,11 +215,22 @@ class Game {
     }
 
     loop = () => {
-        requestAnimationFrame(this.loop);
-        const dt = Math.min(0.033, this.clock.getDelta());
-        if (this.state === 'play') this.update(dt);
-        else if (this.world) this.world.update(dt * 0.35, this.clock.elapsedTime);
-        this.render();
+        const tick = () => {
+            const dt = Math.min(0.033, this.clock.getDelta());
+            if (this.state === 'play') this.update(dt);
+            else if (this.world) this.world.update(dt * 0.35, this.clock.elapsedTime);
+            this.render();
+        };
+        if (window.LabRuntime) {
+            this._raf = LabRuntime.createLoop(() => tick());
+            this._raf.start();
+        } else {
+            const run = () => {
+                requestAnimationFrame(run);
+                if (!document.hidden) tick();
+            };
+            requestAnimationFrame(run);
+        }
     };
 
     update(dt) {

--- a/labs/cyberos/index.html
+++ b/labs/cyberos/index.html
@@ -29,7 +29,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=VT323&display=swap"
     rel="stylesheet">
-  <link rel="stylesheet" href="/labs/shared.css?v=12">
+  <link rel="stylesheet" href="/labs/shared.css?v=13">
   <link rel="stylesheet" href="style.css?v=3">
   <script type="application/ld+json">
   {
@@ -246,7 +246,7 @@
 
   <footer data-lab-footer data-home-href="/" class="cyber-lab-footer"></footer>
 
-  <script src="/labs/shared.js?v=12" defer></script>
+  <script src="/labs/shared.js?v=13" defer></script>
   <script src="script.js?v=2" defer></script>
 </body>
 

--- a/labs/cyberos/index.html
+++ b/labs/cyberos/index.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
-  <title>CyberOS Terminal | Diogo Paulino</title>
+  <title>CyberOS Terminal — estação hacker | Diogo Paulino</title>
   <meta name="description"
     content="Estação de trabalho retrô/hacker no navegador: terminal explorável, minijogos de firewall, Oracle IA e cifrador de mensagens secretas.">
   <meta name="theme-color" content="#050806">
@@ -14,10 +14,10 @@
   <link rel="icon" href="/favicon.ico" sizes="any">
   <meta property="og:site_name" content="Diogo Paulino · Labs">
   <meta property="og:image:alt" content="Diogo Paulino">
-  <meta name="twitter:title" content="CyberOS Terminal | Diogo Paulino">
+  <meta name="twitter:title" content="CyberOS Terminal — estação hacker | Diogo Paulino">
   <meta name="twitter:description" content="Sistema operacional cyberpunk no browser. Explore arquivos secretos, hackeie firewalls e consulte o Oracle.">
   <meta name="twitter:image" content="https://diogopaulino.com.br/assets/img/diogo.jpeg">
-  <meta property="og:title" content="CyberOS Terminal | Diogo Paulino">
+  <meta property="og:title" content="CyberOS Terminal — estação hacker | Diogo Paulino">
   <meta property="og:description"
     content="Sistema operacional cyberpunk no browser. Explore arquivos secretos, hackeie firewalls e consulte o Oracle.">
   <meta property="og:url" content="https://diogopaulino.com.br/labs/cyberos/">

--- a/labs/english-duo/index.html
+++ b/labs/english-duo/index.html
@@ -22,7 +22,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Talk | Diogo Paulino">
     <meta name="twitter:description" content="Aprenda idiomas de forma divertida e interativa com o Talk.">
-    <link rel="stylesheet" href="/labs/shared.css?v=12">
+    <link rel="stylesheet" href="/labs/shared.css?v=13">
     <link rel="stylesheet" href="style.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -417,7 +417,7 @@
     </div>
 
     <div id="toast-container" class="toast-container"></div>
-    <script src="/labs/shared.js?v=12" defer></script>
+    <script src="/labs/shared.js?v=13" defer></script>
     <script src="script.js" defer></script>
 </body>
 

--- a/labs/english-duo/index.html
+++ b/labs/english-duo/index.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
-    <title>Talk | Diogo Paulino</title>
+    <title>Talk — aprenda idiomas jogando | Diogo Paulino</title>
     <meta name="description" content="Aprenda idiomas de forma divertida e interativa com o Talk.">
     <link rel="canonical" href="https://diogopaulino.com.br/labs/english-duo/">
     <meta name="author" content="Diogo Paulino">
@@ -17,10 +17,10 @@
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="Diogo Paulino · Labs">
     <meta property="og:url" content="https://diogopaulino.com.br/labs/english-duo/">
-    <meta property="og:title" content="Talk | Diogo Paulino">
+    <meta property="og:title" content="Talk — aprenda idiomas jogando | Diogo Paulino">
     <meta property="og:description" content="Aprenda idiomas de forma divertida e interativa com o Talk.">
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Talk | Diogo Paulino">
+    <meta name="twitter:title" content="Talk — aprenda idiomas jogando | Diogo Paulino">
     <meta name="twitter:description" content="Aprenda idiomas de forma divertida e interativa com o Talk.">
     <link rel="stylesheet" href="/labs/shared.css?v=13">
     <link rel="stylesheet" href="style.css">

--- a/labs/eyra/index.html
+++ b/labs/eyra/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;600;700;800&family=Outfit:wght@400;500;600;700;800&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=12">
+    <link rel="stylesheet" href="/labs/shared.css?v=13">
     <link rel="stylesheet" href="style.css">
 
     <script type="importmap">
@@ -261,7 +261,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=12" defer></script>
+    <script src="/labs/shared.js?v=13" defer></script>
     <script>
         (function () {
             function hasGpu() {

--- a/labs/eyra/src/main.js
+++ b/labs/eyra/src/main.js
@@ -77,7 +77,8 @@ class Eyra {
             roll: document.getElementById('btnRoll')
         });
 
-        window.addEventListener('resize', () => this.resize());
+        if (window.LabRuntime) LabRuntime.debounceResize(() => this.resize());
+        else window.addEventListener('resize', () => this.resize());
         document.addEventListener('visibilitychange', () => {
             if (document.hidden && this.state === 'play') this.pause();
         });
@@ -106,7 +107,9 @@ class Eyra {
                 this.last = performance.now();
                 this.fpsAcc = 0;
                 this.fpsFrames = 0;
-                this.renderer.setAnimationLoop((now) => this.frame(now));
+                const loop = (now) => this.frame(now);
+                if (window.LabRuntime) LabRuntime.bindThreeLoop(this.renderer, loop);
+                else this.renderer.setAnimationLoop(loop);
             }, 280);
         } catch (err) {
             console.error(err);

--- a/labs/f1-racing/index.html
+++ b/labs/f1-racing/index.html
@@ -28,7 +28,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="preconnect" href="https://cdn.babylonjs.com" crossorigin>
-    <link rel="stylesheet" href="/labs/shared.css?v=12">
+    <link rel="stylesheet" href="/labs/shared.css?v=13">
     <link rel="stylesheet" href="style.css?v=13">
     <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700&family=Orbitron:wght@500;600;700;800;900&display=swap"
         rel="stylesheet">
@@ -180,7 +180,7 @@
 
     <script src="https://cdn.babylonjs.com/babylon.js"></script>
     <script src="https://cdn.babylonjs.com/loaders/babylonjs.loaders.min.js"></script>
-    <script src="/labs/shared.js?v=12" defer></script>
+    <script src="/labs/shared.js?v=13" defer></script>
     <script type="module" src="src/main.js"></script>
 </body>
 

--- a/labs/f1-racing/src/main.js
+++ b/labs/f1-racing/src/main.js
@@ -131,7 +131,8 @@ class F1GrandPrix {
         if (window.LabRuntime) LabRuntime.bindBabylonLoop(this.engine, this._renderLoop);
         else this.engine.runRenderLoop(this._renderLoop);
 
-        window.addEventListener('resize', () => this.engine.resize());
+        if (window.LabRuntime) LabRuntime.debounceResize(() => this.engine.resize());
+        else window.addEventListener('resize', () => this.engine.resize());
     }
 
     loadCircuit(key) {

--- a/labs/forrest-run/index.html
+++ b/labs/forrest-run/index.html
@@ -34,7 +34,7 @@
     <link rel="preconnect" href="https://cdn.babylonjs.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,500;0,700;1,500&family=Outfit:wght@400;500;600;700&family=Share+Tech+Mono&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=12">
+    <link rel="stylesheet" href="/labs/shared.css?v=13">
     <link rel="stylesheet" href="style.css">
 
     <script type="application/ld+json">
@@ -260,7 +260,7 @@
 
     <script src="https://cdn.babylonjs.com/babylon.js"></script>
     <script src="https://cdn.babylonjs.com/loaders/babylonjs.loaders.min.js"></script>
-    <script src="/labs/shared.js?v=12" defer></script>
+    <script src="/labs/shared.js?v=13" defer></script>
     <script type="module" src="src/main.js"></script>
 </body>
 

--- a/labs/forrest-run/src/main.js
+++ b/labs/forrest-run/src/main.js
@@ -167,7 +167,7 @@ class Game {
 
         // Loop de Renderização
         this.lastFrame = performance.now();
-        this.engine.runRenderLoop(() => {
+        this._renderLoop = () => {
             const now = performance.now();
             const dt = clamp((now - this.lastFrame) / 1000, 0, 0.05);
             this.lastFrame = now;
@@ -185,9 +185,12 @@ class Game {
                 this.fpsAccum = 0;
                 this.fpsFrames = 0;
             }
-        });
+        };
+        if (window.LabRuntime) LabRuntime.bindBabylonLoop(this.engine, this._renderLoop);
+        else this.engine.runRenderLoop(this._renderLoop);
 
-        window.addEventListener('resize', () => this.engine.resize());
+        if (window.LabRuntime) LabRuntime.debounceResize(() => this.engine.resize());
+        else window.addEventListener('resize', () => this.engine.resize());
         document.addEventListener('visibilitychange', () => {
             if (document.hidden && this.state === 'playing') this.pause();
         });

--- a/labs/grao/index.html
+++ b/labs/grao/index.html
@@ -29,7 +29,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=12">
+    <link rel="stylesheet" href="/labs/shared.css?v=13">
     <link rel="stylesheet" href="style.css">
     <script type="application/ld+json">
     {
@@ -273,7 +273,7 @@
     <div class="toast-region" id="toast-region" aria-live="polite"></div>
     <p class="sr-only" id="live-region" role="status" aria-live="polite"></p>
 
-    <script src="/labs/shared.js?v=12" defer></script>
+    <script src="/labs/shared.js?v=13" defer></script>
     <script type="module" src="script.js"></script>
 </body>
 

--- a/labs/grao/index.html
+++ b/labs/grao/index.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
-    <title>Grão | Diogo Paulino</title>
+    <title>Grão — companheiro de cafeína | Diogo Paulino</title>
     <meta name="description"
         content="Companheiro de cafeína no navegador: registre o café, veja quanto ainda circula no corpo e a que horas parar para dormir bem.">
     <link rel="canonical" href="https://diogopaulino.com.br/labs/grao/">
@@ -18,11 +18,11 @@
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="Diogo Paulino · Labs">
     <meta property="og:url" content="https://diogopaulino.com.br/labs/grao/">
-    <meta property="og:title" content="Grão | Diogo Paulino">
+    <meta property="og:title" content="Grão — companheiro de cafeína | Diogo Paulino">
     <meta property="og:description"
         content="Quanto cafeína ainda circula em você — e a que horas parar de beber café.">
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Grão | Diogo Paulino">
+    <meta name="twitter:title" content="Grão — companheiro de cafeína | Diogo Paulino">
     <meta name="twitter:description"
         content="Companheiro de cafeína: curva em tempo real, corte para o sono e histórico local.">
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/labs/grao/script.js
+++ b/labs/grao/script.js
@@ -734,8 +734,12 @@ function bind() {
         if (document.visibilityState === 'visible') render();
     });
 
-    const mo = new MutationObserver(() => drawChart(new Date()));
-    mo.observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme'] });
+    if (window.LabTheme) {
+        LabTheme.onChange(() => drawChart(new Date()));
+    } else {
+        const mo = new MutationObserver(() => drawChart(new Date()));
+        mo.observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme'] });
+    }
 }
 
 bind();

--- a/labs/gravity/index.html
+++ b/labs/gravity/index.html
@@ -26,7 +26,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=12">
+    <link rel="stylesheet" href="/labs/shared.css?v=13">
     <link rel="stylesheet" href="style.css">
     <script type="application/ld+json">
     {
@@ -270,7 +270,7 @@
 
     <footer data-lab-footer data-home-href="/"></footer>
 
-    <script src="/labs/shared.js?v=12" defer></script>
+    <script src="/labs/shared.js?v=13" defer></script>
     <script src="script.js" defer></script>
 </body>
 

--- a/labs/gravity/style.css
+++ b/labs/gravity/style.css
@@ -211,8 +211,8 @@ header .app-logo svg {
     border-radius: 999px;
     border: 1px solid var(--border);
     background: var(--panel);
-    backdrop-filter: blur(16px) saturate(160%);
-    -webkit-backdrop-filter: blur(16px) saturate(160%);
+    backdrop-filter: blur(12px) saturate(160%);
+    -webkit-backdrop-filter: blur(12px) saturate(160%);
 }
 
 .warp-btn {
@@ -275,8 +275,8 @@ header .app-logo svg {
     border-radius: 16px;
     border: 1px solid var(--border);
     background: var(--panel-solid);
-    backdrop-filter: blur(20px) saturate(170%);
-    -webkit-backdrop-filter: blur(20px) saturate(170%);
+    backdrop-filter: blur(12px) saturate(170%);
+    -webkit-backdrop-filter: blur(12px) saturate(170%);
     box-shadow: 0 10px 36px rgba(0, 0, 0, 0.4);
 }
 
@@ -374,8 +374,8 @@ header .app-logo svg {
     border-radius: 999px;
     border: 1px solid var(--border);
     background: var(--panel);
-    backdrop-filter: blur(18px) saturate(160%);
-    -webkit-backdrop-filter: blur(18px) saturate(160%);
+    backdrop-filter: blur(12px) saturate(160%);
+    -webkit-backdrop-filter: blur(12px) saturate(160%);
     color: var(--muted);
     cursor: pointer;
     font-family: inherit;
@@ -416,8 +416,8 @@ header .app-logo svg {
     border-radius: var(--dock-radius);
     border: 1px solid var(--border);
     background: var(--panel);
-    backdrop-filter: blur(22px) saturate(170%);
-    -webkit-backdrop-filter: blur(22px) saturate(170%);
+    backdrop-filter: blur(12px) saturate(170%);
+    -webkit-backdrop-filter: blur(12px) saturate(170%);
     box-shadow: 0 12px 40px rgba(0, 0, 0, 0.38);
 }
 
@@ -480,8 +480,8 @@ header .app-logo svg {
     border-radius: 18px;
     border: 1px solid var(--border);
     background: var(--panel-solid);
-    backdrop-filter: blur(22px);
-    -webkit-backdrop-filter: blur(22px);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
 }
 
 .tune-panel[hidden] {

--- a/labs/guerreiro-castelo/index.html
+++ b/labs/guerreiro-castelo/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.babylonjs.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;600;700;800&family=Outfit:wght@300;400;500;600;700&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=12">
+    <link rel="stylesheet" href="/labs/shared.css?v=13">
     <link rel="stylesheet" href="css/style.css">
 
     <script type="application/ld+json">
@@ -256,7 +256,7 @@
     <script src="https://cdn.babylonjs.com/babylon.js"></script>
     <script src="https://cdn.babylonjs.com/loaders/babylonjs.loaders.min.js"></script>
     <script src="https://cdn.babylonjs.com/materialsLibrary/babylonjs.materials.min.js"></script>
-    <script src="/labs/shared.js?v=12" defer></script>
+    <script src="/labs/shared.js?v=13" defer></script>
     <script type="module" src="js/main.js"></script>
 </body>
 

--- a/labs/guerreiro-castelo/js/core/Game.js
+++ b/labs/guerreiro-castelo/js/core/Game.js
@@ -96,9 +96,11 @@ export class Game {
         this.pauseMenu = new PauseMenu(this);
 
         // Redimensionamento
-        window.addEventListener('resize', () => {
+        const onResize = () => {
             this.engine.resize();
-        });
+        };
+        if (window.LabRuntime) LabRuntime.debounceResize(onResize);
+        else window.addEventListener('resize', onResize);
 
         await this.assets.preloadEssential((p) => {
             this.menu.setProgress(p);

--- a/labs/guerreiro-castelo/js/game/StoryDirector.js
+++ b/labs/guerreiro-castelo/js/game/StoryDirector.js
@@ -172,7 +172,7 @@ export class StoryDirector {
                 g.showEnding();
                 break;
             default:
-                if (extra) console.log('[story]', event, extra);
+                break;
         }
     }
 

--- a/labs/honor-front/index.html
+++ b/labs/honor-front/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.babylonjs.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@600;700;800&family=Oswald:wght@400;500;600;700&family=Outfit:wght@300;400;500;600;700&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=12">
+    <link rel="stylesheet" href="/labs/shared.css?v=13">
     <link rel="stylesheet" href="style.css?v=1">
 
     <script type="application/ld+json">
@@ -216,7 +216,7 @@
 
     <script src="https://cdn.babylonjs.com/babylon.js"></script>
     <script src="https://cdn.babylonjs.com/loaders/babylonjs.loaders.min.js"></script>
-    <script src="/labs/shared.js?v=12" defer></script>
+    <script src="/labs/shared.js?v=13" defer></script>
     <script type="module" src="src/main.js"></script>
 </body>
 

--- a/labs/honor-front/src/main.js
+++ b/labs/honor-front/src/main.js
@@ -206,7 +206,8 @@ class HonorFront {
         if (window.LabRuntime) LabRuntime.bindBabylonLoop(this.engine, this._renderLoop);
         else this.engine.runRenderLoop(this._renderLoop);
 
-        window.addEventListener('resize', () => this.engine.resize());
+        if (window.LabRuntime) LabRuntime.debounceResize(() => this.engine.resize());
+        else window.addEventListener('resize', () => this.engine.resize());
     }
 
     start() {

--- a/labs/image-editor/index.html
+++ b/labs/image-editor/index.html
@@ -24,7 +24,7 @@
     <meta name="twitter:description" content="Editor de imagens no navegador: recorte, filtros, ajustes de brilho, contraste e saturação, tudo processado localmente sem enviar nada para servidor.">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="stylesheet" href="/labs/shared.css?v=12">
+    <link rel="stylesheet" href="/labs/shared.css?v=13">
     <link rel="stylesheet" href="style.css">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <script type="application/ld+json">
@@ -218,7 +218,7 @@
 
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
-    <script src="/labs/shared.js?v=12" defer></script>
+    <script src="/labs/shared.js?v=13" defer></script>
     <script src="script.js" defer></script>
 </body>
 

--- a/labs/image-editor/index.html
+++ b/labs/image-editor/index.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
-    <title>Image Editor | Diogo Paulino</title>
+    <title>Image Editor — recorte e filtros locais | Diogo Paulino</title>
     <meta name="description" content="Editor de imagens no navegador: recorte, filtros, ajustes de brilho, contraste e saturação, tudo processado localmente sem enviar nada para servidor.">
     <link rel="canonical" href="https://diogopaulino.com.br/labs/image-editor/">
     <meta name="author" content="Diogo Paulino">
@@ -17,10 +17,10 @@
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="Diogo Paulino · Labs">
     <meta property="og:url" content="https://diogopaulino.com.br/labs/image-editor/">
-    <meta property="og:title" content="Image Editor | Diogo Paulino">
+    <meta property="og:title" content="Image Editor — recorte e filtros locais | Diogo Paulino">
     <meta property="og:description" content="Editor de imagens no navegador: recorte, filtros, ajustes de brilho, contraste e saturação, tudo processado localmente sem enviar nada para servidor.">
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Image Editor | Diogo Paulino">
+    <meta name="twitter:title" content="Image Editor — recorte e filtros locais | Diogo Paulino">
     <meta name="twitter:description" content="Editor de imagens no navegador: recorte, filtros, ajustes de brilho, contraste e saturação, tudo processado localmente sem enviar nada para servidor.">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/labs/image-optimizer/index.html
+++ b/labs/image-optimizer/index.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
-    <title>Image Optimizer | Diogo Paulino</title>
+    <title>Image Optimizer — JPG, PNG e WEBP locais | Diogo Paulino</title>
     <meta name="description" content="Otimize e converta suas imagens para JPG, PNG ou WEBP diretamente no navegador.">
     <link rel="canonical" href="https://diogopaulino.com.br/labs/image-optimizer/">
     <meta name="author" content="Diogo Paulino">
@@ -17,10 +17,10 @@
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="Diogo Paulino · Labs">
     <meta property="og:url" content="https://diogopaulino.com.br/labs/image-optimizer/">
-    <meta property="og:title" content="Image Optimizer | Diogo Paulino">
+    <meta property="og:title" content="Image Optimizer — JPG, PNG e WEBP locais | Diogo Paulino">
     <meta property="og:description" content="Otimize e converta suas imagens para JPG, PNG ou WEBP diretamente no navegador.">
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Image Optimizer | Diogo Paulino">
+    <meta name="twitter:title" content="Image Optimizer — JPG, PNG e WEBP locais | Diogo Paulino">
     <meta name="twitter:description" content="Otimize e converta suas imagens para JPG, PNG ou WEBP diretamente no navegador.">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/labs/image-optimizer/index.html
+++ b/labs/image-optimizer/index.html
@@ -24,7 +24,7 @@
     <meta name="twitter:description" content="Otimize e converta suas imagens para JPG, PNG ou WEBP diretamente no navegador.">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="stylesheet" href="/labs/shared.css?v=12">
+    <link rel="stylesheet" href="/labs/shared.css?v=13">
     <link rel="stylesheet" href="style.css">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <script type="application/ld+json">
@@ -130,7 +130,7 @@
 
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
-    <script src="/labs/shared.js?v=12" defer></script>
+    <script src="/labs/shared.js?v=13" defer></script>
     <script src="script.js" defer></script>
 </body>
 

--- a/labs/index.html
+++ b/labs/index.html
@@ -1605,7 +1605,7 @@
     </div>
     <footer data-lab-footer data-home-href="/"></footer>
   </div>
-  <script src="/labs/shared.js?v=12"></script>
+  <script src="/labs/shared.js?v=13"></script>
   <script src="/labs/index.js?v=2"></script>
 </body>
 

--- a/labs/joao-e-o-pe-de-feijao/index.html
+++ b/labs/joao-e-o-pe-de-feijao/index.html
@@ -35,7 +35,7 @@
     <link rel="preconnect" href="https://assets.babylonjs.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;600;700;800&family=Nunito:wght@400;600;700;800&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=12">
+    <link rel="stylesheet" href="/labs/shared.css?v=13">
     <link rel="stylesheet" href="style.css?v=2">
 
     <script type="application/ld+json">
@@ -292,7 +292,7 @@
 
     <script src="https://cdn.babylonjs.com/babylon.js"></script>
     <script src="https://cdn.babylonjs.com/loaders/babylonjs.loaders.min.js"></script>
-    <script src="/labs/shared.js?v=12" defer></script>
+    <script src="/labs/shared.js?v=13" defer></script>
     <script>
         (function () {
             function hasGpu() {

--- a/labs/joao-e-o-pe-de-feijao/src/main.js
+++ b/labs/joao-e-o-pe-de-feijao/src/main.js
@@ -109,7 +109,8 @@ class Game {
         this.player.setVisible(false);
 
         this._bindUi();
-        window.addEventListener('resize', () => this._resize());
+        if (window.LabRuntime) LabRuntime.debounceResize(() => this._resize());
+        else window.addEventListener('resize', () => this._resize());
 
         await this._loadChapter(0, { menu: true });
         this.hud.setLoading(1, 'O conto espera.');

--- a/labs/jornada-do-anel/index.html
+++ b/labs/jornada-do-anel/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;600;700;800&family=Outfit:wght@300;400;500;600;700&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=12">
+    <link rel="stylesheet" href="/labs/shared.css?v=13">
     <link rel="stylesheet" href="style.css?v=1">
 
     <script type="importmap">
@@ -294,7 +294,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=12" defer></script>
+    <script src="/labs/shared.js?v=13" defer></script>
     <script>
         (function () {
             function hasGpu() {

--- a/labs/jungle-run/index.html
+++ b/labs/jungle-run/index.html
@@ -7,7 +7,7 @@
     <meta name="theme-color" content="#07150f">
     <meta name="description"
         content="Jungle Run: uma aventura retrô pela selva. Corra, salte, balance em cipós e descubra relíquias.">
-    <meta property="og:title" content="Jungle Run — Uma aventura retrô | Diogo Paulino">
+    <meta property="og:title" content="Jungle Run — uma aventura retrô | Diogo Paulino">
     <meta property="og:description" content="Até onde você consegue chegar na selva?">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://diogopaulino.com.br/labs/jungle-run/">
@@ -20,10 +20,10 @@
     <meta property="og:image:alt" content="Diogo Paulino">
     <meta property="og:locale" content="pt_BR">
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Jungle Run — Uma aventura retrô | Diogo Paulino">
+    <meta name="twitter:title" content="Jungle Run — uma aventura retrô | Diogo Paulino">
     <meta name="twitter:description" content="Até onde você consegue chegar na selva?">
     <meta name="twitter:image" content="https://diogopaulino.com.br/assets/img/diogo.jpeg">
-    <title>Jungle Run | Diogo Paulino</title>
+    <title>Jungle Run — uma aventura retrô | Diogo Paulino</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@600;900&family=Plus+Jakarta+Sans:wght@400;500;700;800&display=swap" rel="stylesheet">

--- a/labs/jungle-run/index.html
+++ b/labs/jungle-run/index.html
@@ -28,7 +28,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@600;900&family=Plus+Jakarta+Sans:wght@400;500;700;800&display=swap" rel="stylesheet">
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
-    <link rel="stylesheet" href="/labs/shared.css?v=12">
+    <link rel="stylesheet" href="/labs/shared.css?v=13">
     <link rel="stylesheet" href="style.css?v=3">
     <script src="https://cdn.jsdelivr.net/npm/pixi.js@8.6.6/dist/pixi.min.js" defer></script>
     <script type="application/ld+json">
@@ -305,7 +305,7 @@
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
 
-    <script src="/labs/shared.js?v=12" defer></script>
+    <script src="/labs/shared.js?v=13" defer></script>
     <script src="script.js?v=5" defer></script>
 </body>
 

--- a/labs/jungle-run/script.js
+++ b/labs/jungle-run/script.js
@@ -259,6 +259,7 @@ class JungleRun {
             this.renderLevelSelector();
 
             this.app.ticker.add(this.gameLoop, this);
+            if (window.LabRuntime) LabRuntime.bindPixiTicker(this.app);
             this.state = 'intro';
             this.syncHud(true);
             
@@ -517,6 +518,11 @@ class JungleRun {
 
         document.addEventListener('visibilitychange', () => {
             if (document.hidden && this.state === 'playing') this.pauseGame();
+            // LabRuntime.bindPixiTicker reinicia o ticker ao voltar; se ainda
+            // estamos pausados, mantém parado até o resume explícito.
+            else if (!document.hidden && this.state === 'paused' && this.app?.ticker) {
+                this.app.ticker.stop();
+            }
         });
 
         document.getElementById('startBtn').addEventListener('click', () => this.startExpedition());
@@ -836,6 +842,7 @@ class JungleRun {
         if (this.state !== 'playing') return;
         this.state = 'paused';
         this.releaseInputs();
+        if (this.app?.ticker) this.app.ticker.stop();
         document.getElementById('pauseScreen').classList.remove('hidden');
         document.getElementById('pauseScreen').setAttribute('aria-hidden', 'false');
         document.getElementById('hud').classList.add('is-dimmed');
@@ -847,6 +854,7 @@ class JungleRun {
     resumeGame() {
         if (this.state !== 'paused') return;
         this.state = 'playing';
+        if (this.app?.ticker) this.app.ticker.start();
         document.getElementById('pauseScreen').classList.add('hidden');
         document.getElementById('pauseScreen').setAttribute('aria-hidden', 'true');
         document.getElementById('hud').classList.remove('is-dimmed');

--- a/labs/jurassic/index.html
+++ b/labs/jurassic/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,500;0,600;0,700;1,500&family=Barlow:wght@400;500;600;700&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=12">
+    <link rel="stylesheet" href="/labs/shared.css?v=13">
     <link rel="stylesheet" href="style.css?v=1">
 
     <script type="importmap">
@@ -285,7 +285,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=12" defer></script>
+    <script src="/labs/shared.js?v=13" defer></script>
     <script>
         (function () {
             function hasGpu() {

--- a/labs/kong-kong/index.html
+++ b/labs/kong-kong/index.html
@@ -29,7 +29,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@500;700;800&family=Titan+One&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="/labs/shared.css?v=12">
+  <link rel="stylesheet" href="/labs/shared.css?v=13">
   <link rel="stylesheet" href="style.css">
   <script type="application/ld+json">
   {
@@ -147,7 +147,7 @@
   </div>
 
   <p class="sr-only" id="announcer" aria-live="assertive"></p>
-  <script src="/labs/shared.js?v=12" defer></script>
+  <script src="/labs/shared.js?v=13" defer></script>
   <script type="module" src="src/main.js"></script>
 </body>
 

--- a/labs/lander/index.html
+++ b/labs/lander/index.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
-    <title>Lunar Lander | Diogo Paulino</title>
+    <title>Lunar Lander — pouso com física | Diogo Paulino</title>
     <meta name="description" content="Pouso lunar com física realista: gravidade, inércia, consumo de combustível e terreno gerado por procedimento. Desça devagar e no ângulo certo.">
     <link rel="canonical" href="https://diogopaulino.com.br/labs/lander/">
     <meta name="author" content="Diogo Paulino">
@@ -17,10 +17,10 @@
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="Diogo Paulino · Labs">
     <meta property="og:url" content="https://diogopaulino.com.br/labs/lander/">
-    <meta property="og:title" content="Lunar Lander | Diogo Paulino">
+    <meta property="og:title" content="Lunar Lander — pouso com física | Diogo Paulino">
     <meta property="og:description" content="Pouso lunar com física realista: gravidade, inércia, consumo de combustível e terreno gerado por procedimento. Desça devagar e no ângulo certo.">
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Lunar Lander | Diogo Paulino">
+    <meta name="twitter:title" content="Lunar Lander — pouso com física | Diogo Paulino">
     <meta name="twitter:description" content="Pouso lunar com física realista: gravidade, inércia, consumo de combustível e terreno gerado por procedimento. Desça devagar e no ângulo certo.">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/labs/lander/index.html
+++ b/labs/lander/index.html
@@ -24,7 +24,7 @@
     <meta name="twitter:description" content="Pouso lunar com física realista: gravidade, inércia, consumo de combustível e terreno gerado por procedimento. Desça devagar e no ângulo certo.">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="stylesheet" href="/labs/shared.css?v=12">
+    <link rel="stylesheet" href="/labs/shared.css?v=13">
     <link rel="stylesheet" href="style.css?v=4">
     <link href="https://fonts.googleapis.com/css2?family=VT323&display=swap" rel="stylesheet">
     <script type="application/ld+json">
@@ -184,7 +184,7 @@
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
 
-    <script src="/labs/shared.js?v=12" defer></script>
+    <script src="/labs/shared.js?v=13" defer></script>
     <script src="script.js?v=4" defer></script>
 </body>
 

--- a/labs/lander/script.js
+++ b/labs/lander/script.js
@@ -638,6 +638,8 @@ function draw() {
     lander.draw(ctx);
 }
 
+let rafId = 0;
+
 function gameLoop(timestamp) {
     if (!lastTime) lastTime = timestamp;
     const frameTime = Math.min((timestamp - lastTime) / 1000, PHYSICS.maxFrameTime);
@@ -661,7 +663,20 @@ function gameLoop(timestamp) {
     checkLowFuel();
     updateHUD();
     draw();
-    requestAnimationFrame(gameLoop);
+    rafId = requestAnimationFrame(gameLoop);
+}
+
+function startLoop() {
+    if (rafId) return;
+    lastTime = 0;
+    rafId = requestAnimationFrame(gameLoop);
+}
+
+function stopLoop() {
+    if (!rafId) return;
+    const id = rafId;
+    rafId = 0;
+    cancelAnimationFrame(id);
 }
 
 window.addEventListener('keydown', event => {
@@ -724,9 +739,14 @@ if (labAudio) {
     labAudio.onChange(() => setEngineLevel(lander.engineOn ? 1 : 0));
 }
 
-// Aba escondida: o motor não pode continuar roncando em segundo plano.
+// Aba escondida: corta o motor e cancela o rAF (LabAudio mute permanece).
 document.addEventListener('visibilitychange', () => {
-    if (document.hidden) setEngineLevel(0);
+    if (document.hidden) {
+        setEngineLevel(0);
+        stopLoop();
+    } else {
+        startLoop();
+    }
 });
 
 generateStars();
@@ -735,4 +755,4 @@ lander.reset();
 setGameState('START');
 setFlightStatus('READY');
 draw();
-requestAnimationFrame(gameLoop);
+startLoop();

--- a/labs/lavandula/index.html
+++ b/labs/lavandula/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;600;700;800&family=Outfit:wght@300;400;500;600;700&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=12">
+    <link rel="stylesheet" href="/labs/shared.css?v=13">
     <link rel="stylesheet" href="style.css?v=1">
 
     <script type="importmap">
@@ -264,7 +264,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=12" defer></script>
+    <script src="/labs/shared.js?v=13" defer></script>
     <script>
         (function () {
             function hasGpu() {

--- a/labs/matrix/index.html
+++ b/labs/matrix/index.html
@@ -27,7 +27,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Share+Tech+Mono&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=12">
+    <link rel="stylesheet" href="/labs/shared.css?v=13">
     <link rel="stylesheet" href="style.css?v=4">
     <script type="application/ld+json">
     {
@@ -336,7 +336,7 @@
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
 
-    <script src="/labs/shared.js?v=12" defer></script>
+    <script src="/labs/shared.js?v=13" defer></script>
     <script src="script.js" defer></script>
 </body>
 

--- a/labs/matrix/index.html
+++ b/labs/matrix/index.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
-    <title>Matrix | Diogo Paulino</title>
+    <title>Matrix — chuva digital CRT | Diogo Paulino</title>
     <meta name="description"
         content="Simulação fiel da chuva digital de Matrix: glifos katakana espelhados, bloom CRT, scanlines e controles completos.">
     <link rel="canonical" href="https://diogopaulino.com.br/labs/matrix/">
@@ -18,10 +18,10 @@
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="Diogo Paulino · Labs">
     <meta property="og:url" content="https://diogopaulino.com.br/labs/matrix/">
-    <meta property="og:title" content="Matrix | Diogo Paulino">
+    <meta property="og:title" content="Matrix — chuva digital CRT | Diogo Paulino">
     <meta property="og:description" content="Simulação fiel da chuva digital de Matrix: glifos katakana espelhados, bloom CRT, scanlines e controles completos.">
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Matrix | Diogo Paulino">
+    <meta name="twitter:title" content="Matrix — chuva digital CRT | Diogo Paulino">
     <meta name="twitter:description" content="Simulação fiel da chuva digital de Matrix: glifos katakana espelhados, bloom CRT, scanlines e controles completos.">
     <meta name="theme-color" content="#000000">
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/labs/matrix/script.js
+++ b/labs/matrix/script.js
@@ -1059,10 +1059,19 @@
     });
 
     // O contador de streams muda pouco; atualizar fora do loop evita layout a 60fps.
-    setInterval(function () {
-        const total = layers.reduce(function (sum, layer) { return sum + layer.streams.length; }, 0);
-        ui.streamCount.textContent = total;
-    }, 500);
+    const streamCounter = window.LabRuntime
+        ? LabRuntime.createInterval(function () {
+            const total = layers.reduce(function (sum, layer) { return sum + layer.streams.length; }, 0);
+            ui.streamCount.textContent = total;
+        }, 500)
+        : null;
+    if (streamCounter) streamCounter.start();
+    else {
+        setInterval(function () {
+            const total = layers.reduce(function (sum, layer) { return sum + layer.streams.length; }, 0);
+            ui.streamCount.textContent = total;
+        }, 500);
+    }
 
     syncUI();
     resize();

--- a/labs/menina-da-lanterna/index.html
+++ b/labs/menina-da-lanterna/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@500;600;700&family=Nunito:wght@400;600;700;800&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=12">
+    <link rel="stylesheet" href="/labs/shared.css?v=13">
     <link rel="stylesheet" href="style.css?v=2">
 
     <script type="importmap">
@@ -312,7 +312,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=12" defer></script>
+    <script src="/labs/shared.js?v=13" defer></script>
     <script>
         (function () {
             function hasGpu() {

--- a/labs/mimo/index.html
+++ b/labs/mimo/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;600;700&family=Outfit:wght@400;500;600;700&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=12">
+    <link rel="stylesheet" href="/labs/shared.css?v=13">
     <link rel="stylesheet" href="style.css">
 
     <script type="importmap">
@@ -275,7 +275,9 @@
         </div>
     </main>
 
-    <script src="/labs/shared.js?v=12"></script>
+    <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
+
+    <script src="/labs/shared.js?v=13"></script>
     <script type="module" src="src/main.js"></script>
 </body>
 

--- a/labs/mimo/src/main.js
+++ b/labs/mimo/src/main.js
@@ -165,7 +165,8 @@ class Mimo {
         this._renderLoop = () => this.frame();
         if (window.LabRuntime) LabRuntime.bindThreeLoop(this.renderer, this._renderLoop);
         else this.renderer.setAnimationLoop(this._renderLoop);
-        window.addEventListener('resize', () => this.resize());
+        if (window.LabRuntime) LabRuntime.debounceResize(() => this.resize());
+        else window.addEventListener('resize', () => this.resize());
     }
 
     setupLights() {

--- a/labs/mimo/style.css
+++ b/labs/mimo/style.css
@@ -122,6 +122,26 @@ input, select {
 
 .game-shell > header > * { pointer-events: auto; }
 
+/* Fora do shell fixo: não empurra layout nem rouba altura do fullscreen. */
+.lab-foot {
+    position: fixed;
+    left: 0;
+    right: 0;
+    bottom: calc(0.4rem + var(--safe-bottom));
+    z-index: 30;
+    width: auto;
+    max-width: none;
+    margin: 0;
+    padding: 0.4rem;
+    border: 0;
+    font-size: 0.72rem;
+    color: var(--text-dim);
+    opacity: 0.5;
+    pointer-events: none;
+}
+
+.lab-foot a { color: var(--text-soft); pointer-events: auto; }
+
 .app-logo {
     display: flex;
     align-items: center;

--- a/labs/minesweeper/index.html
+++ b/labs/minesweeper/index.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
-    <title>Campo Minado 95 | Diogo Paulino</title>
+    <title>Campo Minado 95 — clássico Windows 95 | Diogo Paulino</title>
     <meta name="description" content="Clássico jogo de Campo Minado estilo Windows 95.">
     <link rel="canonical" href="https://diogopaulino.com.br/labs/minesweeper/">
     <meta name="author" content="Diogo Paulino">
@@ -17,12 +17,12 @@
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="Diogo Paulino · Labs">
     <meta property="og:url" content="https://diogopaulino.com.br/labs/minesweeper/">
-    <meta property="og:title" content="Campo Minado 95 | Diogo Paulino">
+    <meta property="og:title" content="Campo Minado 95 — clássico Windows 95 | Diogo Paulino">
     <meta property="og:description" content="Clássico jogo de Campo Minado estilo Windows 95.">
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Campo Minado 95 | Diogo Paulino">
+    <meta name="twitter:title" content="Campo Minado 95 — clássico Windows 95 | Diogo Paulino">
     <meta name="twitter:description" content="Clássico jogo de Campo Minado estilo Windows 95.">
-    <link rel="stylesheet" href="/labs/shared.css?v=12">
+    <link rel="stylesheet" href="/labs/shared.css?v=13">
     <link rel="stylesheet" href="style.css?v=2">
     <script type="application/ld+json">
     {
@@ -145,7 +145,7 @@
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
 
-    <script src="/labs/shared.js?v=12" defer></script>
+    <script src="/labs/shared.js?v=13" defer></script>
     <script src="script.js?v=2" defer></script>
 </body>
 

--- a/labs/neon-rider/index.html
+++ b/labs/neon-rider/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Audiowide&family=Outfit:wght@400;500;600;700&family=Share+Tech+Mono&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=12">
+    <link rel="stylesheet" href="/labs/shared.css?v=13">
     <link rel="stylesheet" href="style.css?v=2">
 
     <script type="importmap">
@@ -268,7 +268,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=12" defer></script>
+    <script src="/labs/shared.js?v=13" defer></script>
     <script type="module" src="src/main.js?v=4"></script>
 </body>
 

--- a/labs/neon-rider/src/main.js
+++ b/labs/neon-rider/src/main.js
@@ -155,8 +155,11 @@ class Game {
         setTimeout(() => this.hud.hideLoading(), 280);
 
         this.lastFrame = performance.now();
-        this.renderer.setAnimationLoop((now) => this.frame(now));
-        window.addEventListener('resize', () => this.resize());
+        const loop = (now) => this.frame(now);
+        if (window.LabRuntime) LabRuntime.bindThreeLoop(this.renderer, loop);
+        else this.renderer.setAnimationLoop(loop);
+        if (window.LabRuntime) LabRuntime.debounceResize(() => this.resize());
+        else window.addEventListener('resize', () => this.resize());
             document.addEventListener('visibilitychange', () => {
                 if (document.hidden && this.state === 'playing') this.pause();
             });

--- a/labs/nereida/index.html
+++ b/labs/nereida/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,500;0,600;0,700;1,500&family=Figtree:wght@400;600;700;800&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=12">
+    <link rel="stylesheet" href="/labs/shared.css?v=13">
     <link rel="stylesheet" href="style.css">
 
     <script type="importmap">
@@ -248,7 +248,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=12" defer></script>
+    <script src="/labs/shared.js?v=13" defer></script>
     <script>
         (function () {
             function hasGpu() {

--- a/labs/nereida/src/main.js
+++ b/labs/nereida/src/main.js
@@ -114,7 +114,8 @@ class Nereida {
             pulse: document.getElementById('btnPulse')
         });
 
-        window.addEventListener('resize', () => this.resize());
+        if (window.LabRuntime) LabRuntime.debounceResize(() => this.resize());
+        else window.addEventListener('resize', () => this.resize());
         document.addEventListener('visibilitychange', () => {
             if (document.hidden && this.state === 'play') this.pause();
         });
@@ -147,7 +148,9 @@ class Nereida {
             this.hud.hideLoading();
             this.enterMenu();
             this.last = performance.now();
-            this.renderer.setAnimationLoop((now) => this.frame(now));
+            const loop = (now) => this.frame(now);
+            if (window.LabRuntime) LabRuntime.bindThreeLoop(this.renderer, loop);
+            else this.renderer.setAnimationLoop(loop);
         }, 280);
     }
 

--- a/labs/nina/index.html
+++ b/labs/nina/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Fredoka:wght@500;600;700&family=Nunito:wght@400;600;700;800&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=12">
+    <link rel="stylesheet" href="/labs/shared.css?v=13">
     <link rel="stylesheet" href="style.css">
 
     <script type="importmap">
@@ -248,7 +248,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=12" defer></script>
+    <script src="/labs/shared.js?v=13" defer></script>
     <script>
         (function () {
             function hasGpu() {

--- a/labs/nina/src/audio.js
+++ b/labs/nina/src/audio.js
@@ -52,7 +52,12 @@ export class NinaAudio {
     setEnabled(on) {
         this.enabled = on;
         if (this.master) this.master.gain.value = on ? this.volume : 0;
-        if (on) this.init();
+        if (on) {
+            this.init();
+            this._resumeTune();
+        } else {
+            this._pauseTune();
+        }
     }
 
     _osc(type, freq, dest, gain = 0.08) {
@@ -108,7 +113,7 @@ export class NinaAudio {
     _tuneLoop() {
         const scale = [261.63, 293.66, 329.63, 392.0, 440.0, 523.25];
         const pattern = [0, 2, 4, 2, 5, 4, 2, 0, 4, 3, 2, 0];
-        const tick = () => {
+        this._tick = () => {
             if (!this.ctx || !this.enabled) return;
             const now = this.ctx.currentTime;
             const i = this._step % pattern.length;
@@ -116,8 +121,28 @@ export class NinaAudio {
             if (i % 4 === 0) this._pluck(scale[pattern[i]] * 0.5, now, 1.2, 0.04);
             this._step++;
         };
-        tick();
-        this._timer = setInterval(tick, 520);
+        this._tick();
+        this._resumeTune();
+        if (window.LabVisibility && !this._visBound) {
+            this._visBound = true;
+            window.LabVisibility.onChange((hidden) => {
+                if (hidden) this._pauseTune();
+                else if (this.enabled) this._resumeTune();
+            });
+        }
+    }
+
+    _pauseTune() {
+        if (this._timer != null) {
+            clearInterval(this._timer);
+            this._timer = null;
+        }
+    }
+
+    _resumeTune() {
+        if (!this._tick || !this.enabled || document.hidden) return;
+        if (this._timer != null) return;
+        this._timer = setInterval(this._tick, 520);
     }
 
     _blip(freq, dur, type = 'sine', gain = 0.12) {

--- a/labs/nina/src/main.js
+++ b/labs/nina/src/main.js
@@ -117,7 +117,8 @@ class Nina {
             run: document.getElementById('btnRun')
         });
 
-        window.addEventListener('resize', () => this.resize());
+        if (window.LabRuntime) LabRuntime.debounceResize(() => this.resize());
+        else window.addEventListener('resize', () => this.resize());
         document.addEventListener('visibilitychange', () => {
             if (document.hidden && this.state === 'play') this.pause();
         });
@@ -149,7 +150,9 @@ class Nina {
             this.hud.hideLoading();
             this.enterMenu();
             this.last = performance.now();
-            this.renderer.setAnimationLoop((now) => this.frame(now));
+            const loop = (now) => this.frame(now);
+            if (window.LabRuntime) LabRuntime.bindThreeLoop(this.renderer, loop);
+            else this.renderer.setAnimationLoop(loop);
         }, 280);
     }
 

--- a/labs/orbis/index.html
+++ b/labs/orbis/index.html
@@ -34,7 +34,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;600;700&family=Syne:wght@400;500;600;700;800&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=12">
+    <link rel="stylesheet" href="/labs/shared.css?v=13">
     <link rel="stylesheet" href="style.css">
 
     <script type="importmap">
@@ -175,7 +175,9 @@
         <p class="fps-badge" aria-hidden="true"><span id="fps">60</span> fps</p>
     </main>
 
-    <script src="/labs/shared.js?v=12" defer></script>
+    <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
+
+    <script src="/labs/shared.js?v=13" defer></script>
     <script type="module" src="./src/main.js"></script>
 </body>
 

--- a/labs/orbis/src/main.js
+++ b/labs/orbis/src/main.js
@@ -102,7 +102,8 @@ class Orbis {
         this.renderer.compile(this.scene, this.camera);
         this.hideLoading();
 
-        window.addEventListener('resize', () => this.resize());
+        if (window.LabRuntime) LabRuntime.debounceResize(() => this.resize());
+        else window.addEventListener('resize', () => this.resize());
         this._renderLoop = () => this.frame();
         if (window.LabRuntime) LabRuntime.bindThreeLoop(this.renderer, this._renderLoop);
         else this.renderer.setAnimationLoop(this._renderLoop);

--- a/labs/orbis/style.css
+++ b/labs/orbis/style.css
@@ -113,6 +113,26 @@ header[data-lab-header] {
     box-shadow: none !important;
 }
 
+/* Fora do shell: fixed para não empurrar o viewport fullscreen. */
+.lab-foot {
+    position: fixed;
+    left: 0;
+    right: 0;
+    bottom: calc(0.4rem + var(--safe-bottom));
+    z-index: 30;
+    width: auto;
+    max-width: none;
+    margin: 0;
+    padding: 0.4rem;
+    border: 0;
+    font-size: 0.72rem;
+    color: var(--text-dim);
+    opacity: 0.5;
+    pointer-events: none;
+}
+
+.lab-foot a { color: var(--text-soft); pointer-events: auto; }
+
 .app-logo {
     display: flex;
     align-items: center;

--- a/labs/paint/index.html
+++ b/labs/paint/index.html
@@ -28,7 +28,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@100..900&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=12">
+    <link rel="stylesheet" href="/labs/shared.css?v=13">
     <link rel="stylesheet" href="style.css?v=5">
     <script type="application/ld+json">
     {
@@ -305,7 +305,7 @@
 
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
-    <script src="/labs/shared.js?v=12" defer></script>
+    <script src="/labs/shared.js?v=13" defer></script>
     <script src="script.js?v=3" defer></script>
 </body>
 

--- a/labs/partitura/index.html
+++ b/labs/partitura/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover">
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="mobile-web-app-capable" content="yes">
-  <title>Partitura: Maestro Quest | Diogo Paulino</title>
+  <title>Partitura — Maestro Quest e leitura musical | Diogo Paulino</title>
   <meta name="description" content="Aprenda a ler partituras, notas na Clave de Sol e Fá, e escalas musicais com interatividade, áudio sintético pro e gamificação.">
     <link rel="canonical" href="https://diogopaulino.com.br/labs/partitura/">
   <meta name="author" content="Diogo Paulino">
@@ -19,10 +19,10 @@
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="Diogo Paulino · Labs">
     <meta property="og:url" content="https://diogopaulino.com.br/labs/partitura/">
-    <meta property="og:title" content="Partitura: Maestro Quest | Diogo Paulino">
+    <meta property="og:title" content="Partitura — Maestro Quest e leitura musical | Diogo Paulino">
     <meta property="og:description" content="Aprenda a ler partituras, notas na Clave de Sol e Fá, e escalas musicais com interatividade, áudio sintético pro e gamificação.">
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Partitura: Maestro Quest | Diogo Paulino">
+    <meta name="twitter:title" content="Partitura — Maestro Quest e leitura musical | Diogo Paulino">
     <meta name="twitter:description" content="Aprenda a ler partituras, notas na Clave de Sol e Fá, e escalas musicais com interatividade, áudio sintético pro e gamificação.">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/labs/partitura/index.html
+++ b/labs/partitura/index.html
@@ -27,7 +27,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;500;700;800&family=Space+Mono:wght@400;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="/labs/shared.css?v=12">
+  <link rel="stylesheet" href="/labs/shared.css?v=13">
   <link rel="stylesheet" href="style.css">
   <script type="application/ld+json">
   {
@@ -275,7 +275,7 @@
     <footer data-lab-footer data-home-href="/" class="compact-footer"></footer>
   </div>
 
-  <script src="/labs/shared.js?v=12" defer></script>
+  <script src="/labs/shared.js?v=13" defer></script>
   <script src="script.js" defer></script>
 </body>
 

--- a/labs/piano/index.html
+++ b/labs/piano/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover">
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="mobile-web-app-capable" content="yes">
-  <title>Piano | Diogo Paulino</title>
+  <title>Piano — 4 oitavas minimalistas | Diogo Paulino</title>
   <meta name="description" content="Piano minimalista com sons ultra realistas. 4 oitavas completas.">
     <link rel="canonical" href="https://diogopaulino.com.br/labs/piano/">
   <meta name="author" content="Diogo Paulino">
@@ -19,12 +19,12 @@
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="Diogo Paulino · Labs">
     <meta property="og:url" content="https://diogopaulino.com.br/labs/piano/">
-    <meta property="og:title" content="Piano | Diogo Paulino">
+    <meta property="og:title" content="Piano — 4 oitavas minimalistas | Diogo Paulino">
     <meta property="og:description" content="Piano minimalista com sons ultra realistas. 4 oitavas completas.">
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Piano | Diogo Paulino">
+    <meta name="twitter:title" content="Piano — 4 oitavas minimalistas | Diogo Paulino">
     <meta name="twitter:description" content="Piano minimalista com sons ultra realistas. 4 oitavas completas.">
-  <link rel="stylesheet" href="/labs/shared.css?v=12">
+  <link rel="stylesheet" href="/labs/shared.css?v=13">
   <link rel="stylesheet" href="style.css">
   <script type="application/ld+json">
   {
@@ -133,7 +133,7 @@
     <footer data-lab-footer data-home-href="/"></footer>
   </div>
 
-  <script src="/labs/shared.js?v=12" defer></script>
+  <script src="/labs/shared.js?v=13" defer></script>
   <script src="script.js" defer></script>
 </body>
 

--- a/labs/piano/script.js
+++ b/labs/piano/script.js
@@ -530,11 +530,6 @@ function init() {
       wrapper.scrollLeft = (piano.offsetWidth - wrapper.offsetWidth) / 2;
     }, 100);
   }
-
-  console.log('🎹 Piano Ultra Realista');
-  console.log('✨ 8 harmônicas por nota');
-  console.log('🎚️ Velocity-sensitive');
-  console.log('⬇️ Sustain como piano real');
 }
 
 if (document.readyState === 'loading') {

--- a/labs/pomodoro/index.html
+++ b/labs/pomodoro/index.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
-    <title>Pomodoro | Diogo Paulino</title>
+    <title>Pomodoro — timer com tarefas | Diogo Paulino</title>
     <meta name="description"
         content="Timer Pomodoro com tarefas, estatísticas, sons personalizáveis e notificações do navegador.">
     <link rel="canonical" href="https://diogopaulino.com.br/labs/pomodoro/">
@@ -18,15 +18,15 @@
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="Diogo Paulino · Labs">
     <meta property="og:url" content="https://diogopaulino.com.br/labs/pomodoro/">
-    <meta property="og:title" content="Pomodoro | Diogo Paulino">
+    <meta property="og:title" content="Pomodoro — timer com tarefas | Diogo Paulino">
     <meta property="og:description" content="Timer Pomodoro com tarefas, estatísticas, sons personalizáveis e notificações do navegador.">
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Pomodoro | Diogo Paulino">
+    <meta name="twitter:title" content="Pomodoro — timer com tarefas | Diogo Paulino">
     <meta name="twitter:description" content="Timer Pomodoro com tarefas, estatísticas, sons personalizáveis e notificações do navegador.">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=12">
+    <link rel="stylesheet" href="/labs/shared.css?v=13">
     <link rel="stylesheet" href="style.css?v=4">
     <script type="application/ld+json">
     {
@@ -357,7 +357,7 @@
     <div class="toast-region" id="toast-region" aria-live="polite" aria-atomic="false"></div>
     <p class="sr-only" id="live-region" role="status" aria-live="polite"></p>
 
-    <script src="/labs/shared.js?v=12" defer></script>
+    <script src="/labs/shared.js?v=13" defer></script>
     <script src="script.js?v=3" defer></script>
 </body>
 

--- a/labs/ps5-controller/index.html
+++ b/labs/ps5-controller/index.html
@@ -36,6 +36,7 @@
         crossorigin>
     <link rel="preload" href="/labs/ps5-controller/assets/draco/gltf/draco_decoder.wasm" as="fetch" crossorigin>
     <link rel="preload" href="/labs/ps5-controller/assets/models/first-light-controller.glb" as="fetch" crossorigin>
+    <link rel="stylesheet" href="/labs/shared.css?v=13">
     <link rel="stylesheet" href="style.css?v=1">
 
     <script type="importmap">
@@ -101,7 +102,7 @@
     <div id="app"></div>
     <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
 
-    <script src="/labs/shared.js?v=12" defer></script>
+    <script src="/labs/shared.js?v=13" defer></script>
     <script type="module" src="src/main.js?v=2"></script>
 </body>
 

--- a/labs/pulsar/index.html
+++ b/labs/pulsar/index.html
@@ -29,7 +29,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Oxanium:wght@400;600;700;800&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=12">
+    <link rel="stylesheet" href="/labs/shared.css?v=13">
     <link rel="stylesheet" href="style.css">
     <script type="application/ld+json">
     {
@@ -182,7 +182,7 @@
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
 
-    <script src="/labs/shared.js?v=12" defer></script>
+    <script src="/labs/shared.js?v=13" defer></script>
     <script src="script.js" defer></script>
 </body>
 

--- a/labs/pulsar/script.js
+++ b/labs/pulsar/script.js
@@ -1004,10 +1004,16 @@
         else startLoop();
     });
 
-    const themeObs = new MutationObserver(function () {
-        applyThemeVars();
-    });
-    themeObs.observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme'] });
+    if (window.LabTheme) {
+        LabTheme.onChange(function () {
+            applyThemeVars();
+        });
+    } else {
+        const themeObs = new MutationObserver(function () {
+            applyThemeVars();
+        });
+        themeObs.observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme'] });
+    }
 
     finePointer = window.matchMedia('(pointer: fine)').matches;
     applyThemeVars();

--- a/labs/quimera/index.html
+++ b/labs/quimera/index.html
@@ -34,7 +34,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,500;0,9..144,650;1,9..144,500&family=Outfit:wght@300;400;500;600;700&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=12">
+    <link rel="stylesheet" href="/labs/shared.css?v=13">
     <link rel="stylesheet" href="style.css">
 
     <script type="importmap">
@@ -194,7 +194,7 @@
         <footer data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=12" defer></script>
+    <script src="/labs/shared.js?v=13" defer></script>
     <script type="module" src="./src/main.js"></script>
 </body>
 

--- a/labs/rastro-vermelho/index.html
+++ b/labs/rastro-vermelho/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.babylonjs.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;600;700;800&family=Outfit:wght@300;400;500;600;700&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=12">
+    <link rel="stylesheet" href="/labs/shared.css?v=13">
     <link rel="stylesheet" href="style.css?v=1">
 
     <script type="application/ld+json">
@@ -257,7 +257,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=12" defer></script>
+    <script src="/labs/shared.js?v=13" defer></script>
     <script>
         (function () {
             function hasGpu() {

--- a/labs/rastro-vermelho/src/main.js
+++ b/labs/rastro-vermelho/src/main.js
@@ -279,7 +279,8 @@ class RastroVermelho {
         this._renderLoop = () => this.frame();
         if (window.LabRuntime) LabRuntime.bindBabylonLoop(this.engine, this._renderLoop);
         else this.engine.runRenderLoop(this._renderLoop);
-        addEventListener('resize', () => this.engine.resize());
+        if (window.LabRuntime) LabRuntime.debounceResize(() => this.engine.resize());
+        else window.addEventListener('resize', () => this.engine.resize());
     }
 
     updateChunks() {

--- a/labs/ravi-123/index.html
+++ b/labs/ravi-123/index.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover, user-scalable=no">
-  <title>Ravi 1·2·3: A Grande Festa Surpresa | Diogo Paulino</title>
+  <title>Ravi 1·2·3 — a grande festa surpresa | Diogo Paulino</title>
   <meta name="description"
     content="Jogo educativo de contagem de 1 a 9 em pixel art 320×200, no molde dos clássicos educativos de DOS. Ajude o Ravi a preparar uma festa surpresa.">
   <meta name="robots" content="index, follow">
@@ -16,13 +16,13 @@
   <meta property="og:image" content="https://diogopaulino.com.br/assets/img/diogo.jpeg">
   <meta property="og:image:alt" content="Diogo Paulino">
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="Ravi 1·2·3: A Grande Festa Surpresa | Diogo Paulino">
+  <meta name="twitter:title" content="Ravi 1·2·3 — a grande festa surpresa | Diogo Paulino">
   <meta name="twitter:description" content="Conte de 1 a 9 e ajude o Ravi a convidar heróis para a maior festa surpresa do reino. Pixel art 320×200, tudo em vanilla.">
   <meta name="twitter:image" content="https://diogopaulino.com.br/assets/img/diogo.jpeg">
 
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://diogopaulino.com.br/labs/ravi-123/">
-  <meta property="og:title" content="Ravi 1·2·3: A Grande Festa Surpresa | Diogo Paulino">
+  <meta property="og:title" content="Ravi 1·2·3 — a grande festa surpresa | Diogo Paulino">
   <meta property="og:description"
     content="Conte de 1 a 9 e ajude o Ravi a convidar heróis para a maior festa surpresa do reino. Pixel art 320×200, tudo em vanilla.">
   <meta property="og:locale" content="pt_BR">

--- a/labs/ravi-123/index.html
+++ b/labs/ravi-123/index.html
@@ -27,7 +27,7 @@
     content="Conte de 1 a 9 e ajude o Ravi a convidar heróis para a maior festa surpresa do reino. Pixel art 320×200, tudo em vanilla.">
   <meta property="og:locale" content="pt_BR">
 
-  <link rel="stylesheet" href="/labs/shared.css?v=12">
+  <link rel="stylesheet" href="/labs/shared.css?v=13">
   <link rel="stylesheet" href="style.css?v=23">
   <script type="application/ld+json">
   {
@@ -97,6 +97,8 @@
     <p id="announcer" class="sr-only" aria-live="polite"></p>
   </main>
 
+  <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
+
   <noscript>
     <p style="color:#fff;font:16px sans-serif;padding:24px">
       Este laboratório precisa de JavaScript para rodar o jogo.
@@ -104,7 +106,7 @@
   </noscript>
 
   <script type="module" src="main.js?v=23"></script>
-  <script src="/labs/shared.js?v=12" defer></script>
+  <script src="/labs/shared.js?v=13" defer></script>
 </body>
 
 </html>

--- a/labs/ravi-123/main.js
+++ b/labs/ravi-123/main.js
@@ -22,8 +22,10 @@ let running = true;
 let rafId = 0;
 
 function loop(now) {
-  rafId = requestAnimationFrame(loop);
-  if (!running) return;
+  if (!running) {
+    rafId = 0;
+    return;
+  }
 
   const seconds = now / 1000;
   let delta = last ? seconds - last : STEP;
@@ -40,6 +42,12 @@ function loop(now) {
   if (guard === 8) accumulator = 0;
 
   draw(ctx);
+  rafId = requestAnimationFrame(loop);
+}
+
+function startLoop() {
+  if (rafId) return;
+  rafId = requestAnimationFrame(loop);
 }
 
 /* --------------------------------------------------------------------------
@@ -128,12 +136,18 @@ async function boot() {
     document.addEventListener('visibilitychange', () => {
       if (document.hidden) {
         running = false;
+        if (rafId) {
+          const id = rafId;
+          rafId = 0;
+          cancelAnimationFrame(id);
+        }
         Audio.suspend();
       } else {
         running = true;
         last = 0;          // descarta o intervalo em que a aba ficou oculta
         accumulator = 0;
         Audio.resume();
+        startLoop();
       }
     });
 
@@ -147,7 +161,7 @@ async function boot() {
     // escala do canvas ficaria congelada na medida da janela antiga.
     document.addEventListener('fullscreenchange', fit);
 
-    rafId = requestAnimationFrame(loop);
+    startLoop();
   } catch (err) {
     ctx.fillStyle = 'red';
     ctx.fillText('ERRO: ' + err.message, 20, 120);
@@ -156,7 +170,11 @@ async function boot() {
 }
 
 window.addEventListener('pagehide', () => {
-  cancelAnimationFrame(rafId);
+  if (rafId) {
+    const id = rafId;
+    rafId = 0;
+    cancelAnimationFrame(id);
+  }
   Audio.suspend();
 });
 

--- a/labs/riftball/index.html
+++ b/labs/riftball/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600;700;800&family=Syne:wght@700;800&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=12">
+    <link rel="stylesheet" href="/labs/shared.css?v=13">
     <link rel="stylesheet" href="style.css">
 
     <script type="importmap">
@@ -284,7 +284,7 @@
     </main>
 
     <script src="https://cdn.jsdelivr.net/npm/peerjs@1.5.4/dist/peerjs.min.js" defer></script>
-    <script src="/labs/shared.js?v=12" defer></script>
+    <script src="/labs/shared.js?v=13" defer></script>
     <script type="module" src="src/main.js"></script>
 </body>
 

--- a/labs/river-knight/index.html
+++ b/labs/river-knight/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;600;700;800&family=Outfit:wght@300;400;500;600;700&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=12">
+    <link rel="stylesheet" href="/labs/shared.css?v=13">
     <link rel="stylesheet" href="style.css?v=5">
 
     <script type="importmap">
@@ -300,7 +300,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=12" defer></script>
+    <script src="/labs/shared.js?v=13" defer></script>
     <script type="module" src="src/main.js?v=16"></script>
 </body>
 

--- a/labs/river-knight/src/main.js
+++ b/labs/river-knight/src/main.js
@@ -225,9 +225,12 @@ class Game {
 
         this.enterMenu();
         this.lastFrame = performance.now();
-        this.renderer.setAnimationLoop((now) => this.frame(now));
+        const loop = (now) => this.frame(now);
+        if (window.LabRuntime) LabRuntime.bindThreeLoop(this.renderer, loop);
+        else this.renderer.setAnimationLoop(loop);
 
-        window.addEventListener('resize', () => this.resize());
+        if (window.LabRuntime) LabRuntime.debounceResize(() => this.resize());
+        else window.addEventListener('resize', () => this.resize());
         document.addEventListener('visibilitychange', () => {
             if (document.hidden && this.state === 'playing') this.pause();
         });

--- a/labs/river-knight/style.css
+++ b/labs/river-knight/style.css
@@ -25,7 +25,7 @@
 
     --radius: 14px;
     --radius-lg: 22px;
-    --blur: 20px;
+    --blur: 12px;
 
     --safe-top: env(safe-area-inset-top, 0px);
     --safe-bottom: env(safe-area-inset-bottom, 0px);

--- a/labs/rock-kombat/index.html
+++ b/labs/rock-kombat/index.html
@@ -22,7 +22,7 @@
   <meta property="og:title" content="Rock Kombat — 2D Arcade Fight | Diogo Paulino">
   <meta property="og:description" content="Escolha sua lenda. Leia a distância. Domine o palco.">
   <meta property="og:url" content="https://diogopaulino.com.br/labs/rock-kombat/">
-  <link rel="stylesheet" href="/labs/shared.css?v=12">
+  <link rel="stylesheet" href="/labs/shared.css?v=13">
   <link rel="stylesheet" href="style.css?v=6">
   <script type="application/ld+json">
   {
@@ -264,7 +264,7 @@
 
   <footer data-lab-footer data-home-href="/"></footer>
 
-  <script src="/labs/shared.js?v=12" defer></script>
+  <script src="/labs/shared.js?v=13" defer></script>
   <script type="module" src="main.js?v=4"></script>
 </body>
 </html>

--- a/labs/rock-kombat/index.html
+++ b/labs/rock-kombat/index.html
@@ -23,7 +23,7 @@
   <meta property="og:description" content="Escolha sua lenda. Leia a distância. Domine o palco.">
   <meta property="og:url" content="https://diogopaulino.com.br/labs/rock-kombat/">
   <link rel="stylesheet" href="/labs/shared.css?v=13">
-  <link rel="stylesheet" href="style.css?v=6">
+  <link rel="stylesheet" href="style.css?v=7">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",

--- a/labs/rock-kombat/main.js
+++ b/labs/rock-kombat/main.js
@@ -328,15 +328,32 @@ function fixedUpdate() {
   if ((frameNumber & 1) === 0) hudSignature = updateHud(match, hudSignature);
 }
 
+let rafId = 0;
+
+function startLoop() {
+  if (rafId) return;
+  rafId = requestAnimationFrame(loop);
+}
+
+function stopLoop() {
+  if (!rafId) return;
+  const id = rafId;
+  rafId = 0;
+  cancelAnimationFrame(id);
+}
+
 function togglePause(force) {
   if (!match || match.phase === 'complete') return;
   paused = typeof force === 'boolean' ? force : !paused;
   $('#pause-layer').hidden = !paused;
-  if (paused) audio.stopMusic();
-  else {
+  if (paused) {
+    audio.stopMusic();
+    stopLoop();
+  } else {
     lastTime = performance.now();
     accumulator = 0;
     audio.startMusic(stageId);
+    if (!document.hidden) startLoop();
   }
 }
 
@@ -349,7 +366,8 @@ function loop(now) {
     accumulator -= STEP;
   }
   render(ctx, match, frameNumber, images, renderState);
-  requestAnimationFrame(loop);
+  if (!paused && !document.hidden) rafId = requestAnimationFrame(loop);
+  else rafId = 0;
 }
 
 function goSelect() {
@@ -424,7 +442,13 @@ $$('#difficulty-options button').forEach(button => {
 });
 
 document.addEventListener('visibilitychange', () => {
-  if (document.hidden && match && !paused) togglePause(true);
+  if (document.hidden) {
+    if (match && !paused) togglePause(true);
+    stopLoop();
+  } else if (!paused) {
+    lastTime = performance.now();
+    startLoop();
+  }
 });
 
 rosterApi = renderRoster(FIGHTERS, (p1, cpu) => {
@@ -488,4 +512,4 @@ loadAssets().catch(error => {
   console.error(error);
 });
 
-requestAnimationFrame(loop);
+startLoop();

--- a/labs/rock-kombat/style.css
+++ b/labs/rock-kombat/style.css
@@ -1375,10 +1375,16 @@ dialog h2 {
 
   header .back-link,
   header .header-actions button {
-    padding: 8px !important;
+    padding: 0 !important;
     font-size: 11px !important;
-    min-height: 44px;
-    min-width: 44px;
+    min-height: 44px !important;
+    min-width: 44px !important;
+    width: 44px;
+    height: 44px;
+    display: inline-flex !important;
+    align-items: center;
+    justify-content: center;
+    box-sizing: border-box;
   }
 
   header .back-link span {
@@ -1397,9 +1403,15 @@ dialog h2 {
   }
 
   #help-button {
-    font-size: 10px !important;
+    font-size: 0 !important;
     letter-spacing: 0 !important;
-    padding: 8px 7px !important;
+    padding: 0 !important;
+  }
+
+  #help-button::after {
+    content: "?";
+    font-size: 16px;
+    font-weight: 800;
   }
 
   /* Hero screen mobile */

--- a/labs/safari-dourado/index.html
+++ b/labs/safari-dourado/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.babylonjs.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@500;600;700;800&family=Outfit:wght@300;400;500;600;700&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=12">
+    <link rel="stylesheet" href="/labs/shared.css?v=13">
     <link rel="stylesheet" href="style.css?v=1">
 
     <script type="application/ld+json">
@@ -206,7 +206,7 @@
 
     <script src="https://cdn.babylonjs.com/babylon.js"></script>
     <script src="https://cdn.babylonjs.com/loaders/babylonjs.loaders.min.js"></script>
-    <script src="/labs/shared.js?v=12" defer></script>
+    <script src="/labs/shared.js?v=13" defer></script>
     <script type="module" src="src/main.js"></script>
 </body>
 

--- a/labs/safari-dourado/src/main.js
+++ b/labs/safari-dourado/src/main.js
@@ -133,7 +133,8 @@ class SafariDourado {
         if (window.LabRuntime) LabRuntime.bindBabylonLoop(this.engine, this._renderLoop);
         else this.engine.runRenderLoop(this._renderLoop);
 
-        window.addEventListener('resize', () => this.engine.resize());
+        if (window.LabRuntime) LabRuntime.debounceResize(() => this.engine.resize());
+        else window.addEventListener('resize', () => this.engine.resize());
     }
 
     start() {

--- a/labs/shared.css
+++ b/labs/shared.css
@@ -664,3 +664,45 @@ footer a:hover {
         transition-duration: 0.01ms !important;
     }
 }
+
+/* Transparência reduzida: blur em cima de canvas/WebGL é caro e desnecessário
+   quando o usuário pediu menos transparência no SO. */
+@media (prefers-reduced-transparency: reduce) {
+    .glass-panel,
+    .lab-hud-dock,
+    .back-link,
+    .theme-toggle,
+    .lab-icon-btn {
+        backdrop-filter: none !important;
+        -webkit-backdrop-filter: none !important;
+    }
+}
+
+/* Rodapé mínimo para shells fullscreen que escondem o credit durante o jogo. */
+.lab-foot {
+    width: 100%;
+    max-width: 1200px;
+    margin-top: 0;
+    padding: 0.75rem 1rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    color: var(--text-secondary, rgba(255, 255, 255, 0.55));
+    font-size: 0.8rem;
+    text-align: center;
+}
+
+.lab-foot a {
+    color: inherit;
+    text-decoration: none;
+    font-weight: 500;
+    min-height: var(--touch-target);
+    display: inline-flex;
+    align-items: center;
+    padding-inline: 0.5rem;
+}
+
+.lab-foot a:hover {
+    color: var(--accent, #4f8bf0);
+}

--- a/labs/shared.css
+++ b/labs/shared.css
@@ -678,8 +678,11 @@ footer a:hover {
     }
 }
 
-/* Rodapé mínimo para shells fullscreen que escondem o credit durante o jogo. */
-.lab-foot {
+/* Rodapé mínimo para shells fullscreen que escondem o credit durante o jogo.
+   Separado de `footer` (galeria/labs com borda e margem): um `<footer class="lab-foot">`
+   herda as regras do elemento `footer` — aqui resetamos o que conflita. */
+.lab-foot,
+footer.lab-foot {
     width: 100%;
     max-width: 1200px;
     margin-top: 0;
@@ -691,9 +694,11 @@ footer a:hover {
     color: var(--text-secondary, rgba(255, 255, 255, 0.55));
     font-size: 0.8rem;
     text-align: center;
+    border-top: none;
 }
 
-.lab-foot a {
+.lab-foot a,
+footer.lab-foot a {
     color: inherit;
     text-decoration: none;
     font-weight: 500;
@@ -703,6 +708,7 @@ footer a:hover {
     padding-inline: 0.5rem;
 }
 
-.lab-foot a:hover {
+.lab-foot a:hover,
+footer.lab-foot a:hover {
     color: var(--accent, #4f8bf0);
 }

--- a/labs/shared.js
+++ b/labs/shared.js
@@ -520,6 +520,23 @@
             });
         }
 
+        /* PixiJS: para o ticker na aba oculta (ou no pause do lab). Sem isto o
+           canvas continua apresentando frames e o updateAmbient segue vivo. */
+        function bindPixiTicker(app, options) {
+            if (!app || !app.ticker) return () => {};
+            const mode = options && options.onHidden === 'pause' ? 'pause' : 'stop';
+            return VisibilityAPI.onChange((hidden) => {
+                if (hidden) {
+                    if (mode === 'pause' && typeof app.ticker.pause === 'function') app.ticker.pause();
+                    else app.ticker.stop();
+                } else if (mode === 'pause' && typeof app.ticker.resume === 'function') {
+                    app.ticker.resume();
+                } else {
+                    app.ticker.start();
+                }
+            });
+        }
+
         function debounceResize(fn, ms) {
             const delay = typeof ms === 'number' ? ms : 150;
             let timer = null;
@@ -577,9 +594,44 @@
             createLoop,
             bindBabylonLoop,
             bindThreeLoop,
+            bindPixiTicker,
             debounceResize,
             createInterval
         });
+    })();
+
+    /* Observa mudanças de data-theme sem cada lab montar seu MutationObserver. */
+    const ThemeAPI = (function () {
+        const listeners = new Set();
+        let observing = false;
+
+        function current() {
+            return html.getAttribute('data-theme') === 'dark' ? 'dark' : 'light';
+        }
+
+        function notify() {
+            const theme = current();
+            listeners.forEach((fn) => {
+                try { fn(theme); } catch (err) { console.error(err); }
+            });
+        }
+
+        function ensureObserver() {
+            if (observing) return;
+            observing = true;
+            new MutationObserver(notify).observe(html, {
+                attributes: true,
+                attributeFilter: ['data-theme']
+            });
+        }
+
+        function onChange(fn) {
+            ensureObserver();
+            listeners.add(fn);
+            return () => listeners.delete(fn);
+        }
+
+        return Object.freeze({ current, onChange });
     })();
 
     function init() {
@@ -602,6 +654,7 @@
     window.LabAudio = AudioAPI;
     window.LabVisibility = VisibilityAPI;
     window.LabRuntime = RuntimeAPI;
+    window.LabTheme = ThemeAPI;
 
     if (document.readyState === 'loading') {
         document.addEventListener('DOMContentLoaded', init, { once: true });

--- a/labs/snake/index.html
+++ b/labs/snake/index.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
-    <title>Retro Snake | Diogo Paulino</title>
+    <title>Retro Snake — console 8-bit | Diogo Paulino</title>
     <meta name="description"
         content="Snake retrô em um console portátil 8-bit: colete frutas, ganhe velocidade e bata o seu recorde direto no navegador.">
     <meta name="theme-color" content="#0a0a0a">
@@ -17,15 +17,15 @@
     <meta property="og:image:alt" content="Diogo Paulino">
     <meta property="og:locale" content="pt_BR">
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Retro Snake | Diogo Paulino">
+    <meta name="twitter:title" content="Retro Snake — console 8-bit | Diogo Paulino">
     <meta name="twitter:description" content="Snake retrô em um console portátil 8-bit: colete frutas, ganhe velocidade e bata o seu recorde.">
     <meta name="twitter:image" content="https://diogopaulino.com.br/assets/img/diogo.jpeg">
     <meta property="og:type" content="website">
-    <meta property="og:title" content="Retro Snake | Diogo Paulino">
+    <meta property="og:title" content="Retro Snake — console 8-bit | Diogo Paulino">
     <meta property="og:description"
         content="Snake retrô em um console portátil 8-bit: colete frutas, ganhe velocidade e bata o seu recorde.">
     <meta property="og:url" content="https://diogopaulino.com.br/labs/snake/">
-    <link rel="stylesheet" href="/labs/shared.css?v=12">
+    <link rel="stylesheet" href="/labs/shared.css?v=13">
     <link rel="stylesheet" href="style.css?v=2">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -179,7 +179,7 @@
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
 
-    <script src="/labs/shared.js?v=12" defer></script>
+    <script src="/labs/shared.js?v=13" defer></script>
     <script src="script.js?v=3" defer></script>
 </body>
 

--- a/labs/snake/script.js
+++ b/labs/snake/script.js
@@ -643,10 +643,17 @@ document.addEventListener('visibilitychange', () => {
 });
 
 // Keep the LCD palette in sync with the theme toggle.
-new MutationObserver(() => {
-    syncColors();
-    draw();
-}).observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme'] });
+if (window.LabTheme) {
+    LabTheme.onChange(() => {
+        syncColors();
+        draw();
+    });
+} else {
+    new MutationObserver(() => {
+        syncColors();
+        draw();
+    }).observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme'] });
+}
 
 // O aparelho é desenhado numa base fixa de 320x562px e escalado para caber na
 // tela — cresce no desktop, encolhe no celular e em paisagem curta.

--- a/labs/space-shooter/index.html
+++ b/labs/space-shooter/index.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
-    <title>Neon Invaders | Diogo Paulino</title>
+    <title>Neon Invaders — tiro espacial neon | Diogo Paulino</title>
     <meta name="description" content="Jogo de tiro espacial estilo arcade com gráficos neon.">
     <link rel="canonical" href="https://diogopaulino.com.br/labs/space-shooter/">
     <meta name="author" content="Diogo Paulino">
@@ -17,10 +17,10 @@
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="Diogo Paulino · Labs">
     <meta property="og:url" content="https://diogopaulino.com.br/labs/space-shooter/">
-    <meta property="og:title" content="Neon Invaders | Diogo Paulino">
+    <meta property="og:title" content="Neon Invaders — tiro espacial neon | Diogo Paulino">
     <meta property="og:description" content="Jogo de tiro espacial estilo arcade com gráficos neon.">
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Neon Invaders | Diogo Paulino">
+    <meta name="twitter:title" content="Neon Invaders — tiro espacial neon | Diogo Paulino">
     <meta name="twitter:description" content="Jogo de tiro espacial estilo arcade com gráficos neon.">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/labs/space-shooter/index.html
+++ b/labs/space-shooter/index.html
@@ -24,7 +24,7 @@
     <meta name="twitter:description" content="Jogo de tiro espacial estilo arcade com gráficos neon.">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="stylesheet" href="/labs/shared.css?v=12">
+    <link rel="stylesheet" href="/labs/shared.css?v=13">
     <link rel="stylesheet" href="style.css?v=3">
     <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
     <script type="application/ld+json">
@@ -194,7 +194,7 @@
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
 
-    <script src="/labs/shared.js?v=12" defer></script>
+    <script src="/labs/shared.js?v=13" defer></script>
     <script src="script.js?v=4" defer></script>
 </body>
 

--- a/labs/space-shooter/script.js
+++ b/labs/space-shooter/script.js
@@ -415,9 +415,8 @@ function draw() {
     });
     ctx.globalAlpha = 1;
 
-    // Draw Player
-    ctx.shadowBlur = 20;
-    ctx.shadowColor = player.color;
+    // Draw Player — sem shadowBlur (caro em mobile); brilho via alpha no fill
+    ctx.shadowBlur = 0;
     ctx.fillStyle = player.color;
     // Simple ship shape
     ctx.beginPath();
@@ -429,7 +428,6 @@ function draw() {
     ctx.fill();
 
     // Draw Bullets
-    ctx.shadowColor = '#fff';
     ctx.fillStyle = '#fff';
     bullets.forEach(b => {
         ctx.fillRect(b.x, b.y, b.width, b.height);
@@ -437,7 +435,6 @@ function draw() {
 
     // Draw Enemies
     enemies.forEach(e => {
-        ctx.shadowColor = e.color;
         ctx.fillStyle = e.color;
         // Alien shape (simple invader)
         const w = e.width;
@@ -453,8 +450,6 @@ function draw() {
 
     // Draw Particles
     particles.forEach(p => {
-        ctx.shadowBlur = 10;
-        ctx.shadowColor = p.color;
         ctx.fillStyle = p.color;
         ctx.globalAlpha = p.life;
         ctx.fillRect(p.x, p.y, 3, 3);

--- a/labs/spider-swing/index.html
+++ b/labs/spider-swing/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Outfit:wght@400;500;600;700&family=Share+Tech+Mono&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=12">
+    <link rel="stylesheet" href="/labs/shared.css?v=13">
     <link rel="stylesheet" href="style.css">
 
     <script type="importmap">
@@ -271,7 +271,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=12" defer></script>
+    <script src="/labs/shared.js?v=13" defer></script>
     <script type="module" src="src/main.js"></script>
 </body>
 

--- a/labs/spider-swing/src/main.js
+++ b/labs/spider-swing/src/main.js
@@ -133,8 +133,11 @@ class Game {
             setTimeout(() => this.hud.hideLoading(), 280);
 
             this.lastFrame = performance.now();
-            this.renderer.setAnimationLoop((now) => this.frame(now));
-            window.addEventListener('resize', () => this.resize());
+            const loop = (now) => this.frame(now);
+            if (window.LabRuntime) LabRuntime.bindThreeLoop(this.renderer, loop);
+            else this.renderer.setAnimationLoop(loop);
+            if (window.LabRuntime) LabRuntime.debounceResize(() => this.resize());
+            else window.addEventListener('resize', () => this.resize());
             document.addEventListener('visibilitychange', () => {
                 if (document.hidden && this.state === 'playing') this.pause();
             });

--- a/labs/tamagotchi/index.html
+++ b/labs/tamagotchi/index.html
@@ -23,7 +23,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="RakuRaku Dinokun / Dinkie Dino (1997) | Diogo Paulino">
     <meta name="twitter:description" content="Recriação pesquisada do RakuRaku Dinokun / Dinkie Dino: carcaça, LCD, controles e ciclo de cuidado em tempo real.">
-  <link rel="stylesheet" href="/labs/shared.css?v=12">
+  <link rel="stylesheet" href="/labs/shared.css?v=13">
   <link rel="stylesheet" href="style.css?v=13">
   <script type="application/ld+json">
   {
@@ -175,7 +175,7 @@
     <footer data-lab-footer data-home-href="/"></footer>
   </div>
 
-  <script src="/labs/shared.js?v=12" defer></script>
+  <script src="/labs/shared.js?v=13" defer></script>
   <script src="script.js?v=9" defer></script>
 </body>
 

--- a/labs/tamagotchi/index.html
+++ b/labs/tamagotchi/index.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
-  <title>RakuRaku Dinokun / Dinkie Dino (1997) | Diogo Paulino</title>
+  <title>RakuRaku Dinokun — pet virtual LCD 1997 | Diogo Paulino</title>
   <meta name="description"
     content="Recriação pesquisada do RakuRaku Dinokun / Dinkie Dino: carcaça, LCD, controles e ciclo de cuidado em tempo real.">
     <link rel="canonical" href="https://diogopaulino.com.br/labs/tamagotchi/">
@@ -18,10 +18,10 @@
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="Diogo Paulino · Labs">
     <meta property="og:url" content="https://diogopaulino.com.br/labs/tamagotchi/">
-    <meta property="og:title" content="RakuRaku Dinokun / Dinkie Dino (1997) | Diogo Paulino">
+    <meta property="og:title" content="RakuRaku Dinokun — pet virtual LCD 1997 | Diogo Paulino">
     <meta property="og:description" content="Recriação pesquisada do RakuRaku Dinokun / Dinkie Dino: carcaça, LCD, controles e ciclo de cuidado em tempo real.">
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="RakuRaku Dinokun / Dinkie Dino (1997) | Diogo Paulino">
+    <meta name="twitter:title" content="RakuRaku Dinokun — pet virtual LCD 1997 | Diogo Paulino">
     <meta name="twitter:description" content="Recriação pesquisada do RakuRaku Dinokun / Dinkie Dino: carcaça, LCD, controles e ciclo de cuidado em tempo real.">
   <link rel="stylesheet" href="/labs/shared.css?v=13">
   <link rel="stylesheet" href="style.css?v=13">

--- a/labs/tatu-bola/index.html
+++ b/labs/tatu-bola/index.html
@@ -33,7 +33,7 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Press+Start+2P&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=12">
+    <link rel="stylesheet" href="/labs/shared.css?v=13">
     <link rel="stylesheet" href="style.css">
 
     <script type="importmap">
@@ -276,7 +276,7 @@
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
-    <script src="/labs/shared.js?v=12" defer></script>
+    <script src="/labs/shared.js?v=13" defer></script>
     <script type="module" src="src/main.js"></script>
 </body>
 

--- a/labs/tetris/index.html
+++ b/labs/tetris/index.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
-    <title>Tetris 90s | Diogo Paulino</title>
+    <title>Tetris 90s — clássico no navegador | Diogo Paulino</title>
     <meta name="description" content="Jogue Tetris clássico estilo anos 90 no seu navegador.">
     <link rel="canonical" href="https://diogopaulino.com.br/labs/tetris/">
     <meta name="author" content="Diogo Paulino">
@@ -17,12 +17,12 @@
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="Diogo Paulino · Labs">
     <meta property="og:url" content="https://diogopaulino.com.br/labs/tetris/">
-    <meta property="og:title" content="Tetris 90s | Diogo Paulino">
+    <meta property="og:title" content="Tetris 90s — clássico no navegador | Diogo Paulino">
     <meta property="og:description" content="Jogue Tetris clássico estilo anos 90 no seu navegador.">
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Tetris 90s | Diogo Paulino">
+    <meta name="twitter:title" content="Tetris 90s — clássico no navegador | Diogo Paulino">
     <meta name="twitter:description" content="Jogue Tetris clássico estilo anos 90 no seu navegador.">
-    <link rel="stylesheet" href="/labs/shared.css?v=12">
+    <link rel="stylesheet" href="/labs/shared.css?v=13">
     <link rel="stylesheet" href="style.css?v=2">
     <script type="application/ld+json">
     {
@@ -172,7 +172,7 @@
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
 
-    <script src="/labs/shared.js?v=12" defer></script>
+    <script src="/labs/shared.js?v=13" defer></script>
     <script src="script.js?v=2" defer></script>
 </body>
 

--- a/labs/tetris/script.js
+++ b/labs/tetris/script.js
@@ -374,8 +374,9 @@ let dropCounter = 0;
 let dropInterval = 1000;
 let lastTime = 0;
 let state = 'ready'; // ready | playing | paused | over
+let rafId = 0;
 
-function update(time = 0) {
+function tick(time = 0) {
     const deltaTime = Math.min(time - lastTime, 250);
     lastTime = time;
 
@@ -390,7 +391,36 @@ function update(time = 0) {
     clearFlash = Math.max(0, clearFlash - deltaTime / 260);
 
     draw();
-    requestAnimationFrame(update);
+}
+
+const labLoop = window.LabRuntime
+    ? LabRuntime.createLoop(tick, { autoPause: false })
+    : null;
+
+function update(time = 0) {
+    tick(time);
+    rafId = requestAnimationFrame(update);
+}
+
+function startLoop() {
+    if (labLoop) {
+        labLoop.start();
+        return;
+    }
+    if (rafId) return;
+    lastTime = performance.now();
+    rafId = requestAnimationFrame(update);
+}
+
+function stopLoop() {
+    if (labLoop) {
+        labLoop.stop();
+        return;
+    }
+    if (!rafId) return;
+    const id = rafId;
+    rafId = 0;
+    cancelAnimationFrame(id);
 }
 
 function updateScore() {
@@ -707,9 +737,14 @@ document.querySelectorAll('.controls button').forEach(button => {
     });
 });
 
-/* Sair da aba durante a partida pausa em vez de deixar a peça cair sozinha. */
+/* Sair da aba: pausa a partida e cancela o rAF (não só o estado). */
 document.addEventListener('visibilitychange', () => {
-    if (document.hidden && state === 'playing') setState('paused');
+    if (document.hidden) {
+        if (state === 'playing') setState('paused');
+        stopLoop();
+    } else {
+        startLoop();
+    }
 });
 
 /* ---------- Escala do console ---------- */
@@ -752,4 +787,4 @@ window.visualViewport?.addEventListener('resize', fitConsole);
 document.getElementById('highscore').innerText = highScore;
 resetGame();
 fitConsole();
-update();
+startLoop();

--- a/labs/ultimo-bastiao/index.html
+++ b/labs/ultimo-bastiao/index.html
@@ -29,7 +29,7 @@
   <link rel="preconnect" href="https://cdn.babylonjs.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;600;700;800&family=Manrope:wght@400;500;600;700&family=Outfit:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/labs/shared.css?v=13">
-  <link rel="stylesheet" href="style.css?v=5">
+  <link rel="stylesheet" href="style.css?v=6">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",

--- a/labs/ultimo-bastiao/index.html
+++ b/labs/ultimo-bastiao/index.html
@@ -27,8 +27,9 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="preconnect" href="https://cdn.babylonjs.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;600;700;800&family=Manrope:wght@400;500;600;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="style.css?v=3">
+  <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;600;700;800&family=Manrope:wght@400;500;600;700&family=Outfit:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/labs/shared.css?v=13">
+  <link rel="stylesheet" href="style.css?v=4">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -63,15 +64,17 @@
   <main class="game-shell">
     <canvas id="renderCanvas" aria-label="Batalha medieval no pátio do castelo de Vardheim"></canvas>
 
-    <header class="topbar">
-      <a class="back-link" href="/labs/" aria-label="Voltar aos Labs">
-        <span aria-hidden="true">←</span><span>Labs</span>
-      </a>
-      <div class="brand"><i aria-hidden="true"></i><span>O Último Bastião</span></div>
-      <div class="top-actions">
-        <button id="soundButton" class="icon-button" type="button" aria-label="Alternar som" aria-pressed="true">♪</button>
-        <button id="pauseButton" class="icon-button" type="button" aria-label="Pausar jogo">Ⅱ</button>
-      </div>
+    <header data-lab-header data-title="O Último Bastião" data-back-label="Labs">
+      <template data-slot="logo">
+        <div class="app-logo">
+          <span class="brand-mark" aria-hidden="true"></span>
+          <span>O Último Bastião</span>
+        </div>
+      </template>
+      <template data-slot="actions">
+        <button id="soundButton" class="lab-icon-btn" type="button" aria-label="Alternar som" aria-pressed="true">♪</button>
+        <button id="pauseButton" class="lab-icon-btn" type="button" aria-label="Pausar jogo">Ⅱ</button>
+      </template>
     </header>
 
     <section id="hud" class="hud" hidden aria-label="Estado da batalha">
@@ -199,12 +202,13 @@
       </div>
     </section>
 
-    <footer class="credit"><a href="/">Diogo Paulino</a><span>·</span><span>Experimento em Babylon.js</span></footer>
+    <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
   </main>
 
+  <script src="/labs/shared.js?v=13"></script>
   <script src="https://cdn.babylonjs.com/babylon.js"></script>
   <script src="https://cdn.babylonjs.com/loaders/babylonjs.loaders.min.js"></script>
-  <script type="module" src="src/game.js?v=5"></script>
+  <script type="module" src="src/game.js?v=6"></script>
 </body>
 
 </html>

--- a/labs/ultimo-bastiao/index.html
+++ b/labs/ultimo-bastiao/index.html
@@ -29,7 +29,7 @@
   <link rel="preconnect" href="https://cdn.babylonjs.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;600;700;800&family=Manrope:wght@400;500;600;700&family=Outfit:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/labs/shared.css?v=13">
-  <link rel="stylesheet" href="style.css?v=4">
+  <link rel="stylesheet" href="style.css?v=5">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",

--- a/labs/ultimo-bastiao/src/game.js
+++ b/labs/ultimo-bastiao/src/game.js
@@ -515,12 +515,17 @@ class Game {
       this.bindUi();
       await this.scene.whenReadyAsync();
       this.setLoading(1, 'O inimigo se aproxima…');
-      this.engine.runRenderLoop(() => this.frame());
-      let resizeFrame = 0;
-      window.addEventListener('resize', () => {
-        cancelAnimationFrame(resizeFrame);
-        resizeFrame = requestAnimationFrame(() => this.engine.resize());
-      }, { passive: true });
+      this._renderLoop = () => this.frame();
+      if (window.LabRuntime) LabRuntime.bindBabylonLoop(this.engine, this._renderLoop);
+      else this.engine.runRenderLoop(this._renderLoop);
+      if (window.LabRuntime) LabRuntime.debounceResize(() => this.engine.resize());
+      else {
+        let resizeFrame = 0;
+        window.addEventListener('resize', () => {
+          cancelAnimationFrame(resizeFrame);
+          resizeFrame = requestAnimationFrame(() => this.engine.resize());
+        }, { passive: true });
+      }
       document.addEventListener('visibilitychange', () => { if (document.hidden && this.state === 'running') this.pause(); });
       setTimeout(() => this.showMenu(), 450);
     } catch (error) {

--- a/labs/ultimo-bastiao/style.css
+++ b/labs/ultimo-bastiao/style.css
@@ -14,6 +14,11 @@ html, body {
   width: 100%; height: 100%; margin: 0; overflow: hidden; overflow-x: clip;
   background: #090a0c; color: var(--ink); font-family: "Manrope", sans-serif;
   touch-action: none; overscroll-behavior: none;
+  /* Neutraliza o padding do shared.css no shell fullscreen. */
+  padding: 0 !important;
+  display: block !important;
+  min-height: 100dvh;
+  align-items: stretch;
 }
 
 button, select { font: inherit; }
@@ -24,22 +29,46 @@ button { color: inherit; }
 .game-shell { position: relative; width: 100%; height: 100dvh; overflow: hidden; isolation: isolate; }
 #renderCanvas { display: block; width: 100%; height: 100%; outline: none; touch-action: none; }
 
-.topbar {
+/* Chrome compartilhado (shared.js) posicionado como topbar do jogo. */
+.game-shell > header {
   position: fixed; z-index: 30; inset: 0 0 auto; min-height: 58px;
-  display: grid; grid-template-columns: 1fr auto 1fr; align-items: center;
+  margin: 0; max-width: none; width: auto;
   padding: max(9px, env(safe-area-inset-top)) max(16px, env(safe-area-inset-right)) 8px max(16px, env(safe-area-inset-left));
   background: linear-gradient(to bottom, rgba(5, 6, 7, .84), transparent);
-  pointer-events: none;
+  pointer-events: none; gap: 0.6rem;
 }
-
-.back-link, .top-actions, .brand { pointer-events: auto; }
-.back-link { width: max-content; display: flex; gap: 9px; align-items: center; color: #ddd5c3; text-decoration: none; font-size: 12px; letter-spacing: .12em; text-transform: uppercase; min-height: 44px; min-width: 44px; justify-content: center; padding-inline: 6px; }
-.back-link span:first-child { font-size: 20px; font-weight: 300; transform: translateY(-1px); }
-.brand { display: flex; align-items: center; gap: 10px; font: 600 13px/1 "Cinzel", serif; letter-spacing: .12em; text-transform: uppercase; text-shadow: 0 2px 12px #000; }
-.brand i { display: block; width: 7px; height: 7px; background: var(--gold); transform: rotate(45deg); box-shadow: 0 0 14px rgba(201, 164, 91, .75); }
-.top-actions { justify-self: end; display: flex; gap: 8px; }
-.icon-button { width: 44px; height: 44px; border: 1px solid var(--line); border-radius: 50%; background: rgba(8, 9, 10, .62); backdrop-filter: blur(12px); cursor: pointer; }
-.icon-button:hover { border-color: var(--gold); background: rgba(35, 29, 20, .8); }
+.game-shell > header > * { pointer-events: auto; }
+.game-shell > header .back-link {
+  color: #ddd5c3; font-size: 12px; letter-spacing: .12em; text-transform: uppercase;
+  background: rgba(8, 9, 10, .62); border-color: var(--line); box-shadow: none;
+}
+.game-shell > header .back-link:hover { color: var(--gold); border-color: var(--gold); transform: none; }
+.game-shell > header .app-logo {
+  font: 600 13px/1 "Cinzel", serif; letter-spacing: .12em; text-transform: uppercase;
+  text-shadow: 0 2px 12px #000; color: var(--ink); gap: 10px;
+}
+.game-shell > header .brand-mark {
+  display: block; width: 7px; height: 7px; background: var(--gold);
+  transform: rotate(45deg); box-shadow: 0 0 14px rgba(201, 164, 91, .75); flex-shrink: 0;
+}
+.game-shell > header .header-actions { gap: 8px; }
+.game-shell > header .lab-icon-btn {
+  width: 44px; height: 44px; border-color: var(--line);
+  background: rgba(8, 9, 10, .62); backdrop-filter: blur(12px); color: var(--ink);
+}
+.game-shell > header .lab-icon-btn:hover { border-color: var(--gold); background: rgba(35, 29, 20, .8); }
+.game-shell > header .theme-toggle {
+  border-color: var(--line); background: rgba(8, 9, 10, .62);
+}
+.game-shell > header .subtitle { display: none; }
+.lab-foot {
+  position: fixed; z-index: 15; right: max(18px, env(safe-area-inset-right));
+  bottom: max(10px, env(safe-area-inset-bottom)); left: auto; width: auto; max-width: none;
+  margin: 0; padding: 0; justify-content: flex-end; pointer-events: none;
+  color: rgba(230,220,200,.43); font-size: 8px; letter-spacing: .1em; text-transform: uppercase;
+  border: 0; background: transparent;
+}
+.lab-foot a { color: inherit; pointer-events: auto; min-height: auto; }
 
 .hud { position: fixed; z-index: 20; inset: 0; pointer-events: none; }
 .panel { border: 1px solid var(--line); background: var(--panel); box-shadow: 0 15px 35px rgba(0, 0, 0, .28); backdrop-filter: blur(12px) saturate(.8); }
@@ -155,13 +184,12 @@ kbd { display: inline-block; min-width: 26px; margin-right: 5px; padding: 4px 6p
 .credit a { color: inherit; text-decoration: none; pointer-events: auto; }
 
 @media (pointer: coarse) {
-  .credit { display: none; }
-  .topbar { min-height: 50px; }
+  .lab-foot { display: none; }
+  .game-shell > header { min-height: 50px; }
 }
 
 @media (max-width: 768px) {
-  .brand { font-size: 10px; }
-  .back-link span:last-child { display: none; }
+  .game-shell > header .app-logo { font-size: 10px; }
   .vitals { top: max(60px, calc(env(safe-area-inset-top) + 50px)); width: min(270px, calc(100vw - 106px)); padding: 8px 12px 8px 8px; }
   .portrait { width: 36px; height: 36px; font-size: 16px; }
   .bars { gap: 6px; }
@@ -184,14 +212,14 @@ kbd { display: inline-block; min-width: 26px; margin-right: 5px; padding: 4px 6p
   .key-grid { gap: 7px; }
   .controls-copy { display: none; }
   .settings-row { margin-top: 17px; }
-  .credit { font-size: 7px; }
+  .lab-foot { font-size: 7px; }
 }
 
 @media (max-height: 520px) and (orientation: landscape) {
-  .topbar { min-height: 42px; padding-top: max(5px, env(safe-area-inset-top)); }
-  .brand { display: none; }
+  .game-shell > header { min-height: 42px; padding-top: max(5px, env(safe-area-inset-top)); }
+  .game-shell > header .app-logo { display: none; }
   /* 44px vale também no celular: são som e pausa, tocados em pleno combate. */
-  .icon-button { width: 44px; height: 44px; }
+  .game-shell > header .lab-icon-btn { width: 44px; height: 44px; }
   .vitals { top: max(46px, calc(env(safe-area-inset-top) + 40px)); left: max(10px, env(safe-area-inset-left)); width: 245px; padding-block: 6px; }
   .portrait { width: 32px; height: 32px; }
   .combo { top: max(46px, calc(env(safe-area-inset-top) + 40px)); }
@@ -215,7 +243,7 @@ kbd { display: inline-block; min-width: 26px; margin-right: 5px; padding: 4px 6p
   .difficulty-options small { margin-top: 2px; }
   .settings-row { margin-top: 10px; }
   .primary-button { min-height: 45px; margin-top: 10px; }
-  .credit { display: none; }
+  .lab-foot { display: none; }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/labs/ultimo-bastiao/style.css
+++ b/labs/ultimo-bastiao/style.css
@@ -31,7 +31,9 @@ button { color: inherit; }
 
 /* Chrome compartilhado (shared.js) posicionado como topbar do jogo. */
 .game-shell > header {
-  position: fixed; z-index: 30; inset: 0 0 auto; min-height: 58px;
+  position: fixed; z-index: 80; inset: 0 0 auto; min-height: 58px;
+  display: grid; grid-template-columns: minmax(0, 1fr) minmax(0, auto) minmax(0, 1fr);
+  align-items: center;
   margin: 0; max-width: none; width: auto;
   padding: max(9px, env(safe-area-inset-top)) max(16px, env(safe-area-inset-right)) 8px max(16px, env(safe-area-inset-left));
   background: linear-gradient(to bottom, rgba(5, 6, 7, .84), transparent);
@@ -179,9 +181,6 @@ kbd { display: inline-block; min-width: 26px; margin-right: 5px; padding: 4px 6p
 .combat-button.attack { right: 0; bottom: 23px; width: 78px; height: 78px; border-color: rgba(193, 142, 75, .5); }
 .combat-button.dodge { right: 78px; bottom: 0; }
 .combat-button.block { right: 76px; bottom: 78px; }
-
-.credit { position: fixed; z-index: 15; right: max(18px, env(safe-area-inset-right)); bottom: max(10px, env(safe-area-inset-bottom)); display: flex; gap: 7px; color: rgba(230,220,200,.43); font-size: 8px; letter-spacing: .1em; text-transform: uppercase; pointer-events: none; }
-.credit a { color: inherit; text-decoration: none; pointer-events: auto; }
 
 @media (pointer: coarse) {
   .lab-foot { display: none; }

--- a/labs/ultimo-bastiao/style.css
+++ b/labs/ultimo-bastiao/style.css
@@ -188,7 +188,9 @@ kbd { display: inline-block; min-width: 26px; margin-right: 5px; padding: 4px 6p
 }
 
 @media (max-width: 768px) {
-  .game-shell > header .app-logo { font-size: 10px; }
+  /* Título longo + som + pausa + tema não cabem em 375px; o menu já carrega a marca. */
+  .game-shell > header .app-logo { display: none; }
+  .game-shell > header .header-actions { gap: 6px; }
   .vitals { top: max(60px, calc(env(safe-area-inset-top) + 50px)); width: min(270px, calc(100vw - 106px)); padding: 8px 12px 8px 8px; }
   .portrait { width: 36px; height: 36px; font-size: 16px; }
   .bars { gap: 6px; }

--- a/labs/videogame/index.html
+++ b/labs/videogame/index.html
@@ -25,11 +25,11 @@
 
 
 
-    <link rel="stylesheet" href="/labs/shared.css?v=12">
+    <link rel="stylesheet" href="/labs/shared.css?v=13">
     <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="mobile.css">
     <script src="/labs/videogame/lib/nostalgist.umd.js" defer></script>
-    <script src="/labs/shared.js?v=12" defer></script>
+    <script src="/labs/shared.js?v=13" defer></script>
     <script src="games.js" defer></script>
     <script src="script.js" defer></script>
     <script type="application/ld+json">

--- a/labs/videogame/index.html
+++ b/labs/videogame/index.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
-    <title>Videogame | Diogo Paulino</title>
+    <title>Videogame — emulador de clássicos | Diogo Paulino</title>
     <meta name="description" content="Emulador de jogos clássicos no navegador. Jogue Sonic e outros títulos retrô.">
     <link rel="canonical" href="https://diogopaulino.com.br/labs/videogame/">
     <meta name="author" content="Diogo Paulino">
@@ -17,10 +17,10 @@
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="Diogo Paulino · Labs">
     <meta property="og:url" content="https://diogopaulino.com.br/labs/videogame/">
-    <meta property="og:title" content="Videogame | Diogo Paulino">
+    <meta property="og:title" content="Videogame — emulador de clássicos | Diogo Paulino">
     <meta property="og:description" content="Emulador de jogos clássicos no navegador. Jogue Sonic e outros títulos retrô.">
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Videogame | Diogo Paulino">
+    <meta name="twitter:title" content="Videogame — emulador de clássicos | Diogo Paulino">
     <meta name="twitter:description" content="Emulador de jogos clássicos no navegador. Jogue Sonic e outros títulos retrô.">
 
 

--- a/labs/winamp/index.html
+++ b/labs/winamp/index.html
@@ -10,20 +10,20 @@
     <meta name="color-scheme" content="light">
     <meta property="og:type" content="website">
     <meta property="og:locale" content="pt_BR">
-    <meta property="og:title" content="Winamp JS | Diogo Paulino">
+    <meta property="og:title" content="Winamp JS — player retrô e equalizador | Diogo Paulino">
     <meta property="og:description"
         content="Player retrô 100% vanilla: playlist, equalizador, visualizador e músicas chiptune sintetizadas no navegador.">
     <meta property="og:url" content="https://diogopaulino.com.br/labs/winamp/">
     <meta property="og:image" content="https://diogopaulino.com.br/assets/img/diogo.jpeg">
     <meta name="twitter:card" content="summary_large_image">
-    <title>Winamp JS | Diogo Paulino</title>
+    <title>Winamp JS — player retrô e equalizador | Diogo Paulino</title>
     <link rel="canonical" href="https://diogopaulino.com.br/labs/winamp/">
     <meta name="author" content="Diogo Paulino">
     <meta name="robots" content="index, follow">
     <link rel="icon" href="/favicon.ico" sizes="any">
     <meta property="og:site_name" content="Diogo Paulino · Labs">
     <meta property="og:image:alt" content="Diogo Paulino">
-    <meta name="twitter:title" content="Winamp JS | Diogo Paulino">
+    <meta name="twitter:title" content="Winamp JS — player retrô e equalizador | Diogo Paulino">
     <meta name="twitter:description" content="Player retrô 100% vanilla: playlist, equalizador, visualizador e músicas chiptune sintetizadas no navegador.">
     <meta name="twitter:image" content="https://diogopaulino.com.br/assets/img/diogo.jpeg">
     <link rel="stylesheet" href="/labs/shared.css?v=13">

--- a/labs/winamp/index.html
+++ b/labs/winamp/index.html
@@ -26,8 +26,8 @@
     <meta name="twitter:title" content="Winamp JS | Diogo Paulino">
     <meta name="twitter:description" content="Player retrô 100% vanilla: playlist, equalizador, visualizador e músicas chiptune sintetizadas no navegador.">
     <meta name="twitter:image" content="https://diogopaulino.com.br/assets/img/diogo.jpeg">
-    <link rel="stylesheet" href="/labs/shared.css?v=12">
-    <link rel="stylesheet" href="style.css?v=5">
+    <link rel="stylesheet" href="/labs/shared.css?v=13">
+    <link rel="stylesheet" href="style.css?v=7">
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
@@ -414,9 +414,11 @@
         </footer>
     </div>
 
+    <footer class="lab-foot winamp-lab-foot" data-lab-footer data-home-href="/"></footer>
+
     <noscript>Ative o JavaScript para usar o player.</noscript>
     <script type="module" src="script.js?v=5"></script>
-    <script src="/labs/shared.js?v=12" defer></script>
+    <script src="/labs/shared.js?v=13" defer></script>
 </body>
 
 </html>

--- a/labs/winamp/style.css
+++ b/labs/winamp/style.css
@@ -109,8 +109,11 @@ body {
     padding-right: 0 !important;
     padding-bottom: 0 !important;
     padding-left: 0 !important;
-    display: block !important;
+    display: flex !important;
+    flex-direction: column !important;
     align-items: stretch !important;
+    height: 100dvh;
+    max-height: 100dvh;
     background: var(--desktop);
     background-image: none !important;
     color: #000;
@@ -125,6 +128,7 @@ header[data-lab-header] {
     position: sticky;
     top: 0;
     z-index: 1000;
+    flex: 0 0 auto;
     margin: 0 !important;
     max-width: none !important;
     width: 100%;
@@ -205,8 +209,9 @@ a:focus-visible {
 .desktop {
     position: relative;
     width: 100%;
-    height: calc(100dvh - 52px);
-    min-height: max(430px, calc(100dvh - 52px));
+    flex: 1 1 auto;
+    height: auto;
+    min-height: 0;
     overflow: hidden;
     background:
         radial-gradient(circle at 82% 16%, rgba(255, 255, 255, 0.035) 0 1px, transparent 1px 100%),
@@ -1541,6 +1546,37 @@ noscript {
         transition: none !important;
     }
 }
+
+/* Shared lab footer below the XP desktop — not the taskbar */
+.winamp-lab-foot {
+    position: relative;
+    z-index: 1;
+    flex: 0 0 auto;
+    width: 100%;
+    max-width: none;
+    margin: 0;
+    padding: 0.55rem 1rem calc(0.55rem + env(safe-area-inset-bottom, 0px));
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    color: rgba(255, 255, 255, 0.55);
+    font-size: 0.75rem;
+    text-align: center;
+    background: transparent;
+    pointer-events: auto;
+}
+
+.winamp-lab-foot a {
+    color: inherit;
+    text-decoration: none;
+    font-weight: 500;
+}
+
+.winamp-lab-foot a:hover {
+    color: #fff;
+}
+
 /* --- lab-responsive-pass --- */
 @media (max-width: 760px) {
     header[data-lab-header] .back-link { min-height: 44px; min-width: 44px; }

--- a/labs/xadrez/index.html
+++ b/labs/xadrez/index.html
@@ -32,7 +32,7 @@
     <link rel="preconnect" href="https://cdn.babylonjs.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;600;700&family=Outfit:wght@300;400;500;600;700&display=swap"
         rel="stylesheet">
-    <link rel="stylesheet" href="/labs/shared.css?v=12">
+    <link rel="stylesheet" href="/labs/shared.css?v=13">
     <link rel="stylesheet" href="style.css">
     <script type="application/ld+json">
     {
@@ -241,7 +241,7 @@
 
     <script src="https://cdn.babylonjs.com/babylon.js"></script>
     <script src="https://cdn.babylonjs.com/loaders/babylonjs.loaders.min.js"></script>
-    <script src="/labs/shared.js?v=12" defer></script>
+    <script src="/labs/shared.js?v=13" defer></script>
     <script type="module" src="src/main.js"></script>
 </body>
 

--- a/labs/xadrez/src/main.js
+++ b/labs/xadrez/src/main.js
@@ -233,14 +233,12 @@ class Atelier {
         if (window.LabRuntime) LabRuntime.bindBabylonLoop(this.engine, this._renderLoop);
         else this.engine.runRenderLoop(this._renderLoop);
 
-        window.addEventListener('resize', () => {
+        const onResize = () => {
             this.engine.resize();
             this.fitCameraFov();
-        });
-        window.visualViewport?.addEventListener('resize', () => {
-            this.engine.resize();
-            this.fitCameraFov();
-        });
+        };
+        if (window.LabRuntime) LabRuntime.debounceResize(onResize);
+        else window.addEventListener('resize', onResize);
     }
 
     // Em telas estreitas (retrato), FOV vertical fixo faz o campo de visão


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 🎯 Objetivo

Revisar e otimizar os 55 labs: padronizar chrome compartilhado, pausar GPU/rAF com a aba oculta, polir UI/performance e validar jogos no browser.

## ✨ O que mudou

- `shared.js` / `shared.css` v13: `bindPixiTicker`, `LabTheme`, `prefers-reduced-transparency`, `.lab-foot`
- Loops 2D cancelam rAF/Pixi ticker com a aba oculta (Tetris, Lander, Rock Kombat, Claude Bros, Ravi, Jungle Run, …)
- Labs 3D usam `LabRuntime.bindBabylonLoop` / `bindThreeLoop` + `debounceResize` (Forrest Run, Último Bastião, River Knight, Spider Swing, Neon Rider, Eyra, Nina, Nereida, Cúpola 64, F1, Safari, Honor, Xadrez, …)
- Chrome padronizado: Último Bastião, Mimo, Orbis, Ravi 1·2·3, Winamp; PS5 Controller com `shared.css` + overrides
- Títulos com gancho SEO (` — `) em todos os labs; blur de HUD limitado; menos `console.log` / `shadowBlur` / intervals em background
- Fix mobile: título do Último Bastião não sobrepõe ações; Rock Kombat força alvos 44×44

## 🧪 Como testar

1. Na raiz: `python3 -m http.server 8000`
2. Home e galeria: [http://localhost:8000/](http://localhost:8000/) · [http://localhost:8000/labs/](http://localhost:8000/labs/)
3. Smoke de jogos: Tetris, Snake, Jungle Run, Claude Bros, Kong Kong, Rock Kombat, Último Bastião, River Knight, Forrest Run
4. Responsivo: **375×667**, **390×844**, landscape ~667×375
5. Trocar de aba durante um jogo: GPU/rAF devem pausar

## ✅ Checklist

- [x] Links conferidos: pasta ↔ galeria ↔ README ↔ sitemap
- [x] README / contagem intactos (sem lab novo/renomeado)
- [x] SEO consistente (titles com gancho, OG/Twitter/JSON-LD)
- [x] Testado via HTTP na raiz
- [x] Responsivo: correções mobile no Último Bastião e Rock Kombat; smoke 390px nos clássicos
- [x] Nada fora do escopo foi quebrado

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a07458-f03f-7910-917c-ed15f861e79e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a07458-f03f-7910-917c-ed15f861e79e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

