### PR TITLE
🎨 refina experiência 3D do xadrez

### DIFF
--- a/labs/xadrez/src/main.js
+++ b/labs/xadrez/src/main.js
@@ -20,9 +20,9 @@ const GLYPH = {
 };
 
 const QUALITY = {
-    low: { id: 'low', pr: 1, seg: 24, shadows: false, shadowMap: 1024 },
-    medium: { id: 'medium', pr: 1.35, seg: 40, shadows: true, shadowMap: 2048 },
-    high: { id: 'high', pr: 1.75, seg: 56, shadows: true, shadowMap: 2048 }
+    low: { id: 'low', pr: 1, seg: 24, shadows: false, shadowMap: 768 },
+    medium: { id: 'medium', pr: 1.25, seg: 40, shadows: true, shadowMap: 1536 },
+    high: { id: 'high', pr: 1.5, seg: 56, shadows: true, shadowMap: 2048 }
 };
 
 function isMobile() {
@@ -51,6 +51,7 @@ class Atelier {
         this.player = 'w';
         this.flip = false;
         this.selected = -1;
+        this.hover = -1;
         this.legal = [];
         this.history = [];
         this.busy = false;
@@ -62,6 +63,7 @@ class Atelier {
         this.expect = null;
         this.pendingPromo = null;
         this.drag = { x: 0, y: 0, active: false };
+        this.lastHoverAt = 0;
         this.generation = 0;
         this.reducedMotion = matchMedia('(prefers-reduced-motion: reduce)').matches;
 
@@ -180,8 +182,11 @@ class Atelier {
         try {
             this.engine = new BABYLON.Engine(this.canvas, true, {
                 preserveDrawingBuffer: false,
-                stencil: true,
-                adaptToDeviceRatio: true
+                stencil: false,
+                // The game controls its own render scale below. Keeping the
+                // browser's DPR out of this path prevents 3x mobile screens
+                // from silently rendering three times more pixels than needed.
+                adaptToDeviceRatio: false
             });
             this.scene = new BABYLON.Scene(this.engine);
             this.scene.useRightHandedSystem = true;
@@ -198,8 +203,8 @@ class Atelier {
         // padrão do Babylon (0.8) achatam a perspectiva: sem isso, a casa mais
         // próxima da câmera aparecia enorme e a última fileira, minúscula.
         this.camera = new BABYLON.ArcRotateCamera('camera', Math.PI / 2, 0.63, 20, new BABYLON.Vector3(0, 0.35, 0), this.scene);
-        this.camera.fov = 0.62;
-        this.camera.lowerRadiusLimit = 14;
+        this.camera.fov = 0.60;
+        this.camera.lowerRadiusLimit = isMobile() ? 12.5 : 14;
         this.camera.upperRadiusLimit = 28;
         this.camera.lowerBetaLimit = 0.02;
         this.camera.upperBetaLimit = Math.PI / 2.4;
@@ -207,6 +212,10 @@ class Atelier {
         this.camera.pinchDeltaPercentage = 0.015;
         this.camera.inertia = 0.85;
         this.camera.panningSensibility = 0;
+        this.camera.angularSensibilityX = isMobile() ? 6500 : 4200;
+        this.camera.angularSensibilityY = isMobile() ? 6500 : 4200;
+        this.camera.useNaturalPinchZoom = true;
+        this.camera.allowUpsideDown = false;
         this.camera.useAutoRotationBehavior = false;
         if (this.camera.autoRotationBehavior) {
             this.camera.autoRotationBehavior.idleRotationSpeed = 0.15;
@@ -221,7 +230,7 @@ class Atelier {
         this.setLoad(0.45, 'Montando o atelier…');
         setupEnvironment(BABYLON, this.scene);
         this.world = buildWorld(BABYLON, this.scene, tex, this.quality);
-        this.lights = setupLights(BABYLON, this.scene, { ...this.quality, shadows: true, shadowMap: 1024 });
+        this.lights = setupLights(BABYLON, this.scene, this.quality);
         this.postProcess = setupPostProcess(BABYLON, this.scene, this.quality);
 
         this.factory = new PieceFactory(this.scene, tex, this.quality);
@@ -236,6 +245,7 @@ class Atelier {
         this.canvas.addEventListener('pointerup', (e) => this.onUp(e));
         this.canvas.addEventListener('pointercancel', () => this.cancelDrag());
         this.canvas.addEventListener('lostpointercapture', () => this.cancelDrag());
+        this.canvas.addEventListener('contextmenu', (e) => e.preventDefault());
         new ResizeObserver(() => { this.engine.resize(); this.fitCameraFov(); }).observe(this.canvas);
 
         this.fillLists();
@@ -358,6 +368,7 @@ class Atelier {
         this.game.load(fen);
         this.history = [];
         this.selected = -1;
+        this.hover = -1;
         this.expect = null;
         this.busy = false;
         this.pendingPromo = null;
@@ -463,7 +474,11 @@ class Atelier {
     }
 
     onMove(e) {
-        if (!this.drag.active || !this.drag.mesh || Math.hypot(e.clientX - this.drag.x, e.clientY - this.drag.y) < 8) return;
+        if (!this.drag.active) {
+            this.updateHover();
+            return;
+        }
+        if (!this.drag.mesh || Math.hypot(e.clientX - this.drag.x, e.clientY - this.drag.y) < 8) return;
         const ray = this.scene.createPickingRay(this.scene.pointerX, this.scene.pointerY, window.BABYLON.Matrix.Identity(), this.camera);
         // Plane at y = 0.5 to lift the piece slightly
         const hit = ray.intersectsPlane(new window.BABYLON.Plane(0, 1, 0, -0.6));
@@ -509,6 +524,26 @@ class Atelier {
             return;
         }
         this.onSquare(hit);
+        this.updateHover();
+    }
+
+    updateHover() {
+        if (this.busy || this.pendingPromo || !this.scene) return;
+        const now = performance.now();
+        if (now - this.lastHoverAt < 32) return;
+        this.lastHoverAt = now;
+        const hit = this.hit();
+        if (hit === this.hover) return;
+        this.hover = hit;
+        const mark = this.world?.marks?.hover;
+        if (!mark) return;
+        mark.isVisible = false;
+        if (hit < 0) return;
+        const piece = this.game.board[hit];
+        const canSelect = piece && piece.c === this.game.side && (this.mode !== 'cpu' || this.game.side === this.player);
+        if (canSelect || this.selected >= 0 && this.game.findMove(this.selected, hit)) {
+            placeMark(mark, hit);
+        }
     }
 
     hit() {
@@ -550,6 +585,7 @@ class Atelier {
             return;
         }
         this.selected = -1;
+        this.hover = -1;
         this.legal = [];
         this.refreshMarks();
     }
@@ -625,6 +661,7 @@ class Atelier {
         this.history.push({ san, color: mover });
 
         this.selected = -1;
+        this.hover = -1;
         this.legal = [];
         this.busy = true;
 
@@ -825,6 +862,7 @@ class Atelier {
             this.history.pop();
         }
         this.selected = -1;
+        this.hover = -1;
         this.legal = [];
         this.rebuildPieces();
         this.renderHud();
@@ -877,12 +915,18 @@ class Atelier {
         m.lastTo.isVisible = false;
         m.check.isVisible = false;
         m.hint.isVisible = false;
+        if (m.hover) m.hover.isVisible = false;
     }
 
     refreshMarks() {
         this.clearMarks();
         const m = this.world.marks;
         if (this.selected >= 0) placeMark(m.select, this.selected);
+        if (this.hover >= 0) {
+            const hovered = this.game.board[this.hover];
+            const canSelect = hovered && hovered.c === this.game.side && (this.mode !== 'cpu' || this.game.side === this.player);
+            if (canSelect || this.selected >= 0 && this.game.findMove(this.selected, this.hover)) placeMark(m.hover, this.hover);
+        }
         let di = 0;
         let ci = 0;
         for (const mv of this.legal) {

--- a/labs/xadrez/src/pieces.js
+++ b/labs/xadrez/src/pieces.js
@@ -203,6 +203,11 @@ export function makeMaterials(BABYLON, scene, tex, theme = 'classic') {
     }
     ivory.metallic = 0.02;
     ivory.roughness = 0.38;
+    if (tex.ivory?.roughnessMap) {
+        ivory.metallicTexture = tex.ivory.roughnessMap;
+        ivory.useRoughnessFromMetallicTextureGreen = true;
+        ivory.useMetallnessFromMetallicTextureBlue = false;
+    }
     ivory.clearCoat.isEnabled = true;
     ivory.clearCoat.intensity = 0.32;
     ivory.clearCoat.roughness = 0.2;
@@ -218,6 +223,11 @@ export function makeMaterials(BABYLON, scene, tex, theme = 'classic') {
     }
     ebony.metallic = 0.05;
     ebony.roughness = 0.3;
+    if (tex.ebony?.roughnessMap) {
+        ebony.metallicTexture = tex.ebony.roughnessMap;
+        ebony.useRoughnessFromMetallicTextureGreen = true;
+        ebony.useMetallnessFromMetallicTextureBlue = false;
+    }
     ebony.clearCoat.isEnabled = true;
     ebony.clearCoat.intensity = 0.42;
     ebony.clearCoat.roughness = 0.22;

--- a/labs/xadrez/src/textures.js
+++ b/labs/xadrez/src/textures.js
@@ -168,10 +168,12 @@ export function createTextures(scene) {
 
     const marble = pack(scene, (ctx, w) => {
         const rand = rng(88);
-        ctx.fillStyle = '#dcd4c8';
+        // Pedra grafite: o salão deve enquadrar a mesa sem competir com as
+        // casas claras. As veias continuam legíveis mesmo em qualidade baixa.
+        ctx.fillStyle = '#30363a';
         ctx.fillRect(0, 0, w, w);
         for (let v = 0; v < 14; v++) {
-            ctx.strokeStyle = `rgba(90,80,70,${0.08 + rand() * 0.12})`;
+            ctx.strokeStyle = `rgba(190,185,174,${0.08 + rand() * 0.10})`;
             ctx.lineWidth = 1 + rand() * 3.5;
             ctx.beginPath();
             let x = rand() * w;

--- a/labs/xadrez/src/world.js
+++ b/labs/xadrez/src/world.js
@@ -39,7 +39,7 @@ function makePhysMat(BABYLON, name, scene, texMap, extra = {}) {
     if (texMap) {
         if (texMap.map) mat.albedoTexture = texMap.map;
         if (texMap.normalMap) mat.bumpTexture = texMap.normalMap;
-        if (texMap.roughnessMap) {
+        if (texMap.roughnessMap && extra.useRoughnessMap !== false) {
             mat.metallicTexture = texMap.roughnessMap;
             mat.useRoughnessFromMetallicTextureAlpha = false;
             mat.useRoughnessFromMetallicTextureGreen = true;
@@ -48,6 +48,7 @@ function makePhysMat(BABYLON, name, scene, texMap, extra = {}) {
     }
     mat.roughness = extra.roughness !== undefined ? extra.roughness : 0.35;
     mat.metallic = extra.metallic !== undefined ? extra.metallic : 0.04;
+    if (extra.environmentIntensity !== undefined) mat.environmentIntensity = extra.environmentIntensity;
     mat.clearCoat.isEnabled = true;
     mat.clearCoat.intensity = extra.clearcoat !== undefined ? extra.clearcoat : 0.6;
     mat.clearCoat.roughness = 0.2;
@@ -59,14 +60,16 @@ function makePhysMat(BABYLON, name, scene, texMap, extra = {}) {
 
 export function buildWorld(BABYLON, scene, tex, quality) {
     const lightMat = makePhysMat(BABYLON, 'mat_sq_light', scene, tex.maple, {
-        color: new BABYLON.Color3(0.96, 0.87, 0.73),
-        clearcoat: 0.35,
-        roughness: 0.3
+        color: new BABYLON.Color3(1.0, 0.94, 0.84),
+        clearcoat: 0.18,
+        roughness: 0.44,
+        environmentIntensity: 0.62
     });
     const darkMat = makePhysMat(BABYLON, 'mat_sq_dark', scene, tex.walnut, {
-        color: new BABYLON.Color3(0.85, 0.82, 0.78),
-        clearcoat: 0.35,
-        roughness: 0.35
+        color: new BABYLON.Color3(0.92, 0.86, 0.78),
+        clearcoat: 0.16,
+        roughness: 0.5,
+        environmentIntensity: 0.62
     });
 
     const squares = [];
@@ -87,26 +90,66 @@ export function buildWorld(BABYLON, scene, tex, quality) {
         }
     }
 
-    // Moldura do tabuleiro (Mogno laqueado)
+    // As casas não precisam ser meshes individuais: a seleção usa o plano
+    // matemático do tabuleiro como fallback. Duas malhas estáticas reduzem
+    // drasticamente o custo de desenho sem perder precisão no toque.
+    const lightSquares = BABYLON.Mesh.MergeMeshes(
+        squares.filter((_, i) => {
+            const f = i % 8;
+            const r = Math.floor(i / 8);
+            return (f + r) % 2 !== 0;
+        }), true, true, undefined, false, false
+    );
+    const darkSquares = BABYLON.Mesh.MergeMeshes(
+        squares.filter((_, i) => {
+            const f = i % 8;
+            const r = Math.floor(i / 8);
+            return (f + r) % 2 === 0;
+        }), true, true, undefined, false, false
+    );
+    for (const batch of [lightSquares, darkSquares]) {
+        if (!batch) continue;
+        batch.isPickable = false;
+        batch.receiveShadows = true;
+        batch.metadata = { kind: 'board-surface' };
+    }
+
+    // Moldura do tabuleiro (mogno laqueado). A base rebaixada deixa uma
+    // sombra física entre a moldura, o feltro e o tampo — é ela que dá escala
+    // ao conjunto em vez de fazer as casas parecerem uma textura plana.
     const frameMat = makePhysMat(BABYLON, 'mat_frame', scene, tex.mahogany, {
-        color: new BABYLON.Color3(0.76, 0.73, 0.7),
-        clearcoat: 0.355,
-        roughness: 0.25
+        color: new BABYLON.Color3(0.92, 0.78, 0.62),
+        clearcoat: 0.52,
+        roughness: 0.22,
+        environmentIntensity: 0.45
     });
     const frame = BABYLON.MeshBuilder.CreateBox('board_frame', {
-        width: 9.25,
-        height: 0.16,
-        depth: 9.25
+        width: 9.35,
+        height: 0.2,
+        depth: 9.35
     }, scene);
-    frame.position.y = -0.06;
+    frame.position.y = -0.08;
     frame.material = frameMat;
     frame.receiveShadows = true;
     frame.isPickable = false;
 
+    const plinth = BABYLON.MeshBuilder.CreateBox('board_plinth', {
+        width: 10.15,
+        height: 0.16,
+        depth: 10.15
+    }, scene);
+    plinth.position.y = -0.22;
+    plinth.material = tableMatPlaceholder(BABYLON, scene, tex.mahogany);
+    plinth.receiveShadows = true;
+    plinth.isPickable = false;
+
     // Feltro sob as casas
     const feltMat = new BABYLON.PBRMaterial('mat_felt', scene);
-    feltMat.albedoColor = new BABYLON.Color3(0.08, 0.28, 0.16);
-    feltMat.roughness = 0.95;
+    feltMat.albedoColor = new BABYLON.Color3(0.42, 0.72, 0.52);
+    feltMat.albedoTexture = tex.felt?.map || null;
+    feltMat.bumpTexture = tex.felt?.normalMap || null;
+    feltMat.roughness = 0.94;
+    feltMat.useAlphaFromAlbedoTexture = false;
     feltMat.metallic = 0.0;
     const felt = BABYLON.MeshBuilder.CreateBox('board_felt', {
         width: 8.04,
@@ -117,21 +160,51 @@ export function buildWorld(BABYLON, scene, tex, quality) {
     felt.material = feltMat;
     felt.isPickable = false;
 
-    // Mesa de mogno
+    // Mesa de mogno: tampo, saia e travessas. O enquadramento costuma mostrar
+    // mais mesa do que tabuleiro; esses volumes evitam que o entorno pareça
+    // um plano infinito sem espessura.
     const tableMat = makePhysMat(BABYLON, 'mat_table', scene, tex.mahogany, {
-        color: new BABYLON.Color3(0.66, 0.65, 0.64),
-        roughness: 0.48,
-        clearcoat: 0.25
+        color: new BABYLON.Color3(0.78, 0.64, 0.49),
+        roughness: 0.54,
+        clearcoat: 0.14,
+        environmentIntensity: 0.28,
+        useRoughnessMap: false
     });
     const table = BABYLON.MeshBuilder.CreateBox('table_top', {
         width: 16,
-        height: 0.28,
+        height: 0.34,
         depth: 12
     }, scene);
-    table.position.y = -0.28;
+    table.position.y = -0.38;
     table.material = tableMat;
     table.receiveShadows = true;
     table.isPickable = false;
+
+    // A prancha elevada lê melhor a luz de recorte e separa o objeto jogável
+    // do tampo sem precisar de um contorno artificial.
+    const tableLip = BABYLON.MeshBuilder.CreateBox('table_lip', {
+        width: 15.7,
+        height: 0.18,
+        depth: 11.7
+    }, scene);
+    tableLip.position.y = -0.17;
+    tableLip.material = tableMat;
+    tableLip.receiveShadows = true;
+    tableLip.isPickable = false;
+
+    const apron = [
+        { name: 'apron_front', width: 15.6, height: 1.05, depth: 0.24, x: 0, z: 5.72 },
+        { name: 'apron_back', width: 15.6, height: 1.05, depth: 0.24, x: 0, z: -5.72 },
+        { name: 'apron_left', width: 0.24, height: 1.05, depth: 11.2, x: -7.72, z: 0 },
+        { name: 'apron_right', width: 0.24, height: 1.05, depth: 11.2, x: 7.72, z: 0 }
+    ];
+    apron.forEach(({ name, width, height, depth, x, z }) => {
+        const rail = BABYLON.MeshBuilder.CreateBox(name, { width, height, depth }, scene);
+        rail.position.set(x, -1.02, z);
+        rail.material = tableMat;
+        rail.receiveShadows = true;
+        rail.isPickable = false;
+    });
 
     // Pés da mesa
     const legMat = makePhysMat(BABYLON, 'mat_leg', scene, tex.mahogany, {
@@ -150,14 +223,17 @@ export function buildWorld(BABYLON, scene, tex, quality) {
         leg.isPickable = false;
     }
 
-    // Tapete de veludo bordô sob a mesa
+    // Tapete de veludo sob a mesa. A textura de feltro também evita o aspecto
+    // de círculo sólido quando a câmera desce para o detalhe.
     const rugMat = new BABYLON.PBRMaterial('mat_rug', scene);
-    rugMat.albedoColor = new BABYLON.Color3(0.06, 0.10, 0.12);
-    rugMat.roughness = 0.92;
+    rugMat.albedoColor = new BABYLON.Color3(0.46, 0.18, 0.12);
+    rugMat.albedoTexture = tex.felt?.map || null;
+    rugMat.bumpTexture = tex.felt?.normalMap || null;
+    rugMat.roughness = 0.9;
     rugMat.metallic = 0.0;
     const rug = BABYLON.MeshBuilder.CreateDisc('rug', {
-        radius: 7.5,
-        tessellation: 48
+        radius: 8.5,
+        tessellation: quality.id === 'low' ? 40 : 64
     }, scene);
     rug.rotation.x = Math.PI / 2;
     rug.position.y = -2.83;
@@ -165,19 +241,23 @@ export function buildWorld(BABYLON, scene, tex, quality) {
     rug.receiveShadows = true;
     rug.isPickable = false;
 
-    // Piso de mármore do salão
+    // Piso de mármore do salão. Antes o mapa gerado era imediatamente
+    // removido abaixo, deixando um disco cinza chapado no fundo.
     const floorMat = makePhysMat(BABYLON, 'mat_floor', scene, tex.marble, {
-        color: new BABYLON.Color3(0.075, 0.10, 0.12),
-        roughness: 0.8,
-        clearcoat: 0.9,
-        metallic: 0.05
+        color: new BABYLON.Color3(0.46, 0.49, 0.50),
+        roughness: 0.5,
+        clearcoat: 0.35,
+        metallic: 0.02
     });
-    floorMat.albedoTexture = null; floorMat.bumpTexture = null; floorMat.clearCoat.isEnabled = false;
-    const floor = BABYLON.MeshBuilder.CreateDisc('floor', {
-        radius: 18,
-        tessellation: 64
+    floorMat.albedoTexture.uScale = 3;
+    floorMat.albedoTexture.vScale = 3;
+    floorMat.bumpTexture.uScale = 3;
+    floorMat.bumpTexture.vScale = 3;
+    const floor = BABYLON.MeshBuilder.CreateBox('floor', {
+        width: 44,
+        height: 0.22,
+        depth: 36
     }, scene);
-    floor.rotation.x = Math.PI / 2;
     floor.position.y = -2.85;
     floor.material = floorMat;
     floor.receiveShadows = true;
@@ -187,8 +267,8 @@ export function buildWorld(BABYLON, scene, tex, quality) {
         color: new BABYLON.Color3(0.65, 0.48, 0.23), metallic: 0.8, roughness: 0.32
     });
     for (const axis of ['x', 'z']) for (const sign of [-1, 1]) {
-        const rail = BABYLON.MeshBuilder.CreateBox('inlay', {width: axis === 'z' ? 8.8 : 0.025, depth: axis === 'x' ? 8.8 : 0.025, height: 0.01}, scene);
-        rail.position[axis] = sign * 4.4; rail.position.y = 0.028; rail.material = brass; rail.isPickable = false;
+        const rail = BABYLON.MeshBuilder.CreateBox('inlay', {width: axis === 'z' ? 8.8 : 0.025, depth: axis === 'x' ? 8.8 : 0.025, height: 0.012}, scene);
+        rail.position[axis] = sign * 4.4; rail.position.y = 0.09; rail.material = brass; rail.isPickable = false;
     }
     for (let i = 0; i < 8; i++) for (const edge of ['file', 'rank']) {
         const texture = new BABYLON.DynamicTexture(`coord_${edge}_${i}`, 128, scene, false);
@@ -197,14 +277,24 @@ export function buildWorld(BABYLON, scene, tex, quality) {
         const mat = new BABYLON.StandardMaterial(`label_${edge}_${i}`, scene);
         mat.diffuseTexture = texture; mat.emissiveColor.set(0.4, 0.36, 0.28); mat.specularColor.set(0,0,0); mat.useAlphaFromDiffuseTexture = true;
         const label = BABYLON.MeshBuilder.CreateGround(`label_${edge}_${i}`, {width:0.23,height:0.23}, scene);
-        label.position.set(edge === 'file' ? i - 3.5 : -4.19, 0.035, edge === 'file' ? 4.19 : 3.5 - i);
+        label.position.set(edge === 'file' ? i - 3.5 : -4.19, 0.095, edge === 'file' ? 4.19 : 3.5 - i);
         label.material = mat; label.isPickable = false;
     }
     for (const mesh of scene.meshes) if (!mesh.name.startsWith('label')) mesh.freezeWorldMatrix();
 
     const marks = buildMarks(BABYLON, scene);
 
-    return { squares, frame, table, floor, marks };
+    return { squares: [lightSquares, darkSquares], frame, table, floor, marks };
+}
+
+function tableMatPlaceholder(BABYLON, scene, tex) {
+    return makePhysMat(BABYLON, 'mat_plinth', scene, tex.mahogany, {
+        color: new BABYLON.Color3(0.72, 0.54, 0.39),
+        roughness: 0.29,
+        clearcoat: 0.42,
+        environmentIntensity: 0.34,
+        useRoughnessMap: false
+    });
 }
 
 function buildMarks(BABYLON, scene) {
@@ -237,6 +327,11 @@ function buildMarks(BABYLON, scene) {
     hintMat.diffuseColor = new BABYLON.Color3(0.3, 0.85, 1.0);
     hintMat.emissiveColor = new BABYLON.Color3(0.2, 0.6, 0.9);
     hintMat.alpha = 0.9;
+
+    const hoverMat = new BABYLON.StandardMaterial('mat_mark_hover', scene);
+    hoverMat.diffuseColor = new BABYLON.Color3(0.75, 0.88, 0.98);
+    hoverMat.emissiveColor = new BABYLON.Color3(0.26, 0.56, 0.82);
+    hoverMat.alpha = 0.34;
 
     const dots = [];
     for (let i = 0; i < 28; i++) {
@@ -286,7 +381,12 @@ function buildMarks(BABYLON, scene) {
     hint.isVisible = false;
     hint.isPickable = false;
 
-    return { dots, caps, select, lastFrom, lastTo, check, hint };
+    const hover = BABYLON.MeshBuilder.CreateTorus('mark_hover', { diameter: 0.94, thickness: 0.035, tessellation: 32 }, scene);
+    hover.material = hoverMat;
+    hover.isVisible = false;
+    hover.isPickable = false;
+
+    return { dots, caps, select, lastFrom, lastTo, check, hint, hover };
 }
 
 export function placeMark(mesh, index, flip = false) {
@@ -300,21 +400,24 @@ export function setupLights(BABYLON, scene, quality) {
     // Luz ambiente suave — intensidade mais alta e chão mais claro para que o
     // ébano (muito escuro) não vire silhueta pura nas áreas de sombra.
     const hemi = new BABYLON.HemisphericLight('hemi_light', new BABYLON.Vector3(0, 1, 0), scene);
-    hemi.diffuse = new BABYLON.Color3(0.78, 0.73, 0.66);
-    hemi.groundColor = new BABYLON.Color3(0.38, 0.32, 0.26);
-    hemi.intensity = 0.65;
+    hemi.diffuse = new BABYLON.Color3(0.82, 0.78, 0.70);
+    hemi.groundColor = new BABYLON.Color3(0.22, 0.15, 0.12);
+    hemi.intensity = 0.72;
 
     // Sol / Luz direcionada com sombras
     const sun = new BABYLON.DirectionalLight('sun_light', new BABYLON.Vector3(-4, -10, 6).normalize(), scene);
     sun.position = new BABYLON.Vector3(8, 18, -12);
     sun.diffuse = new BABYLON.Color3(1.0, 0.95, 0.88);
-    sun.intensity = 2.1;
+    sun.intensity = 1.05;
+    sun.specular = new BABYLON.Color3(0.48, 0.42, 0.34);
 
     let shadowGen = null;
     if (quality.shadows) {
         shadowGen = new BABYLON.ShadowGenerator(quality.shadowMap || 2048, sun);
         shadowGen.usePercentageCloserFiltering = true;
-        shadowGen.filteringQuality = BABYLON.ShadowGenerator.QUALITY_MEDIUM;
+        shadowGen.filteringQuality = quality.id === 'high'
+            ? BABYLON.ShadowGenerator.QUALITY_HIGH
+            : BABYLON.ShadowGenerator.QUALITY_MEDIUM;
         shadowGen.bias = 0.001;
         shadowGen.normalBias = 0.002;
         shadowGen.darkness = 0.35;
@@ -323,14 +426,15 @@ export function setupLights(BABYLON, scene, quality) {
     // Luz de preenchimento fria, do lado oposto ao sol — sem ela o lado
     // sombreado das peças (sobretudo as de ébano) desaparecia em preto puro.
     const fill = new BABYLON.DirectionalLight('fill_light', new BABYLON.Vector3(5, -6, -8).normalize(), scene);
-    fill.diffuse = new BABYLON.Color3(0.55, 0.60, 0.68);
+    fill.diffuse = new BABYLON.Color3(0.48, 0.56, 0.68);
     fill.specular = new BABYLON.Color3(0.2, 0.2, 0.24);
-    fill.intensity = 0.9;
+    fill.intensity = 0.72;
 
     // Ponto de luz quente sobre a mesa
     const warmLamp = new BABYLON.PointLight('warm_lamp', new BABYLON.Vector3(0, 5, 0), scene);
     warmLamp.diffuse = new BABYLON.Color3(1.0, 0.85, 0.65);
-    warmLamp.intensity = 0.25;
+    warmLamp.specular = new BABYLON.Color3(0.12, 0.08, 0.04);
+    warmLamp.intensity = 0.03;
     warmLamp.range = 14;
 
     return { hemi, sun, fill, shadowGen, warmLamp };
@@ -353,10 +457,12 @@ export function setupEnvironment(BABYLON, scene) {
         g.addColorStop(1, bottom);
         ctx.fillStyle = g;
         ctx.fillRect(0, 0, size, size);
+        ctx.globalAlpha = 0.16;
         ctx.fillStyle = '#d3ddeb';
         ctx.fillRect(40, 24, 65, 108);
         ctx.fillStyle = '#f5e5c8';
         ctx.fillRect(116, 24, 65, 108);
+        ctx.globalAlpha = 1;
         return el.toDataURL('image/png');
     };
     const side = face('#8c7c68', '#171310');
@@ -364,7 +470,7 @@ export function setupEnvironment(BABYLON, scene) {
     const bottom = face('#171310', '#050403');
     const env = BABYLON.CubeTexture.CreateFromImages([side, side, top, bottom, side, side], scene);
     scene.environmentTexture = env;
-    scene.environmentIntensity = 0.65;
+    scene.environmentIntensity = 0.28;
     return env;
 }
 

--- a/labs/xadrez/style.css
+++ b/labs/xadrez/style.css
@@ -1,11 +1,325 @@
-/* The board owns its viewport. Panels never float over playable squares. */
-:root{color-scheme:dark;--ink:#101619;--text:#f0eee8;--muted:#aeb8b9;--gold:#d7bb80;--line:#ffffff18;--safe-top:env(safe-area-inset-top,0px);--safe-bottom:env(safe-area-inset-bottom,0px)}
-*{box-sizing:border-box}html,body{margin:0;width:100%;height:100%;overflow-x:clip;background:var(--ink)}body{padding:0!important;display:block!important;color:var(--text);font-family:Outfit,system-ui,sans-serif;font-size:16px}button,select{font:inherit;color:inherit}button{cursor:pointer}button:disabled{opacity:.4;cursor:default}button,select{min-height:44px}button{background:none;border:1px solid var(--line);border-radius:8px;padding:10px 14px}button:hover,button[aria-pressed=true]{background:#d7bb801c;border-color:#d7bb8080;color:var(--gold)}:focus-visible{outline:2px solid var(--gold);outline-offset:3px}[hidden]{display:none!important}.sr-only{position:absolute;width:1px;height:1px;overflow:hidden;clip-path:inset(50%)}
-.game-shell{position:fixed;inset:0;background:#101619}.game-shell>header{position:absolute;inset:0 0 auto;height:64px;border-bottom:1px solid var(--line);padding-top:var(--safe-top);z-index:10;background:#101619}.brand-mark{color:var(--gold)}.app-logo{display:flex;gap:12px;align-items:center}.stage{position:absolute;top:64px;left:0;right:340px;bottom:0;background:#141b1e}#scene{width:100%;height:100%;display:block;touch-action:none;outline:none;cursor:grab}#scene.is-dragging{cursor:grabbing}.vignette{position:absolute;inset:0;pointer-events:none;background:radial-gradient(ellipse,transparent 55%,#080d1238)}.camera-bar{position:absolute;z-index:3;left:24px;right:24px;bottom:44px;display:flex;justify-content:center;gap:4px;align-items:center;pointer-events:none}.camera-bar button{pointer-events:auto;background:#11191ee8;backdrop-filter:blur(12px);font-size:14px}.camera-bar span{color:var(--muted);font-size:12px;padding:8px}.camera-help{position:absolute;bottom:8px;left:0;right:0;text-align:center;font-size:12px;color:#b6bec2;pointer-events:none}
-.hud{position:absolute;top:64px;bottom:0;right:0;width:340px;padding:24px;display:flex;flex-direction:column;gap:20px;border-left:1px solid var(--line);overflow:auto;background:#101619;padding-bottom:max(20px,var(--safe-bottom))}.tray{order:0;display:flex;flex-direction:column;gap:12px;min-height:120px}.eyebrow{color:var(--gold);font-size:12px;letter-spacing:.18em;font-weight:500;margin:0}.opponent-name{font-size:20px;margin:0;text-transform:capitalize}.status{margin:0;font-size:16px;color:#b9d5c6;display:flex;align-items:center;gap:8px}.status:before{content:'';width:6px;height:6px;border-radius:50%;background:currentColor}.status.is-check{color:#ffac99}.captured{font-size:22px;min-height:28px;letter-spacing:2px;color:#c1c7c5}.moves{margin:0;padding:8px 0;list-style:none;overflow:auto;max-height:180px;font-variant-numeric:tabular-nums;font-size:14px}.moves:empty:before{content:'Os lances aparecem aqui.';color:#879498;font-size:14px}.moves li{display:grid;grid-template-columns:40px 1fr 1fr;padding:8px;border-radius:4px}.moves li:nth-child(odd){background:#ffffff05}.moves .n{color:#88979c}.coach{order:1;border-top:1px solid var(--line);padding-top:16px}.coach-toggle{display:flex;flex-direction:column;align-items:start;gap:10px;border:none;width:100%;padding:0 0 12px;text-align:left}.coach-toggle:hover{background:none}.coach-toggle>span:last-child{font-size:18px}.coach-body{overflow:auto;max-height:42dvh}.coach-text{font-size:16px;line-height:1.6;color:#c3cccd;margin:0 0 12px}.coach-tip{font-size:14px;line-height:1.5;color:var(--gold);margin:0 0 16px}.is-collapsed .coach-body{display:none}.lesson-nav{display:flex;gap:8px;margin-bottom:12px}.lesson-nav button{flex:1}.lesson-list{padding:0;margin:0;display:grid;gap:5px;list-style:none}.lesson-list button{width:100%;text-align:left;display:flex;gap:8px;align-items:center;font-size:14px}.lesson-list [aria-current=true]{border-color:var(--gold);background:#d7bb8015}.lesson-list .done{color:#a5ceb9}.dock{order:2;margin-top:auto;display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:6px;padding-top:18px;border-top:1px solid var(--line)}.dock-btn{font-size:14px;padding:10px 6px}.accent{color:var(--gold);background:#d7bb8012}
-.overlay{position:absolute;inset:64px 0 0;z-index:30;display:grid;place-items:center;padding:20px;background:#050a0db3;backdrop-filter:blur(7px)}.overlay-card{padding:32px;max-height:calc(100dvh - 110px);overflow:auto;width:min(480px,100%);background:#141c20;border:1px solid var(--line);border-radius:16px;box-shadow:0 24px 80px #0007}.overlay-card h2{font-family:Cinzel,Georgia,serif;font-size:clamp(28px,4vw,42px);font-weight:500;margin:16px 0;line-height:1.15}.lede{color:#aebdc0;line-height:1.6;margin:0 0 28px}.settings-row{display:grid;grid-template-columns:1fr 1fr;gap:16px}.field{display:flex;flex-direction:column;gap:8px;min-width:0;font-size:14px;color:#afbec2}.field select{width:100%;background:#10171b;border:1px solid #ffffff24;border-radius:7px;padding:10px;color:var(--text)}.card-actions{display:flex;flex-wrap:wrap;gap:12px;margin-top:24px}.primary-button{background:var(--gold);color:#192024;border-color:var(--gold);font-weight:600;display:flex;align-items:center;justify-content:space-between;gap:24px;min-height:50px}.primary-button:hover{background:#e4cc9d;color:#192024}.learn-button{border:0;color:var(--gold);font-size:14px;width:100%;padding:8px 0}.promo-row{display:grid;grid-template-columns:1fr 1fr;gap:8px}.load-bar{height:3px;background:#ffffff20}.load-bar i{display:block;width:8%;height:100%;background:var(--gold)}#intro{left:auto;width:340px;backdrop-filter:none;background:#101619;padding:24px;border-left:1px solid var(--line)}#intro .overlay-card{background:none;border:none;box-shadow:none;border-radius:0;padding:0;max-height:100%;width:100%}#intro .settings-row{grid-template-columns:1fr}#intro .primary-button{width:100%}#intro .lede{font-size:16px}#intro h2{font-size:36px}body[data-state=intro] .hud{visibility:hidden}.lab-foot{display:none}
-@media(max-width:1000px) and (min-width:769px){.stage{right:300px}.hud,#intro{width:300px;padding:18px}.camera-bar{left:8px;right:8px}.camera-bar span{display:none}}
-@media(max-width:768px){.game-shell>header{height:52px}.stage{top:52px;right:0;bottom:230px}.hud{top:auto;left:0;right:0;bottom:0;width:100%;height:230px;padding:12px max(12px,env(safe-area-inset-right));gap:8px;border-top:1px solid var(--line);border-left:0;display:grid;grid-template-columns:1fr;align-content:start}.tray{min-height:0;display:grid;grid-template-columns:1fr auto;gap:4px}.tray>.eyebrow,.captured,.moves{display:none}.opponent-name{font-size:14px}.status{font-size:14px}.coach{padding-top:6px}.coach-toggle{min-height:44px;padding:4px 0;flex-direction:row;align-items:center;justify-content:space-between}.coach-toggle>span:last-child{font-size:16px}.coach-body{max-height:150px}.coach-text{font-size:16px}.dock{padding-top:6px;grid-template-columns:repeat(5,minmax(0,1fr));margin-top:0;gap:4px}.dock-btn{font-size:14px;padding:8px 2px}.camera-bar{left:4px;right:4px;bottom:8px}.camera-bar button{font-size:12px;padding:8px}.camera-bar span,.camera-help{display:none}.overlay{inset:52px 0 0;padding:16px}.overlay-card{padding:24px;max-height:calc(100dvh - 86px)}#intro{inset:auto 0 0;width:100%;height:280px;padding:18px;display:block;border-top:1px solid var(--line)}#intro h2,#intro>.overlay-card>.eyebrow,#intro .lede{display:none}#intro .settings-row{grid-template-columns:1fr 1fr;gap:10px}#intro .field{gap:3px}#intro .card-actions{margin-top:14px;gap:4px}#intro .primary-button{min-height:44px}#intro .learn-button{min-height:38px}body[data-state=intro] .stage{bottom:280px}body[data-mode=academy][data-state=play] .hud,body[data-mode=puzzles][data-state=play] .hud{height:300px}body[data-mode=academy][data-state=play] .stage,body[data-mode=puzzles][data-state=play] .stage{bottom:300px}.lesson-list{display:none}.coach-tip{margin-bottom:8px}.lesson-nav{margin-bottom:0}.coach-body{overflow:auto}.settings-row{grid-template-columns:1fr 1fr}}
-@media(max-height:520px) and (orientation:landscape){.game-shell>header{height:44px}.stage,body[data-state=intro] .stage,body[data-mode=academy][data-state=play] .stage,body[data-mode=puzzles][data-state=play] .stage{top:44px;right:260px;bottom:0}.hud,body[data-mode=academy][data-state=play] .hud,body[data-mode=puzzles][data-state=play] .hud{top:44px;left:auto;right:0;width:260px;height:auto;bottom:0;padding:12px;display:flex;overflow:auto}#intro{inset:44px 0 0 auto;width:260px;height:auto;padding:16px}#intro .settings-row{grid-template-columns:1fr 1fr}.dock{grid-template-columns:repeat(3,minmax(0,1fr))}.coach-body{max-height:180px}.tray{display:block}.tray .status{margin-top:4px}.overlay{top:44px}.camera-bar button{padding:8px;font-size:12px}.camera-bar span,.camera-help{display:none}.camera-bar{bottom:8px}.overlay-card{max-height:calc(100dvh - 72px)}}
-@media(prefers-reduced-motion:reduce){*{scroll-behavior:auto!important;transition:none!important}}
-.game-shell .lab-header{max-width:none;width:100%;color:var(--text)}.game-shell header h1{color:var(--text)!important}.game-shell header .theme-toggle{display:none}.game-shell header a{background:#1b252a!important;color:#d8dfe0!important;border:1px solid var(--line)!important}.asset-credit{display:block;color:#8f9da2;font-size:12px;text-align:center;margin-top:16px;text-decoration:underline}
+/* Xadrez owns the viewport: the board is always the playable surface and the
+   interface stays in a separate rail, never above a square. */
+:root {
+    color-scheme: dark;
+    --ink: #080d10;
+    --surface: #10171b;
+    --surface-raised: #151f23;
+    --surface-soft: #1a2529;
+    --text: #f3f0e9;
+    --muted: #9eabad;
+    --gold: #e0c388;
+    --gold-bright: #f2dca9;
+    --mint: #afd5c0;
+    --danger: #f5a08d;
+    --line: #ffffff1a;
+    --line-strong: #ffffff2a;
+    --safe-top: env(safe-area-inset-top, 0px);
+    --safe-right: env(safe-area-inset-right, 0px);
+    --safe-bottom: env(safe-area-inset-bottom, 0px);
+    --safe-left: env(safe-area-inset-left, 0px);
+    --rail: 370px;
+}
+
+* { box-sizing: border-box; }
+html,
+body { width: 100%; height: 100%; margin: 0; overflow: hidden; background: var(--ink); }
+body {
+    padding: 0 !important;
+    display: block !important;
+    color: var(--text);
+    font-family: Outfit, system-ui, sans-serif;
+    font-size: 16px;
+    -webkit-font-smoothing: antialiased;
+}
+button,
+select { font: inherit; color: inherit; }
+button { min-height: 44px; cursor: pointer; }
+button:disabled { opacity: .42; cursor: default; }
+button,
+select {
+    border: 1px solid var(--line);
+    border-radius: 9px;
+    background: #ffffff05;
+}
+button { padding: 10px 14px; transition: border-color .2s ease, background .2s ease, color .2s ease, transform .2s ease; }
+button:hover,
+button[aria-pressed="true"] { background: #e0c38818; border-color: #e0c38870; color: var(--gold-bright); }
+button:active { transform: translateY(1px); }
+:focus-visible { outline: 2px solid var(--gold); outline-offset: 3px; }
+[hidden] { display: none !important; }
+.sr-only { position: absolute; width: 1px; height: 1px; overflow: hidden; clip-path: inset(50%); }
+
+.game-shell {
+    position: fixed;
+    inset: 0;
+    overflow: hidden;
+    background:
+        radial-gradient(circle at 26% 18%, #29404b22, transparent 38%),
+        linear-gradient(135deg, #0a1013, #11191d 60%, #0a0e10);
+}
+.game-shell > header {
+    position: absolute;
+    inset: 0 0 auto;
+    z-index: 10;
+    height: 64px;
+    padding-top: var(--safe-top);
+    border-bottom: 1px solid var(--line);
+    background: linear-gradient(180deg, #10171bf5, #10171bea);
+    box-shadow: 0 12px 34px #00000016;
+}
+.game-shell .lab-header { width: 100%; max-width: none; color: var(--text); }
+.game-shell header h1 { color: var(--text) !important; }
+.game-shell header a { background: #1b252a !important; color: #d8dfe0 !important; border-color: var(--line) !important; }
+.brand-mark { color: var(--gold); }
+.app-logo { display: flex; align-items: center; gap: 12px; }
+
+.stage {
+    position: absolute;
+    inset: 64px var(--rail) 0 0;
+    overflow: hidden;
+    background: #11191d;
+    box-shadow: inset -24px 0 60px #00000025;
+}
+.stage::before {
+    content: "";
+    position: absolute;
+    z-index: 1;
+    inset: 0;
+    pointer-events: none;
+    background:
+        linear-gradient(130deg, #d7bd8b0c, transparent 34%),
+        radial-gradient(ellipse at 50% 48%, transparent 48%, #0205074a 100%);
+    mix-blend-mode: screen;
+}
+#scene {
+    display: block;
+    width: 100%;
+    height: 100%;
+    outline: none;
+    cursor: grab;
+    touch-action: none;
+}
+#scene.is-dragging { cursor: grabbing; }
+.vignette { position: absolute; inset: 0; pointer-events: none; background: radial-gradient(ellipse, transparent 52%, #0205072e 100%); }
+
+.camera-bar {
+    position: absolute;
+    z-index: 3;
+    right: 24px;
+    bottom: calc(34px + var(--safe-bottom));
+    left: 24px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 5px;
+    pointer-events: none;
+}
+.camera-bar button { pointer-events: auto; min-width: 86px; padding: 9px 12px; background: #11191de8; backdrop-filter: blur(14px); font-size: 13px; }
+.camera-bar span { padding: 8px 10px; color: var(--muted); font-size: 12px; letter-spacing: .04em; }
+.camera-help { position: absolute; right: 0; bottom: 7px; left: 0; margin: 0; color: #bdc6c8; font-size: 11px; text-align: center; pointer-events: none; opacity: .8; }
+
+.hud {
+    position: absolute;
+    top: 64px;
+    right: 0;
+    bottom: 0;
+    z-index: 12;
+    display: flex;
+    width: var(--rail);
+    flex-direction: column;
+    gap: 16px;
+    overflow: auto;
+    padding: 24px 22px max(22px, var(--safe-bottom));
+    border-left: 1px solid var(--line);
+    background:
+        radial-gradient(circle at 80% 8%, #d3b47d0a, transparent 34%),
+        linear-gradient(180deg, #10171bf8, #0d1316fc);
+    box-shadow: -18px 0 44px #00000018;
+}
+.tray {
+    display: flex;
+    min-height: 152px;
+    flex-direction: column;
+    gap: 10px;
+    padding: 2px 2px 17px;
+    border-bottom: 1px solid var(--line);
+}
+.eyebrow { margin: 0; color: var(--gold); font-size: 11px; font-weight: 600; letter-spacing: .2em; }
+.opponent-name { margin: 0; color: var(--text); font-size: clamp(18px, 2vw, 22px); letter-spacing: -.02em; }
+.status { display: flex; align-items: center; gap: 9px; margin: 0; color: var(--mint); font-size: 15px; }
+.status::before { width: 7px; height: 7px; border-radius: 50%; background: currentColor; box-shadow: 0 0 0 4px currentColor22; content: ""; }
+.status.is-check { color: var(--danger); }
+.captured { min-height: 28px; color: #cbd0cc; font-size: 21px; letter-spacing: 2px; }
+.moves { max-height: 164px; margin: 0; padding: 5px 0; overflow: auto; list-style: none; font-size: 13px; font-variant-numeric: tabular-nums; scrollbar-color: #d7bb8060 transparent; }
+.moves:empty::before { color: #7f8e92; content: "Os lances aparecem aqui."; font-size: 13px; }
+.moves li { display: grid; grid-template-columns: 40px 1fr 1fr; padding: 8px 7px; border-radius: 6px; }
+.moves li:nth-child(odd) { background: #ffffff05; }
+.moves .n { color: #849499; }
+
+.coach { padding-top: 2px; }
+.coach-toggle { display: flex; width: 100%; min-height: 44px; flex-direction: column; align-items: flex-start; gap: 7px; padding: 0 0 10px; border: 0; text-align: left; }
+.coach-toggle:hover { background: none; border-color: transparent; color: inherit; }
+.coach-toggle > span:last-child { color: var(--text); font-size: 19px; letter-spacing: -.02em; }
+.coach-body { max-height: 40dvh; overflow: auto; }
+.coach-text { margin: 0 0 10px; color: #c2ccce; font-size: 15px; line-height: 1.55; }
+.coach-tip { margin: 0 0 14px; color: var(--gold); font-size: 13px; line-height: 1.45; }
+.is-collapsed .coach-body { display: none; }
+.lesson-nav { display: flex; gap: 7px; margin-bottom: 10px; }
+.lesson-nav button { flex: 1; font-size: 13px; }
+.lesson-list { display: grid; gap: 5px; margin: 0; padding: 0; list-style: none; }
+.lesson-list button { display: flex; width: 100%; align-items: center; gap: 8px; padding: 8px 10px; text-align: left; font-size: 13px; }
+.lesson-list [aria-current="true"] { border-color: var(--gold); background: #d7bb8015; }
+.lesson-list .done { color: var(--mint); }
+
+.dock {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 6px;
+    margin-top: auto;
+    padding-top: 16px;
+    border-top: 1px solid var(--line);
+}
+.dock-btn { min-width: 0; padding: 10px 6px; font-size: 13px; }
+.dock .accent { color: var(--gold-bright); background: #d7bb8014; }
+
+.overlay {
+    position: absolute;
+    inset: 64px 0 0;
+    z-index: 30;
+    display: grid;
+    place-items: center;
+    padding: 20px;
+    background: #05090cb3;
+    backdrop-filter: blur(8px);
+}
+.overlay-card {
+    width: min(480px, 100%);
+    max-height: min(92dvh, 700px);
+    overflow: auto;
+    padding: 32px;
+    border: 1px solid var(--line-strong);
+    border-radius: 17px;
+    background: linear-gradient(145deg, #172125f5, #0f171af5);
+    box-shadow: 0 28px 90px #00000080, inset 0 1px #ffffff0d;
+}
+.overlay-card h2 { margin: 16px 0; color: var(--text); font-family: Cinzel, Georgia, serif; font-size: clamp(28px, 4vw, 44px); font-weight: 500; line-height: 1.12; }
+.lede { margin: 0 0 28px; color: #b0bec0; line-height: 1.6; }
+.settings-row { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; }
+.field { display: flex; min-width: 0; flex-direction: column; gap: 7px; color: #afbec2; font-size: 13px; }
+.field select { width: 100%; min-height: 46px; padding: 10px; border-color: #ffffff22; background: #0c1316; }
+.card-actions { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 24px; }
+.primary-button { display: flex; min-height: 50px; flex: 0 1 auto; align-items: center; justify-content: space-between; gap: 24px; border-color: var(--gold); background: linear-gradient(135deg, var(--gold-bright), var(--gold)); color: #192024; font-weight: 700; }
+.primary-button:hover { border-color: var(--gold-bright); background: #f1dba6; color: #192024; }
+.learn-button { width: 100%; padding: 8px 0; border: 0; color: var(--gold); font-size: 13px; }
+.learn-button:hover { background: none; border-color: transparent; }
+.promo-row { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }
+.load-bar { height: 3px; overflow: hidden; background: #ffffff18; }
+.load-bar i { display: block; width: 8%; height: 100%; background: var(--gold); transition: width .25s ease; }
+#intro {
+    inset: 64px 0 0 auto;
+    display: block;
+    width: var(--rail);
+    padding: 30px 24px max(24px, var(--safe-bottom));
+    border-left: 1px solid var(--line);
+    background: radial-gradient(circle at 80% 0%, #cfad6814, transparent 32%), #10171b;
+    backdrop-filter: none;
+}
+#intro .overlay-card { width: 100%; max-height: 100%; padding: 0; border: 0; border-radius: 0; background: none; box-shadow: none; }
+#intro .settings-row { grid-template-columns: 1fr; }
+#intro .primary-button { width: 100%; flex: 0 0 100%; }
+#intro h2 { font-size: 38px; }
+body[data-state="intro"] .hud { visibility: hidden; }
+.lab-foot { display: none; }
+.eyebrow--danger { color: var(--danger); }
+.asset-credit { display: block; margin-top: 15px; color: #8f9da2; font-size: 11px; text-align: center; text-decoration: underline; }
+
+@media (max-width: 1100px) and (min-width: 769px) {
+    :root { --rail: 310px; }
+    .hud,
+    #intro { padding-right: 17px; padding-left: 17px; }
+    .camera-bar { right: 8px; left: 8px; }
+    .camera-bar span { display: none; }
+}
+
+@media (max-width: 768px) {
+    html, body { overflow: hidden; }
+    .game-shell > header { height: 52px; }
+    .stage { inset: 52px 0 248px; }
+    .hud {
+        top: auto;
+        right: 0;
+        bottom: 0;
+        left: 0;
+        width: 100%;
+        height: 248px;
+        display: grid;
+        align-content: start;
+        gap: 7px;
+        padding: 10px max(12px, var(--safe-right)) max(10px, var(--safe-bottom)) max(12px, var(--safe-left));
+        border-top: 1px solid var(--line);
+        border-left: 0;
+    }
+    .tray { display: grid; min-height: 0; grid-template-columns: 1fr auto; gap: 3px 10px; padding: 0 0 6px; }
+    .tray > .eyebrow,
+    .captured,
+    .moves { display: none; }
+    .opponent-name { font-size: 14px; }
+    .status { justify-self: end; font-size: 13px; }
+    .coach { padding-top: 0; }
+    .coach-toggle { min-height: 40px; flex-direction: row; align-items: center; justify-content: space-between; padding: 0; }
+    .coach-toggle > span:last-child { font-size: 16px; }
+    .coach-body { max-height: 126px; }
+    .coach-text { margin-bottom: 6px; font-size: 14px; line-height: 1.4; }
+    .coach-tip { margin-bottom: 6px; font-size: 12px; }
+    .lesson-list { display: none; }
+    .lesson-nav { margin-bottom: 0; }
+    .dock { grid-template-columns: repeat(5, minmax(0, 1fr)); gap: 4px; margin-top: 0; padding-top: 7px; }
+    .dock-btn { min-height: 44px; padding: 8px 2px; font-size: 12px; }
+    .camera-bar { right: 4px; bottom: 8px; left: 4px; }
+    .camera-bar button { min-width: 0; padding: 8px 10px; font-size: 12px; }
+    .camera-bar span,
+    .camera-help { display: none; }
+    .overlay { inset: 52px 0 0; padding: 16px; }
+    .overlay-card { max-height: min(92dvh, 620px); padding: 24px; }
+    #intro { inset: auto 0 0; width: 100%; height: 318px; padding: 18px max(18px, var(--safe-right)) max(18px, var(--safe-bottom)) max(18px, var(--safe-left)); border-top: 1px solid var(--line); border-left: 0; }
+    #intro h2,
+    #intro > .overlay-card > .eyebrow,
+    #intro .lede { display: none; }
+    #intro .settings-row { grid-template-columns: 1fr 1fr; gap: 9px; }
+    #intro .field { gap: 3px; font-size: 12px; }
+    #intro .field select { min-height: 44px; }
+    #intro .card-actions { gap: 5px; margin-top: 13px; }
+    #intro .primary-button { min-height: 46px; }
+    #intro .learn-button { min-height: 38px; }
+    body[data-state="intro"] .stage { bottom: 318px; }
+    body[data-mode="academy"][data-state="play"] .hud,
+    body[data-mode="puzzles"][data-state="play"] .hud { height: 302px; }
+    body[data-mode="academy"][data-state="play"] .stage,
+    body[data-mode="puzzles"][data-state="play"] .stage { bottom: 302px; }
+}
+
+@media (max-height: 520px) and (orientation: landscape) {
+    .game-shell > header { height: 44px; }
+    .stage { inset: 44px 286px 0 0; }
+    body[data-state="intro"] .stage,
+    body[data-mode="academy"][data-state="play"] .stage,
+    body[data-mode="puzzles"][data-state="play"] .stage { bottom: 0; }
+    .hud { top: 44px; right: 0; bottom: 0; left: auto; width: 286px; height: auto; padding: 11px 12px max(11px, var(--safe-bottom)); }
+    #intro { inset: 44px 0 0 auto; width: 286px; height: auto; padding: 16px 14px max(14px, var(--safe-bottom)); }
+    #intro .settings-row { grid-template-columns: 1fr 1fr; }
+    .dock { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+    .coach-body { max-height: 175px; }
+    .tray { display: block; }
+    .tray .status { justify-self: auto; margin-top: 4px; }
+    .camera-bar { bottom: 8px; }
+    .camera-bar button { padding: 8px; font-size: 12px; }
+    .camera-bar span,
+    .camera-help { display: none; }
+    .overlay { top: 44px; }
+    .overlay-card { max-height: calc(100dvh - 66px); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after { scroll-behavior: auto !important; transition: none !important; }
+}


### PR DESCRIPTION
## 🎯 Objetivo

Elevar o laboratório de xadrez 3D a uma experiência mais realista, confortável e otimizada para jogar em desktop e mobile.

## ✨ O que mudou

- Refinada a cena 3D com mesa, plinto, feltro, piso de mármore e iluminação mais controlada.
- Ajustados materiais PBR, roughness, reflexos e acabamento das peças Staunton.
- Mescladas as 64 casas em duas malhas estáticas para reduzir draw calls.
- Otimizado o render scale, sombras, câmera, zoom, picking e hover.
- Melhorada a hierarquia visual do HUD, seleção de peças e feedback de jogadas.
- Corrigidos os breakpoints mobile e landscape, incluindo a introdução e o rail lateral.

## 🧪 Como testar

1. Na raiz do repo: `python3 -m http.server 8000`
2. Abrir `http://localhost:8000/labs/xadrez/`.
3. Jogar contra a máquina, selecionar peças, arrastar ou tocar em uma casa legal e usar Dica/Desfazer.
4. Testar o modo Aprender e as vistas Jogar, Vista superior e Detalhe.
5. Validar em 375×667, 390×844 e 667×375 — sem overflow horizontal e com controles acessíveis.

## ✅ Checklist

- [x] Links conferidos: o slug não mudou, portanto catálogo, README e sitemap permanecem consistentes.
- [x] README atualizado — não aplicável: lab existente sem alteração de nome ou catálogo.
- [x] SEO consistente — não houve alteração de slug ou metadados.
- [x] Testado via HTTP na raiz, não via `file://`.
- [x] Responsivo: 375px / 390px / landscape — overflow, HUD, toque e safe-area.
- [x] Nada fora do escopo foi quebrado.
