### PR TITLE
🧪 refina Rastro Vermelho para uma jornada western

### DIFF
--- a/labs/rastro-vermelho/index.html
+++ b/labs/rastro-vermelho/index.html
@@ -6,9 +6,9 @@
     <meta name="viewport"
         content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover">
     <meta name="theme-color" content="#1a0e08">
-    <title>Rastro Vermelho — galope sem fim pelo faroeste | Diogo Paulino</title>
+    <title>Rastro Vermelho — uma jornada pela fronteira | Diogo Paulino</title>
     <meta name="description"
-        content="Mundo aberto 3D cinematográfico em Babylon.js: galope sem parar por serras, cânions e pradarias de um faroeste vivo.">
+        content="Cavalgue pelo faroeste de Diogo Paulino: seis destinos, entregas, emboscadas e acampamentos em uma jornada 3D pela fronteira.">
     <link rel="canonical" href="https://diogopaulino.com.br/labs/rastro-vermelho/">
     <meta name="author" content="Diogo Paulino">
     <meta name="robots" content="index, follow">
@@ -21,12 +21,12 @@
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="Diogo Paulino · Labs">
     <meta property="og:url" content="https://diogopaulino.com.br/labs/rastro-vermelho/">
-    <meta property="og:title" content="Rastro Vermelho — galope sem fim pelo faroeste | Diogo Paulino">
+    <meta property="og:title" content="Rastro Vermelho — uma jornada pela fronteira | Diogo Paulino">
     <meta property="og:description"
-        content="Mundo aberto 3D cinematográfico em Babylon.js: galope sem parar por serras, cânions e pradarias de um faroeste vivo.">
+        content="Cavalgue pelo faroeste de Diogo Paulino: seis destinos, entregas, emboscadas e acampamentos em uma jornada 3D pela fronteira.">
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Rastro Vermelho — galope sem fim pelo faroeste | Diogo Paulino">
-    <meta name="twitter:description" content="Mundo aberto 3D cinematográfico em Babylon.js: galope sem parar por serras, cânions e pradarias de um faroeste vivo.">
+    <meta name="twitter:title" content="Rastro Vermelho — uma jornada pela fronteira | Diogo Paulino">
+    <meta name="twitter:description" content="Cavalgue pelo faroeste de Diogo Paulino: seis destinos, entregas, emboscadas e acampamentos em uma jornada 3D pela fronteira.">
 
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -34,7 +34,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;600;700;800&family=Outfit:wght@300;400;500;600;700&display=swap"
         rel="stylesheet">
     <link rel="stylesheet" href="/labs/shared.css?v=13">
-    <link rel="stylesheet" href="style.css?v=1">
+    <link rel="stylesheet" href="style.css?v=3">
 
     <script type="application/ld+json">
     {
@@ -44,7 +44,7 @@
           "@type": "WebApplication",
           "name": "Rastro Vermelho",
           "url": "https://diogopaulino.com.br/labs/rastro-vermelho/",
-          "description": "Mundo aberto 3D cinematográfico em Babylon.js: galope sem parar por serras, cânions e pradarias de um faroeste vivo.",
+          "description": "Cavalgue pelo faroeste de Diogo Paulino: seis destinos, entregas, emboscadas e acampamentos em uma jornada 3D pela fronteira.",
           "applicationCategory": "GameApplication",
           "operatingSystem": "Any",
           "inLanguage": "pt-BR",
@@ -95,192 +95,96 @@
             </template>
         </header>
 
-        <canvas id="scene" aria-label="Faroeste 3D em mundo aberto, a cavalo pelas montanhas"></canvas>
-        <div id="vignette" class="vignette" aria-hidden="true"></div>
+        <canvas id="scene" tabindex="0" aria-label="Faroeste 3D. Use W A S D para cavalgar, E para interagir e P para pausar."></canvas>
+        <div class="vignette" aria-hidden="true"></div>
+        <div id="damageVeil" class="damage-veil" aria-hidden="true"></div>
+        <div id="focusVeil" class="focus-veil" aria-hidden="true" hidden></div>
 
         <div id="hud" class="hud" hidden>
-            <div class="hud-top">
-                <div class="panel compass-panel">
-                    <div class="compass" aria-label="Bússola">
-                        <div id="compassRose" class="compass-rose">
-                            <span class="n">N</span>
-                            <span class="e">L</span>
-                            <span class="s">S</span>
-                            <span class="w">O</span>
-                        </div>
-                        <i class="compass-needle" aria-hidden="true"></i>
-                    </div>
-                    <div class="region-block">
-                        <span class="hud-label">Território</span>
-                        <strong id="regionName">Pradaria Dourada</strong>
-                        <span id="biomeLabel" class="meta">pradaria</span>
-                    </div>
-                </div>
-                <div class="panel gait-panel">
-                    <span class="hud-label">Marcha</span>
-                    <div class="speed-row">
-                        <strong id="gaitValue">galope</strong>
-                        <span class="mono"><b id="speedValue">40</b> km/h</span>
-                    </div>
-                    <span id="cruiseHint" class="meta">galope livre</span>
-                </div>
-                <div class="panel trail-panel">
-                    <span class="hud-label">Rastro</span>
-                    <div class="speed-row">
-                        <strong id="distanceValue" class="mono">0 m</strong>
-                        <span id="hourLabel">manhã</span>
-                    </div>
-                    <span id="clockValue" class="mono meta">4:00</span>
-                    · <span id="markCount" class="mono meta">0/6</span>
-                    <div id="markPips" class="mark-pips" aria-label="Marcos encontrados"></div>
-                </div>
-            </div>
-
-            <p id="message" class="message" role="status" aria-live="polite" data-show="false"></p>
-            <p id="prompt" class="prompt">W/↑ galope · A D/← → curva · Espaço espora · G livre</p>
-
+            <div class="location"><span class="eyebrow">TERRITÓRIO LIVRE</span><strong id="regionName">Pradaria Dourada</strong><span id="clockValue">16:00</span></div>
             <div class="hud-actions">
-                <button id="soundButton" class="icon-button" type="button" aria-pressed="true"
-                    title="Som (M)" aria-label="Alternar som">♪</button>
-                <button id="pauseButton" class="icon-button" type="button" title="Pausar (P)"
-                    aria-label="Pausar">II</button>
-                <span id="fpsCounter" class="fps mono">—</span>
+                <button id="soundButton" class="icon-button" type="button" aria-pressed="true" title="Som (M)" aria-label="Alternar som">♪</button>
+                <button id="pauseButton" class="icon-button" type="button" title="Pausar (P)" aria-label="Pausar">Ⅱ</button>
             </div>
-
-            <div id="touchControls" class="touch-controls" hidden>
-                <div id="moveStick" class="stick" aria-label="Galopar">
-                    <i id="moveKnob"></i>
-                    <span>rédea</span>
+            <div class="mission"><span id="chapterLabel" class="eyebrow">CAPÍTULO I · A CARTA</span><strong id="objectiveTitle">Acampamento Aurora</strong><span id="objectiveText">Aproxime-se da fogueira para aceitar a entrega.</span><div id="markPips" class="mark-pips" aria-label="Destinos concluídos"></div></div>
+            <div id="waypoint" class="waypoint" aria-hidden="true"><i>◇</i><span id="waypointDistance"></span></div>
+            <div id="reticle" class="reticle" aria-hidden="true"><i></i><b></b></div>
+            <div id="hitMarker" class="hit-marker" aria-hidden="true">×</div>
+            <div class="rider-hud">
+                <canvas id="minimap" width="240" height="240" role="img" aria-label="Mapa: trilha, destinos, inimigos e sua posição"></canvas>
+                <div class="vitals">
+                    <div class="vital"><span>Vigor</span><meter id="healthMeter" min="0" max="100" value="100" aria-label="Vigor do cavaleiro">100</meter></div>
+                    <div class="vital"><span>Cavalo</span><meter id="staminaMeter" min="0" max="100" value="100" aria-label="Resistência do cavalo">100</meter></div>
+                    <div class="vital"><span>Foco</span><meter id="focusMeter" min="0" max="100" value="100" aria-label="Concentração">100</meter></div>
+                    <span class="ride-info"><b id="speedValue">0</b> km/h <span id="gaitValue">parado</span></span>
                 </div>
-                <div id="lookZone" class="look-zone" aria-label="Olhar"></div>
+            </div>
+            <div class="weapon-hud"><span class="eyebrow">REVÓLVER · .45</span><div><strong id="ammoValue">6</strong><span> / 6</span><b id="moneyValue">$ 0</b></div><span id="weaponHint">R · recarregar</span></div>
+            <p id="message" class="message" role="status" aria-live="polite" data-show="false"></p>
+            <button id="interactButton" class="interaction" type="button" hidden><kbd>E</kbd><span id="interactionText">Aceitar a entrega</span></button>
+            <p id="prompt" class="prompt">WASD cavalgar · Shift disparada · E interagir · arraste para olhar · F atirar · Q foco</p>
+            <div id="touchControls" class="touch-controls" hidden>
+                <div id="moveStick" class="stick" role="group" aria-label="Rédeas: arraste para frente para cavalgar, para trás para frear e para os lados para virar"><i id="moveKnob"></i><span>rédeas</span></div>
+                <div id="lookZone" class="look-zone" aria-label="Arraste para olhar"></div>
                 <div class="touch-buttons">
-                    <button type="button" id="btnSpur" class="pad pad-spur">espora</button>
+                    <button type="button" id="btnFocus" class="pad" aria-pressed="false">Foco</button>
+                    <button type="button" id="btnReload" class="pad">Recarregar</button>
+                    <button type="button" id="btnSpur" class="pad">Galope</button>
+                    <button type="button" id="btnShoot" class="pad pad-fire">Atirar</button>
                 </div>
             </div>
         </div>
 
         <div id="loadingOverlay" class="overlay loading-overlay">
-            <div class="loading-card">
-                <span class="sun-loader" aria-hidden="true"></span>
-                <h1>Rastro Vermelho</h1>
-                <p id="loadingText">O oeste acorda…</p>
-                <div class="loading-bar"><i id="loadingFill"></i></div>
-            </div>
+            <div class="loading-card"><span class="sun-loader" aria-hidden="true"></span><p class="eyebrow">UM WESTERN INTERATIVO</p><h1>Rastro Vermelho</h1><p id="loadingText" role="status">Preparando a fronteira…</p><div class="loading-bar" role="progressbar" aria-label="Carregamento" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0"><i id="loadingFill"></i></div></div>
         </div>
 
         <div id="menuOverlay" class="overlay menu-overlay" hidden>
-            <div class="overlay-card menu-card">
-                <header class="menu-head">
-                    <p class="eyebrow"><i></i> babylon.js · mundo aberto · faroeste</p>
-                    <h1>Rastro <span>Vermelho</span></h1>
-                    <p class="lede">O cavalo já está em galope e não para. Serras, cânions, rios e povoados
-                        nascem na frente — um oeste procedural que não acaba. Espore, cruze a pradaria,
-                        ache a fogueira. O sol faz o dia inteiro.</p>
-                </header>
-
-                <div class="menu-grid">
-                    <section class="menu-section">
-                        <h2>O oeste</h2>
-                        <ul class="species-preview">
-                            <li>Pradaria dourada</li>
-                            <li>Serras e pinheiros</li>
-                            <li>Cânions de pedra</li>
-                            <li>Mesas e cactos</li>
-                            <li>Rios e cachoeiras</li>
-                            <li>Povoados de madeira</li>
-                        </ul>
-                    </section>
-
-                    <section class="menu-section">
-                        <h2>Comandos</h2>
-                        <div class="keys">
-                            <span><kbd>W</kbd><kbd>A</kbd><kbd>S</kbd><kbd>D</kbd> / Setas rédea e curva</span>
-                            <span><kbd>Espaço</kbd> espora · <kbd>Shift</kbd> disparada</span>
-                            <span><kbd>G</kbd> galope livre (não para)</span>
-                            <span><kbd>C</kbd> câmera · <kbd>P</kbd> pausa · <kbd>M</kbd> som</span>
-                            <span>mouse olha · roda aproxima</span>
-                        </div>
-                    </section>
-
-                    <section class="menu-section">
-                        <h2>Ajustes</h2>
+            <div class="menu-card">
+                <header class="menu-head"><p class="eyebrow"><i></i> FRONTEIRA DO NORTE · 1899</p><h1>Rastro<br><span>Vermelho</span></h1><p class="menu-tagline">Toda estrada deixa uma história.</p><p class="lede">Uma carta atravessa a fronteira. Nas suas mãos, a promessa de entregá-la. Sele o cavalo, escolha seu ritmo e descubra o que o oeste guarda.</p></header>
+                <div class="journey-preview"><span><b>06</b> destinos</span><span><b>01</b> promessa</span><span>Um oeste para explorar</span></div>
+                <div class="menu-actions"><button id="startButton" class="primary-button" type="button"><span id="startLabel">Iniciar jornada</span><i aria-hidden="true">→</i></button><button id="newButton" class="ghost-button" type="button" hidden>Nova jornada</button></div>
+                <p id="saveNote" class="section-note">O progresso é salvo em cada destino.</p>
+                <details class="settings"><summary>Controles e preferências <span>+</span></summary>
+                    <div class="settings-content">
+                        <div class="keys"><span><kbd>WASD</kbd> / setas · cavalgar e frear</span><span><kbd>Shift</kbd> disparada · <kbd>G</kbd> marcha automática</span><span><kbd>E</kbd> interagir · <kbd>F</kbd> / clique · atirar</span><span><kbd>Q</kbd> concentração · <kbd>R</kbd> recarregar</span><span><kbd>C</kbd> câmera · <kbd>P</kbd> pausa · <kbd>M</kbd> som</span><span>Arraste para olhar · roda para aproximar</span><span>Controle: analógicos · RT tiro · A galope · X recarga · Y interação · LB foco · Start pausa</span></div>
                         <div class="settings-grid">
-                            <label class="field">
-                                <span>Qualidade</span>
-                                <select id="qualitySelect">
-                                    <option value="auto">Automática</option>
-                                    <option value="low">Performance</option>
-                                    <option value="medium">Equilibrada</option>
-                                    <option value="high">Cinemática</option>
-                                </select>
-                            </label>
-                            <label class="field">
-                                <span>Volume <b id="volumeValue">70</b></span>
-                                <input id="volumeSlider" type="range" min="0" max="100" step="1" value="70">
-                            </label>
+                            <label class="field"><span>Qualidade</span><select id="qualitySelect"><option value="auto">Automática</option><option value="low">Desempenho</option><option value="medium">Equilibrada</option><option value="high">Cinemática</option></select></label>
+                            <label class="field"><span>Volume <b id="volumeValue">70%</b></span><input id="volumeSlider" type="range" min="0" max="100" value="70"></label>
+                            <label class="field"><span>Sensibilidade da câmera</span><input id="sensitivitySlider" type="range" min="0.4" max="2" step="0.1" value="1"></label>
+                            <label class="check-field"><input id="motionToggle" type="checkbox"> Câmera estável e menos efeitos</label>
                         </div>
-                        <p class="section-note">Maior rastro: <b id="bestScore" class="mono">—</b></p>
-                    </section>
-                </div>
-
-                <footer class="menu-foot">
-                    <button id="startButton" class="primary-button" type="button">
-                        <span>Montar e galopar</span>
-                        <i aria-hidden="true">→</i>
-                    </button>
-                </footer>
+                    </div>
+                </details>
+                <footer class="menu-foot"><span>Diogo Paulino · Labs</span><span>Maior rastro <b id="bestScore">0 m</b></span></footer>
             </div>
+            <p class="scene-caption" aria-hidden="true">PRADARIA DOURADA<span>O último sol antes da partida.</span></p>
         </div>
 
-        <div id="pauseOverlay" class="overlay" hidden>
-            <div class="overlay-card compact-card">
-                <p class="eyebrow"><i></i> O cavalo espera</p>
-                <h2>A trilha<br>está pausada.</h2>
-                <div class="card-actions">
-                    <button id="resumeButton" class="primary-button" type="button">
-                        <span>Continuar</span><i aria-hidden="true">→</i>
-                    </button>
-                    <button id="pauseMenuButton" class="ghost-button" type="button">Voltar ao acampamento</button>
-                </div>
-            </div>
+        <div id="pauseOverlay" class="overlay" role="dialog" aria-modal="true" aria-labelledby="pauseTitle" hidden>
+            <div class="overlay-card compact-card"><p class="eyebrow">O CAVALO ESPERA</p><h2 id="pauseTitle">Um respiro<br>na estrada.</h2><p class="lede">Sua jornada está pausada.</p><div class="card-actions"><button id="resumeButton" class="primary-button" type="button">Continuar →</button><button id="pauseMenuButton" class="ghost-button" type="button">Controles e preferências</button></div></div>
         </div>
-
-        <div id="errorOverlay" class="overlay" hidden>
-            <div class="overlay-card compact-card">
-                <p class="eyebrow eyebrow--danger"><i></i> WebGL indisponível</p>
-                <h2>O oeste não<br>pôde abrir.</h2>
-                <p class="lede" id="errorText">Este laboratório precisa de WebGL. Tente um navegador
-                    atualizado ou reative a aceleração de hardware.</p>
-            </div>
+        <div id="endOverlay" class="overlay" role="dialog" aria-modal="true" aria-labelledby="endTitle" hidden>
+            <div class="overlay-card compact-card"><p id="endEyebrow" class="eyebrow">A FRONTEIRA SE LEMBRA</p><h2 id="endTitle">Promessa<br>cumprida.</h2><p id="endText" class="lede"></p><div class="card-actions"><button id="retryButton" class="primary-button" type="button">Continuar explorando →</button><button id="endMenuButton" class="ghost-button" type="button">Voltar ao menu</button></div></div>
         </div>
+        <div id="errorOverlay" class="overlay" role="alert" hidden>
+            <div class="overlay-card compact-card"><p class="eyebrow">A TRILHA NÃO CARREGOU</p><h2>O oeste não<br>pôde abrir.</h2><p class="lede" id="errorText">Este laboratório precisa de WebGL e de acesso aos recursos 3D. Tente novamente ou reative a aceleração de hardware do navegador.</p><button class="primary-button" type="button" onclick="location.reload()">Tentar novamente</button><a class="ghost-button" href="/labs/">Voltar aos labs</a></div>
+        </div>
+        <noscript><div class="overlay"><p>Ative o JavaScript para iniciar a jornada. <a href="/labs/">Voltar aos labs</a></p></div></noscript>
 
         <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
     </main>
 
     <script src="/labs/shared.js?v=13" defer></script>
     <script>
-        (function () {
-            function hasGpu() {
-                try {
-                    var c = document.createElement('canvas');
-                    return !!(c.getContext('webgl2') || c.getContext('webgl'));
-                } catch (e) { return false; }
-            }
-            if (!hasGpu()) {
-                document.addEventListener('DOMContentLoaded', function () {
-                    var err = document.getElementById('errorOverlay');
-                    var load = document.getElementById('loadingOverlay');
-                    if (load) load.hidden = true;
-                    if (err) err.hidden = false;
-                });
-            }
-        })();
+        window.rastroLoadError = function () {
+            document.getElementById('loadingOverlay').hidden = true;
+            document.getElementById('errorOverlay').hidden = false;
+        };
     </script>
-    <script src="https://cdn.babylonjs.com/v9.25.0/babylon.js"></script>
-    <script src="https://cdn.babylonjs.com/v9.25.0/loaders/babylonjs.loaders.min.js"></script>
-    <script src="https://cdn.babylonjs.com/v9.25.0/materialsLibrary/babylonjs.materials.min.js"></script>
-    <script src="https://cdn.babylonjs.com/v9.25.0/proceduralTexturesLibrary/babylonjs.proceduralTextures.min.js"></script>
-    <script type="module" src="src/main.js?v=2"></script>
+    <script src="https://cdn.babylonjs.com/v9.25.0/babylon.js" onerror="rastroLoadError()"></script>
+    <script src="https://cdn.babylonjs.com/v9.25.0/loaders/babylonjs.loaders.min.js" onerror="rastroLoadError()"></script>
+    <script src="https://cdn.babylonjs.com/v9.25.0/materialsLibrary/babylonjs.materials.min.js" onerror="rastroLoadError()"></script>
+    <script type="module" src="src/main.js?v=3" onerror="rastroLoadError()"></script>
 </body>
-
 </html>

--- a/labs/rastro-vermelho/src/audio.js
+++ b/labs/rastro-vermelho/src/audio.js
@@ -1,0 +1,57 @@
+/** Small procedural soundscape: no network audio, one shared noise buffer.
+ * Audio starts only after a gesture and is suspended with the game. */
+export class Soundscape {
+    constructor() { this.context = null; this.hoof = 0; this.bird = 4; }
+    async start(settings) {
+        try {
+            if (!this.context) {
+                const Audio = window.AudioContext || window.webkitAudioContext;
+                if (!Audio) return;
+                const c = this.context = new Audio();
+                this.master = c.createGain(); this.master.connect(c.destination);
+                this.noise = c.createBuffer(1, c.sampleRate * 2, c.sampleRate);
+                const samples = this.noise.getChannelData(0);
+                for (let i = 0; i < samples.length; i++) samples[i] = Math.random() * 2 - 1;
+                const wind = c.createBufferSource(), filter = c.createBiquadFilter();
+                wind.buffer = this.noise; wind.loop = true; filter.type = 'lowpass'; filter.frequency.value = 320;
+                this.wind = c.createGain(); this.wind.gain.value = .025;
+                wind.connect(filter).connect(this.wind).connect(this.master); wind.start();
+            }
+            this.configure(settings); await this.context.resume();
+        } catch { /* Audio is optional when the browser blocks or lacks Web Audio. */ }
+    }
+    configure(settings) { if (this.master) this.master.gain.setTargetAtTime(settings.muted ? 0 : settings.volume / 100 * .45, this.context.currentTime, .05); }
+    pause() { this.context?.suspend().catch(() => {}); }
+    tone(frequency, duration, volume = .2, type = 'sine', end = frequency / 2) {
+        const c = this.context; if (!c || c.state !== 'running') return;
+        const o = c.createOscillator(), gain = c.createGain(), t = c.currentTime;
+        o.type = type; o.frequency.setValueAtTime(frequency, t); o.frequency.exponentialRampToValueAtTime(Math.max(20, end), t + duration);
+        gain.gain.setValueAtTime(volume, t); gain.gain.exponentialRampToValueAtTime(.001, t + duration);
+        o.connect(gain).connect(this.master); o.start(); o.stop(t + duration + .02);
+        o.onended = () => { o.disconnect(); gain.disconnect(); };
+    }
+    burst(duration, volume, frequency) {
+        const c = this.context; if (!c || c.state !== 'running') return;
+        const source = c.createBufferSource(), filter = c.createBiquadFilter(), gain = c.createGain(), t = c.currentTime;
+        source.buffer = this.noise; filter.type = 'lowpass'; filter.frequency.value = frequency;
+        gain.gain.setValueAtTime(volume, t); gain.gain.exponentialRampToValueAtTime(.001, t + duration);
+        source.connect(filter).connect(gain).connect(this.master); source.start(t, Math.random()); source.stop(t + duration);
+        source.onended = () => { source.disconnect(); filter.disconnect(); gain.disconnect(); };
+    }
+    shot() { this.burst(.24, .55, 4000); this.tone(125, .23, .5, 'triangle', 35); }
+    reload() { this.tone(1200, .045, .07, 'triangle', 450); }
+    reward() { this.tone(440, .32, .12, 'sine', 660); }
+    update(dt, speed, hour) {
+        if (!this.context || this.context.state !== 'running') return;
+        this.wind.gain.setTargetAtTime(.025 + speed * .002, this.context.currentTime, .2);
+        this.hoof -= dt; this.bird -= dt;
+        if (speed > .7 && this.hoof <= 0) {
+            this.hoof = Math.max(.12, .7 / Math.sqrt(speed));
+            this.tone(160 + Math.random() * 60, .075, .2, 'triangle', 65); this.burst(.055, .07, 1100);
+        }
+        if (this.bird <= 0) {
+            this.bird = 7 + Math.random() * 12;
+            if (hour > 5 && hour < 20) this.tone(1800, .22, .025, 'sine', 2900);
+        }
+    }
+}

--- a/labs/rastro-vermelho/src/main.js
+++ b/labs/rastro-vermelho/src/main.js
@@ -3,440 +3,472 @@
  * The terrain uses layered value noise; its height is sampled by the rider,
  * the terrain mesh, and the streamed scenery so the world remains continuous.
  */
-
-const B = window.BABYLON;
-const canvas = document.querySelector('#scene');
-const $ = (selector) => document.querySelector(selector);
-const clamp = (value, min, max) => Math.min(max, Math.max(min, value));
-const lerp = (a, b, amount) => a + (b - a) * amount;
-const ASSETS = {
-    horse: 'assets/horse.gltf',
-    ground: 'assets/ground-albedo.webp',
-    groundNormal: 'assets/ground-normal.webp',
-    groundRoughness: 'assets/ground-roughness.webp',
-    rock: 'assets/rock-albedo.webp',
-    rockNormal: 'assets/rock-normal.webp'
-};
-
-if (!B) throw new Error('Babylon.js não foi carregado.');
-
-const qualityProfiles = {
-    low: { id: 'low', scale: 1, radius: 1, segments: 32, shadows: false, grass: 240 },
-    medium: { id: 'medium', scale: 1.25, radius: 2, segments: 42, shadows: true, grass: 620 },
-    high: { id: 'high', scale: 1.5, radius: 2, segments: 58, shadows: true, grass: 1100 }
-};
-
-function hash(x, z) {
-    return (Math.sin(x * 127.1 + z * 311.7) * 43758.5453123) % 1;
-}
-
-function noise(x, z) {
-    const ix = Math.floor(x);
-    const iz = Math.floor(z);
-    const fx = x - ix;
-    const fz = z - iz;
-    const sx = fx * fx * (3 - 2 * fx);
-    const sz = fz * fz * (3 - 2 * fz);
-    const n00 = hash(ix, iz);
-    const n10 = hash(ix + 1, iz);
-    const n01 = hash(ix, iz + 1);
-    const n11 = hash(ix + 1, iz + 1);
-    return lerp(lerp(n00, n10, sx), lerp(n01, n11, sx), sz) * 2 - 1;
-}
-
-function fbm(x, z) {
-    let sum = 0;
-    let amp = 0.5;
-    for (let octave = 0; octave < 5; octave += 1) {
-        sum += noise(x, z) * amp;
-        x *= 2.03;
-        z *= 2.03;
-        amp *= 0.5;
-    }
-    return sum;
-}
-
-function terrainHeight(x, z) {
-    const continent = fbm(x * 0.0032, z * 0.0032) * 17;
-    const ridges = Math.pow(Math.abs(fbm(x * 0.009, z * 0.009)), 2.3) * 25;
-    const rolling = fbm(x * 0.031, z * 0.031) * 5;
-    const river = Math.abs(Math.sin((x + fbm(x * 0.012, z * 0.012) * 38) * 0.021));
-    const valley = Math.pow(1 - clamp(river * 3.8, 0, 1), 3) * 10;
-    return continent + ridges + rolling - valley;
-}
-
-function biomeAt(x, z, height = terrainHeight(x, z)) {
-    const dryness = fbm(x * 0.004, z * 0.004);
-    if (height > 28) return 'serra';
-    if (height < -3) return 'rio';
-    if (dryness > 0.32) return 'cânion';
-    if (dryness < -0.2) return 'pradaria';
-    return 'vale';
-}
-
-function makeTerrainMaterial(scene) {
-    const material = new B.PBRMaterial('terra-pbr', scene);
-    material.albedoColor = B.Color3.FromHexString('#d7a26c');
-    material.albedoTexture = new B.Texture(ASSETS.ground, scene, true, false);
-    material.albedoTexture.uScale = 16;
-    material.albedoTexture.vScale = 16;
-    material.bumpTexture = new B.Texture(ASSETS.groundNormal, scene, true, false);
-    material.bumpTexture.uScale = 16;
-    material.bumpTexture.vScale = 16;
-    material.metallicTexture = new B.Texture(ASSETS.groundRoughness, scene, true, false);
-    material.metallicTexture.uScale = 16;
-    material.metallicTexture.vScale = 16;
-    material.metallicTexture.useRoughnessFromMetallicTextureGreen = true;
-    material.roughness = 0.78;
-    material.metallic = 0;
-    material.useVertexColors = false;
-    material.environmentIntensity = 0.5;
-    return material;
-}
-
-function createTerrain(scene, cx, cz, profile, material) {
-    const size = 82;
-    const subdivisions = profile.segments;
-    const ground = B.MeshBuilder.CreateGround(`chunk-${cx}-${cz}`, { width: size, height: size, subdivisions, updatable: true }, scene);
-    ground.position.set(cx * size, 0, cz * size);
-    const positions = ground.getVerticesData(B.VertexBuffer.PositionKind);
-    for (let i = 0; i < positions.length; i += 3) {
-        const x = positions[i] + ground.position.x;
-        const z = positions[i + 2] + ground.position.z;
-        const y = terrainHeight(x, z);
-        positions[i + 1] = y;
-    }
-    ground.updateVerticesData(B.VertexBuffer.PositionKind, positions);
-    ground.createNormals(true);
-    ground.material = material;
-    ground.receiveShadows = true;
-    ground.freezeWorldMatrix();
-    return ground;
-}
-
-function createRock(scene, position, scale, material) {
-    const rock = B.MeshBuilder.CreateIcoSphere('arenito', { radius: 1, subdivisions: 2 }, scene);
-    rock.position.copyFrom(position);
-    rock.scaling.set(scale * 1.25, scale * (1.5 + Math.random()), scale);
-    rock.rotation.set(Math.random(), Math.random(), Math.random());
-    rock.material = material;
-    return rock;
-}
-
-function createTree(scene, x, z, height) {
-    const tree = new B.TransformNode('pinheiro', scene);
-    const trunk = B.MeshBuilder.CreateCylinder('tronco', { height, diameterTop: 0.22, diameterBottom: 0.5, tessellation: 8 }, scene);
-    trunk.parent = tree;
-    trunk.position.y = height / 2;
-    const bark = new B.PBRMaterial('casca', scene);
-    bark.albedoColor = B.Color3.FromHexString('#24150d');
-    bark.roughness = 1;
-    trunk.material = bark;
-    const needles = new B.PBRMaterial('folhagem', scene);
-    needles.albedoColor = B.Color3.FromHexString('#1b3019');
-    needles.roughness = 0.9;
-    for (let level = 0; level < 3; level += 1) {
-        const crown = B.MeshBuilder.CreateCylinder('copa', {
-            height: height * 0.72,
-            diameterTop: 0,
-            diameterBottom: height * (0.75 - level * 0.13),
-            tessellation: 10
-        }, scene);
-        crown.parent = tree;
-        crown.position.y = height * (0.62 + level * 0.19);
-        crown.material = needles;
-    }
-    tree.position.set(x, terrainHeight(x, z), z);
-    return tree;
-}
-
-async function loadHorse(scene, shadow) {
-    const result = await B.SceneLoader.ImportMeshAsync('', '', ASSETS.horse, scene, undefined, '.gltf');
-    const root = result.meshes[0];
-    root.name = 'cavalo-realista';
-    root.scaling.setAll(0.85);
-    root.rotationQuaternion = null;
-    root.rotation.y = Math.PI;
-    result.meshes.forEach((mesh) => {
-        mesh.receiveShadows = true;
-        shadow?.addShadowCaster(mesh);
-    });
-    result.animationGroups.forEach((group) => group.start(true, 1, group.from, group.to, false));
-    return { root, animations: result.animationGroups };
-}
-
-const SETTINGS_KEY = 'rastro-vermelho:babylon';
-const SETTINGS_DEFAULT = { quality: 'auto', volume: 70, muted: false, best: 0 };
-
-/* Duas falhas reais aqui: o modo privado do Safari estoura na gravação, e um
-   valor corrompido derrubava o lab já no construtor, antes de qualquer tela. */
-function loadSettings() {
-    try {
-        return Object.assign({}, SETTINGS_DEFAULT, JSON.parse(localStorage.getItem(SETTINGS_KEY) || '{}'));
-    } catch (err) {
-        return Object.assign({}, SETTINGS_DEFAULT);
-    }
-}
-
+import { clamp, damp, lerp, angleDelta, terrainHeight, roadX, biomeAt, LANDMARKS, freshPlayer, stepRiding, worldClock, loadSettings, saveSettings, loadJourney, saveJourney } from './simulation.js';
+import { World, PROFILES, loadHorse, createPerson, material } from './world.js';
+import { Soundscape } from './audio.js';
+const B = window.BABYLON, $ = s => document.querySelector(s), canvas = $('#scene');
+const CHAPTERS = ['I · A carta', 'II · Santa Luz', 'III · A passagem', 'IV · Provisões', 'V · Sol poente', 'VI · A promessa'];
+const DEAD_ZONE = .17;
+const axis = value => Math.abs(value || 0) < DEAD_ZONE ? 0 : Math.sign(value) * (Math.abs(value) - DEAD_ZONE) / (1 - DEAD_ZONE);
+const editable = el => el?.matches('input, select, textarea, button, summary, a');
+function storage() { try { return window.localStorage; } catch { return { getItem: () => null, setItem: () => {} }; } }
+function showError(error) { console.error(error); window.rastroLoadError(); }
 class RastroVermelho {
     constructor() {
-        this.canvas = canvas;
-        this.settings = loadSettings();
-        this.profile = this.pickQuality();
-        this.engine = new B.Engine(canvas, true, { preserveDrawingBuffer: false, stencil: true, adaptToDeviceRatio: false });
-        this.engine.setHardwareScalingLevel(1 / this.profile.scale);
-        this.scene = new B.Scene(this.engine);
-        this.scene.clearColor = new B.Color4(0.18, 0.07, 0.025, 1);
-        this.scene.fogMode = B.Scene.FOGMODE_EXP2;
-        this.scene.fogDensity = 0.0017;
-        this.scene.fogColor = B.Color3.FromHexString('#b25b2b');
-        this.chunks = new Map();
-        this.keys = {};
-        this.look = { yaw: 0, pitch: 0.13 };
-        this.player = { x: 12, z: 18, yaw: -0.5, speed: 12, distance: 0, spur: 0, phase: 0, cruise: true };
-        this.state = 'loading';
-        this.elapsed = 0;
-        this.lastHud = 0;
-        this.lastRegion = '';
-        this.marks = new Set();
-        this.init().catch((error) => {
-            console.error(error);
-            $('#errorText').textContent = 'Os assets realistas não puderam ser carregados. Verifique sua conexão e tente novamente.';
-            $('#loadingOverlay').hidden = true;
-            $('#errorOverlay').hidden = false;
-        });
+        this.storage = storage(); this.settings = loadSettings(this.storage); this.checkpoint = loadJourney(this.storage);
+        this.profile = this.pickQuality(); this.state = 'loading'; this.elapsed = 0; this.stage = 0;
+        this.player = freshPlayer(); this.keys = {}; this.touch = { x: 0, z: 0, sprint: false }; this.pad = { steer: 0, throttle: 0, sprint: false, previous: [] };
+        this.look = { yaw: 0, pitch: .2, distance: 8 }; this.enemies = []; this.encounterStage = -1; this.effects = [];
+        this.lastHud = 0; this.lastSave = 0; this.badFrames = 0; this.frameAverage = 16.7; this.timeScale = 1; this.focusActive = false; this.audio = new Soundscape();
+        this.reducedMotion = matchMedia('(prefers-reduced-motion: reduce)').matches;
+        this.coarse = matchMedia('(pointer: coarse)').matches;
+        this.ui = Object.fromEntries([...document.querySelectorAll('[id]')].map(el => [el.id, el]));
+        this.engine = new B.Engine(canvas, true, { preserveDrawingBuffer: false, stencil: false, powerPreference: 'high-performance', adaptToDeviceRatio: false });
+        this.engine.setHardwareScalingLevel(1 / Math.min(devicePixelRatio || 1, this.profile.scale));
+        this.scene = new B.Scene(this.engine); this.scene.skipPointerMovePicking = true; this.scene.autoClear = true;
+        this.scene.fogMode = B.Scene.FOGMODE_EXP2; this.scene.fogDensity = this.profile.id === 'high' ? .005 : .007;
+        this.scene.fogColor = B.Color3.FromHexString('#b0b3a2'); this.scene.clearColor = new B.Color4(.57, .66, .71, 1);
+        this.cameraPosition = new B.Vector3(); this.cameraTarget = new B.Vector3(); this.sunsetFog = B.Color3.FromHexString('#a68a75'); this.dayFog = B.Color3.FromHexString('#a4b6ba'); this.nightFog = B.Color3.FromHexString('#26313e');
+        this.init().catch(error => { this.state = 'error'; this.audio.pause(); this.engine.stopRenderLoop(); showError(error); });
     }
-
-    pickQuality() {
-        const desired = this.settings.quality;
-        if (desired !== 'auto') return qualityProfiles[desired];
-        return matchMedia('(pointer: coarse)').matches ? qualityProfiles.low : qualityProfiles.high;
-    }
-
+    pickQuality() { return PROFILES[this.settings.quality] || (matchMedia('(pointer: coarse)').matches ? PROFILES.low : PROFILES.medium); }
     async init() {
         const scene = this.scene;
-        this.camera = new B.UniversalCamera('câmera', new B.Vector3(0, 4, -8), scene);
-        this.camera.minZ = 0.1; this.camera.maxZ = 800; this.camera.fov = 0.92;
-        this.camera.inputs.clear();
-        this.sky = B.MeshBuilder.CreateSphere('céu', { diameter: 1400, sideOrientation: B.Mesh.BACKSIDE, segments: 24 }, scene);
-        this.skyMaterial = new B.SkyMaterial('atmosfera', scene);
-        this.skyMaterial.backFaceCulling = false;
-        this.skyMaterial.luminance = 1.0;
-        this.skyMaterial.turbidity = 4;
-        this.skyMaterial.rayleigh = 1.2;
-        this.skyMaterial.mieCoefficient = 0.005;
-        this.skyMaterial.mieDirectionalG = 0.8;
-        this.sky.material = this.skyMaterial;
-
-        this.clouds = B.MeshBuilder.CreateSphere('nuvens', { diameter: 1350, sideOrientation: B.Mesh.BACKSIDE, segments: 32 }, scene);
-        const cloudMat = new B.StandardMaterial('nuvensMat', scene);
-        const noiseTex = new B.NoiseProceduralTexture("perlin", 512, scene);
-        noiseTex.octaves = 6;
-        noiseTex.persistence = 1.2;
-        noiseTex.animationSpeedFactor = 1.5;
-        cloudMat.emissiveTexture = noiseTex;
-        cloudMat.opacityTexture = noiseTex;
-        cloudMat.disableLighting = true;
-        cloudMat.alpha = 0.45;
-        this.clouds.material = cloudMat;
-
-        this.sun = new B.DirectionalLight('sol', new B.Vector3(-0.45, -0.7, 0.35), scene);
-        this.sun.position.set(90, 130, -90); this.sun.intensity = 4.1;
-        const hemi = new B.HemisphericLight('céu-ambiente', new B.Vector3(0, 1, 0), scene);
-        hemi.intensity = 1.05; hemi.groundColor = B.Color3.FromHexString('#2b120a');
-        this.shadow = this.profile.shadows ? new B.ShadowGenerator(2048, this.sun) : null;
-        if (this.shadow) { this.shadow.usePercentageCloserFiltering = true; this.shadow.bias = 0.0008; }
-        scene.environmentTexture = B.CubeTexture.CreateFromPrefilteredData('https://assets.babylonjs.com/environments/environmentSpecular.env', scene);
-        scene.environmentIntensity = 0.55;
-        const pipeline = new B.DefaultRenderingPipeline('cinema', true, scene, [this.camera]);
-        pipeline.samples = this.profile.shadows ? 4 : 1;
-        pipeline.bloomEnabled = this.profile.id !== 'low';
-        pipeline.bloomThreshold = 0.78;
-        pipeline.bloomWeight = 0.24;
-        pipeline.imageProcessingEnabled = true;
-        pipeline.imageProcessing.contrast = 1.2;
-        pipeline.imageProcessing.exposure = 1.08;
-        this.terrainMaterial = makeTerrainMaterial(scene);
-        this.rockMaterial = new B.PBRMaterial('arenito-pbr', scene);
-        this.rockMaterial.albedoTexture = new B.Texture(ASSETS.rock, scene, true, false);
-        this.rockMaterial.bumpTexture = new B.Texture(ASSETS.rockNormal, scene, true, false);
-        this.rockMaterial.albedoTexture.uScale = this.rockMaterial.albedoTexture.vScale = 2.5;
-        this.rockMaterial.bumpTexture.uScale = this.rockMaterial.bumpTexture.vScale = 2.5;
-        this.rockMaterial.roughness = 0.72;
-        this.water = B.MeshBuilder.CreateGround('rio-reflexivo', { width: 520, height: 520 }, scene);
-        this.water.position.y = -3.4;
-        const waterMaterial = new B.PBRMaterial('água', scene);
-        waterMaterial.albedoColor = B.Color3.FromHexString('#173c42'); waterMaterial.metallic = 0.46; waterMaterial.roughness = 0.12; waterMaterial.alpha = 0.76;
-        this.water.material = waterMaterial;
-        this.setLoading(0.45, 'Selando um cavalo de verdade…');
-        this.horse = await loadHorse(scene, this.shadow);
-        this.setLoading(0.78, 'Texturizando o território…');
-        this.bindInput();
-        this.bindUi();
-        this.updateChunks();
-        this.setLoading(1, 'O oeste está pronto.');
-        setTimeout(() => { $('#loadingOverlay').hidden = true; $('#menuOverlay').hidden = false; this.state = 'menu'; document.body.dataset.state = 'menu'; }, 450);
+        this.camera = new B.UniversalCamera('câmera', new B.Vector3(0, 14, -12), scene);
+        this.camera.minZ = .15; this.camera.maxZ = 1800; this.camera.fov = .86; this.camera.inputs.clear();
+        this.sky = B.MeshBuilder.CreateSphere('céu', { diameter: 2800, sideOrientation: B.Mesh.BACKSIDE, segments: 24 }, scene);
+        this.skyMaterial = new B.SkyMaterial('atmosfera', scene); this.skyMaterial.backFaceCulling = false;
+        this.skyMaterial.useSunPosition = true; this.skyMaterial.turbidity = 2.2; this.skyMaterial.rayleigh = 2.1; this.skyMaterial.mieCoefficient = .004; this.skyMaterial.mieDirectionalG = .8;
+        this.sky.material = this.skyMaterial; this.sky.isPickable = false; this.sky.applyFog = false; this.sky.infiniteDistance = true;
+        this.sun = new B.DirectionalLight('sol', new B.Vector3(-.6, -.5, .5), scene); this.sun.intensity = 2.3;
+        this.sun.autoUpdateExtends = false; this.sun.autoCalcShadowZBounds = false; this.sun.shadowMinZ = 1; this.sun.shadowMaxZ = 190;
+        this.sun.orthoLeft = -42; this.sun.orthoRight = 42; this.sun.orthoTop = 42; this.sun.orthoBottom = -42;
+        this.hemi = new B.HemisphericLight('luz-do-céu', B.Axis.Y, scene); this.hemi.intensity = .75; this.hemi.groundColor.set(.25, .22, .17);
+        this.shadow = new B.ShadowGenerator(this.profile.shadowSize, this.sun); this.shadow.usePercentageCloserFiltering = true;
+        this.shadow.filteringQuality = B.ShadowGenerator.QUALITY_LOW; this.shadow.bias = .001; this.shadow.normalBias = .025; this.shadow.setDarkness(.23);
+        this.pipeline = new B.DefaultRenderingPipeline('cinema', true, scene, [this.camera]); this.pipeline.samples = 1; this.pipeline.fxaaEnabled = true;
+        this.pipeline.bloomEnabled = this.profile.bloom; this.pipeline.bloomThreshold = 1.15; this.pipeline.bloomWeight = .13; this.pipeline.bloomKernel = 32;
+        this.pipeline.imageProcessing.toneMappingEnabled = true; this.pipeline.imageProcessing.toneMappingType = B.ImageProcessingConfiguration.TONEMAPPING_ACES;
+        this.pipeline.imageProcessing.exposure = 1.05; this.pipeline.imageProcessing.contrast = 1.06;
+        this.setLoading(.15, 'Desenhando estradas e povoados…'); this.world = new World(scene, this.shadow, this.profile);
+        this.setLoading(.35, 'Selando o cavalo…');
+        let timeout;
+        try { this.horse = await Promise.race([loadHorse(scene, this.shadow, this.world.mats), new Promise((_, reject) => { timeout = setTimeout(() => reject(new Error('Tempo de carregamento do cavalo excedido.')), 30000); })]); }
+        finally { clearTimeout(timeout); }
+        this.resetToCheckpoint(false); this.world.update(this.player.x, this.player.z);
+        const total = this.world.queue.length;
+        while (this.world.queue.length) { this.world.update(this.player.x, this.player.z); this.setLoading(.5 + .4 * (1 - this.world.queue.length / total), 'O sol encontra a pradaria…'); await new Promise(requestAnimationFrame); }
+        this.createDust(); this.createHorizon(); this.bindInput(); this.bindUi(); this.updateHorse(0, 0); this.placeCamera(true); this.updateAtmosphere();
+        await scene.whenReadyAsync();
+        this.setLoading(1, 'A fronteira está pronta.'); this.ui.loadingOverlay.hidden = true; this.setState('menu');
+        this.ui.startButton.focus({ preventScroll: true });
         this._renderLoop = () => this.frame();
-        if (window.LabRuntime) LabRuntime.bindBabylonLoop(this.engine, this._renderLoop);
-        else this.engine.runRenderLoop(this._renderLoop);
-        if (window.LabRuntime) LabRuntime.debounceResize(() => this.engine.resize());
-        else window.addEventListener('resize', () => this.engine.resize());
+        if (window.LabRuntime) LabRuntime.bindBabylonLoop(this.engine, this._renderLoop); else this.engine.runRenderLoop(this._renderLoop);
+        const resize = () => { this.engine.resize(); this.placeCamera(true); };
+        if (window.LabRuntime) LabRuntime.debounceResize(resize); else addEventListener('resize', resize);
+        this.engine.onContextLostObservable.add(() => { if (this.state === 'play') this.togglePause(); this.ui.pauseTitle.textContent = 'Reconectando o cenário…'; this.ui.resumeButton.disabled = true; });
+        this.engine.onContextRestoredObservable.add(() => { this.ui.pauseTitle.textContent = 'A trilha está pronta.'; this.ui.resumeButton.disabled = false; });
     }
-
-    updateChunks() {
-        const size = 82;
-        const centerX = Math.floor(this.player.x / size);
-        const centerZ = Math.floor(this.player.z / size);
-        const needed = new Set();
-        for (let z = -this.profile.radius; z <= this.profile.radius; z += 1) for (let x = -this.profile.radius; x <= this.profile.radius; x += 1) {
-            const key = `${centerX + x}:${centerZ + z}`; needed.add(key);
-            if (!this.chunks.has(key)) this.chunks.set(key, this.createChunk(centerX + x, centerZ + z));
-        }
-        this.chunks.forEach((chunk, key) => { if (!needed.has(key)) { chunk.dispose(); this.chunks.delete(key); } });
+    createHorizon() {
+        // A coarse distant landscape fills the horizon without streaming high-detail tiles.
+        this.horizon = B.MeshBuilder.CreateGround('serras-distantes', { width: 3200, height: 3200, subdivisions: 90 }, this.scene);
+        const positions = this.horizon.getVerticesData(B.VertexBuffer.PositionKind);
+        for (let i = 0; i < positions.length; i += 3) positions[i + 1] = terrainHeight(positions[i], positions[i + 2]) - 9;
+        this.horizon.setVerticesData(B.VertexBuffer.PositionKind, positions); this.horizon.createNormals(false);
+        this.horizon.material = material(this.scene, 'terra-distante', '#77816a'); this.horizon.isPickable = false; this.horizon.freezeWorldMatrix();
     }
-
-    createChunk(cx, cz) {
-        const root = new B.TransformNode(`cenário-${cx}-${cz}`, this.scene);
-        createTerrain(this.scene, cx, cz, this.profile, this.terrainMaterial).parent = root;
-        const random = (i) => Math.abs(hash(cx * 37 + i * 2.7, cz * 19 + i * 1.3));
-        for (let i = 0; i < 11; i += 1) {
-            const x = cx * 82 + (random(i) - 0.5) * 70;
-            const z = cz * 82 + (random(i + 22) - 0.5) * 70;
-            const biome = biomeAt(x, z);
-            if (biome === 'serra' || (biome === 'vale' && i % 2)) createTree(this.scene, x, z, 4 + random(i + 9) * 6).parent = root;
-            else if (biome !== 'rio') createRock(this.scene, new B.Vector3(x, terrainHeight(x, z) + 1, z), 0.7 + random(i + 5) * 2.3, this.rockMaterial).parent = root;
-        }
-        return root;
+    createDust() {
+        const texture = new B.DynamicTexture('poeira-textura', 64, this.scene, false), ctx = texture.getContext();
+        const gradient = ctx.createRadialGradient(32, 32, 0, 32, 32, 32); gradient.addColorStop(0, 'rgba(220,193,145,.45)'); gradient.addColorStop(1, 'rgba(220,193,145,0)');
+        ctx.fillStyle = gradient; ctx.fillRect(0, 0, 64, 64); texture.update();
+        this.dust = new B.ParticleSystem('poeira-dos-cascos', this.profile.id === 'low' ? 55 : 140, this.scene);
+        this.dust.particleTexture = texture; this.dust.emitter = new B.Vector3(); this.dust.minEmitBox.set(-.4, 0, -.3); this.dust.maxEmitBox.set(.4, .1, .3);
+        this.dust.color1 = new B.Color4(.7, .58, .37, .2); this.dust.color2 = new B.Color4(.65, .54, .35, .15); this.dust.colorDead = new B.Color4(.6, .5, .35, 0);
+        this.dust.minSize = .3; this.dust.maxSize = 1; this.dust.minLifeTime = .4; this.dust.maxLifeTime = 1.3;
+        this.dust.direction1.set(-.4, .2, -.4); this.dust.direction2.set(.4, .5, .4); this.dust.minEmitPower = .3; this.dust.maxEmitPower = .8;
+        this.dust.blendMode = B.ParticleSystem.BLENDMODE_STANDARD; this.dust.emitRate = 0; this.dust.start();
     }
-
     bindInput() {
-        addEventListener('keydown', (event) => { this.keys[event.code] = true; if (event.code === 'KeyP') this.togglePause(); if (event.code === 'KeyG') this.player.cruise = !this.player.cruise; if (event.code === 'KeyC') this.camera.fov = this.camera.fov < 0.85 ? 0.98 : 0.78; });
-        addEventListener('keyup', (event) => { this.keys[event.code] = false; });
-        canvas.addEventListener('click', () => { if (this.state === 'play') canvas.requestPointerLock?.(); });
-        addEventListener('mousemove', (event) => { if (document.pointerLockElement === canvas && this.state === 'play') { this.look.yaw -= event.movementX * 0.0021; this.look.pitch = clamp(this.look.pitch - event.movementY * 0.0016, -0.22, 0.52); } });
-        const stick = $('#moveStick');
-        stick.addEventListener('pointermove', (event) => { if (!event.buttons) return; const rect = stick.getBoundingClientRect(); this.keys.touchX = clamp((event.clientX - rect.left - rect.width / 2) / (rect.width / 2), -1, 1); this.keys.touchZ = clamp((rect.height / 2 - (event.clientY - rect.top)) / (rect.height / 2), -1, 1); });
-        stick.addEventListener('pointerup', () => { this.keys.touchX = 0; this.keys.touchZ = 0; });
-        $('#btnSpur').addEventListener('click', () => { this.player.spur = 1.4; });
-    }
-
-    bindUi() {
-        $('#startButton').addEventListener('click', () => this.start());
-        $('#resumeButton').addEventListener('click', () => this.togglePause());
-        $('#pauseMenuButton').addEventListener('click', () => this.menu());
-        $('#pauseButton').addEventListener('click', () => this.togglePause());
-        $('#soundButton').addEventListener('click', () => { this.settings.muted = !this.settings.muted; $('#soundButton').setAttribute('aria-pressed', String(!this.settings.muted)); this.persist(); });
-        $('#qualitySelect').value = this.settings.quality || 'auto';
-        $('#qualitySelect').addEventListener('change', (event) => { this.settings.quality = event.target.value; this.persist(); this.say('Qualidade será aplicada ao reiniciar a trilha.', 3); });
-        $('#volumeSlider').value = this.settings.volume || 70;
-        $('#volumeSlider').addEventListener('input', (event) => { this.settings.volume = Number(event.target.value); $('#volumeValue').textContent = event.target.value; this.persist(); });
-        $('#bestScore').textContent = `${Math.round(this.settings.best || 0)} m`;
-        $('#touchControls').hidden = !matchMedia('(pointer: coarse)').matches;
-    }
-
-    start() {
-        $('#menuOverlay').hidden = true; $('#pauseOverlay').hidden = true; $('#hud').hidden = false;
-        this.state = 'play'; document.body.dataset.state = 'play'; this.elapsed = 0; this.marks.clear();
-        this.say('Pradaria Dourada. O cavalo já galopa — o oeste não acaba.', 4);
-    }
-
-    menu() {
-        $('#pauseOverlay').hidden = true; $('#hud').hidden = true; $('#menuOverlay').hidden = false;
-        this.state = 'menu'; document.body.dataset.state = 'menu'; document.exitPointerLock?.();
-        this.settings.best = Math.max(this.settings.best || 0, this.player.distance); this.persist(); $('#bestScore').textContent = `${Math.round(this.settings.best)} m`;
-    }
-
-    togglePause() {
-        if (this.state === 'play') { this.state = 'pause'; $('#pauseOverlay').hidden = false; document.exitPointerLock?.(); }
-        else if (this.state === 'pause') { this.state = 'play'; $('#pauseOverlay').hidden = true; canvas.requestPointerLock?.(); }
-    }
-
-    setLoading(progress, text) { $('#loadingFill').style.width = `${progress * 100}%`; $('#loadingText').textContent = text; }
-    persist() { try { localStorage.setItem(SETTINGS_KEY, JSON.stringify(this.settings)); } catch (err) { /* armazenamento indisponível */ } }
-    say(text, duration = 2.8) { const message = $('#message'); message.textContent = text; message.dataset.show = 'true'; clearTimeout(this.messageTimer); this.messageTimer = setTimeout(() => { message.dataset.show = 'false'; }, duration * 1000); }
-
-    frame() {
-        const dt = Math.min(this.engine.getDeltaTime() / 1000, 0.05);
-        this.elapsed += dt;
-        if (this.state === 'play') this.update(dt);
-        else this.menuCamera(dt);
-        this.sky.position.copyFrom(this.camera.position);
-        if (this.water) {
-            this.water.position.x = this.camera.position.x;
-            this.water.position.z = this.camera.position.z;
-        }
-        if (this.clouds) {
-            this.clouds.position.copyFrom(this.camera.position);
-        }
-        this.scene.render();
-    }
-
-    update(dt) {
-        const steer = (this.keys.KeyA || this.keys.ArrowLeft ? 1 : 0) - (this.keys.KeyD || this.keys.ArrowRight ? 1 : 0) + (this.keys.touchX || 0);
-        const throttle = (this.keys.KeyW || this.keys.ArrowUp ? 1 : 0) - (this.keys.KeyS || this.keys.ArrowDown ? 1 : 0) + (this.keys.touchZ || 0);
-        if (this.keys.Space) this.player.spur = 1.4;
-        this.player.spur = Math.max(0, this.player.spur - dt);
-        const target = this.player.spur > 0 || this.keys.ShiftLeft ? 24 : throttle > 0.1 ? 19 : throttle < -0.1 ? 5 : (this.player.cruise ? 12 : 2.5);
-        this.player.speed = lerp(this.player.speed, target, 1 - Math.exp(-dt * 3.6));
-        this.player.yaw -= steer * dt * clamp(this.player.speed / 12, 0.35, 1.35);
-        const forward = new B.Vector3(Math.sin(this.player.yaw), 0, Math.cos(this.player.yaw));
-        this.player.x += forward.x * this.player.speed * dt; this.player.z += forward.z * this.player.speed * dt;
-        this.player.distance += this.player.speed * dt; this.player.phase += this.player.speed * dt * 2.3;
-        const y = terrainHeight(this.player.x, this.player.z);
-        this.horse.root.position.set(this.player.x, y, this.player.z);
-        this.horse.root.rotation.set((terrainHeight(this.player.x + forward.x * 2, this.player.z + forward.z * 2) - y) * -0.15, this.player.yaw, steer * -0.08);
-        this.horse.animations.forEach((animation) => {
-            animation.speedRatio = clamp(this.player.speed / 12, 0.45, 2.1);
+        const controls = new Set(['KeyW', 'KeyA', 'KeyS', 'KeyD', 'ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', 'Space', 'ShiftLeft', 'ShiftRight', 'KeyE', 'KeyF', 'KeyR', 'KeyQ', 'KeyC', 'KeyG', 'KeyP', 'KeyM', 'Escape']);
+        addEventListener('keydown', event => {
+            if (event.code === 'Tab' && ['menu', 'pause', 'end'].includes(this.state)) { this.trapFocus(event); return; }
+            if (editable(event.target)) return;
+            if (!['play', 'pause'].includes(this.state) || !controls.has(event.code)) return;
+            event.preventDefault();
+            if (!event.repeat) {
+                if (event.code === 'KeyP' || event.code === 'Escape') { this.togglePause(); return; }
+                if (this.state !== 'play') return;
+                if (event.code === 'KeyE') this.interact();
+                if (event.code === 'KeyF') this.shoot();
+                if (event.code === 'KeyR') this.reload();
+                if (event.code === 'KeyQ') this.toggleFocus();
+                if (event.code === 'KeyC') this.cycleCamera();
+                if (event.code === 'KeyG') { this.player.cruise = !this.player.cruise; this.say(this.player.cruise ? 'Marcha automática. S ou rédea para trás para frear.' : 'Marcha manual.'); }
+                if (event.code === 'KeyM') this.toggleSound();
+            }
+            if (this.state === 'play') this.keys[event.code] = true;
         });
-        const wanted = new B.Vector3(this.player.x - forward.x * 8.4, y + 3.4 + Math.sin(this.look.pitch) * 3.2, this.player.z - forward.z * 8.4);
-        this.camera.position = B.Vector3.Lerp(this.camera.position, wanted, 1 - Math.exp(-dt * 5));
-        const look = new B.Vector3(this.player.x + Math.sin(this.look.yaw) * 12, y + 1.7 + Math.sin(this.look.pitch) * 5, this.player.z + Math.cos(this.look.yaw) * 12);
-        this.camera.setTarget(look);
-        this.updateChunks(); this.updateAtmosphere();
-        this.lastHud += dt;
-        if (this.lastHud > 0.12) { this.lastHud = 0; this.updateHud(); }
+        addEventListener('keyup', event => { this.keys[event.code] = false; });
+        addEventListener('blur', () => { this.clearInput(); if (this.state === 'play') this.togglePause(); });
+        document.addEventListener('visibilitychange', () => { if (document.hidden) { this.clearInput(); if (this.state === 'play') this.togglePause(); } });
+        addEventListener('pagehide', () => this.persist());
+        canvas.addEventListener('contextmenu', e => e.preventDefault());
+        const bindLook = el => {
+            let drag = null;
+            el.addEventListener('pointerdown', e => { if (this.state !== 'play' || drag) return; drag = { id: e.pointerId, x: e.clientX, y: e.clientY, moved: 0, button: e.button }; el.setPointerCapture(e.pointerId); canvas.focus({ preventScroll: true }); });
+            el.addEventListener('pointermove', e => {
+                if (!drag || e.pointerId !== drag.id || this.state !== 'play') return;
+                const dx = e.clientX - drag.x, dy = e.clientY - drag.y; drag.moved += Math.abs(dx) + Math.abs(dy);
+                this.look.yaw += dx * .005 * this.settings.sensitivity; this.look.pitch = clamp(this.look.pitch + dy * .003 * this.settings.sensitivity, -.05, .72);
+                drag.x = e.clientX; drag.y = e.clientY;
+            });
+            el.addEventListener('pointerup', e => { if (drag?.id !== e.pointerId) return; const fire = el === canvas && drag.moved < 7 && drag.button === 0 && e.pointerType !== 'touch'; drag = null; if (el.hasPointerCapture(e.pointerId)) el.releasePointerCapture(e.pointerId); if (fire) this.shoot(); });
+            const cancel = () => { drag = null; }; el.addEventListener('pointercancel', cancel); el.addEventListener('lostpointercapture', cancel); this.cancelLook = cancel;
+        };
+        bindLook(canvas); bindLook(this.ui.lookZone);
+        canvas.addEventListener('wheel', e => { if (this.state !== 'play') return; e.preventDefault(); this.look.distance = clamp(this.look.distance + e.deltaY * .008, 4.5, 13); }, { passive: false });
+        const stick = this.ui.moveStick; let pointer = null;
+        const move = e => {
+            if (e.pointerId !== pointer) return;
+            const rect = stick.getBoundingClientRect(), radius = rect.width * .36, x = (e.clientX - rect.left - rect.width / 2) / radius, z = (rect.top + rect.height / 2 - e.clientY) / radius;
+            const length = Math.max(1, Math.hypot(x, z)); this.touch.x = x / length; this.touch.z = z / length;
+            this.ui.moveKnob.style.transform = `translate(${this.touch.x * radius}px, ${-this.touch.z * radius}px)`;
+        };
+        stick.addEventListener('pointerdown', e => { if (pointer !== null || this.state !== 'play') return; pointer = e.pointerId; stick.setPointerCapture(pointer); move(e); });
+        stick.addEventListener('pointermove', move);
+        const release = e => { if (e && e.pointerId !== pointer) return; const old = pointer; pointer = null; this.touch.x = this.touch.z = 0; this.ui.moveKnob.style.transform = ''; if (old !== null && stick.hasPointerCapture(old)) stick.releasePointerCapture(old); };
+        for (const name of ['pointerup', 'pointercancel', 'lostpointercapture']) stick.addEventListener(name, release);
+        this.releaseStick = release;
+        const spur = this.ui.btnSpur;
+        spur.addEventListener('pointerdown', e => { if (this.state !== 'play') return; spur.setPointerCapture(e.pointerId); this.touch.sprint = true; });
+        for (const name of ['pointerup', 'pointercancel', 'lostpointercapture']) spur.addEventListener(name, () => { this.touch.sprint = false; });
+        this.ui.btnShoot.addEventListener('click', () => this.shoot()); this.ui.btnReload.addEventListener('click', () => this.reload());
+        this.ui.btnFocus.addEventListener('click', () => this.toggleFocus()); this.ui.interactButton.addEventListener('click', () => this.interact());
+        addEventListener('gamepaddisconnected', () => { this.pad = { steer: 0, throttle: 0, sprint: false, previous: [] }; if (this.state === 'play') this.togglePause(); });
     }
-
+    trapFocus(event) {
+        const el = this.state === 'menu' ? this.ui.menuOverlay : this.state === 'pause' ? this.ui.pauseOverlay : this.ui.endOverlay;
+        const nodes = [...el.querySelectorAll('button, select, input, summary, a')].filter(n => !n.disabled && n.getClientRects().length);
+        if (!nodes.length) return;
+        const first = nodes[0], last = nodes.at(-1);
+        if (event.shiftKey && (document.activeElement === first || !el.contains(document.activeElement))) { event.preventDefault(); last.focus(); }
+        else if (!event.shiftKey && (document.activeElement === last || !el.contains(document.activeElement))) { event.preventDefault(); first.focus(); }
+    }
+    bindUi() {
+        const ui = this.ui;
+        ui.startButton.addEventListener('click', () => this.start()); ui.newButton.addEventListener('click', () => { this.resetToCheckpoint(true); this.start(); });
+        ui.pauseButton.addEventListener('click', () => this.togglePause()); ui.resumeButton.addEventListener('click', () => this.togglePause());
+        ui.pauseMenuButton.addEventListener('click', () => this.menu()); ui.endMenuButton.addEventListener('click', () => this.menu());
+        ui.retryButton.addEventListener('click', () => { if (this.player.health <= 0) this.resetToCheckpoint(false); this.start(); });
+        ui.soundButton.addEventListener('click', () => this.toggleSound());
+        ui.qualitySelect.value = this.settings.quality;
+        ui.qualitySelect.addEventListener('change', e => { this.settings.quality = e.target.value; this.applyQuality(); this.persist(); });
+        ui.volumeSlider.value = this.settings.volume; ui.volumeValue.textContent = `${this.settings.volume}%`;
+        ui.volumeSlider.addEventListener('input', e => { this.settings.volume = Number(e.target.value); ui.volumeValue.textContent = `${this.settings.volume}%`; this.audio.configure(this.settings); this.persist(); });
+        ui.sensitivitySlider.value = this.settings.sensitivity;
+        ui.sensitivitySlider.addEventListener('input', e => { this.settings.sensitivity = Number(e.target.value); this.persist(); });
+        ui.motionToggle.checked = this.settings.reducedMotion || this.reducedMotion;
+        ui.motionToggle.addEventListener('change', e => { this.settings.reducedMotion = e.target.checked; this.reducedMotion = e.target.checked; this.persist(); });
+        ui.soundButton.setAttribute('aria-pressed', String(!this.settings.muted)); ui.touchControls.hidden = !this.coarse;
+        this.updateMenu();
+    }
+    updateMenu() {
+        this.ui.bestScore.textContent = `${Math.round(this.settings.best)} m`;
+        this.ui.startLabel.textContent = this.hasStarted || this.checkpoint?.stage ? 'Retomar jornada' : 'Iniciar jornada';
+        this.ui.newButton.hidden = !(this.hasStarted || this.checkpoint?.stage);
+        this.ui.saveNote.textContent = this.stage ? `${Math.min(this.stage, 6)} de 6 destinos · progresso salvo no último destino` : 'O progresso é salvo em cada destino.';
+    }
+    clearInput() { this.keys = {}; this.touch = { x: 0, z: 0, sprint: false }; this.pad.steer = this.pad.throttle = 0; this.pad.sprint = false; this.releaseStick?.(); this.cancelLook?.(); }
+    setState(state) {
+        this.state = state; document.body.dataset.state = state; this.clearInput();
+        this.ui.menuOverlay.hidden = state !== 'menu'; this.ui.pauseOverlay.hidden = state !== 'pause'; this.ui.endOverlay.hidden = state !== 'end';
+        this.ui.hud.hidden = !['play', 'pause'].includes(state); this.ui.focusVeil.hidden = state !== 'play' || !this.focusActive;
+        canvas.inert = state !== 'play'; this.ui.hud.inert = state !== 'play';
+        if (state !== 'play') { this.focusActive = false; this.audio.pause(); if (this.dust) this.dust.emitRate = 0; }
+    }
+    start() {
+        if (this.player.health <= 0) this.resetToCheckpoint(false);
+        this.hasStarted = true; this.setState('play'); this.audio.start(this.settings); canvas.focus({ preventScroll: true }); this.placeCamera(true); this.updateHud();
+        this.say(this.stage === 0 ? 'Sua história começa na fogueira. Aceite a carta para partir.' : 'Siga a trilha e o losango dourado. O oeste espera.', 5);
+    }
+    menu() { this.persist(); this.setState('menu'); this.updateMenu(); this.ui.startButton.focus({ preventScroll: true }); }
+    togglePause() {
+        if (this.state === 'play') { this.persist(); this.setState('pause'); this.ui.resumeButton.focus({ preventScroll: true }); }
+        else if (this.state === 'pause') { this.setState('play'); this.audio.start(this.settings); canvas.focus({ preventScroll: true }); }
+    }
+    toggleSound() { this.settings.muted = !this.settings.muted; this.ui.soundButton.setAttribute('aria-pressed', String(!this.settings.muted)); this.audio.configure(this.settings); this.persist(); }
+    cycleCamera() { this.look.distance = this.look.distance < 6 ? 8 : this.look.distance < 10 ? 12 : 4.5; this.look.yaw = 0; this.look.pitch = .2; }
+    toggleFocus() { if (this.state !== 'play') return; if (!this.focusActive && this.player.focus < 15) { this.say('Recupere a concentração antes de usar o foco.'); return; } this.focusActive = !this.focusActive; }
+    applyQuality() {
+        this.profile = this.pickQuality(); this.engine.setHardwareScalingLevel(1 / Math.min(devicePixelRatio || 1, this.profile.scale));
+        this.shadow.getShadowMap().resize(this.profile.shadowSize); this.pipeline.bloomEnabled = this.profile.bloom;
+        this.scene.fogDensity = this.profile.id === 'high' ? .005 : .007;
+        this.world.setProfile(this.profile); this.world.update(this.player.x, this.player.z); this.engine.resize(); this.badFrames = 0;
+        this.ui.saveNote.textContent = 'Qualidade aplicada. Os detalhes do cenário estão sendo atualizados.';
+    }
+    resetToCheckpoint(fresh) {
+        if (fresh) { this.checkpoint = null; this.elapsed = 0; }
+        const saved = fresh ? null : this.checkpoint;
+        this.stage = saved?.stage || 0; this.player = freshPlayer();
+        if (saved) Object.assign(this.player, { money: saved.money, distance: saved.distance, kills: saved.kills });
+        const p = LANDMARKS[Math.max(0, Math.min(5, this.stage - 1))]; this.player.x = p.x + 6; this.player.z = p.z - 5;
+        this.look.yaw = 0; this.look.pitch = .2; this.focusActive = false;
+        for (const e of this.enemies) { e.root.getChildMeshes().forEach(m => this.shadow.removeShadowCaster(m)); e.root.dispose(); }
+        this.enemies = []; this.encounterStage = -1;
+        if (this.world) this.world.update(this.player.x, this.player.z, true);
+        if (fresh) { saveJourney(this.storage, 0, this.player); this.hasStarted = false; }
+    }
+    persist() { this.settings.best = Math.max(this.settings.best, this.player.distance); saveSettings(this.storage, this.settings); }
+    saveCheckpoint() { saveJourney(this.storage, this.stage, this.player); this.checkpoint = { stage: this.stage, money: this.player.money, distance: this.player.distance, kills: this.player.kills }; this.persist(); }
+    say(text, duration = 3.5) { this.ui.message.textContent = text; this.ui.message.dataset.show = 'true'; this.messageRemaining = duration; }
+    setLoading(progress, text) { this.ui.loadingFill.style.width = `${progress * 100}%`; this.ui.loadingFill.parentElement.setAttribute('aria-valuenow', Math.round(progress * 100)); this.ui.loadingText.textContent = text; }
+    readGamepad(dt) {
+        const controller = [...(navigator.getGamepads?.() || [])].find(p => p?.mapping === 'standard');
+        if (!controller) { this.pad.steer = this.pad.throttle = 0; this.pad.sprint = false; return; }
+        const pressed = controller.buttons.map(b => b.pressed), edge = i => pressed[i] && !this.pad.previous[i];
+        if (edge(9) && ['play', 'pause'].includes(this.state)) this.togglePause();
+        if (this.state === 'play') {
+            this.pad.steer = axis(controller.axes[0]); this.pad.throttle = -axis(controller.axes[1]); this.pad.sprint = pressed[0];
+            this.look.yaw += axis(controller.axes[2]) * dt * 1.9 * this.settings.sensitivity; this.look.pitch = clamp(this.look.pitch + axis(controller.axes[3]) * dt * 1.2, -.05, .72);
+            if (pressed[7]) this.shoot(); if (edge(2)) this.reload(); if (edge(3)) this.interact(); if (edge(4)) this.toggleFocus(); if (edge(5)) this.cycleCamera();
+        }
+        this.pad.previous = pressed;
+    }
+    frame() {
+        const raw = this.engine.getDeltaTime() / 1000, dt = Math.min(raw, .05);
+        this.readGamepad(dt);
+        if (this.state === 'play') this.update(dt);
+        else if (this.state === 'menu') { this.world.update(this.player.x, this.player.z); this.menuCamera(dt); this.updateAtmosphere(); }
+        this.sky.position.copyFrom(this.camera.position);
+        this.scene.render();
+        // Adapt only automatic quality, after sustained GPU pressure and after streaming finishes.
+        this.frameAverage = damp(this.frameAverage, raw * 1000, .8, dt);
+        if (this.state === 'play' && this.settings.quality === 'auto' && !this.world.queue.length) {
+            this.badFrames = this.frameAverage > 27 ? this.badFrames + dt : Math.max(0, this.badFrames - dt);
+            if (this.badFrames > 5 && this.engine.getHardwareScalingLevel() < 1.6) { this.engine.setHardwareScalingLevel(Math.min(1.6, this.engine.getHardwareScalingLevel() + .15)); this.engine.resize(); this.badFrames = 0; }
+        }
+    }
+    update(dt) {
+        this.elapsed += dt; this.lastHud += dt; this.lastSave += dt;
+        const p = this.player;
+        const throttle = (this.keys.KeyW || this.keys.ArrowUp ? 1 : 0) - (this.keys.KeyS || this.keys.ArrowDown ? 1 : 0) + this.touch.z + this.pad.throttle;
+        const steer = (this.keys.KeyD || this.keys.ArrowRight ? 1 : 0) - (this.keys.KeyA || this.keys.ArrowLeft ? 1 : 0) + this.touch.x + this.pad.steer;
+        if (throttle < -.1) p.cruise = false;
+        this.timeScale = damp(this.timeScale, this.focusActive ? .32 : 1, 8, dt);
+        p.focus = clamp(p.focus + (this.focusActive ? -22 : 7) * dt, 0, 100);
+        if (p.focus === 0) this.focusActive = false;
+        const simDt = dt * this.timeScale;
+        const riding = stepRiding(p, { throttle, steer, sprint: this.keys.ShiftLeft || this.keys.ShiftRight || this.keys.Space || this.touch.sprint || this.pad.sprint }, simDt, this.world.colliders);
+        if (riding.obstacle && !this.obstacleCooldown) { this.say('Obstacle devant. Reduza e contorne.'.replace('Obstacle devant.', 'Obstáculo à frente.')); this.obstacleCooldown = 3; }
+        this.obstacleCooldown = Math.max(0, (this.obstacleCooldown || 0) - dt);
+        this.updateHorse(simDt, steer); this.placeCamera(false, dt); this.world.update(p.x, p.z); this.updateAtmosphere(); this.world.animate(this.elapsed, p.x, p.z);
+        this.updateEncounter(simDt); this.updateEffects(simDt);
+        this.dust.emitter.set(p.x, terrainHeight(p.x, p.z) + .12, p.z - Math.cos(p.yaw) * .6);
+        this.dust.emitRate = this.settings.reducedMotion || this.reducedMotion ? 0 : p.speed > 4 ? Math.min(45, p.speed * 2.4) : 0;
+        this.dust.updateSpeed = .01 * this.timeScale;
+        this.audio.update(dt, p.speed, worldClock(this.elapsed).hour);
+        this.messageRemaining = Math.max(0, (this.messageRemaining || 0) - dt); if (!this.messageRemaining) this.ui.message.dataset.show = 'false';
+        this.damage = Math.max(0, (this.damage || 0) - dt * 1.4); this.ui.damageVeil.style.opacity = this.damage;
+        this.ui.focusVeil.hidden = !this.focusActive; this.ui.btnFocus.setAttribute('aria-pressed', String(this.focusActive));
+        if (this.lastHud > .1) { this.updateHud(); this.lastHud = 0; }
+        if (this.lastSave > 15) { this.persist(); this.lastSave = 0; }
+    }
+    updateHorse(dt, steer) {
+        const p = this.player, y = terrainHeight(p.x, p.z), ahead = terrainHeight(p.x + Math.sin(p.yaw) * 1.2, p.z + Math.cos(p.yaw) * 1.2);
+        this.horse.root.position.set(p.x, y, p.z); this.horse.root.rotation.y = p.yaw;
+        this.horse.root.rotation.x = damp(this.horse.root.rotation.x, clamp(-(ahead - y) / 1.2, -.32, .32), 5, dt || 1);
+        this.horse.root.rotation.z = damp(this.horse.root.rotation.z, -steer * .05 * clamp(p.speed / 10, 0, 1), 4, dt || 1);
+        this.horse.update(p.speed, p.phase, steer);
+    }
+    placeCamera(snap, dt = 1 / 60) {
+        const p = this.player, heading = p.yaw + this.look.yaw, distance = this.look.distance, y = terrainHeight(p.x, p.z);
+        const bob = this.settings.reducedMotion || this.reducedMotion ? 0 : Math.sin(p.phase * 1.7) * .022 * clamp(p.speed / 12, 0, 1);
+        this.cameraPosition.set(p.x - Math.sin(heading) * distance, y + 3.2 + this.look.pitch * distance * .7 + bob, p.z - Math.cos(heading) * distance);
+        // Camera is clamped over terrain and outside building/tree collision volumes.
+        this.cameraPosition.y = Math.max(this.cameraPosition.y, terrainHeight(this.cameraPosition.x, this.cameraPosition.z) + 1.2);
+        for (const o of this.world.colliders || []) {
+            const dx = this.cameraPosition.x - o.x, dz = this.cameraPosition.z - o.z, d = Math.hypot(dx, dz), r = o.radius + .5;
+            if (d < r) { this.cameraPosition.x = o.x + dx / (d || 1) * r; this.cameraPosition.z = o.z + dz / (d || 1) * r; this.cameraPosition.y = Math.max(this.cameraPosition.y, y + 4); }
+        }
+        if (snap) this.camera.position.copyFrom(this.cameraPosition); else B.Vector3.LerpToRef(this.camera.position, this.cameraPosition, 1 - Math.exp(-dt * 7), this.camera.position);
+        this.camera.position.y = Math.max(this.camera.position.y, terrainHeight(this.camera.position.x, this.camera.position.z) + .8);
+        this.cameraTarget.set(p.x + Math.sin(heading) * 4, y + 2 + this.look.pitch, p.z + Math.cos(heading) * 4);
+        this.camera.setTarget(this.cameraTarget); this.camera.fov = damp(this.camera.fov, this.focusActive ? .72 : .86 + (this.settings.reducedMotion ? 0 : p.speed * .003), 3, dt);
+    }
     menuCamera(dt) {
-        const t = performance.now() * 0.00012;
-        const y = terrainHeight(this.player.x, this.player.z);
-        this.camera.position = B.Vector3.Lerp(this.camera.position, new B.Vector3(this.player.x + Math.cos(t) * 18, y + 9, this.player.z + Math.sin(t) * 18), dt);
-        this.camera.setTarget(new B.Vector3(this.player.x, y + 1.4, this.player.z));
-        this.updateAtmosphere();
+        const p = this.player, y = terrainHeight(p.x, p.z), a = .95 + Math.sin(performance.now() * .00007) * .12;
+        this.cameraPosition.set(p.x + Math.sin(a) * 11, y + 4.2, p.z + Math.cos(a) * 11);
+        B.Vector3.LerpToRef(this.camera.position, this.cameraPosition, 1 - Math.exp(-dt * 1.1), this.camera.position);
+        // Offset the subject to the right to leave room for the title.
+        this.camera.setTarget(new B.Vector3(p.x + 3.3, y + 2, p.z - 1.5));
     }
-
     updateAtmosphere() {
-        const sun = (Math.sin(this.elapsed / 90) + 1) * 0.5;
-        this.sun.intensity = 0.6 + sun * 3.8;
-        this.sun.direction = new B.Vector3(-0.55, -0.22 - sun * 0.75, 0.35);
-
-        if (this.skyMaterial) {
-            this.skyMaterial.sunPosition = this.sun.direction.scale(-100);
-            this.skyMaterial.rayleigh = lerp(2.5, 1.2, sun);
+        const { hour } = worldClock(this.elapsed), angle = (hour - 6) / 12 * Math.PI, elevation = Math.sin(angle), day = clamp(elevation * 3, 0, 1);
+        this.sun.direction.set(-.65, -Math.max(.08, elevation), .45); this.sun.direction.normalize();
+        this.sun.position.set(this.player.x - this.sun.direction.x * 85, terrainHeight(this.player.x, this.player.z) - this.sun.direction.y * 85, this.player.z - this.sun.direction.z * 85);
+        this.sun.intensity = .07 + Math.max(0, elevation) * 2.2; this.sun.diffuse.set(1, lerp(.62, .95, day), lerp(.38, .87, day));
+        this.hemi.intensity = lerp(.28, .8, day);
+        this.skyMaterial.sunPosition.set(-100, elevation * 100, 60); this.skyMaterial.luminance = lerp(.1, .85, day);
+        this.skyMaterial.rayleigh = lerp(1, 2.2, day);
+        B.Color3.LerpToRef(this.sunsetFog, this.dayFog, day, this.scene.fogColor);
+        if (elevation < 0) B.Color3.LerpToRef(this.scene.fogColor, this.nightFog, clamp(-elevation * 5, 0, 1), this.scene.fogColor);
+    }
+    target() { return LANDMARKS[Math.min(this.stage, 5)]; }
+    liveEnemies() { return this.enemies.filter(e => e.health > 0); }
+    interaction() {
+        const p = this.player, target = this.target(), distance = Math.hypot(target.x - p.x, target.z - p.z);
+        if (distance < 13 && this.stage < 6) {
+            if (this.liveEnemies().length) return { label: 'Neutralize os bandidos da passagem', blocked: true };
+            if (p.speed > 4) return { label: 'Freie para interagir', blocked: true };
+            return { label: target.action, mission: true };
         }
-
-        this.scene.fogColor = B.Color3.Lerp(B.Color3.FromHexString('#1b0b18'), B.Color3.FromHexString('#c77342'), sun);
-
-        if (this.clouds && this.clouds.material) {
-            const cloudTint = B.Color3.Lerp(B.Color3.FromHexString('#110a19'), B.Color3.FromHexString('#ffffff'), sun);
-            this.clouds.material.emissiveColor = cloudTint;
+        const camp = LANDMARKS.find(l => l.id < this.stage && Math.hypot(l.x - p.x, l.z - p.z) < 12);
+        if (camp && p.speed < 4 && !this.liveEnemies().some(e => Math.hypot(e.x - p.x, e.z - p.z) < 50)) return { label: 'Descansar e reabastecer', rest: true };
+        return null;
+    }
+    interact() {
+        if (this.state !== 'play') return; const action = this.interaction(); if (!action || action.blocked) return;
+        this.player.speed = 0; this.player.cruise = false; this.player.stamina = this.player.health = this.player.focus = 100; this.player.ammo = 6; this.player.reload = 0; this.player.tired = false;
+        if (action.rest) { this.say('Cavalo descansado. Vigor, foco e munição recuperados.'); this.audio.reward(); return; }
+        const target = this.target(); this.player.money += target.reward; this.stage++; this.audio.reward(); this.saveCheckpoint();
+        this.say(`${target.story}${target.reward ? ` +$ ${target.reward}` : ''}`, 5);
+        this.updateHud();
+        if (this.stage === 6) this.finish(true);
+    }
+    updateEncounter(dt) {
+        const t = this.target(), p = this.player;
+        if (this.stage < 6 && t.enemies && this.encounterStage !== this.stage && Math.hypot(t.x - p.x, t.z - p.z) < 62) {
+            for (const e of this.enemies) { e.root.getChildMeshes().forEach(m => this.shadow.removeShadowCaster(m)); e.root.dispose(); }
+            this.enemies = []; this.encounterStage = this.stage;
+            for (let i = 0; i < t.enemies; i++) {
+                const actor = createPerson(this.scene, { ...this.world.mats, coat: this.world.mats.darkWood, scarf: this.world.mats.scarf });
+                const x = roadX(t.z) + (i % 2 ? 8 : -8), z = t.z - 22 + i * 7;
+                actor.root.position.set(x, terrainHeight(x, z), z); actor.root.getChildMeshes().forEach(m => this.shadow.addShadowCaster(m));
+                this.enemies.push({ ...actor, x, z, homeX: x, homeZ: z, health: 2, timer: 2.2 + i * .7, phase: i * 2, warning: false });
+            }
+            this.say('Emboscada. Mire nos bandidos e atire. Q / Foco desacelera o tempo.', 6);
+        }
+        for (const e of this.enemies) {
+            if (e.health <= 0) continue;
+            const distance = Math.hypot(e.x - p.x, e.z - p.z); e.root.rotation.y = Math.atan2(p.x - e.x, p.z - e.z);
+            if (distance > 65) { e.warning = false; continue; }
+            e.phase += dt; e.timer -= dt;
+            // Small lateral movement, bound to the encounter. No pursuit across the entire world.
+            const nx = e.homeX + Math.sin(e.phase * .65) * 2.5;
+            if (!(this.world.colliders || []).some(o => Math.hypot(nx - o.x, e.z - o.z) < o.radius + .4)) e.x = nx;
+            e.root.position.set(e.x, terrainHeight(e.x, e.z), e.z);
+            e.warning = e.timer < .85 && distance < 48 && this.hasLineOfSight(e.x, e.z, p.x, p.z);
+            e.gun.rotation.x = e.warning ? -.35 : .6;
+            if (e.timer <= 0) {
+                e.timer = 2.5 + (e.phase % 1);
+                if (e.warning) {
+                    this.tracer(new B.Vector3(e.x, e.root.position.y + 1.2, e.z), new B.Vector3(p.x, terrainHeight(p.x, p.z) + 2, p.z), '#dfad70');
+                    // Riding evasively mitigates damage; warnings give a deterministic reaction window.
+                    if (p.speed < 12) { p.health = Math.max(0, p.health - (p.speed > 7 ? 7 : 14)); this.damage = .6; this.audio.burst(.12, .1, 1600); }
+                    if (!p.health) { this.finish(false); return; }
+                }
+            }
         }
     }
-
+    hasLineOfSight(ax, az, bx, bz) {
+        const dx = bx - ax, dz = bz - az, length2 = dx * dx + dz * dz;
+        if (!length2) return true;
+        for (const o of this.world.colliders || []) {
+            const t = clamp(((o.x - ax) * dx + (o.z - az) * dz) / length2, 0, 1);
+            if (t > .03 && t < .97 && Math.hypot(ax + dx * t - o.x, az + dz * t - o.z) < o.radius) return false;
+        }
+        const ya = terrainHeight(ax, az) + 1.6, yb = terrainHeight(bx, bz) + 2;
+        for (let i = 1; i < 8; i++) { const t = i / 8; if (terrainHeight(lerp(ax, bx, t), lerp(az, bz, t)) > lerp(ya, yb, t)) return false; }
+        return true;
+    }
+    aimTarget() {
+        const p = this.player, heading = p.yaw + this.look.yaw, cone = this.coarse ? .65 : this.focusActive ? .38 : .23;
+        let result = null, score = Infinity;
+        for (const e of this.liveEnemies()) {
+            const distance = Math.hypot(e.x - p.x, e.z - p.z), angle = Math.abs(angleDelta(heading, Math.atan2(e.x - p.x, e.z - p.z)));
+            if (distance > 65 || angle > cone || !this.hasLineOfSight(p.x, p.z, e.x, e.z)) continue;
+            const next = angle * 80 + distance * .12;
+            if (next < score) { score = next; result = e; }
+        }
+        return result;
+    }
+    shoot() {
+        const p = this.player; if (this.state !== 'play' || p.cooldown > 0 || p.reload > 0) return;
+        if (p.ammo === 0) { this.reload(); return; }
+        p.ammo--; p.cooldown = .3; this.audio.shot();
+        const enemy = this.aimTarget(), heading = p.yaw + this.look.yaw;
+        const start = new B.Vector3(p.x + .3, terrainHeight(p.x, p.z) + 2.2, p.z + .6);
+        const end = enemy ? new B.Vector3(enemy.x, terrainHeight(enemy.x, enemy.z) + 1.3, enemy.z) : new B.Vector3(p.x + Math.sin(heading) * 55, terrainHeight(p.x, p.z) + 1.8, p.z + Math.cos(heading) * 55);
+        this.tracer(start, end, '#f5d491');
+        if (enemy) {
+            enemy.health -= this.focusActive ? 2 : 1; this.ui.hitMarker.dataset.show = 'true'; this.hitRemaining = .18;
+            if (enemy.health <= 0) { p.kills++; p.focus = clamp(p.focus + 12, 0, 100); enemy.root.rotation.z = Math.PI / 2; enemy.root.position.y += .2; enemy.warning = false; this.say(this.liveEnemies().length ? 'Acertou. Mantenha a atenção.' : 'Passagem livre. Aproxime-se do destino.', 2.5); }
+        }
+        this.updateHud();
+    }
+    reload() { if (this.state !== 'play' || this.player.reload || this.player.ammo === 6) return; this.player.reload = 1.8; this.audio.reload(); this.say('Recarregando o tambor…', 1.8); }
+    tracer(start, end, color) {
+        const line = B.MeshBuilder.CreateLines('rastro-do-tiro', { points: [start, end] }, this.scene); line.color = B.Color3.FromHexString(color); line.isPickable = false;
+        this.effects.push({ mesh: line, life: .085 });
+    }
+    updateEffects(dt) {
+        for (let i = this.effects.length - 1; i >= 0; i--) { const e = this.effects[i]; e.life -= dt; if (e.life <= 0) { e.mesh.dispose(); this.effects.splice(i, 1); } }
+        this.hitRemaining = Math.max(0, (this.hitRemaining || 0) - dt); if (!this.hitRemaining) this.ui.hitMarker.dataset.show = 'false';
+    }
+    finish(success) {
+        this.persist(); this.setState('end');
+        this.ui.endEyebrow.textContent = success ? 'A FRONTEIRA SE LEMBRA' : 'A ESTRADA COBROU SEU PREÇO';
+        this.ui.endTitle.innerHTML = success ? 'Promessa<br>cumprida.' : 'O rastro<br>não termina aqui.';
+        this.ui.endText.textContent = success ? `Seis destinos. ${Math.round(this.player.distance)} metros de história. $ ${this.player.money} em recompensas. O território continua aberto para você.` : 'Você volta ao último destino concluído, com o cavalo descansado e o tambor cheio.';
+        this.ui.retryButton.textContent = success ? 'Continuar explorando →' : 'Retomar do último destino →';
+        this.ui.retryButton.focus({ preventScroll: true });
+    }
     updateHud() {
-        const region = biomeAt(this.player.x, this.player.z);
-        const names = { pradaria: 'Pradaria Dourada', vale: 'Vale da Poeira', cânion: 'Cânion Encarnado', serra: 'Serra do Corvo', rio: 'Riacho dos Ventos' };
-        $('#regionName').textContent = names[region]; $('#biomeLabel').textContent = region;
-        $('#speedValue').textContent = String(Math.round(this.player.speed * 2.45));
-        $('#gaitValue').textContent = this.player.speed > 19 ? 'disparada' : this.player.speed > 10 ? 'galope' : 'trote';
-        $('#distanceValue').textContent = `${Math.round(this.player.distance)} m`;
-        const hours = 4 + Math.floor((this.elapsed / 480) * 24) % 24;
-        $('#clockValue').textContent = `${String(hours).padStart(2, '0')}:00`;
-        $('#hourLabel').textContent = hours < 7 ? 'amanhecer' : hours < 17 ? 'dia' : 'entardecer';
-        $('#compassRose').style.transform = `rotate(${-this.player.yaw}rad)`;
-        $('#fpsCounter').textContent = `${this.engine.getFps().toFixed(0)} fps`;
-        if (names[region] !== this.lastRegion) { this.lastRegion = names[region]; this.say(this.lastRegion, 2.4); }
+        const p = this.player, ui = this.ui, t = this.target(), live = this.liveEnemies();
+        ui.regionName.textContent = biomeAt(p.x, p.z); ui.clockValue.textContent = worldClock(this.elapsed).label;
+        ui.speedValue.textContent = Math.round(p.speed * 3.6); ui.gaitValue.textContent = p.tired ? 'recuperando' : p.speed < .15 ? 'parado' : p.speed < 5 ? 'passo' : p.speed < 10 ? 'trote' : p.speed < 14 ? 'galope' : 'disparada';
+        ui.healthMeter.value = p.health; ui.staminaMeter.value = p.stamina; ui.focusMeter.value = p.focus;
+        ui.ammoValue.textContent = p.reload > 0 ? '↻' : p.ammo; ui.moneyValue.textContent = `$ ${p.money}`;
+        ui.weaponHint.textContent = p.reload > 0 ? `Recarregando ${p.reload.toFixed(1)} s` : this.focusActive ? 'Concentração ativa' : live.length ? `${live.length} bandido${live.length === 1 ? '' : 's'} · mire e atire` : 'R · recarregar';
+        ui.chapterLabel.textContent = this.stage < 6 ? `CAPÍTULO ${CHAPTERS[this.stage].toUpperCase()}` : 'JORNADA CONCLUÍDA';
+        ui.objectiveTitle.textContent = this.stage < 6 ? t.name : 'O oeste é seu';
+        ui.objectiveText.textContent = this.stage >= 6 ? 'Explore a fronteira. Descanse nos acampamentos.' : live.length ? 'Libere a passagem. Use o foco para ganhar tempo.' : this.stage === 0 ? 'Aceite a carta na fogueira para iniciar a jornada.' : `${Math.round(Math.hypot(t.x - p.x, t.z - p.z))} m · siga o losango dourado`;
+        if (this.hudStage !== this.stage) { ui.markPips.innerHTML = LANDMARKS.map((_, i) => `<i data-on="${i < this.stage}"></i>`).join(''); ui.markPips.setAttribute('aria-label', `${this.stage} de 6 destinos concluídos`); this.hudStage = this.stage; }
+        const action = this.interaction(); ui.interactButton.hidden = !action; ui.interactButton.disabled = !!action?.blocked; ui.interactionText.textContent = action?.label || '';
+        const aim = this.aimTarget(); ui.reticle.dataset.target = !!aim; ui.reticle.classList.toggle('threat', live.some(e => e.warning));
+        this.drawMap(); this.updateWaypoint();
+    }
+    updateWaypoint() {
+        const ui = this.ui; ui.waypoint.hidden = this.stage >= 6;
+        if (this.stage >= 6) return;
+        const t = this.target(), w = canvas.clientWidth, h = canvas.clientHeight;
+        const point = B.Vector3.Project(new B.Vector3(t.x, terrainHeight(t.x, t.z) + 3, t.z), B.Matrix.IdentityReadOnly, this.scene.getTransformMatrix(), new B.Viewport(0, 0, w, h));
+        const heading = this.player.yaw + this.look.yaw, difference = angleDelta(heading, Math.atan2(t.x - this.player.x, t.z - this.player.z));
+        const behind = Math.abs(difference) > Math.PI / 2;
+        ui.waypoint.style.left = `${clamp(behind ? difference > 0 ? w - 24 : 24 : point.x, 24, w - 24)}px`;
+        ui.waypoint.style.top = `${clamp(behind ? h * .45 : point.y, h < 520 ? 104 : 190, h - (this.coarse ? 215 : 125))}px`;
+        ui.waypointDistance.textContent = `${behind ? difference > 0 ? '→ ' : '← ' : ''}${Math.round(Math.hypot(t.x - this.player.x, t.z - this.player.z))} m`;
+    }
+    drawMap() {
+        const ctx = this.ui.minimap.getContext('2d'), p = this.player, size = 240, scale = 1.4;
+        ctx.clearRect(0, 0, size, size); ctx.save(); ctx.beginPath(); ctx.arc(120, 120, 113, 0, Math.PI * 2); ctx.clip();
+        ctx.fillStyle = '#d0bd92'; ctx.fillRect(0, 0, size, size);
+        ctx.strokeStyle = '#aa996f'; ctx.lineWidth = 1;
+        for (let i = -8; i < 9; i++) { ctx.beginPath(); for (let x = 0; x <= 240; x += 8) { const y = 120 + i * 22 + Math.sin(x * .025 + i + p.z * .006) * 13; x ? ctx.lineTo(x, y) : ctx.moveTo(x, y); } ctx.stroke(); }
+        const map = (x, z) => [120 + (x - p.x) * scale, 120 - (z - p.z) * scale];
+        ctx.strokeStyle = '#8c7858'; ctx.lineWidth = 5; ctx.beginPath();
+        for (let z = p.z - 95; z <= p.z + 95; z += 3) { const [x, y] = map(roadX(z), z); z === p.z - 95 ? ctx.moveTo(x, y) : ctx.lineTo(x, y); } ctx.stroke();
+        for (const l of LANDMARKS) { const [x, y] = map(l.x, l.z); ctx.fillStyle = l.id < this.stage ? '#62583b' : '#752b21'; ctx.save(); ctx.translate(x, y); ctx.rotate(Math.PI / 4); ctx.fillRect(-4, -4, 8, 8); ctx.restore(); }
+        for (const e of this.liveEnemies()) { const [x, y] = map(e.x, e.z); ctx.fillStyle = e.warning ? '#ffebbe' : '#a02c22'; ctx.beginPath(); ctx.arc(x, y, e.warning ? 6 : 4, 0, Math.PI * 2); ctx.fill(); }
+        ctx.translate(120, 120); ctx.rotate(p.yaw); ctx.fillStyle = '#262c28'; ctx.beginPath(); ctx.moveTo(0, -9); ctx.lineTo(6, 7); ctx.lineTo(0, 4); ctx.lineTo(-6, 7); ctx.closePath(); ctx.fill(); ctx.restore();
+        ctx.strokeStyle = '#e8d6ac'; ctx.lineWidth = 3; ctx.beginPath(); ctx.arc(120, 120, 115, 0, Math.PI * 2); ctx.stroke();
+        ctx.fillStyle = '#f5e9cb'; ctx.font = 'bold 17px Georgia'; ctx.textAlign = 'center'; ctx.fillText('N', 120, 17);
     }
 }
-
-new RastroVermelho();
+export let game = null;
+try {
+    const probe = document.createElement('canvas');
+    const supported = !!(probe.getContext('webgl2', { powerPreference: 'high-performance' }) || probe.getContext('webgl'));
+    if (!B || !supported) throw new Error('WebGL indisponível.');
+    game = new RastroVermelho();
+} catch (error) { showError(error); }

--- a/labs/rastro-vermelho/src/simulation.js
+++ b/labs/rastro-vermelho/src/simulation.js
@@ -1,0 +1,101 @@
+/** Deterministic world and riding rules. Distances are metres; time is seconds. */
+export const clamp = (v, a, b) => Math.min(b, Math.max(a, v));
+export const lerp = (a, b, t) => a + (b - a) * t;
+export const damp = (a, b, rate, dt) => lerp(a, b, 1 - Math.exp(-rate * dt));
+export const angleDelta = (a, b) => Math.atan2(Math.sin(b - a), Math.cos(b - a));
+export function hash(x, z) {
+    const n = Math.sin(x * 127.1 + z * 311.7) * 43758.5453123;
+    return n - Math.floor(n); // JS remainder is negative for negative coordinates.
+}
+export function noise(x, z) {
+    const ix = Math.floor(x), iz = Math.floor(z), fx = x - ix, fz = z - iz;
+    const sx = fx * fx * (3 - 2 * fx), sz = fz * fz * (3 - 2 * fz);
+    return lerp(lerp(hash(ix, iz), hash(ix + 1, iz), sx), lerp(hash(ix, iz + 1), hash(ix + 1, iz + 1), sx), sz) * 2 - 1;
+}
+export function fbm(x, z, octaves = 4) {
+    let value = 0, amplitude = 0.5;
+    for (let i = 0; i < octaves; i++) { value += noise(x, z) * amplitude; x *= 2.03; z *= 2.03; amplitude *= 0.5; }
+    return value;
+}
+export const roadX = z => 24 * Math.sin(z * 0.007) + 12 * Math.sin(z * 0.021);
+export const roadDistance = (x, z) => Math.abs(x - roadX(z));
+const rawHeight = (x, z) => 8 + fbm(x * 0.004, z * 0.004) * 30 + fbm(x * 0.025, z * 0.025, 3) * 3;
+export const LANDMARKS = [
+    { name: 'Acampamento Aurora', z: 24, offset: -15, kind: 'camp', story: 'Uma carta. Seis destinos. Um último favor.', action: 'Aceitar a entrega', reward: 0 },
+    { name: 'Correio de Santa Luz', z: 165, offset: 16, kind: 'town', story: 'A carta chegou. O carteiro precisa de ajuda na estrada.', action: 'Entregar a carta', reward: 25 },
+    { name: 'Passagem dos Corvos', z: 340, offset: -10, kind: 'outpost', story: 'Bandidos tomaram a passagem. Abra caminho.', action: 'Inspecionar a passagem', reward: 40, enemies: 3 },
+    { name: 'Rancho Boa Esperança', z: 530, offset: 18, kind: 'ranch', story: 'O rancho está isolado. Leve as provisões ao norte.', action: 'Recolher provisões', reward: 35 },
+    { name: 'Mina do Sol Poente', z: 745, offset: -12, kind: 'mine', story: 'A última emboscada guarda a entrada da mina.', action: 'Entregar as provisões', reward: 60, enemies: 4 },
+    { name: 'Refúgio da Fronteira', z: 970, offset: 12, kind: 'camp', story: 'O oeste se lembra de quem cumpre a palavra.', action: 'Concluir a jornada', reward: 100 }
+].map((p, id) => ({ ...p, id, x: roadX(p.z) + p.offset }));
+export function terrainHeight(x, z) {
+    let y = rawHeight(x, z);
+    // Blend a 6 m trail into the hills; flatten each settlement to avoid floating buildings.
+    const trail = 1 - clamp((roadDistance(x, z) - 3) / 13, 0, 1);
+    y = lerp(y, rawHeight(roadX(z), z), trail * trail * (3 - 2 * trail));
+    for (const p of LANDMARKS) {
+        const t = 1 - clamp((Math.hypot(x - p.x, z - p.z) - 15) / 16, 0, 1);
+        if (t > 0) y = lerp(y, rawHeight(p.x, p.z), t * t * (3 - 2 * t));
+    }
+    return y;
+}
+export function biomeAt(x, z) {
+    if (z > 630 && z < 865) return 'Cânion Encarnado';
+    if (x < -100) return 'Serra do Corvo';
+    if (z > 880) return 'Fronteira do Norte';
+    return z > 420 ? 'Vale da Esperança' : 'Pradaria Dourada';
+}
+export function freshPlayer() {
+    return { x: roadX(24), z: 20, yaw: 0, speed: 0, distance: 0, stamina: 100, health: 100, focus: 100, ammo: 6, reload: 0, cooldown: 0, cruise: false, tired: false, money: 0, kills: 0, phase: 0 };
+}
+/** Acceleration, slope resistance and stamina use dt; a held spur cannot bypass exhaustion.
+ * Gallop 11 m/s, sprint 17 m/s; stamina -17/s sprinting, +10/s walking, +5/s trotting.
+ * Exhaustion has hysteresis: sprint is unavailable until stamina has recovered to 28%.
+ */
+export function stepRiding(p, input, dt, colliders = []) {
+    const throttle = clamp(input.throttle, -1, 1), steer = clamp(input.steer, -1, 1);
+    if (p.stamina <= 1) p.tired = true;
+    if (p.stamina >= 28) p.tired = false;
+    const sprint = input.sprint && !p.tired && throttle >= 0;
+    let target = throttle < -0.1 ? 0 : sprint ? 17 : throttle > 0.1 ? 11 * throttle : p.cruise ? 8 : 0;
+    const y = terrainHeight(p.x, p.z);
+    const grade = (terrainHeight(p.x + Math.sin(p.yaw) * 2, p.z + Math.cos(p.yaw) * 2) - y) / 2;
+    target *= clamp(1 - Math.max(0, grade) * 0.65, 0.35, 1);
+    p.speed = damp(p.speed, target, target < p.speed ? 3.8 : 1.35, dt);
+    if (p.speed < 0.04) p.speed = 0;
+    p.yaw += steer * dt * (0.65 + 0.7 * clamp(p.speed / 9, 0, 1)) / (1 + p.speed * 0.022);
+    const nx = p.x + Math.sin(p.yaw) * p.speed * dt, nz = p.z + Math.cos(p.yaw) * p.speed * dt;
+    const obstacle = colliders.some(o => Math.hypot(nx - o.x, nz - o.z) < o.radius + 0.65);
+    const steep = Math.abs(terrainHeight(nx, nz) - y) > Math.max(0.6, p.speed * dt * 0.9);
+    if (obstacle || steep) p.speed = damp(p.speed, 0, 16, dt);
+    else { p.distance += Math.hypot(nx - p.x, nz - p.z); p.x = nx; p.z = nz; }
+    p.stamina = clamp(p.stamina + (sprint && p.speed > 10 ? -17 : p.speed < 5 ? 10 : p.speed < 10 ? 5 : -1) * dt, 0, 100);
+    p.phase += p.speed * dt;
+    p.cooldown = Math.max(0, p.cooldown - dt);
+    if (p.reload > 0) { p.reload = Math.max(0, p.reload - dt); if (p.reload === 0) p.ammo = 6; }
+    return { obstacle, grade };
+}
+export function worldClock(elapsed) {
+    const minutes = (16 * 60 + elapsed * 1.5) % 1440;
+    return { hour: minutes / 60, label: `${String(Math.floor(minutes / 60)).padStart(2, '0')}:${String(Math.floor(minutes % 60)).padStart(2, '0')}` };
+}
+const SETTINGS_KEY = 'rastro-vermelho:babylon';
+export const SETTINGS_DEFAULT = { quality: 'auto', volume: 70, muted: false, best: 0, reducedMotion: false, sensitivity: 1 };
+/* Duas falhas reais aqui: o modo privado do Safari estoura na gravação, e um
+   valor corrompido derrubava o lab já no construtor, antes de qualquer tela. */
+export function loadSettings(storage) {
+    try {
+        const raw = JSON.parse(storage.getItem(SETTINGS_KEY) || '{}') || {};
+        return { quality: ['auto', 'low', 'medium', 'high'].includes(raw.quality) ? raw.quality : 'auto', volume: Number.isFinite(raw.volume) ? clamp(raw.volume, 0, 100) : 70, best: Number.isFinite(raw.best) ? Math.max(0, raw.best) : 0, muted: raw.muted === true, reducedMotion: raw.reducedMotion === true, sensitivity: Number.isFinite(raw.sensitivity) ? clamp(raw.sensitivity, 0.4, 2) : 1 };
+    } catch { return { ...SETTINGS_DEFAULT }; }
+}
+export function saveSettings(storage, settings) { try { storage.setItem(SETTINGS_KEY, JSON.stringify(settings)); } catch { /* armazenamento indisponível */ } }
+export function loadJourney(storage) {
+    try {
+        const s = JSON.parse(storage.getItem('rastro-vermelho:journey:v1'));
+        if (!s || !Number.isInteger(s.stage) || s.stage < 0 || s.stage > LANDMARKS.length) return null;
+        // Resume from the last safe checkpoint, never from a saved combat coordinate.
+        return { stage: s.stage, money: clamp(Number(s.money) || 0, 0, 100000), distance: clamp(Number(s.distance) || 0, 0, 1e8), kills: clamp(Number(s.kills) || 0, 0, 100000) };
+    } catch { return null; }
+}
+export function saveJourney(storage, stage, p) { try { storage.setItem('rastro-vermelho:journey:v1', JSON.stringify({ stage, money: p.money, distance: p.distance, kills: p.kills })); } catch { /* A jornada continua sem armazenamento. */ } }

--- a/labs/rastro-vermelho/src/world.js
+++ b/labs/rastro-vermelho/src/world.js
@@ -1,0 +1,266 @@
+/** Streamed scenery shares geometry/materials. Terrain, collision and hooves sample
+ * the same height function; vegetation is deterministic when revisiting a chunk. */
+import { hash, terrainHeight, roadDistance, roadX, LANDMARKS, clamp, lerp } from './simulation.js';
+const B = window.BABYLON;
+export const CHUNK_SIZE = 96;
+export const PROFILES = {
+    low: { id: 'low', scale: 0.8, radius: 2, segments: 24, grass: 140, shadowSize: 512, bloom: false },
+    medium: { id: 'medium', scale: 1, radius: 2, segments: 36, grass: 380, shadowSize: 1024, bloom: false },
+    high: { id: 'high', scale: 1.25, radius: 3, segments: 40, grass: 650, shadowSize: 2048, bloom: true }
+};
+export function material(scene, name, color, roughness = 0.9) {
+    const m = new B.PBRMaterial(name, scene);
+    m.albedoColor = B.Color3.FromHexString(color); m.roughness = roughness; m.metallic = 0;
+    return m;
+}
+function box(scene, parent, name, size, pos, mat) {
+    const m = B.MeshBuilder.CreateBox(name, { width: size[0], height: size[1], depth: size[2] }, scene);
+    m.parent = parent; m.position.set(...pos); m.material = mat; m.isPickable = false; m.receiveShadows = true;
+    return m;
+}
+function sphere(scene, parent, name, size, pos, mat) {
+    const m = B.MeshBuilder.CreateSphere(name, { diameter: 1, segments: 10 }, scene);
+    m.parent = parent; m.scaling.set(...size); m.position.set(...pos); m.material = mat; m.isPickable = false;
+    return m;
+}
+export function createPerson(scene, palette, mounted = false) {
+    const root = new B.TransformNode(mounted ? 'cavaleiro' : 'fora-da-lei', scene);
+    const torso = sphere(scene, root, 'casaco', [.63, .79, .38], [0, 1.13, 0], palette.coat);
+    sphere(scene, root, 'rosto', [.29, .37, .28], [0, 1.77, .02], palette.skin);
+    const brim = B.MeshBuilder.CreateCylinder('aba-do-chapéu', { height: .045, diameter: .67, tessellation: 24 }, scene);
+    brim.parent = root; brim.position.y = 1.97; brim.material = palette.hat;
+    const hat = B.MeshBuilder.CreateCylinder('chapéu', { height: .21, diameterTop: .32, diameterBottom: .39, tessellation: 18 }, scene);
+    hat.parent = root; hat.position.y = 2.07; hat.material = palette.hat;
+    sphere(scene, root, 'lenço', [.33, .13, .33], [0, 1.55, .04], palette.scarf);
+    box(scene, root, 'cinturão', [.57, .09, .4], [0, .84, 0], palette.hat);
+    for (const side of [-1, 1]) {
+        const leg = sphere(scene, root, 'calça', [.23, mounted ? .6 : .75, .26], [side * (mounted ? .41 : .18), mounted ? .45 : .48, mounted ? -.14 : 0], palette.pants);
+        leg.rotation.z = side * (mounted ? .14 : -.05);
+        sphere(scene, root, 'bota', [.25, .34, .39], [side * (mounted ? .43 : .18), .12, .09], palette.hat);
+        const arm = sphere(scene, root, 'manga', [.22, .63, .24], [side * .38, 1.17, mounted ? .16 : 0], palette.coat);
+        arm.rotation.x = mounted ? -.8 : 0; arm.rotation.z = side * .14;
+        sphere(scene, root, 'mão', [.17, .2, .17], [side * .35, mounted ? 1.02 : .86, mounted ? .4 : .01], palette.skin);
+    }
+    const gun = box(scene, root, 'revólver', [.085, .12, .4], [.36, mounted ? 1.03 : .85, .26], palette.metal);
+    root.getChildMeshes().forEach(m => { m.isPickable = false; m.receiveShadows = true; });
+    return { root, torso, gun };
+}
+export class World {
+    constructor(scene, shadow, profile) {
+        this.scene = scene; this.shadow = shadow; this.profile = profile; this.chunks = new Map(); this.queue = []; this.center = ''; this.staticColliders = []; this.fires = [];
+        this.mats = {
+            wood: material(scene, 'madeira-envelhecida', '#65513d'), darkWood: material(scene, 'madeira-escura', '#33281f'),
+            canvas: material(scene, 'lona', '#b4a488'), metal: material(scene, 'ferro', '#343a3a', .42),
+            leaves: material(scene, 'folhas', '#455338'), bark: material(scene, 'casca', '#483c2d'),
+            grass: material(scene, 'capim-seco', '#9d9159'), coat: material(scene, 'casaco', '#514d3d'),
+            pants: material(scene, 'calça', '#333c41'), skin: material(scene, 'pele', '#b38a67'),
+            hat: material(scene, 'couro', '#30261e'), scarf: material(scene, 'lenço-carmim', '#8e3027'),
+            fire: material(scene, 'brasas', '#d76a22'), window: material(scene, 'janela-âmbar', '#bb883e')
+        };
+        this.mats.fire.emissiveColor.set(1, .24, .025); this.mats.window.emissiveColor.set(.26, .12, .025);
+        const terrain = material(scene, 'terra-pbr', '#ded3b9');
+        terrain.albedoTexture = new B.Texture('assets/ground-albedo.webp', scene);
+        terrain.bumpTexture = new B.Texture('assets/ground-normal.webp', scene); terrain.bumpTexture.level = .32;
+        terrain.metallicTexture = new B.Texture('assets/ground-roughness.webp', scene);
+        terrain.useRoughnessFromMetallicTextureAlpha = false; terrain.useRoughnessFromMetallicTextureGreen = true; terrain.useMetallnessFromMetallicTextureBlue = false;
+        terrain.roughness = 1; this.terrainMaterial = terrain;
+        this.rockMaterial = material(scene, 'arenito-pbr', '#a38a68');
+        this.rockMaterial.albedoTexture = new B.Texture('assets/rock-albedo.webp', scene);
+        this.rockMaterial.bumpTexture = new B.Texture('assets/rock-normal.webp', scene); this.rockMaterial.bumpTexture.level = .5;
+        this.createTemplates(); this.createLandmarks();
+        Object.values(this.mats).forEach(m => m.freeze());
+    }
+    createTemplates() {
+        const scene = this.scene;
+        this.rock = B.MeshBuilder.CreateIcoSphere('rocha-modelo', { radius: 1, subdivisions: 2, flat: false }, scene);
+        this.rock.material = this.rockMaterial; this.rock.isVisible = false;
+        const positions = this.rock.getVerticesData(B.VertexBuffer.PositionKind);
+        for (let i = 0; i < positions.length; i += 3) {
+            const d = .86 + hash(positions[i] * 15, positions[i + 2] * 19 + positions[i + 1]) * .28;
+            positions[i] *= d; positions[i + 1] *= d; positions[i + 2] *= d;
+        }
+        this.rock.setVerticesData(B.VertexBuffer.PositionKind, positions); this.rock.createNormals(false);
+        const parts = [];
+        const trunk = B.MeshBuilder.CreateCylinder('tronco', { height: 5, diameterTop: .17, diameterBottom: .55, tessellation: 8 }, scene);
+        trunk.position.y = 2.5; trunk.material = this.mats.bark; parts.push(trunk);
+        for (let i = 0; i < 5; i++) {
+            const crown = B.MeshBuilder.CreateCylinder('ramagem', { height: 2.6 - i * .22, diameterTop: 0, diameterBottom: 3.1 - i * .48, tessellation: 9 }, scene);
+            crown.position.y = 2.1 + i * .8; crown.rotation.y = i * .8; crown.material = this.mats.leaves; parts.push(crown);
+        }
+        this.tree = B.Mesh.MergeMeshes(parts, true, true, undefined, false, true); this.tree.name = 'pinheiro-modelo'; this.tree.isVisible = false;
+        const grass = new B.Mesh('touceira-modelo', scene), data = new B.VertexData();
+        const verts = [], indices = [], normals = [];
+        for (let i = 0; i < 5; i++) {
+            const a = i * 2.4, x = Math.cos(a) * .14, z = Math.sin(a) * .14, h = .28 + hash(i, 4) * .46;
+            const n = verts.length / 3;
+            verts.push(x - .045, 0, z, x + .045, 0, z, x + .13, h, z + .05);
+            indices.push(n, n + 1, n + 2); normals.push(0, 1, 0, 0, 1, 0, 0, 1, 0);
+        }
+        data.positions = verts; data.indices = indices; data.normals = normals; data.applyToMesh(grass);
+        this.mats.grass.backFaceCulling = false; grass.material = this.mats.grass; grass.isVisible = false; this.grass = grass;
+    }
+    createTerrain(cx, cz, segments = this.profile.segments, size = CHUNK_SIZE) {
+        const ground = B.MeshBuilder.CreateGround(`terra-${cx}-${cz}`, { width: size, height: size, subdivisions: segments }, this.scene);
+        const px = cx * size, pz = cz * size;
+        ground.position.set(px, 0, pz);
+        const pos = ground.getVerticesData(B.VertexBuffer.PositionKind), uv = ground.getVerticesData(B.VertexBuffer.UVKind), normals = [], colors = [];
+        for (let i = 0; i < pos.length; i += 3) {
+            const x = pos[i] + px, z = pos[i + 2] + pz, y = terrainHeight(x, z);
+            pos[i + 1] = y;
+            // World-space UV and finite-difference normals keep neighbouring tiles seamless.
+            const dx = terrainHeight(x - .3, z) - terrainHeight(x + .3, z), dz = terrainHeight(x, z - .3) - terrainHeight(x, z + .3);
+            const length = Math.hypot(dx, .6, dz); normals.push(dx / length, .6 / length, dz / length);
+            uv[i / 3 * 2] = x / 9; uv[i / 3 * 2 + 1] = z / 9;
+            const trail = clamp((roadDistance(x, z) - 2.5) / 5, 0, 1), arid = z > 630 && z < 865;
+            const variation = .9 + hash(Math.floor(x / 4), Math.floor(z / 4)) * .1;
+            colors.push(lerp(.79, arid ? .76 : .53, trail) * variation, lerp(.65, arid ? .58 : .58, trail) * variation, lerp(.46, arid ? .39 : .34, trail) * variation, 1);
+        }
+        ground.setVerticesData(B.VertexBuffer.PositionKind, pos); ground.setVerticesData(B.VertexBuffer.NormalKind, normals);
+        ground.setVerticesData(B.VertexBuffer.UVKind, uv); ground.setVerticesData(B.VertexBuffer.ColorKind, colors);
+        ground.material = this.terrainMaterial; ground.receiveShadows = true; ground.isPickable = false; ground.freezeWorldMatrix(); return ground;
+    }
+    createChunk(cx, cz) {
+        const root = new B.TransformNode(`cenário-${cx}-${cz}`, this.scene), colliders = [], shadows = [];
+        this.createTerrain(cx, cz).parent = root;
+        const rng = i => hash(cx * 37 + i * 2.7, cz * 19 + i * 1.3);
+        for (let i = 0; i < 22; i++) {
+            const x = cx * CHUNK_SIZE + (rng(i) - .5) * 92, z = cz * CHUNK_SIZE + (rng(i + 50) - .5) * 92;
+            if (roadDistance(x, z) < 8 || LANDMARKS.some(p => Math.hypot(p.x - x, p.z - z) < 31)) continue;
+            const isTree = !(z > 620 && z < 865) && (i % 3 === 0 || x < -90), scale = isTree ? .8 + rng(i + 80) * 1.1 : .7 + rng(i + 30) * 2.2;
+            const mesh = (isTree ? this.tree : this.rock).createInstance(`paisagem-${cx}-${cz}-${i}`);
+            mesh.parent = root; mesh.position.set(x, terrainHeight(x, z) - (isTree ? .1 : scale * .25), z);
+            mesh.scaling.set(scale * (isTree ? 1 : 1.4), scale, scale); mesh.rotation.y = rng(i + 100) * Math.PI * 2;
+            mesh.isPickable = false; mesh.receiveShadows = true; mesh.freezeWorldMatrix();
+            colliders.push({ x, z, radius: isTree ? scale * .25 : scale * 1.1 });
+            if (isTree && this.profile.id !== 'low') { this.shadow.addShadowCaster(mesh); shadows.push(mesh); }
+        }
+        const matrices = [];
+        for (let i = 0; i < this.profile.grass; i++) {
+            const x = cx * CHUNK_SIZE + (rng(i + 130) - .5) * 96, z = cz * CHUNK_SIZE + (rng(i + 1600) - .5) * 96;
+            if (roadDistance(x, z) < 3.7 || LANDMARKS.some(p => Math.hypot(p.x - x, p.z - z) < 13)) continue;
+            const s = .8 + rng(i + 4000) * 1.6;
+            B.Matrix.Compose(new B.Vector3(s, s, s), B.Quaternion.RotationAxis(B.Axis.Y, rng(i) * 6.28), new B.Vector3(x, terrainHeight(x, z), z)).copyToArray(matrices, matrices.length);
+        }
+        const grass = this.grass.clone(`capim-${cx}-${cz}`, root); grass.isVisible = true; grass.isPickable = false;
+        if (matrices.length) grass.thinInstanceSetBuffer('matrix', new Float32Array(matrices), 16, true);
+        else grass.setEnabled(false);
+        return { root, colliders, shadows };
+    }
+    update(x, z, immediate = false) {
+        // Ground tiles are centred at multiples of 96, so round (not floor) selects the tile.
+        const cx = Math.round(x / CHUNK_SIZE), cz = Math.round(z / CHUNK_SIZE), key = `${cx}:${cz}`;
+        if (key !== this.center) {
+            this.center = key; const needed = new Set(), candidates = [], r = this.profile.radius;
+            for (let dz = -r; dz <= r; dz++) for (let dx = -r; dx <= r; dx++) {
+                const k = `${cx + dx}:${cz + dz}`; needed.add(k);
+                if (!this.chunks.has(k)) candidates.push({ cx: cx + dx, cz: cz + dz, key: k, distance: dx * dx + dz * dz });
+            }
+            this.queue = candidates.sort((a, b) => a.distance - b.distance);
+            for (const [k, c] of this.chunks) if (!needed.has(k)) { c.shadows.forEach(m => this.shadow.removeShadowCaster(m)); c.root.dispose(); this.chunks.delete(k); }
+        }
+        // One tile per frame prevents the old 5/7-tile synchronous burst on crossing a border.
+        let count = immediate ? this.queue.length : 1;
+        while (count-- > 0 && this.queue.length) { const job = this.queue.shift(); this.chunks.set(job.key, this.createChunk(job.cx, job.cz)); }
+        this.colliders = [...this.staticColliders];
+        for (const c of this.chunks.values()) for (const o of c.colliders) if (Math.abs(o.x - x) < 50 && Math.abs(o.z - z) < 50) this.colliders.push(o);
+    }
+    setProfile(profile) {
+        this.profile = profile;
+        for (const c of this.chunks.values()) { c.shadows.forEach(m => this.shadow.removeShadowCaster(m)); c.root.dispose(); }
+        this.chunks.clear(); this.center = ''; this.queue = [];
+    }
+    createLandmarks() {
+        this.places = LANDMARKS.map(p => {
+            const root = new B.TransformNode(p.name, this.scene); root.position.set(p.x, terrainHeight(p.x, p.z), p.z);
+            if (p.kind === 'camp') { this.tent(root, -5, 1); this.campfire(root, 0, 0); this.crate(root, 4, 2); }
+            else {
+                this.building(root, -8, 3, p.kind === 'town' ? 7 : 6, 5, p.kind === 'mine' ? 'MINA' : p.kind === 'ranch' ? 'RANCHO' : p.kind === 'town' ? 'CORREIO' : 'POSTO');
+                this.campfire(root, 2, -3); this.crate(root, 5, 2); this.crate(root, 5.8, 3.5);
+                if (p.kind === 'town' || p.kind === 'ranch') this.building(root, 9, 6, 5, 4, p.kind === 'town' ? 'ARMAZÉM' : 'ESTÁBULO');
+                for (let i = 0; i < 5; i++) {
+                    const x = -14 + i * 2.3;
+                    box(this.scene, root, 'mourão', [.13, 1.2, .15], [x, .6, 10], this.mats.wood);
+                    if (i < 4) for (const h of [.4, .9]) box(this.scene, root, 'cerca', [2.3, .09, .1], [x + 1.15, h, 10], this.mats.wood);
+                }
+            }
+            root.getChildMeshes().forEach(m => { m.computeWorldMatrix(true); m.freezeWorldMatrix(); if (!m.metadata?.fire) this.shadow.addShadowCaster(m); });
+            return root;
+        });
+    }
+    crate(parent, x, z) {
+        box(this.scene, parent, 'caixote', [.9, .8, .85], [x, .4, z], this.mats.wood);
+        for (const offset of [-.32, .32]) box(this.scene, parent, 'cinta', [.09, .84, .89], [x + offset, .42, z], this.mats.darkWood);
+    }
+    tent(parent, x, z) {
+        const tent = B.MeshBuilder.CreateCylinder('barraca', { diameter: 4, height: 4.2, tessellation: 3 }, this.scene);
+        tent.parent = parent; tent.rotation.z = Math.PI / 2; tent.rotation.y = Math.PI / 2; tent.position.set(x, 1, z); tent.material = this.mats.canvas;
+        box(this.scene, parent, 'esteio', [.1, 2.4, .1], [x, 1.2, z - 2.1], this.mats.wood);
+        this.staticColliders.push({ x: parent.position.x + x, z: parent.position.z + z, radius: 2 });
+    }
+    campfire(parent, x, z) {
+        for (let i = 0; i < 9; i++) {
+            const stone = this.rock.createInstance('pedra-da-fogueira'); stone.parent = parent;
+            stone.position.set(x + Math.sin(i * .7) * .8, .12, z + Math.cos(i * .7) * .8); stone.scaling.set(.23, .18, .23);
+        }
+        for (const a of [-.6, .6]) { const log = box(this.scene, parent, 'lenha', [1.3, .15, .17], [x, .17, z], this.mats.darkWood); log.rotation.y = a; }
+        const flame = sphere(this.scene, parent, 'fogo', [.6, .9, .6], [x, .4, z], this.mats.fire); flame.metadata = { fire: true };
+        const light = new B.PointLight('luz-da-fogueira', new B.Vector3(parent.position.x + x, parent.position.y + 1, parent.position.z + z), this.scene);
+        light.diffuse.set(1, .44, .13); light.range = 9; light.intensity = 4;
+        this.fires.push({ mesh: flame, light, x: parent.position.x + x, z: parent.position.z + z });
+    }
+    building(parent, x, z, width, depth, label) {
+        const s = this.scene, m = this.mats;
+        box(s, parent, 'fundação', [width + .3, .3, depth + .2], [x, .15, z], m.darkWood);
+        for (let row = 0; row < 11; row++) {
+            const y = .45 + row * .25;
+            box(s, parent, 'tábua-fundo', [width, .23, .15], [x, y, z + depth / 2], m.wood);
+            for (const side of [-1, 1]) box(s, parent, 'tábua-lateral', [.15, .23, depth], [x + side * width / 2, y, z], m.wood);
+        }
+        box(s, parent, 'fachada', [width, 2.8, .16], [x, 1.55, z - depth / 2], m.wood);
+        box(s, parent, 'porta', [1.1, 2.1, .2], [x, 1.2, z - depth / 2 - .05], m.darkWood);
+        for (const side of [-1, 1]) {
+            box(s, parent, 'vidraça', [1.05, .95, .2], [x + side * width * .3, 1.7, z - depth / 2 - .09], m.window);
+            box(s, parent, 'caixilho', [.07, 1.05, .22], [x + side * width * .3, 1.7, z - depth / 2 - .11], m.darkWood);
+            const roof = box(s, parent, 'telhado', [width / 2 + .6, .16, depth + .8], [x + side * width / 4, 3.1, z], m.darkWood); roof.rotation.z = side * -.22;
+        }
+        box(s, parent, 'varanda', [width + .8, .15, 1.7], [x, .25, z - depth / 2 - .8], m.wood);
+        for (const side of [-1, 1]) box(s, parent, 'pilar', [.14, 2.9, .14], [x + side * (width / 2), 1.6, z - depth / 2 - 1.3], m.darkWood);
+        box(s, parent, 'cobertura-varanda', [width + .8, .15, 1.8], [x, 3, z - depth / 2 - .8], m.darkWood);
+        const texture = new B.DynamicTexture(`letreiro-${label}`, { width: 512, height: 128 }, s, false);
+        texture.drawText(label, null, 84, 'bold 60px Georgia', '#e3d3a7', '#30291e', true);
+        const signMat = new B.StandardMaterial(`placa-${label}`, s); signMat.diffuseTexture = texture; signMat.specularColor.set(0, 0, 0);
+        const sign = B.MeshBuilder.CreatePlane('letreiro', { width: width * .65, height: .8, sideOrientation: B.Mesh.DOUBLESIDE }, s);
+        sign.parent = parent; sign.position.set(x, 3.4, z - depth / 2 - .12); sign.material = signMat;
+        this.staticColliders.push({ x: parent.position.x + x, z: parent.position.z + z, radius: Math.max(width, depth) * .55 });
+    }
+    animate(time, x, z) {
+        for (const f of this.fires) {
+            const near = Math.hypot(x - f.x, z - f.z) < 65;
+            f.light.setEnabled(near); f.mesh.unfreezeWorldMatrix(); f.mesh.scaling.y = .85 + Math.sin(time * 12 + f.x) * .15;
+            if (near) f.light.intensity = 3.5 + Math.sin(time * 9) * .6;
+        }
+        for (let i = 0; i < this.places.length; i++) this.places[i].setEnabled(Math.hypot(x - LANDMARKS[i].x, z - LANDMARKS[i].z) < (this.profile.radius + .35) * CHUNK_SIZE);
+    }
+}
+export async function loadHorse(scene, shadow, palette) {
+    const result = await B.SceneLoader.ImportMeshAsync('', '', 'assets/horse.gltf', scene, undefined, '.gltf');
+    const mount = new B.TransformNode('montaria', scene), model = result.meshes[0];
+    model.parent = mount; model.rotationQuaternion = null; model.rotation.y = 0; model.scaling.setAll(.85);
+    result.animationGroups.forEach(g => g.stop());
+    const animations = new Map(result.animationGroups.map(g => [g.name.toLowerCase(), g]));
+    const rider = createPerson(scene, palette, true); rider.root.parent = mount; rider.root.position.set(0, 3.02, -.18); rider.root.scaling.setAll(.88);
+    const saddle = box(scene, mount, 'sela', [.72, .16, .92], [0, 3.02, -.16], palette.hat);
+    sphere(scene, mount, 'alforje', [.35, .5, .6], [.46, 2.84, -.65], palette.wood);
+    sphere(scene, mount, 'alforje', [.35, .5, .6], [-.46, 2.84, -.65], palette.wood);
+    const reins = B.MeshBuilder.CreateLines('rédeas', { points: [new B.Vector3(-.27, 3.13, .24), new B.Vector3(-.24, 2.97, .8), new B.Vector3(0, 3.12, 1.25), new B.Vector3(.24, 2.97, .8), new B.Vector3(.27, 3.13, .24)] }, scene);
+    reins.parent = mount; reins.color = B.Color3.FromHexString('#37251b'); reins.isPickable = false;
+    mount.getChildMeshes().forEach(m => { m.isPickable = false; m.receiveShadows = true; shadow.addShadowCaster(m); });
+    let active = null;
+    return { root: mount, rider, saddle, animations, update(speed, phase, steer) {
+        const name = speed < .15 ? 'idle' : speed < 6 ? 'walk' : 'gallop', next = animations.get(name);
+        if (next !== active) { active?.stop(); next?.start(true); active = next; }
+        if (active) active.speedRatio = speed < .15 ? 1 : clamp(speed / (name === 'walk' ? 3 : 10), .5, 1.65);
+        rider.root.position.y = 3.02 + (speed > 1 ? Math.sin(phase * 2.3) * .035 : 0);
+        rider.torso.rotation.x = speed > 11 ? .16 : .03; rider.root.rotation.z = steer * -.04;
+    } };
+}

--- a/labs/rastro-vermelho/style.css
+++ b/labs/rastro-vermelho/style.css
@@ -1,670 +1,209 @@
-/* ================================================================
-   Rastro Vermelho — interface
-   Paleta: ferrugem, ocre, poeira, ouro velho, sangue de pôr do sol.
-   ================================================================ */
-
 :root {
-    --ink: oklch(14% 0.04 48);
-    --ink-deep: oklch(8% 0.03 42);
-    --parchment: oklch(92% 0.04 88);
-    --gold: oklch(76% 0.15 72);
-    --gold-deep: oklch(58% 0.14 58);
-    --dust: oklch(70% 0.08 68);
-    --ember: oklch(58% 0.19 38);
-    --blood: oklch(48% 0.18 28);
-
-    --text: oklch(96% 0.02 88);
-    --text-soft: oklch(82% 0.03 80);
-    --text-dim: oklch(64% 0.03 72);
-
-    --panel: color-mix(in oklab, oklch(16% 0.04 48) 64%, transparent);
-    --panel-strong: color-mix(in oklab, oklch(11% 0.04 42) 84%, transparent);
-    --line: color-mix(in oklab, var(--gold) 30%, transparent);
-    --line-soft: color-mix(in oklab, var(--parchment) 12%, transparent);
-
-    --radius: 14px;
-    --radius-lg: 22px;
-    --blur: 20px;
+    --ink: #111313;
+    --ink-deep: #080b0c;
+    --paper: #efe1c1;
+    --paper-soft: #c9b992;
+    --paper-dim: #8d836b;
+    --gold: #e2b862;
+    --red: #a83427;
+    --red-bright: #d1543a;
+    --line: rgba(226,184,98,.3);
+    --line-soft: rgba(239,225,193,.15);
+    --panel: rgba(16,20,19,.72);
+    --panel-heavy: rgba(12,15,15,.93);
     --safe-top: env(safe-area-inset-top, 0px);
+    --safe-right: env(safe-area-inset-right, 0px);
     --safe-bottom: env(safe-area-inset-bottom, 0px);
     --safe-left: env(safe-area-inset-left, 0px);
-    --safe-right: env(safe-area-inset-right, 0px);
-    --ease: cubic-bezier(0.22, 1, 0.36, 1);
+    --ease: cubic-bezier(.22,1,.36,1);
 }
-
-*, *::before, *::after {
-    box-sizing: border-box;
-    -webkit-tap-highlight-color: transparent;
-}
-
-html, body {
-    margin: 0;
-    width: 100%;
-    height: 100%;
-    overflow: clip;
-    overscroll-behavior: none;
-    background: var(--ink-deep);
-}
-
-body {
-    min-height: 100dvh;
-    color: var(--text);
-    font-family: 'Outfit', system-ui, sans-serif;
-    user-select: none;
-    touch-action: none;
-}
-
-button, input, select { font: inherit; color: inherit; }
-button { background: none; border: 0; cursor: pointer; }
-
-.mono {
-    font-variant-numeric: tabular-nums;
-    font-feature-settings: 'tnum' 1;
-}
-
-:focus-visible {
-    outline: 2px solid var(--gold);
-    outline-offset: 3px;
-}
-
-.game-shell {
-    position: fixed;
-    inset: 0;
-    overflow: hidden;
-    background: radial-gradient(120% 90% at 50% 0%, oklch(26% 0.08 48) 0%, var(--ink-deep) 70%);
-}
-
-#scene {
-    position: absolute;
-    inset: 0;
-    width: 100%;
-    height: 100%;
-    display: block;
-    touch-action: none;
-}
-
-.app-logo {
-    display: flex;
-    align-items: center;
-    gap: 0.55rem;
-    font-family: 'Cinzel', Georgia, serif;
-    font-weight: 700;
-    letter-spacing: 0.04em;
-}
-
-.brand-mark {
-    display: grid;
-    place-items: center;
-    width: 1.55rem;
-    height: 1.55rem;
-    border-radius: 999px;
-    background: radial-gradient(circle at 35% 30%, #ffe7a0, #c42818 72%);
-    box-shadow: 0 0 16px color-mix(in oklab, var(--ember) 55%, transparent);
-    font-size: 0.72rem;
-}
-
-.vignette {
-    position: absolute;
-    inset: 0;
-    z-index: 18;
-    pointer-events: none;
-    background:
-        radial-gradient(120% 90% at 50% 42%, transparent 48%, oklch(8% 0.03 42 / 0.58) 100%);
-}
-
-.hud {
-    position: absolute;
-    inset: 0;
-    z-index: 24;
-    pointer-events: none;
-}
-
-.hud-top {
-    position: absolute;
-    top: calc(4.4rem + var(--safe-top));
-    left: calc(16px + var(--safe-left));
-    right: calc(16px + var(--safe-right));
-    display: grid;
-    grid-template-columns: minmax(0, 1.3fr) minmax(0, 1fr) minmax(0, 1fr);
-    gap: 12px;
-    max-width: 920px;
-}
-
-.panel {
-    background: var(--panel);
-    border: 1px solid var(--line-soft);
-    border-radius: var(--radius);
-    padding: 10px 14px;
-    backdrop-filter: blur(var(--blur));
-    min-width: 0;
-}
-
-.hud-label {
-    display: block;
-    font-size: 0.64rem;
-    letter-spacing: 0.16em;
-    text-transform: uppercase;
-    color: var(--gold);
-    margin-bottom: 4px;
-}
-
-.meta {
-    font-size: 0.72rem;
-    color: var(--text-dim);
-}
-
-.compass-panel {
-    display: flex;
-    align-items: center;
-    gap: 12px;
-}
-
-.compass {
-    position: relative;
-    width: 52px;
-    height: 52px;
-    flex-shrink: 0;
-}
-
-.compass-rose {
-    position: absolute;
-    inset: 0;
-    border-radius: 50%;
-    border: 1px solid var(--line);
-    background: color-mix(in oklab, var(--ink) 50%, transparent);
-    transition: transform 0.08s linear;
-}
-
-.compass-rose span {
-    position: absolute;
-    font-size: 0.58rem;
-    letter-spacing: 0.08em;
-    color: var(--text-dim);
-}
-
-.compass-rose .n { top: 3px; left: 50%; transform: translateX(-50%); color: var(--ember); font-weight: 700; }
-.compass-rose .s { bottom: 3px; left: 50%; transform: translateX(-50%); }
-.compass-rose .e { right: 5px; top: 50%; transform: translateY(-50%); }
-.compass-rose .w { left: 4px; top: 50%; transform: translateY(-50%); }
-
-.compass-needle {
-    position: absolute;
-    left: 50%;
-    top: 8px;
-    width: 0;
-    height: 0;
-    border-left: 4px solid transparent;
-    border-right: 4px solid transparent;
-    border-bottom: 10px solid var(--gold);
-    transform: translateX(-50%);
-    z-index: 1;
-}
-
-.region-block {
-    min-width: 0;
-}
-
-.region-block strong {
-    display: block;
-    font-family: 'Cinzel', Georgia, serif;
-    font-size: clamp(0.92rem, 2.2vw, 1.12rem);
-    font-weight: 600;
-    letter-spacing: 0.02em;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-}
-
-.speed-row {
-    display: flex;
-    align-items: baseline;
-    justify-content: space-between;
-    gap: 8px;
-}
-
-.gait-panel strong {
-    font-family: 'Cinzel', Georgia, serif;
-    text-transform: capitalize;
-    font-size: 1.05rem;
-}
-
-.mark-pips {
-    display: flex;
-    gap: 5px;
-    margin-top: 6px;
-}
-
-.mark-pips i {
-    width: 8px;
-    height: 8px;
-    border-radius: 50%;
-    background: color-mix(in oklab, var(--text-dim) 40%, transparent);
-    border: 1px solid var(--line-soft);
-}
-
-.mark-pips i[data-on="true"] {
-    background: var(--gold);
-    box-shadow: 0 0 8px color-mix(in oklab, var(--gold) 60%, transparent);
-}
-
-.message, .prompt {
-    position: absolute;
-    left: 50%;
-    transform: translateX(-50%);
-    text-align: center;
-    max-width: min(92vw, 420px);
-    pointer-events: none;
-}
-
-.message {
-    bottom: calc(96px + var(--safe-bottom));
-    font-family: 'Cinzel', Georgia, serif;
-    font-size: clamp(0.95rem, 2.4vw, 1.2rem);
-    opacity: 0;
-    transition: opacity 0.35s var(--ease);
-    text-shadow: 0 2px 16px oklch(8% 0.04 42 / 0.7);
-}
-
+*, *::before, *::after { box-sizing: border-box; -webkit-tap-highlight-color: transparent; }
+html, body { width: 100%; height: 100%; margin: 0; overflow: clip; background: var(--ink-deep); }
+body { min-height: 100dvh; color: var(--paper); font-family: Outfit, system-ui, sans-serif; user-select: none; touch-action: none; }
+button, input, select { color: inherit; font: inherit; }
+button { border: 0; background: none; cursor: pointer; }
+button:disabled { cursor: default; opacity: .48; }
+a { color: var(--gold); }
+:focus-visible { outline: 2px solid var(--gold); outline-offset: 3px; }
+.game-shell { position: fixed; inset: 0; overflow: hidden; background: #1c1b18; }
+#scene { position: absolute; inset: 0; width: 100%; height: 100%; display: block; outline: 0; touch-action: none; }
+.app-logo { display: flex; align-items: center; gap: .55rem; color: var(--paper); font: 700 .9rem/1 Cinzel, Georgia, serif; letter-spacing: .05em; }
+.brand-mark { display: grid; place-items: center; width: 1.5rem; height: 1.5rem; border-radius: 50%; color: #2a1d12; background: radial-gradient(circle at 35% 30%, #ffe5a4, #bd4226 73%); box-shadow: 0 0 17px rgba(198,65,34,.55); font-size: .7rem; }
+.vignette { position: absolute; inset: 0; z-index: 18; pointer-events: none; background: radial-gradient(110% 90% at 50% 42%, transparent 40%, rgba(3,5,6,.08) 66%, rgba(3,5,6,.72) 100%); }
+.damage-veil, .focus-veil { position: absolute; inset: 0; z-index: 19; pointer-events: none; transition: opacity .2s; }
+.damage-veil { background: radial-gradient(ellipse at center, transparent 35%, rgba(164,28,19,.58) 100%); opacity: 0; }
+.focus-veil { background: radial-gradient(ellipse at center, transparent 37%, rgba(209,174,112,.18) 70%, rgba(8,9,10,.44) 100%); mix-blend-mode: screen; }
+[hidden] { display: none !important; }
+.hud { position: absolute; inset: 0; z-index: 24; pointer-events: none; }
+.location, .mission, .weapon-hud, .rider-hud, .hud-actions { position: absolute; pointer-events: auto; }
+.location { top: calc(4.15rem + var(--safe-top)); left: calc(1.3rem + var(--safe-left)); display: grid; gap: .18rem; max-width: min(32vw, 300px); text-shadow: 0 2px 14px rgba(0,0,0,.7); }
+.location strong { overflow: hidden; color: var(--paper); font: 600 clamp(1rem, 2vw, 1.35rem)/1.15 Cinzel, Georgia, serif; text-overflow: ellipsis; white-space: nowrap; }
+.location > span:last-child { color: var(--paper-dim); font: .68rem/1 monospace; letter-spacing: .14em; }
+.eyebrow { display: flex; align-items: center; gap: .45rem; margin: 0; color: var(--gold); font: 700 .62rem/1 Outfit, sans-serif; letter-spacing: .16em; text-transform: uppercase; }
+.eyebrow::before { width: 18px; height: 1px; background: var(--gold); content: ''; }
+.hud-actions { top: calc(4.15rem + var(--safe-top)); right: calc(1.3rem + var(--safe-right)); display: flex; gap: .45rem; }
+.icon-button { display: grid; place-items: center; width: 44px; height: 44px; min-width: 44px; border: 1px solid var(--line-soft); border-radius: 10px; background: var(--panel); backdrop-filter: blur(16px); font-size: 1rem; }
+.icon-button[aria-pressed="false"] { color: var(--paper-dim); opacity: .65; }
+.mission { top: calc(4.15rem + var(--safe-top)); left: 50%; width: min(360px, 42vw); transform: translateX(-50%); text-align: center; text-shadow: 0 2px 14px rgba(0,0,0,.72); }
+.mission .eyebrow { justify-content: center; }
+.mission .eyebrow::before { display: none; }
+.mission strong { display: block; margin: .38rem 0 .24rem; color: var(--paper); font: 600 clamp(1rem, 2vw, 1.25rem)/1.15 Cinzel, Georgia, serif; }
+.mission > span:not(.eyebrow) { display: block; color: var(--paper-soft); font-size: .78rem; line-height: 1.35; }
+.mark-pips { display: flex; justify-content: center; gap: 6px; margin-top: .65rem; }
+.mark-pips i { display: block; width: 7px; height: 7px; border: 1px solid var(--paper-dim); border-radius: 50%; background: transparent; }
+.mark-pips i[data-on="true"] { border-color: var(--gold); background: var(--gold); box-shadow: 0 0 9px rgba(226,184,98,.65); }
+.rider-hud { bottom: calc(1.35rem + var(--safe-bottom)); left: calc(1.3rem + var(--safe-left)); display: flex; align-items: end; gap: 12px; }
+#minimap { width: 124px; height: 124px; border-radius: 50%; background: rgba(15,20,19,.66); box-shadow: 0 8px 28px rgba(0,0,0,.3); }
+.vitals { display: grid; gap: 8px; width: 152px; padding-bottom: 3px; }
+.vital { display: grid; grid-template-columns: 48px 1fr; align-items: center; gap: 7px; color: var(--paper-dim); font-size: .62rem; letter-spacing: .08em; text-transform: uppercase; }
+meter { width: 100%; height: 4px; border: 0; background: rgba(239,225,193,.17); }
+meter::-webkit-meter-bar { border: 0; background: rgba(239,225,193,.17); }
+meter::-webkit-meter-optimum-value { background: var(--gold); }
+.vital:nth-child(1) meter::-webkit-meter-optimum-value { background: var(--red-bright); }
+.vital:nth-child(3) meter::-webkit-meter-optimum-value { background: #79a8b4; }
+.ride-info { color: var(--paper-dim); font-size: .7rem; letter-spacing: .04em; }
+.ride-info b { color: var(--paper); font: 600 1.25rem/1 Cinzel, Georgia, serif; }
+.ride-info span { margin-left: .35rem; text-transform: uppercase; }
+.weapon-hud { right: calc(1.3rem + var(--safe-right)); bottom: calc(1.4rem + var(--safe-bottom)); display: grid; gap: .3rem; min-width: 130px; text-align: right; text-shadow: 0 2px 14px rgba(0,0,0,.7); }
+.weapon-hud .eyebrow { justify-content: end; }
+.weapon-hud .eyebrow::before { display: none; }
+.weapon-hud div { color: var(--paper-dim); font: 1rem monospace; }
+.weapon-hud strong { color: var(--paper); font: 700 2rem/1 Cinzel, Georgia, serif; }
+.weapon-hud b { margin-left: 1rem; color: var(--gold); font: .82rem Outfit, sans-serif; }
+.weapon-hud > span:last-child { color: var(--paper-dim); font: .66rem monospace; }
+.message { position: absolute; bottom: calc(8.5rem + var(--safe-bottom)); left: 50%; max-width: min(88vw, 490px); margin: 0; transform: translateX(-50%); color: var(--paper); font: 600 clamp(.9rem, 2vw, 1.15rem)/1.35 Cinzel, Georgia, serif; text-align: center; text-shadow: 0 2px 18px rgba(0,0,0,.9); opacity: 0; transition: opacity .35s var(--ease); }
 .message[data-show="true"] { opacity: 1; }
-
-.prompt {
-    bottom: calc(58px + var(--safe-bottom));
-    font-size: 0.72rem;
-    letter-spacing: 0.12em;
-    text-transform: uppercase;
-    color: var(--text-dim);
-}
-
-.hud-actions {
-    position: absolute;
-    top: calc(64px + var(--safe-top));
-    right: calc(18px + var(--safe-right));
-    display: none;
-}
-
-body[data-state="play"] .hud-actions {
-    display: flex;
-    gap: 8px;
-    align-items: center;
-    pointer-events: auto;
-    margin-top: 86px;
-}
-
-.icon-button {
-    width: 44px;
-    height: 44px;
-    min-width: 44px;
-    min-height: 44px;
-    border-radius: 10px;
-    background: var(--panel);
-    border: 1px solid var(--line-soft);
-    pointer-events: auto;
-}
-
-.icon-button[aria-pressed="false"] { opacity: 0.55; }
-
-.fps {
-    font-size: 0.68rem;
-    color: var(--text-dim);
-    min-width: 48px;
-}
-
-.touch-controls {
-    position: absolute;
-    inset: 0;
-    pointer-events: none;
-    z-index: 26;
-}
-
-.stick {
-    position: absolute;
-    left: calc(28px + var(--safe-left));
-    bottom: calc(28px + var(--safe-bottom));
-    width: 118px;
-    height: 118px;
-    border-radius: 50%;
-    border: 1px solid var(--line);
-    background: var(--panel);
-    pointer-events: auto;
-    display: grid;
-    place-items: center;
-}
-
-.stick i {
-    width: 42px;
-    height: 42px;
-    border-radius: 50%;
-    background: color-mix(in oklab, var(--gold) 55%, white);
-}
-
-.stick span {
-    position: absolute;
-    bottom: 10px;
-    font-size: 0.62rem;
-    letter-spacing: 0.12em;
-    text-transform: uppercase;
-    color: var(--text-dim);
-}
-
-.look-zone {
-    position: absolute;
-    right: 0;
-    top: 20%;
-    width: 48%;
-    height: 55%;
-    pointer-events: auto;
-}
-
-.touch-buttons {
-    position: absolute;
-    right: calc(22px + var(--safe-right));
-    bottom: calc(28px + var(--safe-bottom));
-    display: flex;
-    flex-direction: column;
-    gap: 10px;
-    pointer-events: auto;
-}
-
-.pad {
-    min-width: 72px;
-    min-height: 52px;
-    height: 52px;
-    border-radius: 14px;
-    background: var(--panel-strong);
-    border: 1px solid var(--line);
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-    font-size: 0.72rem;
-}
-
-.pad-spur {
-    background: color-mix(in oklab, var(--ember) 55%, var(--ink));
-}
-
-.overlay {
-    position: absolute;
-    inset: 0;
-    z-index: 50;
-    display: grid;
-    place-items: center;
-    padding: calc(1.2rem + var(--safe-top)) calc(1.2rem + var(--safe-right))
-             calc(1.2rem + var(--safe-bottom)) calc(1.2rem + var(--safe-left));
-    background: oklch(8% 0.03 42 / 0.55);
-    backdrop-filter: blur(10px);
-}
-
-.overlay[hidden] { display: none !important; }
-
-.overlay-card, .loading-card {
-    width: min(920px, 100%);
-    background: var(--panel-strong);
-    border: 1px solid var(--line);
-    border-radius: var(--radius-lg);
-    padding: 28px 32px;
-    box-shadow: 0 30px 80px oklch(8% 0.04 42 / 0.45);
-}
-
-.loading-card {
-    width: min(380px, 100%);
-    text-align: center;
-}
-
-.sun-loader {
-    display: block;
-    width: 42px;
-    height: 42px;
-    margin: 0 auto 12px;
-    border-radius: 50%;
-    background: radial-gradient(circle at 35% 30%, #ffe7a0, #c42818 70%);
-    box-shadow: 0 0 28px #c44020;
-    animation: pulse 1.6s ease-in-out infinite;
-}
-
-@keyframes pulse {
-    50% { transform: scale(1.08); filter: brightness(1.15); }
-}
-
-.loading-card h1, .menu-head h1, .compact-card h2 {
-    font-family: 'Cinzel', Georgia, serif;
-    font-weight: 700;
-    letter-spacing: 0.02em;
-    margin: 0 0 0.4rem;
-}
-
-.loading-card h1 { font-size: 1.7rem; }
-.menu-head h1 { font-size: clamp(2.1rem, 5vw, 3.4rem); line-height: 0.95; }
+.prompt { position: absolute; bottom: calc(.75rem + var(--safe-bottom)); left: 50%; margin: 0; transform: translateX(-50%); color: rgba(239,225,193,.62); font-size: .66rem; letter-spacing: .09em; text-align: center; text-transform: uppercase; white-space: nowrap; }
+.interaction { position: absolute; bottom: calc(4.3rem + var(--safe-bottom)); left: 50%; display: inline-flex; align-items: center; gap: .5rem; min-height: 44px; padding: .65rem 1rem; transform: translateX(-50%); border: 1px solid var(--line); border-radius: 999px; color: var(--paper); background: var(--panel-heavy); box-shadow: 0 10px 30px rgba(0,0,0,.35); font-size: .76rem; backdrop-filter: blur(14px); }
+.interaction:disabled { border-color: rgba(239,225,193,.18); color: var(--paper-dim); }
+kbd { display: inline-grid; min-width: 1.45rem; height: 1.35rem; place-items: center; padding: 0 .28rem; border: 1px solid var(--line); border-radius: 4px; color: var(--gold); background: rgba(0,0,0,.28); font: 700 .65rem monospace; }
+.waypoint { position: absolute; z-index: 1; display: grid; justify-items: center; gap: 2px; transform: translate(-50%, -50%); color: var(--gold); filter: drop-shadow(0 2px 6px rgba(0,0,0,.8)); pointer-events: none; }
+.waypoint i { font: normal 2rem/1 Cinzel, Georgia, serif; animation: waypoint 1.6s ease-in-out infinite; }
+.waypoint span { color: var(--paper); font: .65rem monospace; }
+@keyframes waypoint { 50% { transform: translateY(-4px) scale(1.08); } }
+.reticle { position: absolute; top: 50%; left: 50%; width: 22px; height: 22px; transform: translate(-50%, -50%); opacity: .6; transition: width .18s, height .18s, opacity .18s; }
+.reticle i, .reticle::before, .reticle::after { position: absolute; content: ''; background: var(--paper); }
+.reticle i { top: 9px; left: 9px; width: 4px; height: 4px; border-radius: 50%; }
+.reticle::before, .reticle::after { top: 10px; width: 6px; height: 1px; }
+.reticle::before { right: 0; } .reticle::after { left: 0; }
+.reticle b { position: absolute; top: 0; left: 10px; width: 1px; height: 6px; background: var(--paper); box-shadow: 0 16px 0 var(--paper); }
+.reticle[data-target="true"] { width: 31px; height: 31px; opacity: 1; }
+.reticle[data-target="true"] i { background: var(--gold); }
+.reticle.threat { filter: drop-shadow(0 0 5px var(--red-bright)); }
+.hit-marker { position: absolute; top: 50%; left: 50%; color: var(--paper); font: 1.8rem/1 Outfit, sans-serif; opacity: 0; transform: translate(-50%, -50%) scale(.6); }
+.hit-marker[data-show="true"] { animation: hit .18s ease-out; }
+@keyframes hit { 0% { opacity: 1; transform: translate(-50%, -50%) scale(1.15); } 100% { opacity: 0; transform: translate(-50%, -50%) scale(.7); } }
+.touch-controls { position: absolute; inset: 0; display: none; pointer-events: none; }
+.stick { position: absolute; bottom: calc(1.2rem + var(--safe-bottom)); left: calc(1.25rem + var(--safe-left)); display: grid; width: 126px; height: 126px; place-items: center; border: 1px solid rgba(239,225,193,.28); border-radius: 50%; background: rgba(12,15,15,.35); pointer-events: auto; touch-action: none; }
+.stick::before { position: absolute; inset: 17px; border: 1px solid rgba(239,225,193,.12); border-radius: 50%; content: ''; }
+.stick i { z-index: 1; width: 48px; height: 48px; border: 1px solid var(--line); border-radius: 50%; background: rgba(226,184,98,.8); box-shadow: 0 4px 15px rgba(0,0,0,.35); transition: transform .08s; }
+.stick span { position: absolute; bottom: 9px; color: var(--paper-dim); font-size: .55rem; letter-spacing: .14em; text-transform: uppercase; }
+.look-zone { position: absolute; inset: 20% 0 20% 35%; pointer-events: auto; touch-action: none; }
+.touch-buttons { position: absolute; right: calc(1.1rem + var(--safe-right)); bottom: calc(1.1rem + var(--safe-bottom)); display: grid; grid-template-columns: repeat(2, 64px); gap: 8px; pointer-events: auto; }
+.pad { min-width: 64px; min-height: 52px; border: 1px solid var(--line-soft); border-radius: 12px; color: var(--paper); background: var(--panel); font-size: .64rem; letter-spacing: .08em; text-transform: uppercase; backdrop-filter: blur(12px); }
+.pad:active, .pad[aria-pressed="true"] { border-color: var(--gold); background: rgba(130,72,29,.7); }
+.pad-fire { border-color: rgba(209,84,58,.55); color: #efb5a3; }
+.overlay { position: absolute; inset: 0; z-index: 50; display: grid; place-items: center; padding: calc(1rem + var(--safe-top)) calc(1rem + var(--safe-right)) calc(1rem + var(--safe-bottom)) calc(1rem + var(--safe-left)); background: rgba(7,9,9,.58); backdrop-filter: blur(18px) saturate(.8); }
+.overlay-card, .menu-card, .loading-card { width: min(100%, 510px); border: 1px solid var(--line); border-radius: 18px; background: linear-gradient(135deg, rgba(29,28,23,.97), rgba(11,14,14,.97)); box-shadow: 0 32px 90px rgba(0,0,0,.5); }
+.menu-card { position: relative; width: min(900px, 100%); padding: clamp(1.45rem, 4vw, 3rem); overflow: hidden; }
+.menu-card::before { position: absolute; top: -35%; right: -10%; width: 55%; height: 120%; background: radial-gradient(ellipse, rgba(163,70,37,.22), transparent 68%); content: ''; pointer-events: none; }
+.menu-head, .journey-preview, .menu-actions, .settings, .menu-foot { position: relative; z-index: 1; }
+.menu-card .menu-head { display: block; width: auto; max-width: none; min-width: 0; margin: 0; padding: 0; }
+.menu-card .menu-head h1 { grid-area: auto; width: auto; }
+.menu-head h1, .compact-card h2, .loading-card h1 { margin: .75rem 0 .3rem; color: var(--paper); font: 700 clamp(2.2rem, 7vw, 4.7rem)/.88 Cinzel, Georgia, serif; letter-spacing: -.035em; }
 .menu-head h1 span { color: var(--gold); }
-
-.loading-bar {
-    margin-top: 16px;
-    height: 6px;
-    border-radius: 99px;
-    background: color-mix(in oklab, var(--ink) 40%, transparent);
-    overflow: hidden;
-}
-
-.loading-bar i {
-    display: block;
-    height: 100%;
-    width: 8%;
-    background: linear-gradient(90deg, #f0c060, #c42818);
-}
-
-.eyebrow {
-    display: flex;
-    align-items: center;
-    gap: 0.55rem;
-    font-size: 0.72rem;
-    letter-spacing: 0.16em;
-    text-transform: uppercase;
-    color: var(--text-dim);
-    margin: 0 0 0.6rem;
-}
-
-.eyebrow i {
-    width: 18px;
-    height: 2px;
-    background: var(--gold);
-    display: inline-block;
-}
-
-.eyebrow--danger { color: var(--ember); }
-
-.lede {
-    color: var(--text-soft);
-    line-height: 1.55;
-    max-width: 48ch;
-}
-
-.menu-grid {
-    display: grid;
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-    gap: 22px;
-    margin: 28px 0 8px;
-}
-
-.menu-section h2 {
-    font-size: 0.72rem;
-    letter-spacing: 0.16em;
-    text-transform: uppercase;
-    color: var(--gold);
-    margin: 0 0 10px;
-}
-
-.species-preview {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 6px 14px;
-    color: var(--text-soft);
-    font-size: 0.92rem;
-}
-
-.keys {
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
-    color: var(--text-soft);
-    font-size: 0.88rem;
-}
-
-kbd {
-    display: inline-grid;
-    place-items: center;
-    min-width: 1.4rem;
-    padding: 0.12rem 0.35rem;
-    margin-right: 0.15rem;
-    border-radius: 6px;
-    border: 1px solid var(--line);
-    background: color-mix(in oklab, var(--ink) 50%, transparent);
-    font-size: 0.72rem;
-}
-
-.settings-grid { display: grid; gap: 12px; }
-
-.field span {
-    display: flex;
-    justify-content: space-between;
-    font-size: 0.78rem;
-    color: var(--text-dim);
-    margin-bottom: 6px;
-}
-
-.field select, .field input[type="range"] {
-    width: 100%;
-    max-width: 100%;
-    background: color-mix(in oklab, var(--ink) 40%, transparent);
-    border: 1px solid var(--line-soft);
-    border-radius: 10px;
-    padding: 0.45rem 0.6rem;
-}
-
-.section-note {
-    margin: 12px 0 0;
-    font-size: 0.78rem;
-    color: var(--text-dim);
-}
-
-.menu-foot, .card-actions {
-    display: flex;
-    gap: 12px;
-    justify-content: flex-end;
-    margin-top: 22px;
-    flex-wrap: wrap;
-}
-
-.primary-button, .ghost-button {
-    pointer-events: auto;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    gap: 0.6rem;
-    padding: 0.75rem 1.2rem;
-    min-height: 44px;
-    border-radius: 999px;
-    font-weight: 600;
-}
-
-.primary-button {
-    background: linear-gradient(180deg, #f0c060, #c44a18);
-    color: var(--ink);
-}
-
-.primary-button:hover { filter: brightness(1.08); }
-
-.ghost-button {
-    border: 1px solid var(--line);
-    color: var(--text-soft);
-}
-
-.compact-card { width: min(460px, 100%); }
-
-.lab-foot {
-    position: absolute;
-    bottom: 8px;
-    left: 50%;
-    transform: translateX(-50%);
-    z-index: 21;
-}
-
+.menu-tagline { margin: .65rem 0 0; color: var(--red-bright); font: italic 1rem/1.2 Georgia, serif; }
+.lede { max-width: 47ch; margin: 1.15rem 0 0; color: var(--paper-soft); font-size: .9rem; line-height: 1.55; }
+.journey-preview { display: flex; flex-wrap: wrap; gap: 1.8rem; margin: 2rem 0 1.35rem; padding: 1rem 0; border-top: 1px solid var(--line-soft); border-bottom: 1px solid var(--line-soft); color: var(--paper-dim); font-size: .72rem; letter-spacing: .08em; text-transform: uppercase; }
+.journey-preview b { display: block; margin-bottom: .25rem; color: var(--gold); font: 700 1.5rem/1 Cinzel, Georgia, serif; }
+.menu-actions, .card-actions { display: flex; flex-wrap: wrap; gap: .6rem; align-items: center; margin-top: 1.2rem; }
+.primary-button, .ghost-button { display: inline-flex; min-height: 46px; align-items: center; justify-content: center; gap: .65rem; padding: .7rem 1.15rem; border-radius: 999px; font-size: .8rem; font-weight: 600; }
+.primary-button { color: #21170d; background: linear-gradient(120deg, #f1cf83, #bd6936); box-shadow: 0 8px 22px rgba(161,83,37,.24); }
+.primary-button:hover { filter: brightness(1.08); transform: translateY(-1px); }
+.ghost-button { border: 1px solid var(--line-soft); color: var(--paper-soft); background: rgba(239,225,193,.04); }
+.section-note { margin: .75rem 0 0; color: var(--paper-dim); font-size: .7rem; }
+.settings { margin-top: 1.3rem; border-top: 1px solid var(--line-soft); padding-top: .85rem; }
+.settings summary { display: flex; justify-content: space-between; cursor: pointer; color: var(--paper-soft); font-size: .75rem; list-style: none; }
+.settings summary::-webkit-details-marker { display: none; }
+.settings-content { display: grid; grid-template-columns: 1.1fr .9fr; gap: 1.4rem; margin-top: 1rem; }
+.keys { display: grid; gap: .45rem; color: var(--paper-dim); font-size: .7rem; line-height: 1.4; }
+.settings-grid { display: grid; gap: .72rem; }
+.field, .check-field { display: grid; gap: .34rem; color: var(--paper-dim); font-size: .67rem; }
+.field span { display: flex; justify-content: space-between; }
+select, input[type="range"] { width: 100%; min-height: 30px; border: 1px solid var(--line-soft); border-radius: 7px; background: rgba(0,0,0,.24); }
+select { padding: .35rem; }
+input[type="range"] { accent-color: var(--gold); }
+.check-field { grid-template-columns: auto 1fr; align-items: center; line-height: 1.3; }
+.check-field input { accent-color: var(--gold); }
+.menu-foot { display: flex; justify-content: space-between; gap: 1rem; margin-top: 2.1rem; color: var(--paper-dim); font: .62rem monospace; letter-spacing: .04em; }
+.menu-foot b { color: var(--gold); }
+.loading-card { width: min(390px, 100%); padding: 2.2rem; text-align: center; }
+.loading-card h1 { margin-top: 1rem; font-size: 2.2rem; }
+.loading-card .eyebrow { justify-content: center; }
+.loading-card .eyebrow::before { display: none; }
+.loading-card > p:not(.eyebrow) { color: var(--paper-dim); font-size: .8rem; }
+.sun-loader { display: block; width: 44px; height: 44px; margin: 0 auto; border-radius: 50%; background: radial-gradient(circle at 35% 30%, #ffe7a0, #bd3c24 72%); box-shadow: 0 0 30px rgba(194,62,34,.65); animation: sunpulse 1.7s ease-in-out infinite; }
+@keyframes sunpulse { 50% { transform: scale(1.08); filter: brightness(1.15); } }
+.loading-bar { height: 5px; margin-top: 1.25rem; overflow: hidden; border-radius: 99px; background: rgba(239,225,193,.1); }
+.loading-bar i { display: block; width: 0; height: 100%; background: linear-gradient(90deg, var(--gold), var(--red-bright)); transition: width .25s; }
+.compact-card { padding: clamp(1.5rem, 4vw, 2.5rem); }
+.compact-card h2 { font-size: clamp(2rem, 6vw, 3.3rem); }
+.compact-card .lede { margin-top: .7rem; }
+.scene-caption { position: absolute; right: calc(2rem + var(--safe-right)); bottom: calc(2rem + var(--safe-bottom)); display: grid; gap: .35rem; color: rgba(239,225,193,.78); font: .72rem Cinzel, Georgia, serif; letter-spacing: .16em; text-align: right; }
+.scene-caption span { color: var(--paper-dim); font: .65rem Outfit, sans-serif; letter-spacing: .04em; }
 body[data-state="play"] .lab-foot { display: none; }
-
-@media (max-width: 860px) {
-    .hud-top {
-        grid-template-columns: 1fr 1fr;
-        top: calc(4.2rem + var(--safe-top));
-    }
-    .trail-panel { display: none; }
-    .menu-grid { grid-template-columns: 1fr; }
-    .overlay-card { padding: 20px; }
-    body[data-state="play"] .hud-actions {
-        margin-top: 0;
-        top: auto;
-        bottom: calc(160px + var(--safe-bottom));
-        right: calc(18px + var(--safe-right));
-    }
-    .message { bottom: calc(11rem + var(--safe-bottom)); }
-    .prompt { bottom: calc(9.5rem + var(--safe-bottom)); }
+@media (max-width: 800px) {
+    .settings-content { grid-template-columns: 1fr; }
+    .mission { width: min(360px, 42vw); }
+    .location { max-width: 34vw; }
+    .scene-caption { right: 1rem; bottom: 1rem; }
 }
-
-@media (max-width: 768px) {
-    .hud-top { grid-template-columns: 1fr; }
-    .gait-panel { display: none; }
-    .region-block strong { white-space: nowrap; }
-}
-
-@media (pointer: coarse) {
-    .icon-button {
-        width: 44px;
-        height: 44px;
-        min-width: 44px;
-        min-height: 44px;
-    }
-}
-
-@media (max-width: 560px) {
-    .overlay,
-    .overlay-card,
-    .menu-card {
-        max-height: min(92dvh, 900px);
-    }
-    .overlay-card,
-    .menu-card {
-        overflow-y: auto;
-        -webkit-overflow-scrolling: touch;
-    }
-    .menu-head h1 { font-size: clamp(1.8rem, 8vw, 2.4rem); }
-    .lede { font-size: 0.92rem; }
-}
-
-@media (max-height: 520px) and (orientation: landscape) {
-    .hud-top {
-        grid-template-columns: 1fr 1fr;
-        gap: 8px;
-        top: calc(3rem + var(--safe-top));
-    }
-    .trail-panel, .gait-panel { display: none; }
-    .stick { width: 96px; height: 96px; }
-    .hud-actions {
-        top: calc(0.75rem + var(--safe-top));
-        bottom: auto;
-        right: calc(0.75rem + var(--safe-right));
-        margin-top: 0;
-    }
-    .touch-controls { height: 100%; }
+@media (max-width: 600px) {
+    .location { top: calc(3.7rem + var(--safe-top)); left: calc(.85rem + var(--safe-left)); max-width: 45vw; }
+    .hud-actions { top: calc(3.7rem + var(--safe-top)); right: calc(.85rem + var(--safe-right)); }
+    .mission { top: calc(8.15rem + var(--safe-top)); width: min(88vw, 360px); }
+    .rider-hud { bottom: calc(1rem + var(--safe-bottom)); left: calc(.75rem + var(--safe-left)); }
+    #minimap { width: 96px; height: 96px; }
+    .vitals { width: 120px; gap: 6px; }
+    .vital { grid-template-columns: 43px 1fr; font-size: .57rem; }
+    .weapon-hud { right: calc(.85rem + var(--safe-right)); bottom: calc(1rem + var(--safe-bottom)); min-width: 110px; }
+    .weapon-hud strong { font-size: 1.6rem; }
     .prompt { display: none; }
-    .message { bottom: calc(5.5rem + var(--safe-bottom)); }
-    .overlay-card { padding: 1rem 1.2rem; }
-    .menu-grid { padding: 0.8rem 0; margin: 12px 0; }
-    .lab-foot { display: none; }
+    .message { bottom: calc(12.2rem + var(--safe-bottom)); max-width: 86vw; }
+    .interaction { bottom: calc(7.4rem + var(--safe-bottom)); max-width: 84vw; font-size: .7rem; }
+    .scene-caption { display: none; }
+    .menu-card { max-height: min(92dvh, 760px); overflow-y: auto; padding: 1.35rem; }
+    .menu-head h1 { font-size: clamp(2.5rem, 14vw, 4rem); }
+    .journey-preview { gap: 1rem; margin-top: 1.4rem; }
+    .journey-preview span:last-child { width: 100%; }
+    .menu-foot { margin-top: 1.5rem; }
 }
-
+@media (pointer: coarse) {
+    .touch-controls { display: block; }
+    .reticle { display: none; }
+    .hud-actions { pointer-events: auto; }
+}
+@media (max-height: 520px) and (orientation: landscape) {
+    .location, .hud-actions { top: calc(.7rem + var(--safe-top)); }
+    .mission { top: calc(.75rem + var(--safe-top)); left: 50%; }
+    .mission strong { margin: .2rem 0; font-size: .9rem; }
+    .mission > span:not(.eyebrow), .mark-pips { display: none; }
+    .rider-hud, .weapon-hud { bottom: calc(.6rem + var(--safe-bottom)); }
+    #minimap { width: 84px; height: 84px; }
+    .vitals { gap: 4px; }
+    .interaction { bottom: calc(2.8rem + var(--safe-bottom)); }
+    .message { bottom: calc(4.7rem + var(--safe-bottom)); }
+    .touch-buttons { grid-template-columns: repeat(4, 58px); gap: 5px; bottom: calc(.6rem + var(--safe-bottom)); right: calc(.6rem + var(--safe-right)); }
+    .pad { min-width: 58px; min-height: 42px; }
+    .stick { width: 92px; height: 92px; bottom: calc(.55rem + var(--safe-bottom)); left: calc(.65rem + var(--safe-left)); }
+    .stick i { width: 36px; height: 36px; }
+    .menu-card { max-height: min(92dvh, 350px); overflow-y: auto; }
+    .menu-head h1 { font-size: 2.5rem; }
+    .menu-tagline, .lede { margin-top: .5rem; font-size: .78rem; }
+    .journey-preview { margin: .7rem 0; padding: .6rem 0; }
+    .settings-content { grid-template-columns: 1fr 1fr; }
+    .scene-caption { display: none; }
+}
 @media (prefers-reduced-motion: reduce) {
-    *, *::before, *::after {
-        animation-duration: 0.01ms !important;
-        animation-iteration-count: 1 !important;
-        transition-duration: 0.01ms !important;
-    }
+    *, *::before, *::after { animation-duration: .01ms !important; animation-iteration-count: 1 !important; transition-duration: .01ms !important; }
 }


### PR DESCRIPTION
## 🎯 Objetivo

Transformar o Rastro Vermelho em uma jornada de faroeste cinematográfica, com controles mais claros, progressão e melhor leitura em telas pequenas.

## ✨ O que mudou

- Reestruturei a experiência em seis destinos conectados por carta, entregas, recompensas, acampamentos e checkpoints salvos.
- Adicionei cavalo com sela, alforjes, rédeas e cavaleiro, terreno procedural contínuo, estrada transitável, vegetação instanciada, povoados, fogueiras e horizonte distante.
- Separei as animações de idle, caminhada e galope; incluí vigor do cavalo, sprint com recuperação, foco em câmera lenta, revólver, recarga, inimigos, linha de visão, dano e marcadores de tiro.
- Refiz o HUD com mapa, waypoint, objetivo, vigor, resistência, foco, munição, dinheiro, feedback de dano e interação contextual.
- Adicionei áudio procedural de vento, cascos, pássaros, tiros e recompensas, além de qualidade automática/manual, sensibilidade, volume, mute e redução de movimento.
- Melhorei o carregamento, streaming de chunks, sombras, PBR, iluminação de ciclo diário, acessibilidade de foco e controles de teclado, toque e gamepad.
- Atualizei o SEO e a descrição do lab para refletir a jornada.

## 🧪 Como testar

1. Na raiz do repo: `python3 -m http.server 8000`
2. Abrir `/labs/rastro-vermelho/` via HTTP.
3. Clicar em “Iniciar jornada”, usar `E` na fogueira e seguir o losango dourado.
4. Testar `WASD`, `Shift`, `F`, `Q`, `R`, `P`, `M`, clique/arraste, controles de toque e gamepad.
5. Responsivo em 375×667, 390×844 e landscape curto (667×375).

## ✅ Checklist

- [x] Links conferidos: slug e canonical permanecem `/labs/rastro-vermelho/`
- [x] README/catalogo não exigem alteração de slug
- [x] SEO consistente: title, description, canonical, author, robots, OG, Twitter e JSON-LD
- [x] Testado via HTTP na raiz, não via `file://`
- [x] Responsivo: 375px / 390px / landscape — sem overflow horizontal, HUD e controles utilizáveis
- [x] Nada fora do escopo foi alterado
