### PR TITLE
🧪 lab: Poker Texas Hold'em vs IA com academia

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 Mais de 20 anos em tecnologia, entre liderança, código hands-on e design UI/UX.
 
 [![Website](https://img.shields.io/badge/Website-diogopaulino.com.br-3B82F6?style=flat-square&logo=googlechrome&logoColor=white)](https://diogopaulino.com.br/)
-[![Labs](https://img.shields.io/badge/Labs-55_experimentos-8B5CF6?style=flat-square&logo=stackblitz&logoColor=white)](https://diogopaulino.com.br/labs/)
+[![Labs](https://img.shields.io/badge/Labs-56_experimentos-8B5CF6?style=flat-square&logo=stackblitz&logoColor=white)](https://diogopaulino.com.br/labs/)
 [![GitHub](https://img.shields.io/badge/GitHub-diogopaulino-181717?style=flat-square&logo=github&logoColor=white)](https://github.com/diogopaulino)
 [![LinkedIn](https://img.shields.io/badge/LinkedIn-Diogo_Paulino-0A66C2?style=flat-square)](https://br.linkedin.com/in/diogopaulino)
 [![Spotify](https://img.shields.io/badge/Spotify-Artist-1DB954?style=flat-square&logo=spotify&logoColor=white)](https://open.spotify.com/intl-pt/artist/0ue2WfDQ1P4XR2vXdSIrYQ)
@@ -32,7 +32,7 @@ Gosto de construir coisas — de time e produto até interface e código. Nessa 
 
 > *Abre, experimenta, quebra, reconstrói. Esse é o espírito.*
 
-Um laboratório aberto com **55 experimentos** que rodam direto no navegador — HTML, CSS e JavaScript puro, sem instalar nada. Catálogo completo em [diogopaulino.com.br/labs](https://diogopaulino.com.br/labs/).
+Um laboratório aberto com **56 experimentos** que rodam direto no navegador — HTML, CSS e JavaScript puro, sem instalar nada. Catálogo completo em [diogopaulino.com.br/labs](https://diogopaulino.com.br/labs/).
 
 Cada pasta em `/labs/<slug>/` é o mesmo slug do card da galeria, da linha abaixo e da URL `https://diogopaulino.com.br/labs/<slug>/`.
 
@@ -73,6 +73,7 @@ Cada pasta em `/labs/<slug>/` é o mesmo slug do card da galeria, da linha abaix
 
 | Projeto | O que é? |
 | :--- | :--- |
+| ♠ **[Poker](https://diogopaulino.com.br/labs/poker/)** | Texas Hold'em heads-up — feltro, cartas realistas, Dealer IA e academia (ranking, blinds, pot odds) |
 | 🤖 **[Claude Bros](https://diogopaulino.com.br/labs/claude-bros/)** | Plataforma 2D em canvas puro: colete estrelas Gemini, pule nos rivais ChatGPT e chegue à bandeira |
 | 🐒 **[Kong Kong](https://diogopaulino.com.br/labs/kong-kong/)** | Platformer estilo SNES — o macaquinho do lenço vermelho, canhões-barril e o Rei Croco |
 | 🎈 **[Ravi 1·2·3](https://diogopaulino.com.br/labs/ravi-123/)** | Festa surpresa com heróis — conte 1 a 9 estilo Mickey's 123 |

--- a/labs/index.html
+++ b/labs/index.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <title>Labs — Diogo Paulino | Jogos 3D, código, música e IA</title>
-  <meta name="description" content="55 experimentos de Diogo Paulino: jogos 3D, ferramentas, música e inteligência artificial em HTML, CSS e JavaScript puro.">
+  <meta name="description" content="56 experimentos de Diogo Paulino: jogos 3D, ferramentas, música e inteligência artificial em HTML, CSS e JavaScript puro.">
   <meta name="author" content="Diogo Paulino">
   <meta name="robots" content="index, follow">
   <meta name="theme-color" content="#fafbfc">
@@ -16,7 +16,7 @@
   <meta property="og:site_name" content="Diogo Paulino · Labs">
   <meta property="og:title" content="Labs — Diogo Paulino | Jogos 3D, código, música e IA">
   <meta property="og:description"
-    content="55 experimentos de Diogo Paulino: jogos 3D, ferramentas, música e inteligência artificial em HTML, CSS e JavaScript puro.">
+    content="56 experimentos de Diogo Paulino: jogos 3D, ferramentas, música e inteligência artificial em HTML, CSS e JavaScript puro.">
   <meta property="og:url" content="https://diogopaulino.com.br/labs/">
   <meta property="og:image" content="https://diogopaulino.com.br/assets/img/diogo.jpeg">
   <meta property="og:image:alt" content="Diogo Paulino">
@@ -24,7 +24,7 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Labs — Diogo Paulino | Jogos 3D, código, música e IA">
   <meta name="twitter:description"
-    content="55 experimentos de Diogo Paulino: jogos 3D, ferramentas, música e inteligência artificial em HTML, CSS e JavaScript puro.">
+    content="56 experimentos de Diogo Paulino: jogos 3D, ferramentas, música e inteligência artificial em HTML, CSS e JavaScript puro.">
   <meta name="twitter:image" content="https://diogopaulino.com.br/assets/img/diogo.jpeg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -40,7 +40,7 @@
       "@id": "https://diogopaulino.com.br/labs/#page",
       "name": "Labs — Diogo Paulino",
       "url": "https://diogopaulino.com.br/labs/",
-      "description": "55 experimentos de Diogo Paulino: jogos 3D, ferramentas, música e inteligência artificial em HTML, CSS e JavaScript puro.",
+      "description": "56 experimentos de Diogo Paulino: jogos 3D, ferramentas, música e inteligência artificial em HTML, CSS e JavaScript puro.",
       "inLanguage": "pt-BR",
       "isPartOf": {
         "@id": "https://diogopaulino.com.br/#website"
@@ -48,7 +48,7 @@
       "creator": {
         "@id": "https://diogopaulino.com.br/#person"
       },
-      "numberOfItems": 55,
+      "numberOfItems": 56,
       "mainEntity": {
         "@id": "https://diogopaulino.com.br/labs/#list"
       }
@@ -57,335 +57,341 @@
       "@type": "ItemList",
       "@id": "https://diogopaulino.com.br/labs/#list",
       "name": "Labs de Diogo Paulino",
-      "numberOfItems": 55,
+      "numberOfItems": 56,
       "itemListElement": [
         {
           "@type": "ListItem",
           "position": 1,
+          "url": "https://diogopaulino.com.br/labs/poker/",
+          "name": "Poker"
+        },
+        {
+          "@type": "ListItem",
+          "position": 2,
           "url": "https://diogopaulino.com.br/labs/ps5-controller/",
           "name": "PS5 Controller"
         },
         {
           "@type": "ListItem",
-          "position": 2,
+          "position": 3,
           "url": "https://diogopaulino.com.br/labs/ultimo-bastiao/",
           "name": "O Último Bastião"
         },
         {
           "@type": "ListItem",
-          "position": 3,
+          "position": 4,
           "url": "https://diogopaulino.com.br/labs/xadrez/",
           "name": "Xadrez"
         },
         {
           "@type": "ListItem",
-          "position": 4,
+          "position": 5,
           "url": "https://diogopaulino.com.br/labs/rastro-vermelho/",
           "name": "Rastro Vermelho"
         },
         {
           "@type": "ListItem",
-          "position": 5,
+          "position": 6,
           "url": "https://diogopaulino.com.br/labs/tatu-bola/",
           "name": "Tatu Bola"
         },
         {
           "@type": "ListItem",
-          "position": 6,
+          "position": 7,
           "url": "https://diogopaulino.com.br/labs/cupola-64/",
           "name": "Cúpola 64"
         },
         {
           "@type": "ListItem",
-          "position": 7,
+          "position": 8,
           "url": "https://diogopaulino.com.br/labs/menina-da-lanterna/",
           "name": "A Menina da Lanterna"
         },
         {
           "@type": "ListItem",
-          "position": 8,
+          "position": 9,
           "url": "https://diogopaulino.com.br/labs/forrest-run/",
           "name": "Forrest Run"
         },
         {
           "@type": "ListItem",
-          "position": 9,
+          "position": 10,
           "url": "https://diogopaulino.com.br/labs/nina/",
           "name": "Nina"
         },
         {
           "@type": "ListItem",
-          "position": 10,
+          "position": 11,
           "url": "https://diogopaulino.com.br/labs/mimo/",
           "name": "Mimo"
         },
         {
           "@type": "ListItem",
-          "position": 11,
+          "position": 12,
           "url": "https://diogopaulino.com.br/labs/quimera/",
           "name": "Quimera"
         },
         {
           "@type": "ListItem",
-          "position": 12,
+          "position": 13,
           "url": "https://diogopaulino.com.br/labs/castelo-estelar/",
           "name": "Castelo Estelar"
         },
         {
           "@type": "ListItem",
-          "position": 13,
+          "position": 14,
           "url": "https://diogopaulino.com.br/labs/eyra/",
           "name": "Eyra"
         },
         {
           "@type": "ListItem",
-          "position": 14,
+          "position": 15,
           "url": "https://diogopaulino.com.br/labs/lavandula/",
           "name": "Lavandula"
         },
         {
           "@type": "ListItem",
-          "position": 15,
+          "position": 16,
           "url": "https://diogopaulino.com.br/labs/nereida/",
           "name": "Nereida"
         },
         {
           "@type": "ListItem",
-          "position": 16,
+          "position": 17,
           "url": "https://diogopaulino.com.br/labs/riftball/",
           "name": "Riftball"
         },
         {
           "@type": "ListItem",
-          "position": 17,
+          "position": 18,
           "url": "https://diogopaulino.com.br/labs/jurassic/",
           "name": "Jurassic"
         },
         {
           "@type": "ListItem",
-          "position": 18,
+          "position": 19,
           "url": "https://diogopaulino.com.br/labs/spider-swing/",
           "name": "Spider Swing"
         },
         {
           "@type": "ListItem",
-          "position": 19,
+          "position": 20,
           "url": "https://diogopaulino.com.br/labs/honor-front/",
           "name": "Honor Front"
         },
         {
           "@type": "ListItem",
-          "position": 20,
+          "position": 21,
           "url": "https://diogopaulino.com.br/labs/safari-dourado/",
           "name": "Safari Dourado"
         },
         {
           "@type": "ListItem",
-          "position": 21,
+          "position": 22,
           "url": "https://diogopaulino.com.br/labs/grao/",
           "name": "Grão"
         },
         {
           "@type": "ListItem",
-          "position": 22,
+          "position": 23,
           "url": "https://diogopaulino.com.br/labs/orbis/",
           "name": "Orbis"
         },
         {
           "@type": "ListItem",
-          "position": 23,
+          "position": 24,
           "url": "https://diogopaulino.com.br/labs/neon-rider/",
           "name": "Neon Rider"
         },
         {
           "@type": "ListItem",
-          "position": 24,
+          "position": 25,
           "url": "https://diogopaulino.com.br/labs/guerreiro-castelo/",
           "name": "O Guerreiro e o Castelo"
         },
         {
           "@type": "ListItem",
-          "position": 25,
+          "position": 26,
           "url": "https://diogopaulino.com.br/labs/river-knight/",
           "name": "River Knight"
         },
         {
           "@type": "ListItem",
-          "position": 26,
+          "position": 27,
           "url": "https://diogopaulino.com.br/labs/jornada-do-anel/",
           "name": "A Jornada do Anel"
         },
         {
           "@type": "ListItem",
-          "position": 27,
+          "position": 28,
           "url": "https://diogopaulino.com.br/labs/joao-e-o-pe-de-feijao/",
           "name": "João e o Pé de Feijão"
         },
         {
           "@type": "ListItem",
-          "position": 28,
+          "position": 29,
           "url": "https://diogopaulino.com.br/labs/beige-box/",
           "name": "Beige Box"
         },
         {
           "@type": "ListItem",
-          "position": 29,
+          "position": 30,
           "url": "https://diogopaulino.com.br/labs/f1-racing/",
           "name": "F1 Grand Prix"
         },
         {
           "@type": "ListItem",
-          "position": 30,
+          "position": 31,
           "url": "https://diogopaulino.com.br/labs/ravi-123/",
           "name": "Ravi 1·2·3"
         },
         {
           "@type": "ListItem",
-          "position": 31,
+          "position": 32,
           "url": "https://diogopaulino.com.br/labs/rock-kombat/",
           "name": "Rock Kombat"
         },
         {
           "@type": "ListItem",
-          "position": 32,
+          "position": 33,
           "url": "https://diogopaulino.com.br/labs/videogame/",
           "name": "Videogame"
         },
         {
           "@type": "ListItem",
-          "position": 33,
+          "position": 34,
           "url": "https://diogopaulino.com.br/labs/lander/",
           "name": "Lunar Lander"
         },
         {
           "@type": "ListItem",
-          "position": 34,
+          "position": 35,
           "url": "https://diogopaulino.com.br/labs/kong-kong/",
           "name": "Kong Kong"
         },
         {
           "@type": "ListItem",
-          "position": 35,
+          "position": 36,
           "url": "https://diogopaulino.com.br/labs/jungle-run/",
           "name": "Jungle Run"
         },
         {
           "@type": "ListItem",
-          "position": 36,
+          "position": 37,
           "url": "https://diogopaulino.com.br/labs/space-shooter/",
           "name": "Neon Invaders"
         },
         {
           "@type": "ListItem",
-          "position": 37,
+          "position": 38,
           "url": "https://diogopaulino.com.br/labs/tetris/",
           "name": "Tetris 90s"
         },
         {
           "@type": "ListItem",
-          "position": 38,
+          "position": 39,
           "url": "https://diogopaulino.com.br/labs/claude-bros/",
           "name": "Claude Bros"
         },
         {
           "@type": "ListItem",
-          "position": 39,
+          "position": 40,
           "url": "https://diogopaulino.com.br/labs/snake/",
           "name": "Retro Snake"
         },
         {
           "@type": "ListItem",
-          "position": 40,
+          "position": 41,
           "url": "https://diogopaulino.com.br/labs/minesweeper/",
           "name": "Campo Minado 95"
         },
         {
           "@type": "ListItem",
-          "position": 41,
+          "position": 42,
           "url": "https://diogopaulino.com.br/labs/tamagotchi/",
           "name": "RakuRaku Dinokun"
         },
         {
           "@type": "ListItem",
-          "position": 42,
+          "position": 43,
           "url": "https://diogopaulino.com.br/labs/cyberos/",
           "name": "CyberOS Terminal"
         },
         {
           "@type": "ListItem",
-          "position": 43,
+          "position": 44,
           "url": "https://diogopaulino.com.br/labs/matrix/",
           "name": "Matrix"
         },
         {
           "@type": "ListItem",
-          "position": 44,
+          "position": 45,
           "url": "https://diogopaulino.com.br/labs/aurora-flow/",
           "name": "Aurora Flow"
         },
         {
           "@type": "ListItem",
-          "position": 45,
+          "position": 46,
           "url": "https://diogopaulino.com.br/labs/paint/",
           "name": "Paint Lab"
         },
         {
           "@type": "ListItem",
-          "position": 46,
+          "position": 47,
           "url": "https://diogopaulino.com.br/labs/gravity/",
           "name": "Gravity"
         },
         {
           "@type": "ListItem",
-          "position": 47,
+          "position": 48,
           "url": "https://diogopaulino.com.br/labs/image-optimizer/",
           "name": "Image Optimizer"
         },
         {
           "@type": "ListItem",
-          "position": 48,
+          "position": 49,
           "url": "https://diogopaulino.com.br/labs/image-editor/",
           "name": "Image Editor"
         },
         {
           "@type": "ListItem",
-          "position": 49,
+          "position": 50,
           "url": "https://diogopaulino.com.br/labs/pomodoro/",
           "name": "Pomodoro"
         },
         {
           "@type": "ListItem",
-          "position": 50,
+          "position": 51,
           "url": "https://diogopaulino.com.br/labs/english-duo/",
           "name": "Talk"
         },
         {
           "@type": "ListItem",
-          "position": 51,
+          "position": 52,
           "url": "https://diogopaulino.com.br/labs/calculator/",
           "name": "Calculator"
         },
         {
           "@type": "ListItem",
-          "position": 52,
+          "position": 53,
           "url": "https://diogopaulino.com.br/labs/partitura/",
           "name": "Partitura: Maestro Quest"
         },
         {
           "@type": "ListItem",
-          "position": 53,
+          "position": 54,
           "url": "https://diogopaulino.com.br/labs/piano/",
           "name": "Piano"
         },
         {
           "@type": "ListItem",
-          "position": 54,
+          "position": 55,
           "url": "https://diogopaulino.com.br/labs/winamp/",
           "name": "Winamp JS"
         },
         {
           "@type": "ListItem",
-          "position": 55,
+          "position": 56,
           "url": "https://diogopaulino.com.br/labs/pulsar/",
           "name": "Pulsar"
         }
@@ -425,7 +431,7 @@
     <section class="labs-hero" aria-label="Playground de Diogo Paulino">
       <div class="labs-hero__copy">
         <p class="labs-hero__eyebrow">Playground aberto · HTML, CSS e JS puro</p>
-        <p class="labs-hero__lead"><strong>55 experimentos</strong> de jogos 3D, ferramentas, música e IA — tudo roda direto no navegador, sem instalar nada.</p>
+        <p class="labs-hero__lead"><strong>56 experimentos</strong> de jogos 3D, ferramentas, música e IA — tudo roda direto no navegador, sem instalar nada.</p>
       </div>
       <div class="labs-toolbar">
         <label class="labs-search" for="labsSearch">
@@ -436,7 +442,7 @@
           <input id="labsSearch" type="search" inputmode="search" autocomplete="off" enterkeyhint="search"
             placeholder="Buscar lab, tag ou tecnologia…" aria-controls="projectsGrid featuredGrid" aria-describedby="labsResultCount">
         </label>
-        <p id="labsResultCount" class="labs-result-count" aria-live="polite">55 labs</p>
+        <p id="labsResultCount" class="labs-result-count" aria-live="polite">56 labs</p>
       </div>
     </section>
 
@@ -500,6 +506,26 @@
     </div>
 
     <div id="projectsGrid" class="projects-grid">
+      <a href="/labs/poker/" class="project-card" data-groups="game,creative">
+        <div class="project-icon">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+            stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <rect x="4" y="3" width="10" height="14" rx="1.5" transform="rotate(-8 9 10)" />
+            <rect x="9" y="5" width="10" height="14" rx="1.5" />
+            <path d="M14 9.5c0 1-.8 1.5-1.5 1.5S11 10.5 11 9.5 11.8 8 12.5 8s1.5.5 1.5 1.5z" opacity="0.7" />
+            <path d="M7.2 8.2c.1-.6.6-1 1.2-1" opacity="0.55" />
+          </svg>
+        </div>
+        <div class="project-content">
+          <h2>Poker</h2>
+          <p>Texas Hold'em heads-up no feltro: cartas realistas, Dealer IA e um mestre que ensina ranking, blinds e pot odds</p>
+          <div class="project-tags">
+            <span class="tag">Poker</span>
+            <span class="tag">IA</span>
+            <span class="tag">Academia</span>
+          </div>
+        </div>
+      </a>
       <a href="/labs/xadrez/" class="project-card" data-groups="game,creative">
         <div class="project-icon">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"

--- a/labs/poker/assets/CREDITS.md
+++ b/labs/poker/assets/CREDITS.md
@@ -1,0 +1,3 @@
+# Poker lab assets
+
+Cartas e mesa renderizadas em CSS puro — sem sprites externos.

--- a/labs/poker/index.html
+++ b/labs/poker/index.html
@@ -1,0 +1,232 @@
+<!DOCTYPE html>
+<html lang="pt-br" data-theme="dark">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover, maximum-scale=1, user-scalable=no">
+  <meta name="theme-color" content="#0c1a12">
+  <title>Poker — Texas Hold'em vs IA que ensina | Diogo Paulino</title>
+  <meta name="description"
+    content="Texas Hold'em heads-up hiper-realista: mesa de feltro, cartas, IA e academia que ensina ranking, blinds, pot odds e estratégia. Um lab de Diogo Paulino.">
+  <link rel="canonical" href="https://diogopaulino.com.br/labs/poker/">
+  <meta name="author" content="Diogo Paulino">
+  <meta name="robots" content="index, follow">
+  <link rel="icon" href="/favicon.ico" sizes="any">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Diogo Paulino · Labs">
+  <meta property="og:url" content="https://diogopaulino.com.br/labs/poker/">
+  <meta property="og:title" content="Poker — Texas Hold'em vs IA que ensina | Diogo Paulino">
+  <meta property="og:description"
+    content="Mesa heads-up com feltro, cartas realistas, Dealer IA e lições de ranking, blinds e pot odds.">
+  <meta property="og:image" content="https://diogopaulino.com.br/assets/img/diogo.jpeg">
+  <meta property="og:image:alt" content="Diogo Paulino">
+  <meta property="og:locale" content="pt_BR">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Poker — Texas Hold'em vs IA que ensina | Diogo Paulino">
+  <meta name="twitter:description"
+    content="Mesa heads-up com feltro, cartas realistas, Dealer IA e lições de ranking, blinds e pot odds.">
+  <meta name="twitter:image" content="https://diogopaulino.com.br/assets/img/diogo.jpeg">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@500;600;700&family=Outfit:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/labs/shared.css?v=13">
+  <link rel="stylesheet" href="style.css">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "WebApplication",
+        "name": "Poker",
+        "url": "https://diogopaulino.com.br/labs/poker/",
+        "description": "Texas Hold'em heads-up hiper-realista com IA e academia que ensina ranking, blinds, pot odds e estratégia.",
+        "applicationCategory": "GameApplication",
+        "operatingSystem": "Any",
+        "inLanguage": "pt-BR",
+        "isAccessibleForFree": true,
+        "author": {
+          "@type": "Person",
+          "name": "Diogo Paulino",
+          "url": "https://diogopaulino.com.br/"
+        },
+        "image": "https://diogopaulino.com.br/assets/img/diogo.jpeg"
+      },
+      {
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "Diogo Paulino",
+            "item": "https://diogopaulino.com.br/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "Labs",
+            "item": "https://diogopaulino.com.br/labs/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 3,
+            "name": "Poker",
+            "item": "https://diogopaulino.com.br/labs/poker/"
+          }
+        ]
+      }
+    ]
+  }
+  </script>
+</head>
+
+<body>
+  <main class="poker-shell">
+    <header data-lab-header data-title="Poker" data-back-href="/labs/" data-back-label="Labs">
+      <template data-slot="logo">
+        <div class="app-logo">
+          <span class="brand-mark" aria-hidden="true">♠</span>
+          <span>Poker</span>
+        </div>
+      </template>
+    </header>
+
+    <section class="table-stage" aria-label="Mesa de Texas Hold'em">
+      <div class="felt" aria-hidden="true">
+        <div class="felt-glow"></div>
+        <div class="felt-rail"></div>
+      </div>
+
+      <div class="table-hud">
+        <p class="meta-line"><span id="handNumber">—</span> · <span id="diffLabel">IA · intermediária</span></p>
+        <p id="streetLabel" class="street-pill">—</p>
+      </div>
+
+      <article class="seat seat--ai" aria-label="Dealer IA">
+        <div class="seat-info">
+          <span id="aiDealer" class="dealer-btn" hidden title="Botão">D</span>
+          <span id="aiBlind" class="blind-tag"></span>
+          <h2 class="seat-name">Dealer IA</h2>
+          <p class="seat-stack"><span id="aiStack">1.000</span> <small>fichas</small></p>
+        </div>
+        <div id="aiCards" class="hole-cards" aria-label="Cartas da IA"></div>
+        <p class="seat-bet">Aposta <strong id="aiBet">0</strong></p>
+      </article>
+
+      <div class="board-wrap">
+        <p class="pot-line">Pote <strong id="potValue">0</strong></p>
+        <div id="board" class="board" aria-label="Cartas comunitárias"></div>
+        <p id="resultBanner" class="result-banner" hidden></p>
+      </div>
+
+      <article class="seat seat--hero" aria-label="Você">
+        <div id="heroCards" class="hole-cards" aria-label="Suas cartas"></div>
+        <div class="seat-info">
+          <span id="heroDealer" class="dealer-btn" hidden title="Botão">D</span>
+          <span id="heroBlind" class="blind-tag"></span>
+          <h2 class="seat-name">Você</h2>
+          <p class="seat-stack"><span id="heroStack">1.000</span> <small>fichas</small></p>
+          <p id="heroHandName" class="hand-name">—</p>
+        </div>
+        <p class="seat-bet">Aposta <strong id="heroBet">0</strong></p>
+      </article>
+    </section>
+
+    <div class="hud">
+      <aside id="coach" class="coach" aria-label="Mestre de poker">
+        <button id="coachToggle" class="coach-toggle" type="button" aria-expanded="true">
+          <span class="eyebrow"><i></i> Mestre</span>
+          <span id="coachTitle">Mesa</span>
+        </button>
+        <div id="coachBody" class="coach-body">
+          <div id="playCoach">
+            <p id="coachText" class="coach-text">Inicie uma mão. Eu explico blinds, pot odds e a força da sua mão.</p>
+          </div>
+          <div id="academyPanel" hidden>
+            <p id="lessonKicker" class="lesson-kicker"></p>
+            <h3 id="lessonTitle" class="lesson-title"></h3>
+            <p id="lessonText" class="coach-text"></p>
+            <p id="lessonTip" class="coach-tip"></p>
+            <div id="lessonQuiz" class="lesson-quiz"></div>
+            <div class="lesson-nav">
+              <button id="prevLesson" class="dock-btn" type="button">Anterior</button>
+              <span id="lessonProgress" class="lesson-progress">1 / 10</span>
+              <button id="nextLesson" class="dock-btn accent" type="button">Próxima</button>
+            </div>
+          </div>
+        </div>
+      </aside>
+
+      <aside class="tray" aria-label="Partida">
+        <p class="eyebrow">PARTIDA</p>
+        <p id="statusLine" class="status" aria-live="polite">Pronto</p>
+        <label class="diff-field">
+          <span>Nível da IA</span>
+          <select id="difficulty" aria-label="Dificuldade da IA">
+            <option value="easy">Iniciante</option>
+            <option value="normal" selected>Intermediária</option>
+            <option value="hard">Agressiva</option>
+          </select>
+        </label>
+        <ol id="eventLog" class="event-log" aria-label="Histórico da mão"></ol>
+      </aside>
+
+      <div class="action-dock">
+        <div id="sizing" class="sizing" hidden>
+          <div class="sizing-head">
+            <span id="betLabel">Aposta</span>
+            <strong id="betValue">0</strong>
+          </div>
+          <input id="betSlider" type="range" min="10" max="1000" value="40" aria-label="Tamanho da aposta">
+          <div class="size-row" role="group" aria-label="Atalhos de tamanho">
+            <button type="button" class="size-chip" data-frac="0.33">⅓ pote</button>
+            <button type="button" class="size-chip" data-frac="0.5">½ pote</button>
+            <button type="button" class="size-chip" data-frac="0.75">¾ pote</button>
+            <button type="button" class="size-chip" data-frac="1">Pote</button>
+          </div>
+        </div>
+        <div id="actions" class="actions" role="toolbar" aria-label="Ações"></div>
+        <div class="dock" role="toolbar" aria-label="Modos">
+          <button id="modePlay" class="dock-btn is-active" data-mode="play" type="button">Jogar</button>
+          <button id="modeAcademy" class="dock-btn" data-mode="academy" type="button">Aprender</button>
+          <button id="modeRanks" class="dock-btn" type="button">Ranking</button>
+          <button id="btnHint" class="dock-btn accent" type="button">Dica</button>
+          <button id="btnNewHand" class="dock-btn" type="button">Nova mão</button>
+          <button id="muteBtn" class="dock-btn" type="button" aria-pressed="false" title="Som (M)">Som</button>
+        </div>
+      </div>
+    </div>
+
+    <div id="intro" class="overlay">
+      <div class="overlay-card">
+        <p class="eyebrow"><i></i> Texas Hold'em</p>
+        <h1>Poker</h1>
+        <p class="lede">Mesa heads-up contra a Dealer IA — e um mestre que ensina ranking, blinds e pot odds enquanto você joga.</p>
+        <div class="intro-actions">
+          <button id="btnStart" class="dock-btn accent" type="button">Sentar à mesa</button>
+          <button id="btnAcademyIntro" class="dock-btn" type="button">Começar aprendendo</button>
+        </div>
+        <p class="intro-note">Sem fichas reais. Só prática, matemática e pressão no feltro.</p>
+      </div>
+    </div>
+
+    <div id="ranksOverlay" class="overlay" hidden>
+      <div class="overlay-card ranks-card">
+        <p class="eyebrow"><i></i> Ranking</p>
+        <h2>Mãos do mais forte ao mais fraco</h2>
+        <ol id="rankList" class="rank-list"></ol>
+        <button id="ranksClose" class="dock-btn accent" type="button">Fechar</button>
+      </div>
+    </div>
+  </main>
+
+  <footer class="lab-footer">
+    <a href="/">Diogo Paulino</a>
+    <span aria-hidden="true">·</span>
+    <a href="/labs/">Labs</a>
+  </footer>
+
+  <script src="/labs/shared.js?v=7" defer></script>
+  <script type="module" src="src/main.js"></script>
+</body>
+
+</html>

--- a/labs/poker/src/ai.js
+++ b/labs/poker/src/ai.js
@@ -1,0 +1,147 @@
+/**
+ * IA heads-up — decisões por força de mão + pot odds + rua.
+ *
+ * Heurística (não é solver GTO):
+ * - Pré-flop: holeStrength → fold / call / raise por faixas.
+ * - Pós-flop: equity Monte Carlo leve vs hole do vilão quando conhecida
+ *   (no play normal a IA NÃO vê as cartas do herói; usa força da própria
+ *   mão + board texture + pot odds).
+ * - Pot odds: call se equityEstimada >= toCall/(pot+toCall) com margem.
+ */
+
+import {
+    estimateEquity,
+    evaluateHand,
+    holeStrength,
+    legalActions,
+    potOdds,
+    STREET
+} from './engine.js';
+
+const DIFFICULTY = {
+    easy: { aggression: 0.55, bluff: 0.06, callMargin: 0.08, thinkMs: [450, 900] },
+    normal: { aggression: 0.75, bluff: 0.12, callMargin: 0.03, thinkMs: [500, 1100] },
+    hard: { aggression: 0.95, bluff: 0.18, callMargin: -0.02, thinkMs: [400, 800] }
+};
+
+export function getDifficulty(level = 'normal') {
+    return DIFFICULTY[level] || DIFFICULTY.normal;
+}
+
+export function chooseAction(match, level = 'normal') {
+    const cfg = getDifficulty(level);
+    const legal = legalActions(match);
+    if (!legal.length) return null;
+
+    const h = match.hand;
+    const seat = h.toAct;
+    const hole = h.holes[seat];
+    const board = h.board;
+    const toCall = Math.max(0, h.currentBet - h.streetContrib[seat]);
+    const stack = match.stacks[seat];
+    const pot = h.pot;
+    const odds = potOdds(toCall, pot);
+
+    let strength;
+    if (h.street === STREET.PREFLOP || board.length === 0) {
+        strength = holeStrength(hole);
+    } else {
+        const made = evaluateHand([...hole, ...board]);
+        // Categoria 0–9 → base; kickers suavizam
+        strength = (made.category + 1) / 10 * 0.7 + (made.ranks[0] || 0) / 12 * 0.15;
+        // Draw bonus simples: flush draw / OESD aproximado
+        strength += drawBonus(hole, board) * 0.12;
+        strength = Math.min(0.98, strength);
+    }
+
+    // Bluff ocasional em spot de check/bet
+    const roll = match.rng();
+    const wantBluff = roll < cfg.bluff && strength < 0.35;
+
+    const fold = legal.find((a) => a.type === 'fold');
+    const check = legal.find((a) => a.type === 'check');
+    const call = legal.find((a) => a.type === 'call');
+    const bet = legal.find((a) => a.type === 'bet');
+    const raise = legal.find((a) => a.type === 'raise');
+    const allin = legal.find((a) => a.type === 'allin');
+
+    // All-in curto: commit se stack <= 8 BB e strength decente
+    const bb = match.bigBlind;
+    if (stack <= bb * 8 && strength >= 0.55 && allin) {
+        return { type: 'allin', amount: allin.amount };
+    }
+
+    if (toCall <= 0) {
+        // Opção de check ou bet
+        if (wantBluff && bet) {
+            return sizeBet(bet, pot, stack, 0.45);
+        }
+        if (strength >= 0.62 * (1.1 - cfg.aggression * 0.2) && bet) {
+            const frac = strength > 0.8 ? 0.75 : 0.55;
+            return sizeBet(bet, pot, stack, frac);
+        }
+        if (check) return { type: 'check', amount: 0 };
+        if (bet) return sizeBet(bet, pot, stack, 0.4);
+        return legal[0];
+    }
+
+    // Facing a bet
+    const equity = strength; // proxy sem ver hole do herói
+    const threshold = odds + cfg.callMargin;
+
+    if (equity + 0.02 < threshold && strength < 0.45) {
+        // Fold fraco
+        if (fold && !wantBluff) return { type: 'fold', amount: 0 };
+    }
+
+    if ((strength >= 0.72 || wantBluff) && raise && equity >= threshold - 0.05) {
+        return sizeRaise(raise, pot, toCall, stack, strength > 0.85 ? 1.0 : 0.7);
+    }
+
+    if (call && (equity >= threshold || strength >= 0.5 || toCall <= bb)) {
+        return { type: 'call', amount: call.amount };
+    }
+
+    if (fold) return { type: 'fold', amount: 0 };
+    if (call) return { type: 'call', amount: call.amount };
+    return legal[0];
+}
+
+function sizeBet(betAction, pot, stack, frac) {
+    const target = Math.round(Math.max(betAction.min, Math.min(betAction.max, pot * frac)));
+    if (target >= stack * 0.9 && betAction.max >= stack) {
+        return { type: 'allin', amount: stack };
+    }
+    return { type: 'bet', amount: Math.min(betAction.max, Math.max(betAction.min, target)) };
+}
+
+function sizeRaise(raiseAction, pot, toCall, stack, mult) {
+    const target = Math.round(toCall + Math.max(pot * 0.55, toCall) * mult);
+    const amt = Math.min(raiseAction.max, Math.max(raiseAction.min, target));
+    if (amt >= stack * 0.85) return { type: 'allin', amount: stack };
+    return { type: 'raise', amount: amt };
+}
+
+/** Flush draw (4 do mesmo naipe) ou quase sequência — bônus 0–1 */
+function drawBonus(hole, board) {
+    const all = [...hole, ...board].map((id) => ({ rank: id[0], suit: id[1] }));
+    const bySuit = {};
+    for (const c of all) bySuit[c.suit] = (bySuit[c.suit] || 0) + 1;
+    let bonus = 0;
+    if (Object.values(bySuit).some((n) => n === 4)) bonus += 0.7;
+    if (Object.values(bySuit).some((n) => n >= 5)) bonus += 0.2;
+    return Math.min(1, bonus);
+}
+
+export function aiThinkDelay(level = 'normal') {
+    const cfg = getDifficulty(level);
+    const [a, b] = cfg.thinkMs;
+    return a + Math.random() * (b - a);
+}
+
+/** Coach helper: equity real (com hole do herói) só para dicas educativas */
+export function coachingEquity(match) {
+    const h = match.hand;
+    if (!h || h.board.length < 3) return null;
+    return estimateEquity(h.holes[0], h.holes[1], h.board, 80, match.rng);
+}

--- a/labs/poker/src/audio.js
+++ b/labs/poker/src/audio.js
@@ -1,0 +1,61 @@
+/**
+ * Sons leves via Web Audio API — sem arquivos externos.
+ */
+
+let ctx = null;
+let muted = false;
+
+function ac() {
+    if (!ctx) ctx = new (window.AudioContext || window.webkitAudioContext)();
+    if (ctx.state === 'suspended') ctx.resume();
+    return ctx;
+}
+
+export function setMuted(v) {
+    muted = !!v;
+}
+
+export function isMuted() {
+    return muted;
+}
+
+function tone(freq, dur, type = 'sine', gain = 0.04, delay = 0) {
+    if (muted) return;
+    const c = ac();
+    const t0 = c.currentTime + delay;
+    const o = c.createOscillator();
+    const g = c.createGain();
+    o.type = type;
+    o.frequency.setValueAtTime(freq, t0);
+    g.gain.setValueAtTime(0.0001, t0);
+    g.gain.exponentialRampToValueAtTime(gain, t0 + 0.02);
+    g.gain.exponentialRampToValueAtTime(0.0001, t0 + dur);
+    o.connect(g);
+    g.connect(c.destination);
+    o.start(t0);
+    o.stop(t0 + dur + 0.02);
+}
+
+export function sfxDeal() {
+    tone(420, 0.06, 'triangle', 0.03);
+    tone(520, 0.05, 'triangle', 0.025, 0.04);
+}
+
+export function sfxChip() {
+    tone(180, 0.08, 'square', 0.02);
+    tone(240, 0.06, 'square', 0.015, 0.03);
+}
+
+export function sfxFold() {
+    tone(160, 0.12, 'sine', 0.03);
+}
+
+export function sfxWin() {
+    tone(523, 0.1, 'sine', 0.04);
+    tone(659, 0.12, 'sine', 0.035, 0.09);
+    tone(784, 0.16, 'sine', 0.03, 0.18);
+}
+
+export function sfxClick() {
+    tone(660, 0.04, 'sine', 0.02);
+}

--- a/labs/poker/src/cards.js
+++ b/labs/poker/src/cards.js
@@ -1,0 +1,47 @@
+/**
+ * Renderização de cartas — HTML/CSS hiper-realista.
+ */
+
+import { RANK_LABEL, SUIT_SYMBOL, SUIT_COLOR, parseCard } from './engine.js';
+
+export function cardElement(cardId, { faceDown = false, small = false, dealDelay = 0 } = {}) {
+    const el = document.createElement('div');
+    el.className = `card${faceDown ? ' is-back' : ''}${small ? ' is-small' : ''}`;
+    el.style.setProperty('--deal-delay', `${dealDelay}ms`);
+    el.dataset.card = cardId || '';
+
+    if (faceDown || !cardId) {
+        el.innerHTML = `<div class="card-face card-back" aria-hidden="true"><i></i></div>`;
+        el.setAttribute('aria-label', 'Carta fechada');
+        return el;
+    }
+
+    const { rank, suit } = parseCard(cardId);
+    const color = SUIT_COLOR[suit];
+    const sym = SUIT_SYMBOL[suit];
+    const label = RANK_LABEL[rank];
+    el.classList.add(color === 'red' ? 'is-red' : 'is-black');
+    el.setAttribute('aria-label', `${label} de ${suitName(suit)}`);
+    el.innerHTML = `
+      <div class="card-face card-front">
+        <span class="corner tl"><b>${label}</b><i>${sym}</i></span>
+        <span class="pip">${sym}</span>
+        <span class="corner br"><b>${label}</b><i>${sym}</i></span>
+      </div>`;
+    return el;
+}
+
+function suitName(s) {
+    return { s: 'espadas', h: 'copas', d: 'ouros', c: 'paus' }[s] || s;
+}
+
+export function clearChildren(node) {
+    while (node.firstChild) node.removeChild(node.firstChild);
+}
+
+export function renderCards(container, ids, opts = {}) {
+    clearChildren(container);
+    (ids || []).forEach((id, i) => {
+        container.appendChild(cardElement(id, { ...opts, dealDelay: (opts.baseDelay || 0) + i * 70 }));
+    });
+}

--- a/labs/poker/src/coach.js
+++ b/labs/poker/src/coach.js
@@ -1,0 +1,244 @@
+/**
+ * Academia de Poker — lições e dicas ao vivo.
+ */
+
+export const LESSONS = [
+    {
+        id: 'objetivo',
+        title: 'O que é Texas Hold\'em',
+        kicker: 'Fundamento',
+        text: 'Texas Hold\'em é o poker mais jogado no mundo. Cada jogador recebe 2 cartas fechadas (hole cards). Depois saem 5 cartas comunitárias no centro. Você monta a melhor mão de 5 cartas usando qualquer combinação das 7.',
+        tip: 'Objetivo: ganhar fichas. Dá para vencer sem mostrar a mão — se todos desistirem (fold), o pot é seu.',
+        quiz: {
+            prompt: 'Quantas cartas comunitárias o board tem no total?',
+            options: ['3', '5', '7'],
+            answer: 1,
+            success: 'Cinco: flop (3) + turn (1) + river (1).'
+        }
+    },
+    {
+        id: 'ranking',
+        title: 'Ranking das mãos',
+        kicker: 'Fundamento',
+        text: 'Do mais forte ao mais fraco: Royal flush → Straight flush → Quadra → Full house → Flush → Sequência → Trinca → Dois pares → Par → Carta alta. Empate: comparam-se os kickers.',
+        tip: 'Decore a ordem. Em dúvida no jogo, o mestre mostra a categoria da sua mão atual.',
+        quiz: {
+            prompt: 'O que vence: flush ou full house?',
+            options: ['Flush', 'Full house', 'Empate'],
+            answer: 1,
+            success: 'Full house (trinca + par) está acima do flush no ranking.'
+        }
+    },
+    {
+        id: 'blinds',
+        title: 'Blinds e o botão',
+        kicker: 'Apostas',
+        text: 'Antes de qualquer carta, dois jogadores pagam blinds (apostas obrigatórias): small blind e big blind. O botão marca o dealer. Em heads-up (1×1), o botão paga o small blind e age primeiro pré-flop.',
+        tip: 'Blinds forçam ação — sem eles, todos poderiam esperar a mão perfeita para sempre.',
+        quiz: {
+            prompt: 'No heads-up, quem paga o small blind?',
+            options: ['O big blind', 'O botão (dealer)', 'Sempre o herói'],
+            answer: 1,
+            success: 'No HU o botão é SB e age primeiro pré-flop; pós-flop o BB age primeiro.'
+        }
+    },
+    {
+        id: 'ruas',
+        title: 'As quatro ruas',
+        kicker: 'Apostas',
+        text: 'Pré-flop: só as 2 hole cards. Flop: 3 cartas no board. Turn: a 4ª. River: a 5ª. Em cada rua há uma rodada de apostas — fold, check, bet, call ou raise.',
+        tip: 'Check = passar a vez sem apostar (só se ninguém apostou ainda). Fold = desistir da mão e do pot.',
+        quiz: {
+            prompt: 'Quando você pode dar check?',
+            options: [
+                'Sempre',
+                'Só se não há aposta para pagar',
+                'Só no river'
+            ],
+            answer: 1,
+            success: 'Check só existe quando não há aposta aberta. Se alguém apostou, você fold, call ou raise.'
+        }
+    },
+    {
+        id: 'pot-odds',
+        title: 'Pot odds',
+        kicker: 'Matemática',
+        text: 'Pot odds = quanto você precisa pagar ÷ (pote + call). Ex.: pote 90, call 10 → 10/100 = 10%. Se sua chance de ganhar (equity) for maior que 10%, o call é +EV a longo prazo.',
+        tip: 'Fórmula: equity > toCall / (pot + toCall). O mestre mostra isso quando você enfrentar uma aposta.',
+        quiz: {
+            prompt: 'Pote 80, call 20. Qual a pot odd?',
+            options: ['20%', '25%', '50%'],
+            answer: 0,
+            success: '20 / (80+20) = 20%. Você precisa de ~20% de equity para um call zero.'
+        }
+    },
+    {
+        id: 'posicao',
+        title: 'Posição',
+        kicker: 'Estratégia',
+        text: 'Agir por último é vantagem: você viu o que o rival fez. Em heads-up, pós-flop o botão age por último — posição favorável. Pré-flop o SB (botão) age primeiro.',
+        tip: 'Com posição, dá para bluffar mais e controlar o tamanho do pot.',
+        quiz: {
+            prompt: 'Por que posição é boa?',
+            options: [
+                'Você paga menos blinds',
+                'Você age depois de ver a ação do rival',
+                'Suas cartas ficam melhores'
+            ],
+            answer: 1,
+            success: 'Informação. Poker é um jogo de decisões sob incerteza — ver a ação rival reduz incerteza.'
+        }
+    },
+    {
+        id: 'preflop',
+        title: 'Mãos iniciais',
+        kicker: 'Estratégia',
+        text: 'Pares altos (AA–TT), Ás com figura (AK, AQ) e conectores do mesmo naipe (JTs, 98s) são fortes. Mãos lixo (72o, 83o) quase sempre se descartam — sobretudo fora de posição.',
+        tip: 'Iniciante: jogue apertado. Menos mãos, mas melhores. A disciplina vence o “eu senti”.',
+        quiz: {
+            prompt: 'Qual mão é a mais forte pré-flop?',
+            options: ['AKo', '72o', 'AA'],
+            answer: 2,
+            success: 'Par de ases é a melhor mão inicial. AKo é forte, mas ainda perde ~18% do tempo vs AA.'
+        }
+    },
+    {
+        id: 'cbet',
+        title: 'Continuation bet',
+        kicker: 'Estratégia',
+        text: 'Se você foi o último a aumentar pré-flop, no flop costuma “continuar” com uma aposta (c-bet) — mesmo sem ter acertado o board. O rival folda mãos médias com frequência.',
+        tip: 'Não c-bete sempre em boards perigosos (ex.: três do mesmo naipe). A IA também usa isso.',
+        quiz: {
+            prompt: 'C-bet significa…',
+            options: [
+                'Apostar no flop após ter raisado pré-flop',
+                'Ir all-in no river',
+                'Desistir no turn'
+            ],
+            answer: 0,
+            success: 'Continuation bet: você representa força mantendo a iniciativa da mão.'
+        }
+    },
+    {
+        id: 'showdown',
+        title: 'Showdown',
+        kicker: 'Fundamento',
+        text: 'Se alguém chega ao river e a aposta é paga (ou todos dão check), as cartas abrem. A melhor mão de cinco cartas leva o pot. Empate divide o pot.',
+        tip: 'Você não é obrigado a chegar ao showdown. Foldar uma mão segunda é habilidade — não covardia.',
+        quiz: {
+            prompt: 'No showdown, quantas cartas entram na melhor mão?',
+            options: [
+                'Sempre as 2 hole + 3 do board',
+                'Qualquer 5 entre as 7 disponíveis',
+                'Só as 5 do board'
+            ],
+            answer: 1,
+            success: 'Qualquer combinação de 5 entre hole (2) + board (5). Dá para usar 0, 1 ou 2 hole cards.'
+        }
+    },
+    {
+        id: 'bankroll',
+        title: 'Gestão de fichas',
+        kicker: 'Mentalidade',
+        text: 'Não vá all-in por tédio. Preserve stack para mãos fortes. Em stacks curtos (<10 BB) all-in com mão decente é correto — all-in com 72o é doação.',
+        tip: 'Varie: às vezes check com mão forte (slow play), às vezes bluff. Previsibilidade é explorável.',
+        quiz: {
+            prompt: 'Com stack de 8 big blinds e AK, o quê costuma ser correto?',
+            options: [
+                'Fold',
+                'Empurrar all-in / jogar por stack',
+                'Só limpar (call) sempre'
+            ],
+            answer: 1,
+            success: 'Stack curto: commit com mãos fortes. Não há room para jogar “pequeno”.'
+        }
+    }
+];
+
+export const HAND_RANK_CHART = [
+    { name: 'Royal flush', example: 'A♠ K♠ Q♠ J♠ T♠', cat: 9 },
+    { name: 'Straight flush', example: '9♥ 8♥ 7♥ 6♥ 5♥', cat: 8 },
+    { name: 'Quadra', example: 'K♦ K♣ K♥ K♠ 2♣', cat: 7 },
+    { name: 'Full house', example: 'Q♠ Q♥ Q♦ 7♣ 7♥', cat: 6 },
+    { name: 'Flush', example: 'A♦ J♦ 8♦ 4♦ 2♦', cat: 5 },
+    { name: 'Sequência', example: 'T♣ 9♦ 8♠ 7♥ 6♣', cat: 4 },
+    { name: 'Trinca', example: '8♠ 8♥ 8♦ K♣ 3♥', cat: 3 },
+    { name: 'Dois pares', example: 'A♠ A♦ 5♣ 5♥ 9♦', cat: 2 },
+    { name: 'Par', example: 'J♣ J♥ A♠ 8♦ 3♣', cat: 1 },
+    { name: 'Carta alta', example: 'A♠ K♦ 9♣ 5♥ 2♠', cat: 0 }
+];
+
+/**
+ * Dica contextual durante a partida.
+ */
+export function liveTip(match, legal) {
+    const h = match.hand;
+    if (!h) return { title: 'Mesa', text: 'Inicie uma mão para receber dicas ao vivo.' };
+
+    const hero = match.heroSeat;
+    const toCall = Math.max(0, h.currentBet - h.streetContrib[hero]);
+    const streetLabel = {
+        preflop: 'Pré-flop',
+        flop: 'Flop',
+        turn: 'Turn',
+        river: 'River',
+        showdown: 'Showdown',
+        done: 'Fim da mão'
+    }[h.street] || h.street;
+
+    if (h.street === 'done') {
+        const r = match.lastResult;
+        if (!r) return { title: 'Mão encerrada', text: 'Prepare a próxima.' };
+        if (r.reason === 'fold') {
+            return {
+                title: 'Pot sem showdown',
+                text: 'Alguém foldou. Nem sempre a melhor mão vence — pressão e posição importam.'
+            };
+        }
+        const mine = r.hands?.[hero];
+        return {
+            title: 'Showdown',
+            text: mine
+                ? `Sua mão: ${mine.name}. Compare kickers quando a categoria empatar.`
+                : 'Cartas abertas — a melhor combinação de cinco leva o pot.'
+        };
+    }
+
+    if (h.toAct !== hero) {
+        return {
+            title: `${streetLabel} · aguardando`,
+            text: 'A IA está pensando. Observe o tamanho da aposta em relação ao pote — isso revela força ou blefe.'
+        };
+    }
+
+    if (h.street === 'preflop') {
+        return {
+            title: 'Pré-flop',
+            text: toCall > 0
+                ? `Há ${toCall} para pagar. Pares altos e Ás-figura costumam call/raise; mãos lixo foldam.`
+                : 'Sem aposta extra. Com mão forte, considere raise para construir o pot e tomar a iniciativa.'
+        };
+    }
+
+    if (toCall > 0) {
+        const odds = toCall / (h.pot + toCall);
+        const pct = Math.round(odds * 100);
+        return {
+            title: `Pot odds ~${pct}%`,
+            text: `Call ${toCall} num pote de ${h.pot}. Você precisa de cerca de ${pct}% de chance de ganhar para o call ser equilibrado.`,
+            potOdds: odds
+        };
+    }
+
+    const hasBet = legal?.some((a) => a.type === 'bet');
+    return {
+        title: streetLabel,
+        text: hasBet
+            ? 'Ninguém apostou. Check controla o pot; bet extrai valor ou faz foldar mãos melhores.'
+            : 'Escolha sua ação. Lembre: fold também é uma jogada vencedora a longo prazo.'
+    };
+}
+
+export function lessonById(id) {
+    return LESSONS.find((l) => l.id === id) || LESSONS[0];
+}

--- a/labs/poker/src/engine.js
+++ b/labs/poker/src/engine.js
@@ -1,0 +1,669 @@
+/**
+ * Motor Texas Hold'em heads-up.
+ *
+ * Regras documentadas:
+ * - Blinds: no HU o botão (dealer) paga small blind; o outro paga big blind.
+ * - Ordem pré-flop: SB age primeiro; pós-flop: BB age primeiro (fora do botão).
+ * - Ruas: preflop → flop (3) → turn (1) → river (1) → showdown.
+ * - Ranking (maior → menor): royal flush, straight flush, quadra, full house,
+ *   flush, straight, trinca, dois pares, par, high card.
+ * - Empate: split pot (chips ímpares vão ao primeiro seat no split).
+ * - All-in: side pots simplificados (só 2 jogadores → pot único).
+ */
+
+export const RANKS = ['2', '3', '4', '5', '6', '7', '8', '9', 'T', 'J', 'Q', 'K', 'A'];
+export const SUITS = ['s', 'h', 'd', 'c']; // spades, hearts, diamonds, clubs
+export const SUIT_SYMBOL = { s: '♠', h: '♥', d: '♦', c: '♣' };
+export const SUIT_COLOR = { s: 'black', h: 'red', d: 'red', c: 'black' };
+export const RANK_LABEL = {
+    '2': '2', '3': '3', '4': '4', '5': '5', '6': '6', '7': '7', '8': '8', '9': '9',
+    T: '10', J: 'J', Q: 'Q', K: 'K', A: 'A'
+};
+
+export const HAND_NAMES = [
+    'Carta alta',
+    'Par',
+    'Dois pares',
+    'Trinca',
+    'Sequência',
+    'Flush',
+    'Full house',
+    'Quadra',
+    'Straight flush',
+    'Royal flush'
+];
+
+export const STREET = {
+    PREFLOP: 'preflop',
+    FLOP: 'flop',
+    TURN: 'turn',
+    RIVER: 'river',
+    SHOWDOWN: 'showdown',
+    DONE: 'done'
+};
+
+const RANK_VALUE = Object.fromEntries(RANKS.map((r, i) => [r, i]));
+
+export function cardId(rank, suit) {
+    return `${rank}${suit}`;
+}
+
+export function parseCard(id) {
+    return { id, rank: id[0], suit: id[1], value: RANK_VALUE[id[0]] };
+}
+
+export function createDeck() {
+    const deck = [];
+    for (const suit of SUITS) {
+        for (const rank of RANKS) deck.push(cardId(rank, suit));
+    }
+    return deck;
+}
+
+/** Fisher–Yates */
+export function shuffle(deck, rng = Math.random) {
+    const a = deck.slice();
+    for (let i = a.length - 1; i > 0; i--) {
+        const j = Math.floor(rng() * (i + 1));
+        [a[i], a[j]] = [a[j], a[i]];
+    }
+    return a;
+}
+
+/**
+ * Avalia a melhor mão de 5 cartas entre até 7.
+ * Retorna { category: 0–9, ranks: number[], name, cards }.
+ * Comparação lexicográfica de [category, ...ranks].
+ */
+export function evaluateHand(cardIds) {
+    const cards = cardIds.map(parseCard);
+    if (cards.length < 5) {
+        return { category: -1, ranks: [], name: '—', cards: cardIds };
+    }
+
+    let best = null;
+    const combos = combinations(cards, 5);
+    for (const five of combos) {
+        const score = scoreFive(five);
+        if (!best || compareScores(score, best) > 0) best = score;
+    }
+    return best;
+}
+
+function combinations(arr, k) {
+    const out = [];
+    const n = arr.length;
+    const idx = Array.from({ length: k }, (_, i) => i);
+    while (true) {
+        out.push(idx.map((i) => arr[i]));
+        let i = k - 1;
+        while (i >= 0 && idx[i] === i + n - k) i--;
+        if (i < 0) break;
+        idx[i]++;
+        for (let j = i + 1; j < k; j++) idx[j] = idx[j - 1] + 1;
+    }
+    return out;
+}
+
+function scoreFive(five) {
+    const sorted = five.slice().sort((a, b) => b.value - a.value);
+    const values = sorted.map((c) => c.value);
+    const suits = sorted.map((c) => c.suit);
+    const flush = suits.every((s) => s === suits[0]);
+
+    // Ás baixo para wheel A-2-3-4-5
+    let straightHigh = straightHighValue(values);
+    const isStraight = straightHigh >= 0;
+
+    const counts = countRanks(values);
+    const groups = Object.entries(counts)
+        .map(([v, n]) => ({ v: Number(v), n }))
+        .sort((a, b) => b.n - a.n || b.v - a.v);
+
+    let category;
+    let ranks;
+
+    if (isStraight && flush) {
+        category = straightHigh === 12 ? 9 : 8; // royal / SF
+        ranks = [straightHigh];
+    } else if (groups[0].n === 4) {
+        category = 7;
+        ranks = [groups[0].v, groups[1].v];
+    } else if (groups[0].n === 3 && groups[1].n === 2) {
+        category = 6;
+        ranks = [groups[0].v, groups[1].v];
+    } else if (flush) {
+        category = 5;
+        ranks = values;
+    } else if (isStraight) {
+        category = 4;
+        ranks = [straightHigh];
+    } else if (groups[0].n === 3) {
+        category = 3;
+        ranks = [groups[0].v, ...groups.slice(1).map((g) => g.v)];
+    } else if (groups[0].n === 2 && groups[1].n === 2) {
+        category = 2;
+        const high = Math.max(groups[0].v, groups[1].v);
+        const low = Math.min(groups[0].v, groups[1].v);
+        ranks = [high, low, groups[2].v];
+    } else if (groups[0].n === 2) {
+        category = 1;
+        ranks = [groups[0].v, ...groups.slice(1).map((g) => g.v)];
+    } else {
+        category = 0;
+        ranks = values;
+    }
+
+    return {
+        category,
+        ranks,
+        name: HAND_NAMES[category],
+        cards: sorted.map((c) => c.id)
+    };
+}
+
+function countRanks(values) {
+    const m = {};
+    for (const v of values) m[v] = (m[v] || 0) + 1;
+    return m;
+}
+
+/** Retorna o valor alto da sequência, ou -1. Aceita wheel (A2345 → high=3). */
+function straightHighValue(valuesDesc) {
+    const uniq = [...new Set(valuesDesc)].sort((a, b) => b - a);
+    if (uniq.length < 5) return -1;
+
+    // Normal
+    for (let i = 0; i <= uniq.length - 5; i++) {
+        let ok = true;
+        for (let j = 1; j < 5; j++) {
+            if (uniq[i + j] !== uniq[i] - j) {
+                ok = false;
+                break;
+            }
+        }
+        if (ok) return uniq[i];
+    }
+
+    // Wheel: A,5,4,3,2
+    const set = new Set(uniq);
+    if (set.has(12) && set.has(3) && set.has(2) && set.has(1) && set.has(0)) return 3;
+    return -1;
+}
+
+export function compareScores(a, b) {
+    if (a.category !== b.category) return a.category - b.category;
+    const n = Math.max(a.ranks.length, b.ranks.length);
+    for (let i = 0; i < n; i++) {
+        const av = a.ranks[i] ?? -1;
+        const bv = b.ranks[i] ?? -1;
+        if (av !== bv) return av - bv;
+    }
+    return 0;
+}
+
+export function describeHand(score) {
+    if (!score || score.category < 0) return '—';
+    const rankWord = (v) => RANK_LABEL[RANKS[v]] || String(v);
+    switch (score.category) {
+        case 9: return 'Royal flush';
+        case 8: return `Straight flush até ${rankWord(score.ranks[0])}`;
+        case 7: return `Quadra de ${rankWord(score.ranks[0])}`;
+        case 6: return `Full house ${rankWord(score.ranks[0])} cheio de ${rankWord(score.ranks[1])}`;
+        case 5: return `Flush (alta ${rankWord(score.ranks[0])})`;
+        case 4: return `Sequência até ${rankWord(score.ranks[0])}`;
+        case 3: return `Trinca de ${rankWord(score.ranks[0])}`;
+        case 2: return `Dois pares ${rankWord(score.ranks[0])} e ${rankWord(score.ranks[1])}`;
+        case 1: return `Par de ${rankWord(score.ranks[0])}`;
+        default: return `Carta alta ${rankWord(score.ranks[0])}`;
+    }
+}
+
+/**
+ * Força relativa pré-flop simplificada (0–1) para mãos de 2 cartas.
+ * Usada pela IA e pelo coach — não é equity exata Monte Carlo.
+ */
+export function holeStrength(hole) {
+    if (!hole || hole.length !== 2) return 0;
+    const [a, b] = hole.map(parseCard);
+    const hi = Math.max(a.value, b.value);
+    const lo = Math.min(a.value, b.value);
+    const pair = a.value === b.value;
+    const suited = a.suit === b.suit;
+    const gap = hi - lo;
+
+    let s = (hi + 1) / 13 * 0.45 + (lo + 1) / 13 * 0.15;
+    if (pair) s = 0.55 + hi / 13 * 0.4;
+    else {
+        if (suited) s += 0.08;
+        if (gap === 1) s += 0.06;
+        else if (gap === 2) s += 0.03;
+        else if (gap >= 4) s -= 0.04 * Math.min(gap - 3, 4);
+        if (hi === 12) s += 0.06; // Ás
+    }
+    return Math.max(0.02, Math.min(0.98, s));
+}
+
+/**
+ * Equity aproximada pós-flop via amostragem Monte Carlo leve.
+ * samples: número de boards futuros (default 120).
+ */
+export function estimateEquity(heroHole, villainHole, board, samples = 120, rng = Math.random) {
+    const used = new Set([...heroHole, ...villainHole, ...board]);
+    const remaining = createDeck().filter((c) => !used.has(c));
+    const need = 5 - board.length;
+    if (need < 0) return 0.5;
+
+    let wins = 0;
+    let ties = 0;
+    const n = Math.min(samples, 400);
+
+    for (let i = 0; i < n; i++) {
+        const pool = shuffle(remaining, rng);
+        const fill = pool.slice(0, need);
+        const full = board.concat(fill);
+        const h = evaluateHand([...heroHole, ...full]);
+        const v = evaluateHand([...villainHole, ...full]);
+        const cmp = compareScores(h, v);
+        if (cmp > 0) wins++;
+        else if (cmp === 0) ties++;
+    }
+    return (wins + ties * 0.5) / n;
+}
+
+export function potOdds(toCall, pot) {
+    // Fórmula: call / (pot + call). Se equity > pot odds, call +EV.
+    if (toCall <= 0) return 0;
+    return toCall / (pot + toCall);
+}
+
+export function createMatch({
+    startingStack = 1000,
+    smallBlind = 5,
+    bigBlind = 10,
+    heroSeat = 0,
+    rng = Math.random
+} = {}) {
+    return {
+        startingStack,
+        smallBlind,
+        bigBlind,
+        heroSeat,
+        rng,
+        button: 1, // AI começa no botão; hero recebe BB na 1ª mão
+        handNumber: 0,
+        stacks: [startingStack, startingStack],
+        players: [
+            { id: 0, name: 'Você', isHero: true },
+            { id: 1, name: 'Dealer IA', isHero: false }
+        ],
+        hand: null,
+        log: [],
+        lastResult: null
+    };
+}
+
+export function canContinue(match) {
+    return match.stacks[0] > 0 && match.stacks[1] > 0;
+}
+
+export function startHand(match) {
+    if (!canContinue(match)) return null;
+
+    match.button = match.handNumber === 0 ? match.button : 1 - match.button;
+    match.handNumber += 1;
+
+    const deck = shuffle(createDeck(), match.rng);
+    const sbSeat = match.button; // HU: botão = SB
+    const bbSeat = 1 - match.button;
+
+    const sbAmt = Math.min(match.smallBlind, match.stacks[sbSeat]);
+    const bbAmt = Math.min(match.bigBlind, match.stacks[bbSeat]);
+
+    match.stacks[sbSeat] -= sbAmt;
+    match.stacks[bbSeat] -= bbAmt;
+
+    const holes = [[], []];
+    holes[0].push(deck.pop(), deck.pop());
+    holes[1].push(deck.pop(), deck.pop());
+
+    const hand = {
+        deck,
+        board: [],
+        holes,
+        street: STREET.PREFLOP,
+        pot: sbAmt + bbAmt,
+        bets: [0, 0],
+        contrib: [0, 0],
+        streetContrib: [0, 0],
+        currentBet: bbAmt,
+        minRaise: match.bigBlind,
+        lastAggressor: bbSeat,
+        toAct: sbSeat,
+        acted: [false, false],
+        folded: [false, false],
+        allIn: [match.stacks[0] === 0, match.stacks[1] === 0],
+        sbSeat,
+        bbSeat,
+        button: match.button,
+        winners: null,
+        showdown: false,
+        pendingAdvance: false
+    };
+    hand.bets[sbSeat] = sbAmt;
+    hand.bets[bbSeat] = bbAmt;
+    hand.contrib[sbSeat] = sbAmt;
+    hand.contrib[bbSeat] = bbAmt;
+    hand.streetContrib[sbSeat] = sbAmt;
+    hand.streetContrib[bbSeat] = bbAmt;
+
+    if (hand.allIn[0] || hand.allIn[1]) {
+        hand.acted = [true, true];
+    }
+
+    match.hand = hand;
+    match.lastResult = null;
+    pushLog(match, `Mão #${match.handNumber} — blinds ${sbAmt}/${bbAmt}`);
+    return hand;
+}
+
+function pushLog(match, msg) {
+    match.log.unshift({ t: Date.now(), msg });
+    if (match.log.length > 40) match.log.length = 40;
+}
+
+export function legalActions(match) {
+    const h = match.hand;
+    if (!h || h.street === STREET.SHOWDOWN || h.street === STREET.DONE) return [];
+    if (h.pendingAdvance) return [];
+
+    const seat = h.toAct;
+    if (h.folded[seat] || h.allIn[seat]) return [];
+
+    const toCall = h.currentBet - h.streetContrib[seat];
+    const stack = match.stacks[seat];
+    const actions = [];
+
+    if (toCall <= 0) {
+        actions.push({ type: 'check', label: 'Check', amount: 0 });
+        if (stack > 0) {
+            const minBet = Math.min(stack, Math.max(match.bigBlind, h.minRaise));
+            actions.push({ type: 'bet', label: 'Apostar', min: minBet, max: stack, amount: minBet });
+            if (stack > minBet) actions.push({ type: 'allin', label: 'All-in', amount: stack });
+        }
+    } else {
+        actions.push({ type: 'fold', label: 'Fold', amount: 0 });
+        const callAmt = Math.min(stack, toCall);
+        actions.push({ type: 'call', label: callAmt >= stack ? 'All-in (call)' : 'Call', amount: callAmt });
+        if (stack > toCall) {
+            const minRaiseTotal = h.currentBet + h.minRaise;
+            const minPut = minRaiseTotal - h.streetContrib[seat];
+            if (stack > toCall) {
+                const minAmt = Math.min(stack, Math.max(toCall + 1, minPut));
+                if (minAmt < stack) {
+                    actions.push({
+                        type: 'raise',
+                        label: 'Raise',
+                        min: minAmt,
+                        max: stack,
+                        amount: minAmt
+                    });
+                }
+                actions.push({ type: 'allin', label: 'All-in', amount: stack });
+            }
+        }
+    }
+    return actions;
+}
+
+/**
+ * Aplica ação do jogador toAct.
+ * amount: chips a colocar nesta ação (além do já contribuído na rua para bet/raise = total put this street action).
+ * Para bet/raise/allin, amount = chips adicionais a enviar agora.
+ */
+export function applyAction(match, action) {
+    const h = match.hand;
+    if (!h) return { ok: false, error: 'Sem mão' };
+    const seat = h.toAct;
+    const legal = legalActions(match);
+    const found = legal.find((a) => a.type === action.type);
+    if (!found) return { ok: false, error: 'Ação ilegal' };
+
+    let put = 0;
+    const name = match.players[seat].name;
+
+    switch (action.type) {
+        case 'fold': {
+            h.folded[seat] = true;
+            h.acted[seat] = true;
+            pushLog(match, `${name} desiste (fold)`);
+            return finishByFold(match, 1 - seat);
+        }
+        case 'check': {
+            h.acted[seat] = true;
+            pushLog(match, `${name} dá check`);
+            break;
+        }
+        case 'call': {
+            put = Math.min(match.stacks[seat], h.currentBet - h.streetContrib[seat]);
+            commit(match, seat, put);
+            h.acted[seat] = true;
+            pushLog(match, `${name} paga ${put}`);
+            break;
+        }
+        case 'bet': {
+            put = clampAmount(action.amount, found.min, found.max);
+            commit(match, seat, put);
+            h.currentBet = h.streetContrib[seat];
+            h.minRaise = put;
+            h.lastAggressor = seat;
+            h.acted = [false, false];
+            h.acted[seat] = true;
+            pushLog(match, `${name} aposta ${put}`);
+            break;
+        }
+        case 'raise': {
+            put = clampAmount(action.amount, found.min, found.max);
+            const prevBet = h.currentBet;
+            commit(match, seat, put);
+            const raiseSize = h.streetContrib[seat] - prevBet;
+            h.minRaise = Math.max(match.bigBlind, raiseSize);
+            h.currentBet = h.streetContrib[seat];
+            h.lastAggressor = seat;
+            h.acted = [false, false];
+            h.acted[seat] = true;
+            pushLog(match, `${name} aumenta para ${h.currentBet} (+${put})`);
+            break;
+        }
+        case 'allin': {
+            put = match.stacks[seat];
+            const prevBet = h.currentBet;
+            commit(match, seat, put);
+            if (h.streetContrib[seat] > h.currentBet) {
+                const raiseSize = h.streetContrib[seat] - prevBet;
+                h.minRaise = Math.max(match.bigBlind, raiseSize);
+                h.currentBet = h.streetContrib[seat];
+                h.lastAggressor = seat;
+                h.acted = [false, false];
+            }
+            h.acted[seat] = true;
+            h.allIn[seat] = true;
+            pushLog(match, `${name} vai all-in (${put})`);
+            break;
+        }
+        default:
+            return { ok: false, error: 'Ação desconhecida' };
+    }
+
+    return afterAction(match);
+}
+
+function clampAmount(v, min, max) {
+    const n = Number(v);
+    if (!Number.isFinite(n)) return min;
+    return Math.max(min, Math.min(max, Math.round(n)));
+}
+
+function commit(match, seat, amount) {
+    const h = match.hand;
+    const put = Math.min(amount, match.stacks[seat]);
+    match.stacks[seat] -= put;
+    h.streetContrib[seat] += put;
+    h.contrib[seat] += put;
+    h.bets[seat] = h.streetContrib[seat];
+    h.pot += put;
+    if (match.stacks[seat] === 0) h.allIn[seat] = true;
+}
+
+function afterAction(match) {
+    const h = match.hand;
+
+    // Ambos all-in ou um all-in e o outro cobriu → runout
+    if (bettingRoundClosed(match)) {
+        if (h.folded[0] || h.folded[1]) {
+            // já tratado
+            return { ok: true };
+        }
+        if (bothCommittedOrAllIn(match) && h.street !== STREET.RIVER) {
+            return runoutToShowdown(match);
+        }
+        if (h.street === STREET.RIVER) {
+            return goShowdown(match);
+        }
+        return advanceStreet(match);
+    }
+
+    h.toAct = 1 - h.toAct;
+    // Pular quem fold/all-in
+    if (h.folded[h.toAct] || (h.allIn[h.toAct] && h.streetContrib[h.toAct] >= h.currentBet)) {
+        if (bettingRoundClosed(match)) {
+            if (h.street === STREET.RIVER) return goShowdown(match);
+            if (bothCommittedOrAllIn(match)) return runoutToShowdown(match);
+            return advanceStreet(match);
+        }
+    }
+    return { ok: true };
+}
+
+function bothCommittedOrAllIn(match) {
+    const h = match.hand;
+    const a0 = h.allIn[0] || h.streetContrib[0] >= h.currentBet;
+    const a1 = h.allIn[1] || h.streetContrib[1] >= h.currentBet;
+    return (h.allIn[0] || h.allIn[1]) && a0 && a1;
+}
+
+function bettingRoundClosed(match) {
+    const h = match.hand;
+    if (h.folded[0] || h.folded[1]) return true;
+
+    for (let s = 0; s < 2; s++) {
+        if (h.folded[s]) continue;
+        if (h.allIn[s]) continue;
+        if (!h.acted[s]) return false;
+        if (h.streetContrib[s] < h.currentBet && match.stacks[s] > 0) return false;
+    }
+    return true;
+}
+
+function finishByFold(match, winner) {
+    const h = match.hand;
+    const pot = h.pot;
+    match.stacks[winner] += pot;
+    h.winners = [winner];
+    h.street = STREET.DONE;
+    h.showdown = false;
+    match.lastResult = {
+        winners: [winner],
+        pot,
+        reason: 'fold',
+        hands: null
+    };
+    pushLog(match, `${match.players[winner].name} leva ${pot} (fold)`);
+    return { ok: true, handOver: true };
+}
+
+function advanceStreet(match) {
+    const h = match.hand;
+    h.streetContrib = [0, 0];
+    h.bets = [0, 0];
+    h.currentBet = 0;
+    h.minRaise = match.bigBlind;
+    h.acted = [false, false];
+
+    if (h.street === STREET.PREFLOP) {
+        h.street = STREET.FLOP;
+        h.board.push(h.deck.pop(), h.deck.pop(), h.deck.pop());
+        pushLog(match, `Flop: ${h.board.join(' ')}`);
+    } else if (h.street === STREET.FLOP) {
+        h.street = STREET.TURN;
+        h.board.push(h.deck.pop());
+        pushLog(match, `Turn: ${h.board[3]}`);
+    } else if (h.street === STREET.TURN) {
+        h.street = STREET.RIVER;
+        h.board.push(h.deck.pop());
+        pushLog(match, `River: ${h.board[4]}`);
+    } else {
+        return goShowdown(match);
+    }
+
+    // Pós-flop: primeiro a agir é o não-botão (BB no HU)
+    h.toAct = 1 - h.button;
+    if (h.allIn[0] && h.allIn[1]) return runoutToShowdown(match);
+    if (h.allIn[h.toAct]) h.toAct = 1 - h.toAct;
+    return { ok: true, streetAdvanced: true };
+}
+
+function runoutToShowdown(match) {
+    const h = match.hand;
+    while (h.board.length < 5) {
+        h.board.push(h.deck.pop());
+    }
+    if (h.street === STREET.PREFLOP) pushLog(match, `All-in runout: ${h.board.join(' ')}`);
+    else pushLog(match, `Runout: ${h.board.join(' ')}`);
+    h.street = STREET.RIVER;
+    return goShowdown(match);
+}
+
+function goShowdown(match) {
+    const h = match.hand;
+    h.street = STREET.SHOWDOWN;
+    h.showdown = true;
+
+    const hand0 = evaluateHand([...h.holes[0], ...h.board]);
+    const hand1 = evaluateHand([...h.holes[1], ...h.board]);
+    const cmp = compareScores(hand0, hand1);
+    const pot = h.pot;
+    let winners;
+    if (cmp > 0) winners = [0];
+    else if (cmp < 0) winners = [1];
+    else winners = [0, 1];
+
+    if (winners.length === 2) {
+        const half = Math.floor(pot / 2);
+        match.stacks[0] += half;
+        match.stacks[1] += pot - half;
+        pushLog(match, `Split pot ${pot} — ${describeHand(hand0)}`);
+    } else {
+        match.stacks[winners[0]] += pot;
+        pushLog(match, `${match.players[winners[0]].name} vence ${pot} com ${describeHand(winners[0] === 0 ? hand0 : hand1)}`);
+    }
+
+    h.winners = winners;
+    h.street = STREET.DONE;
+    match.lastResult = {
+        winners,
+        pot,
+        reason: 'showdown',
+        hands: [hand0, hand1]
+    };
+    return { ok: true, handOver: true, showdown: true };
+}
+
+export function heroToAct(match) {
+    const h = match.hand;
+    return !!(h && h.street !== STREET.DONE && h.toAct === match.heroSeat && !h.folded[match.heroSeat]);
+}
+
+export function formatChips(n) {
+    return new Intl.NumberFormat('pt-BR').format(n);
+}

--- a/labs/poker/src/main.js
+++ b/labs/poker/src/main.js
@@ -1,0 +1,616 @@
+/**
+ * Poker Lab — Texas Hold'em heads-up vs IA + academia.
+ */
+
+import {
+    applyAction,
+    canContinue,
+    createMatch,
+    describeHand,
+    evaluateHand,
+    formatChips,
+    heroToAct,
+    holeStrength,
+    legalActions,
+    potOdds,
+    startHand,
+    STREET
+} from './engine.js';
+import { aiThinkDelay, chooseAction } from './ai.js';
+import { HAND_RANK_CHART, LESSONS, liveTip } from './coach.js';
+import { renderCards } from './cards.js';
+import { isMuted, setMuted, sfxChip, sfxClick, sfxDeal, sfxFold, sfxWin } from './audio.js';
+
+const $ = (sel, root = document) => root.querySelector(sel);
+const $$ = (sel, root = document) => [...root.querySelectorAll(sel)];
+
+const state = {
+    mode: 'play', // play | academy
+    difficulty: 'normal',
+    match: null,
+    busy: false,
+    lessonIndex: 0,
+    betAmount: 0,
+    showAiCards: false
+};
+
+function init() {
+    state.match = createMatch({ startingStack: 1000, smallBlind: 5, bigBlind: 10 });
+    bindUi();
+    renderAll();
+    showIntro(true);
+}
+
+function bindUi() {
+    $('#btnStart')?.addEventListener('click', () => {
+        showIntro(false);
+        beginMatch();
+    });
+    $('#btnAcademyIntro')?.addEventListener('click', () => {
+        showIntro(false);
+        setMode('academy');
+    });
+
+    $('#modePlay')?.addEventListener('click', () => setMode('play'));
+    $('#modeAcademy')?.addEventListener('click', () => setMode('academy'));
+    $('#modeRanks')?.addEventListener('click', () => openRanks(true));
+
+    $('#btnNewHand')?.addEventListener('click', () => {
+        if (state.busy) return;
+        if (!canContinue(state.match)) {
+            state.match = createMatch({
+                startingStack: 1000,
+                smallBlind: 5,
+                bigBlind: 10,
+                button: state.match.button
+            });
+        }
+        dealNewHand();
+    });
+
+    $('#btnHint')?.addEventListener('click', onHint);
+    $('#muteBtn')?.addEventListener('click', () => {
+        setMuted(!isMuted());
+        $('#muteBtn').setAttribute('aria-pressed', String(isMuted()));
+        $('#muteBtn').textContent = isMuted() ? 'Mudo' : 'Som';
+        sfxClick();
+    });
+
+    $('#difficulty')?.addEventListener('change', (e) => {
+        state.difficulty = e.target.value;
+    });
+
+    $('#coachToggle')?.addEventListener('click', () => {
+        const body = $('#coachBody');
+        const open = body.hasAttribute('hidden');
+        if (open) body.removeAttribute('hidden');
+        else body.setAttribute('hidden', '');
+        $('#coachToggle').setAttribute('aria-expanded', String(open));
+    });
+
+    $('#prevLesson')?.addEventListener('click', () => {
+        state.lessonIndex = Math.max(0, state.lessonIndex - 1);
+        renderAcademy();
+        sfxClick();
+    });
+    $('#nextLesson')?.addEventListener('click', () => {
+        state.lessonIndex = Math.min(LESSONS.length - 1, state.lessonIndex + 1);
+        renderAcademy();
+        sfxClick();
+    });
+
+    $('#ranksClose')?.addEventListener('click', () => openRanks(false));
+    $('#ranksOverlay')?.addEventListener('click', (e) => {
+        if (e.target === e.currentTarget) openRanks(false);
+    });
+
+    $('#betSlider')?.addEventListener('input', (e) => {
+        state.betAmount = Number(e.target.value);
+        $('#betValue').textContent = formatChips(state.betAmount);
+    });
+
+    $('#actions')?.addEventListener('click', onActionClick);
+
+    document.addEventListener('keydown', (e) => {
+        if (e.target.matches('input, select, textarea')) return;
+        if (e.key === 'm' || e.key === 'M') $('#muteBtn')?.click();
+        if (e.key === 'n' || e.key === 'N') $('#btnNewHand')?.click();
+    });
+}
+
+function showIntro(show) {
+    const el = $('#intro');
+    if (!el) return;
+    el.hidden = !show;
+}
+
+function openRanks(show) {
+    const el = $('#ranksOverlay');
+    if (!el) return;
+    el.hidden = !show;
+    if (show) renderRankChart();
+}
+
+function setMode(mode) {
+    state.mode = mode;
+    $$('.dock-btn[data-mode]').forEach((btn) => {
+        btn.classList.toggle('is-active', btn.dataset.mode === mode);
+    });
+    const academy = $('#academyPanel');
+    const playCoach = $('#playCoach');
+    if (mode === 'academy') {
+        academy?.removeAttribute('hidden');
+        playCoach?.setAttribute('hidden', '');
+        renderAcademy();
+    } else {
+        academy?.setAttribute('hidden', '');
+        playCoach?.removeAttribute('hidden');
+        updateCoachLive();
+    }
+    sfxClick();
+}
+
+function beginMatch() {
+    setMode('play');
+    dealNewHand();
+}
+
+function dealNewHand() {
+    if (!canContinue(state.match)) {
+        state.match = createMatch({ startingStack: 1000, smallBlind: 5, bigBlind: 10 });
+    }
+    startHand(state.match);
+    state.showAiCards = false;
+    state.busy = false;
+    sfxDeal();
+    renderAll();
+    maybeAiTurn();
+}
+
+async function onActionClick(e) {
+    const btn = e.target.closest('[data-action]');
+    if (!btn || state.busy) return;
+    if (!heroToAct(state.match)) return;
+
+    const type = btn.dataset.action;
+    let amount = state.betAmount;
+    if (type === 'bet' || type === 'raise') {
+        amount = state.betAmount;
+    } else if (type === 'allin') {
+        amount = state.match.stacks[state.match.heroSeat];
+    } else if (type === 'call') {
+        const call = legalActions(state.match).find((a) => a.type === 'call');
+        amount = call?.amount || 0;
+    } else {
+        amount = 0;
+    }
+
+    if (type === 'fold') sfxFold();
+    else sfxChip();
+
+    const result = applyAction(state.match, { type, amount });
+    if (!result.ok) return;
+
+    renderAll();
+    if (result.handOver) {
+        onHandOver();
+        return;
+    }
+    await maybeAiTurn();
+}
+
+async function maybeAiTurn() {
+    const match = state.match;
+    const h = match.hand;
+    if (!h || h.street === STREET.DONE) return;
+    if (h.toAct === match.heroSeat) return;
+    if (h.folded[h.toAct] || (h.allIn[h.toAct] && h.streetContrib[h.toAct] >= h.currentBet)) {
+        // shouldn't happen often
+    }
+
+    state.busy = true;
+    renderActions();
+    setStatus('Dealer IA pensa…');
+    await sleep(aiThinkDelay(state.difficulty));
+
+    // Loop while AI to act (e.g. after street advance if somehow)
+    while (
+        match.hand &&
+        match.hand.street !== STREET.DONE &&
+        match.hand.toAct !== match.heroSeat &&
+        !match.hand.folded[match.hand.toAct]
+    ) {
+        const action = chooseAction(match, state.difficulty);
+        if (!action) break;
+        if (action.type === 'fold') sfxFold();
+        else sfxChip();
+        const result = applyAction(match, action);
+        renderAll();
+        if (result.handOver) {
+            state.busy = false;
+            onHandOver();
+            return;
+        }
+        if (match.hand.toAct === match.heroSeat) break;
+        if (match.hand.allIn[0] || match.hand.allIn[1]) {
+            // runout handled inside engine
+            if (match.hand.street === STREET.DONE) {
+                state.busy = false;
+                onHandOver();
+                return;
+            }
+        }
+        await sleep(280);
+    }
+
+    state.busy = false;
+    renderAll();
+}
+
+function onHandOver() {
+    state.showAiCards = true;
+    const r = state.match.lastResult;
+    if (r?.winners?.includes(0)) sfxWin();
+    renderAll();
+
+    if (!canContinue(state.match)) {
+        const heroWins = state.match.stacks[0] > 0;
+        setStatus(heroWins ? 'Você zerou a IA — mesa sua!' : 'Stack zerado — nova sessão?');
+        $('#btnNewHand').textContent = 'Nova sessão';
+    } else {
+        $('#btnNewHand').textContent = 'Próxima mão';
+    }
+}
+
+function onHint() {
+    const match = state.match;
+    const h = match.hand;
+    if (!h || h.street === STREET.DONE) {
+        setCoach('Dica', 'Comece uma mão. Eu comento pot odds, força e ruas em tempo real.');
+        return;
+    }
+    const hero = match.heroSeat;
+    const hole = h.holes[hero];
+    const strength = holeStrength(hole);
+    const pct = Math.round(strength * 100);
+    let text = `Suas hole cards têm força relativa ~${pct}% (heurística pré-flop).`;
+
+    if (h.board.length >= 3) {
+        const made = evaluateHand([...hole, ...h.board]);
+        text = `Mão atual: ${describeHand(made)}. `;
+        const toCall = Math.max(0, h.currentBet - h.streetContrib[hero]);
+        if (toCall > 0) {
+            const odds = potOdds(toCall, h.pot);
+            text += `Pot odds ${Math.round(odds * 100)}% (call ${toCall} / pote ${h.pot}). `;
+            text += made.category >= 2
+                ? 'Com dois pares ou melhor, call/raise costuma ser correto.'
+                : 'Sem mão feita forte, weigh pot odds e draws antes de pagar.';
+        } else {
+            text += made.category >= 3
+                ? 'Mão forte — considere bet para valor.'
+                : 'Sem aposta: check é válido; bet só com plano (valor ou blefe).';
+        }
+    } else {
+        text += strength >= 0.7
+            ? ' Mão premium — raise para construir pot.'
+            : strength >= 0.45
+                ? ' Jogável — call ou raise pequeno conforme posição.'
+                : ' Fraca — fold é o default, sobretudo fora de posição.';
+    }
+    setCoach('Dica', text);
+    sfxClick();
+}
+
+function renderAll() {
+    renderStacks();
+    renderBoard();
+    renderHoles();
+    renderPot();
+    renderActions();
+    renderLog();
+    renderBadges();
+    updateCoachLive();
+    renderHandResult();
+}
+
+function renderStacks() {
+    const m = state.match;
+    $('#heroStack').textContent = formatChips(m.stacks[0]);
+    $('#aiStack').textContent = formatChips(m.stacks[1]);
+    const h = m.hand;
+    $('#heroBet').textContent = h ? formatChips(h.streetContrib[0] || 0) : '0';
+    $('#aiBet').textContent = h ? formatChips(h.streetContrib[1] || 0) : '0';
+
+    const heroSeat = $('.seat--hero');
+    const aiSeat = $('.seat--ai');
+    heroSeat?.classList.toggle('is-turn', !!(h && h.street !== STREET.DONE && h.toAct === 0));
+    aiSeat?.classList.toggle('is-turn', !!(h && h.street !== STREET.DONE && h.toAct === 1));
+    heroSeat?.classList.toggle('is-winner', !!(h && h.street === STREET.DONE && h.winners?.includes(0)));
+    aiSeat?.classList.toggle('is-winner', !!(h && h.street === STREET.DONE && h.winners?.includes(1)));
+    heroSeat?.classList.toggle('is-folded', !!(h && h.folded[0]));
+    aiSeat?.classList.toggle('is-folded', !!(h && h.folded[1]));
+
+    const btn = h?.button ?? m.button;
+    $('#heroDealer').hidden = btn !== 0;
+    $('#aiDealer').hidden = btn !== 1;
+
+    const heroBlind = h ? (h.sbSeat === 0 ? 'SB' : 'BB') : '';
+    const aiBlind = h ? (h.sbSeat === 1 ? 'SB' : 'BB') : '';
+    $('#heroBlind').textContent = heroBlind;
+    $('#aiBlind').textContent = aiBlind;
+}
+
+function renderBoard() {
+    const board = $('#board');
+    const h = state.match.hand;
+    const cards = h?.board || [];
+    renderCards(board, cards, { baseDelay: 40 });
+    // Placeholders até 5
+    for (let i = cards.length; i < 5; i++) {
+        const ph = document.createElement('div');
+        ph.className = 'card card-slot';
+        ph.setAttribute('aria-hidden', 'true');
+        board.appendChild(ph);
+    }
+    $('#streetLabel').textContent = streetName(h?.street);
+}
+
+function streetName(s) {
+    return {
+        preflop: 'Pré-flop',
+        flop: 'Flop',
+        turn: 'Turn',
+        river: 'River',
+        showdown: 'Showdown',
+        done: 'Mão encerrada'
+    }[s] || '—';
+}
+
+function renderHoles() {
+    const h = state.match.hand;
+    const hero = h?.holes[0] || [];
+    const ai = h?.holes[1] || [];
+    renderCards($('#heroCards'), hero, { baseDelay: 0 });
+
+    const reveal = state.showAiCards || (h && h.showdown) || (h && h.street === STREET.DONE && h.winners);
+    if (reveal && ai.length) {
+        renderCards($('#aiCards'), ai, { baseDelay: 80 });
+    } else if (ai.length) {
+        renderCards($('#aiCards'), ['?', '?'], { faceDown: true });
+        // faceDown with fake ids
+        const box = $('#aiCards');
+        box.innerHTML = '';
+        box.appendChild(cardBack(0));
+        box.appendChild(cardBack(70));
+    } else {
+        $('#aiCards').innerHTML = '';
+    }
+
+    // Hand label
+    if (h && hero.length === 2) {
+        if (h.board.length >= 3) {
+            $('#heroHandName').textContent = describeHand(evaluateHand([...hero, ...h.board]));
+        } else {
+            const s = Math.round(holeStrength(hero) * 100);
+            $('#heroHandName').textContent = `Força ~${s}%`;
+        }
+    } else {
+        $('#heroHandName').textContent = '—';
+    }
+}
+
+function cardBack(delay) {
+    const el = document.createElement('div');
+    el.className = 'card is-back';
+    el.style.setProperty('--deal-delay', `${delay}ms`);
+    el.innerHTML = '<div class="card-face card-back" aria-hidden="true"><i></i></div>';
+    el.setAttribute('aria-label', 'Carta fechada');
+    return el;
+}
+
+function renderPot() {
+    const h = state.match.hand;
+    $('#potValue').textContent = formatChips(h?.pot || 0);
+}
+
+function renderActions() {
+    const box = $('#actions');
+    const sizing = $('#sizing');
+    box.innerHTML = '';
+
+    const h = state.match.hand;
+    if (!h || h.street === STREET.DONE) {
+        sizing.hidden = true;
+        const next = document.createElement('button');
+        next.type = 'button';
+        next.className = 'act-btn act-btn--accent';
+        next.dataset.action = 'nexthand';
+        next.textContent = canContinue(state.match) ? 'Próxima mão' : 'Nova sessão';
+        next.addEventListener('click', () => $('#btnNewHand').click());
+        box.appendChild(next);
+        setStatus(h?.street === STREET.DONE ? statusAfterHand() : 'Pronto para repartir');
+        return;
+    }
+
+    if (state.busy || !heroToAct(state.match)) {
+        sizing.hidden = true;
+        setStatus(state.busy ? 'Dealer IA pensa…' : 'Aguardando…');
+        return;
+    }
+
+    const legal = legalActions(state.match);
+    let betOrRaise = legal.find((a) => a.type === 'bet' || a.type === 'raise');
+
+    legal.forEach((a) => {
+        if (a.type === 'bet' || a.type === 'raise') return; // handled via confirm
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className = `act-btn act-btn--${a.type}`;
+        btn.dataset.action = a.type;
+        btn.textContent = a.type === 'call' ? `${a.label} ${formatChips(a.amount)}` : a.label;
+        box.appendChild(btn);
+    });
+
+    if (betOrRaise) {
+        sizing.hidden = false;
+        const min = betOrRaise.min;
+        const max = betOrRaise.max;
+        const slider = $('#betSlider');
+        slider.min = min;
+        slider.max = max;
+        slider.step = 1;
+        if (!state.betAmount || state.betAmount < min || state.betAmount > max) {
+            state.betAmount = Math.min(max, Math.max(min, Math.round((min + Math.min(max, state.match.hand.pot)) / 2)));
+        }
+        slider.value = state.betAmount;
+        $('#betValue').textContent = formatChips(state.betAmount);
+        $('#betLabel').textContent = betOrRaise.type === 'bet' ? 'Aposta' : 'Raise';
+
+        const confirm = document.createElement('button');
+        confirm.type = 'button';
+        confirm.className = 'act-btn act-btn--bet';
+        confirm.dataset.action = betOrRaise.type;
+        confirm.textContent = betOrRaise.type === 'bet' ? 'Apostar' : 'Aumentar';
+        box.appendChild(confirm);
+
+        // Quick sizes
+        const pot = h.pot;
+        $$('.size-chip').forEach((chip) => {
+            const frac = Number(chip.dataset.frac);
+            const amt = Math.min(max, Math.max(min, Math.round(pot * frac) || min));
+            chip.onclick = () => {
+                state.betAmount = amt;
+                slider.value = amt;
+                $('#betValue').textContent = formatChips(amt);
+            };
+        });
+    } else {
+        sizing.hidden = true;
+    }
+
+    setStatus('Sua vez');
+}
+
+function statusAfterHand() {
+    const r = state.match.lastResult;
+    if (!r) return 'Mão encerrada';
+    if (r.reason === 'fold') {
+        return r.winners[0] === 0 ? 'Rival foldou — você leva o pot' : 'Você foldou';
+    }
+    if (r.winners.length === 2) return `Split pot · ${describeHand(r.hands[0])}`;
+    const w = r.winners[0];
+    const hand = r.hands[w];
+    return `${w === 0 ? 'Você' : 'IA'} vence com ${describeHand(hand)}`;
+}
+
+function setStatus(msg) {
+    const el = $('#statusLine');
+    if (el) el.textContent = msg;
+}
+
+function renderLog() {
+    const ul = $('#eventLog');
+    if (!ul) return;
+    ul.innerHTML = state.match.log
+        .slice(0, 12)
+        .map((e) => `<li>${escapeHtml(e.msg)}</li>`)
+        .join('');
+}
+
+function renderBadges() {
+    $('#handNumber').textContent = state.match.handNumber
+        ? `Mão #${state.match.handNumber}`
+        : '—';
+    $('#diffLabel').textContent = ({
+        easy: 'IA · iniciante',
+        normal: 'IA · intermediária',
+        hard: 'IA · agressiva'
+    })[state.difficulty];
+}
+
+function updateCoachLive() {
+    if (state.mode === 'academy') return;
+    const legal = state.match.hand ? legalActions(state.match) : [];
+    const tip = liveTip(state.match, legal);
+    setCoach(tip.title, tip.text);
+}
+
+function setCoach(title, text) {
+    const t = $('#coachTitle');
+    const p = $('#coachText');
+    if (t) t.textContent = title;
+    if (p) p.textContent = text;
+}
+
+function renderHandResult() {
+    const banner = $('#resultBanner');
+    const h = state.match.hand;
+    if (!h || h.street !== STREET.DONE) {
+        banner.hidden = true;
+        return;
+    }
+    banner.hidden = false;
+    banner.textContent = statusAfterHand();
+}
+
+function renderAcademy() {
+    const lesson = LESSONS[state.lessonIndex];
+    $('#lessonKicker').textContent = lesson.kicker;
+    $('#lessonTitle').textContent = lesson.title;
+    $('#lessonText').textContent = lesson.text;
+    $('#lessonTip').textContent = lesson.tip;
+    $('#lessonProgress').textContent = `${state.lessonIndex + 1} / ${LESSONS.length}`;
+    $('#prevLesson').disabled = state.lessonIndex === 0;
+    $('#nextLesson').disabled = state.lessonIndex === LESSONS.length - 1;
+
+    const quiz = $('#lessonQuiz');
+    quiz.innerHTML = '';
+    if (lesson.quiz) {
+        const q = document.createElement('p');
+        q.className = 'quiz-prompt';
+        q.textContent = lesson.quiz.prompt;
+        quiz.appendChild(q);
+        const row = document.createElement('div');
+        row.className = 'quiz-options';
+        lesson.quiz.options.forEach((opt, i) => {
+            const b = document.createElement('button');
+            b.type = 'button';
+            b.className = 'quiz-btn';
+            b.textContent = opt;
+            b.addEventListener('click', () => {
+                $$('.quiz-btn', row).forEach((x) => x.classList.remove('is-correct', 'is-wrong'));
+                if (i === lesson.quiz.answer) {
+                    b.classList.add('is-correct');
+                    $('#lessonTip').textContent = lesson.quiz.success;
+                    sfxWin();
+                } else {
+                    b.classList.add('is-wrong');
+                    sfxFold();
+                }
+            });
+            row.appendChild(b);
+        });
+        quiz.appendChild(row);
+    }
+}
+
+function renderRankChart() {
+    const list = $('#rankList');
+    list.innerHTML = HAND_RANK_CHART.map(
+        (r) => `<li><strong>${escapeHtml(r.name)}</strong><span>${escapeHtml(r.example)}</span></li>`
+    ).join('');
+}
+
+function escapeHtml(s) {
+    return String(s)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;');
+}
+
+function sleep(ms) {
+    return new Promise((r) => setTimeout(r, ms));
+}
+
+init();

--- a/labs/poker/style.css
+++ b/labs/poker/style.css
@@ -1,0 +1,994 @@
+/* Poker — mesa heads-up hiper-realista */
+
+:root {
+  --felt-deep: #0a1f14;
+  --felt: #0f3d28;
+  --felt-lit: #1a5c3a;
+  --rail: #3a2416;
+  --rail-hi: #6b4428;
+  --cream: #f4efe6;
+  --ink: #1a1410;
+  --gold: #c9a227;
+  --gold-soft: #e8d5a3;
+  --danger: #c45c4a;
+  --ok: #3d9a6a;
+  --glass: rgba(12, 22, 16, 0.72);
+  --glass-border: rgba(232, 213, 163, 0.14);
+  --card-w: clamp(52px, 14vw, 78px);
+  --card-h: calc(var(--card-w) * 1.4);
+  --safe-top: env(safe-area-inset-top, 0px);
+  --safe-right: env(safe-area-inset-right, 0px);
+  --safe-bottom: env(safe-area-inset-bottom, 0px);
+  --safe-left: env(safe-area-inset-left, 0px);
+}
+
+html,
+body {
+  overflow-x: clip;
+  max-width: 100%;
+}
+
+body {
+  margin: 0;
+  min-height: 100dvh;
+  padding: 0;
+  background:
+    radial-gradient(ellipse 80% 50% at 50% -10%, rgba(201, 162, 39, 0.12), transparent 50%),
+    radial-gradient(ellipse at 20% 80%, rgba(15, 61, 40, 0.5), transparent 40%),
+    linear-gradient(165deg, #070b09 0%, #0c1510 45%, #0a100e 100%);
+  color: var(--cream);
+  font-family: 'Outfit', system-ui, sans-serif;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+}
+
+.poker-shell {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  width: min(1100px, 100%);
+  margin: 0 auto;
+  padding:
+    calc(0.5rem + var(--safe-top))
+    max(0.75rem, var(--safe-right))
+    calc(0.75rem + var(--safe-bottom))
+    max(0.75rem, var(--safe-left));
+  gap: 0.75rem;
+  min-height: 0;
+}
+
+.app-logo {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  font-family: 'Cormorant Garamond', Georgia, serif;
+  font-weight: 600;
+  font-size: 1.15rem;
+  letter-spacing: 0.04em;
+}
+
+.brand-mark {
+  color: var(--gold);
+  font-size: 1.25rem;
+}
+
+/* —— Mesa —— */
+.table-stage {
+  position: relative;
+  isolation: isolate;
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  gap: 0.35rem;
+  min-height: min(52dvh, 420px);
+  padding: 0.85rem 0.75rem 1rem;
+  border-radius: 1.25rem;
+  overflow: hidden;
+}
+
+.felt {
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  border-radius: inherit;
+  background:
+    radial-gradient(ellipse 70% 55% at 50% 45%, var(--felt-lit), var(--felt) 55%, var(--felt-deep) 100%);
+  box-shadow:
+    inset 0 0 0 3px rgba(201, 162, 39, 0.18),
+    inset 0 0 60px rgba(0, 0, 0, 0.45),
+    0 20px 50px rgba(0, 0, 0, 0.45);
+}
+
+.felt::before {
+  content: '';
+  position: absolute;
+  inset: 10px;
+  border-radius: 48% / 42%;
+  border: 1px solid rgba(232, 213, 163, 0.08);
+  pointer-events: none;
+}
+
+.felt-glow {
+  position: absolute;
+  inset: 20% 15%;
+  background: radial-gradient(circle, rgba(255, 255, 255, 0.06), transparent 65%);
+  pointer-events: none;
+  animation: breathe 6s ease-in-out infinite;
+}
+
+.felt-rail {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  box-shadow:
+    inset 0 0 0 14px var(--rail),
+    inset 0 0 0 16px var(--rail-hi),
+    inset 0 0 28px rgba(0, 0, 0, 0.55);
+  pointer-events: none;
+  opacity: 0.92;
+}
+
+@keyframes breathe {
+  0%, 100% { opacity: 0.7; transform: scale(1); }
+  50% { opacity: 1; transform: scale(1.03); }
+}
+
+.table-hud {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0 0.35rem;
+  z-index: 1;
+}
+
+.meta-line {
+  font-size: 0.75rem;
+  opacity: 0.75;
+  margin: 0;
+}
+
+.street-pill {
+  margin: 0;
+  padding: 0.25rem 0.7rem;
+  border-radius: 999px;
+  background: rgba(0, 0, 0, 0.35);
+  border: 1px solid var(--glass-border);
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--gold-soft);
+}
+
+/* Seats */
+.seat {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.35rem;
+  transition: opacity 0.3s, filter 0.3s;
+  z-index: 1;
+}
+
+.seat.is-folded {
+  opacity: 0.45;
+  filter: grayscale(0.4);
+}
+
+.seat.is-turn .seat-name::after {
+  content: '';
+  display: inline-block;
+  width: 0.45rem;
+  height: 0.45rem;
+  margin-left: 0.4rem;
+  border-radius: 50%;
+  background: var(--gold);
+  box-shadow: 0 0 10px var(--gold);
+  animation: pulse 1.2s ease-in-out infinite;
+}
+
+.seat.is-winner {
+  animation: winPulse 1.2s ease;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.35; }
+}
+
+@keyframes winPulse {
+  0%, 100% { filter: brightness(1); }
+  40% { filter: brightness(1.25); }
+}
+
+.seat-info {
+  text-align: center;
+  position: relative;
+}
+
+.seat-name {
+  margin: 0;
+  font-family: 'Cormorant Garamond', Georgia, serif;
+  font-size: clamp(1rem, 3vw, 1.25rem);
+  font-weight: 600;
+  letter-spacing: 0.03em;
+}
+
+.seat-stack {
+  margin: 0.1rem 0 0;
+  font-size: 0.85rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.seat-stack small {
+  opacity: 0.55;
+  font-size: 0.7em;
+}
+
+.hand-name {
+  margin: 0.15rem 0 0;
+  font-size: 0.72rem;
+  color: var(--gold-soft);
+  max-width: 16rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.seat-bet {
+  margin: 0;
+  font-size: 0.72rem;
+  opacity: 0.8;
+}
+
+.dealer-btn {
+  position: absolute;
+  left: -1.6rem;
+  top: 0.1rem;
+  width: 1.35rem;
+  height: 1.35rem;
+  border-radius: 50%;
+  background: linear-gradient(145deg, #f5f5f0, #c8c4b8);
+  color: #222;
+  font-size: 0.65rem;
+  font-weight: 700;
+  display: grid;
+  place-items: center;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.35);
+}
+
+.blind-tag {
+  display: inline-block;
+  min-height: 1rem;
+  font-size: 0.65rem;
+  letter-spacing: 0.06em;
+  color: var(--gold);
+  opacity: 0.9;
+}
+
+.board-wrap {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.45rem;
+  min-height: 0;
+  z-index: 1;
+}
+
+.pot-line {
+  margin: 0;
+  padding: 0.3rem 0.85rem;
+  border-radius: 999px;
+  background: rgba(0, 0, 0, 0.4);
+  border: 1px solid rgba(201, 162, 39, 0.35);
+  font-size: 0.8rem;
+  letter-spacing: 0.04em;
+}
+
+.pot-line strong {
+  color: var(--gold-soft);
+  font-variant-numeric: tabular-nums;
+}
+
+.board,
+.hole-cards {
+  display: flex;
+  gap: clamp(0.25rem, 1.5vw, 0.5rem);
+  justify-content: center;
+  flex-wrap: nowrap;
+}
+
+.result-banner {
+  margin: 0;
+  max-width: min(92%, 28rem);
+  padding: 0.4rem 0.85rem;
+  border-radius: 0.5rem;
+  background: rgba(0, 0, 0, 0.55);
+  border: 1px solid rgba(201, 162, 39, 0.4);
+  font-size: clamp(0.78rem, 2.5vw, 0.92rem);
+  text-align: center;
+  animation: fadeUp 0.45s ease;
+}
+
+@keyframes fadeUp {
+  from { opacity: 0; transform: translateY(6px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+/* —— Cartas —— */
+.card {
+  --deal-delay: 0ms;
+  width: var(--card-w);
+  height: var(--card-h);
+  border-radius: calc(var(--card-w) * 0.08);
+  position: relative;
+  transform-style: preserve-3d;
+  animation: dealIn 0.45s cubic-bezier(0.22, 1, 0.36, 1) both;
+  animation-delay: var(--deal-delay);
+  box-shadow:
+    0 4px 10px rgba(0, 0, 0, 0.4),
+    0 1px 0 rgba(255, 255, 255, 0.35) inset;
+}
+
+.card-slot {
+  background: rgba(0, 0, 0, 0.18);
+  border: 1px dashed rgba(232, 213, 163, 0.18);
+  box-shadow: none;
+  animation: none;
+}
+
+@keyframes dealIn {
+  from {
+    opacity: 0;
+    transform: translateY(-18px) rotateX(12deg) scale(0.92);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) rotateX(0) scale(1);
+  }
+}
+
+.card-face {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  overflow: hidden;
+}
+
+.card-front {
+  background:
+    linear-gradient(145deg, #fffef9 0%, #f3eee4 48%, #ebe4d6 100%);
+  color: var(--ink);
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  padding: 0.28em 0.32em;
+  font-family: 'Cormorant Garamond', Georgia, serif;
+}
+
+.card.is-red .card-front { color: #b42318; }
+.card.is-black .card-front { color: #1a1a1a; }
+
+.corner {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  line-height: 1;
+  font-size: calc(var(--card-w) * 0.22);
+  font-weight: 700;
+}
+
+.corner i {
+  font-style: normal;
+  font-size: 0.85em;
+}
+
+.corner.br {
+  justify-self: end;
+  transform: rotate(180deg);
+}
+
+.pip {
+  display: grid;
+  place-items: center;
+  font-size: calc(var(--card-w) * 0.42);
+  opacity: 0.92;
+  text-shadow: 0 1px 0 rgba(255, 255, 255, 0.4);
+}
+
+.card-back {
+  background:
+    linear-gradient(135deg, rgba(255, 255, 255, 0.08), transparent 40%),
+    repeating-linear-gradient(
+      45deg,
+      #1a3a5c 0 4px,
+      #152f4a 4px 8px
+    );
+  border: 2px solid #c9a22755;
+}
+
+.card-back i {
+  position: absolute;
+  inset: 8%;
+  border: 1px solid rgba(201, 162, 39, 0.45);
+  border-radius: 4px;
+  background:
+    radial-gradient(circle at 50% 50%, rgba(201, 162, 39, 0.25), transparent 55%),
+    linear-gradient(160deg, #0e2438, #1a3a5c);
+}
+
+.card-back i::after {
+  content: '♠';
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  color: rgba(201, 162, 39, 0.55);
+  font-size: calc(var(--card-w) * 0.35);
+}
+
+/* —— HUD —— */
+.hud {
+  display: grid;
+  grid-template-columns: minmax(0, 1.1fr) minmax(0, 0.85fr);
+  grid-template-areas:
+    'coach tray'
+    'actions actions';
+  gap: 0.65rem;
+  align-items: start;
+}
+
+.coach {
+  grid-area: coach;
+  background: var(--glass);
+  border: 1px solid var(--glass-border);
+  border-radius: 0.9rem;
+  backdrop-filter: blur(12px);
+  overflow: hidden;
+  max-height: min(42dvh, 360px);
+  display: flex;
+  flex-direction: column;
+}
+
+.coach-toggle {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+  min-height: var(--touch-target, 44px);
+  padding: 0.65rem 0.9rem;
+  background: transparent;
+  border: 0;
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
+  text-align: left;
+  border-bottom: 1px solid var(--glass-border);
+}
+
+.eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.68rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--gold-soft);
+  opacity: 0.9;
+}
+
+.eyebrow i {
+  width: 0.4rem;
+  height: 0.4rem;
+  border-radius: 50%;
+  background: var(--gold);
+  box-shadow: 0 0 8px var(--gold);
+}
+
+#coachTitle {
+  font-family: 'Cormorant Garamond', Georgia, serif;
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.coach-body {
+  padding: 0.75rem 0.9rem 1rem;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+
+.coach-text {
+  margin: 0;
+  font-size: 0.9rem;
+  line-height: 1.45;
+  color: rgba(244, 239, 230, 0.9);
+}
+
+.coach-tip {
+  margin: 0.65rem 0 0;
+  padding: 0.55rem 0.65rem;
+  border-left: 2px solid var(--gold);
+  background: rgba(201, 162, 39, 0.08);
+  font-size: 0.82rem;
+  line-height: 1.4;
+  color: var(--gold-soft);
+}
+
+.lesson-kicker {
+  margin: 0 0 0.2rem;
+  font-size: 0.68rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--gold);
+}
+
+.lesson-title {
+  margin: 0 0 0.5rem;
+  font-family: 'Cormorant Garamond', Georgia, serif;
+  font-size: 1.35rem;
+  font-weight: 600;
+}
+
+.lesson-nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-top: 0.85rem;
+}
+
+.lesson-progress {
+  font-size: 0.75rem;
+  opacity: 0.7;
+  font-variant-numeric: tabular-nums;
+}
+
+.quiz-prompt {
+  margin: 0.75rem 0 0.45rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+}
+
+.quiz-options {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.quiz-btn {
+  min-height: var(--touch-target, 44px);
+  padding: 0.55rem 0.75rem;
+  border-radius: 0.55rem;
+  border: 1px solid var(--glass-border);
+  background: rgba(255, 255, 255, 0.04);
+  color: inherit;
+  font: inherit;
+  font-size: 0.85rem;
+  text-align: left;
+  cursor: pointer;
+  transition: border-color 0.2s, background 0.2s;
+}
+
+.quiz-btn:hover {
+  border-color: rgba(201, 162, 39, 0.45);
+}
+
+.quiz-btn.is-correct {
+  border-color: var(--ok);
+  background: rgba(61, 154, 106, 0.2);
+}
+
+.quiz-btn.is-wrong {
+  border-color: var(--danger);
+  background: rgba(196, 92, 74, 0.18);
+}
+
+.tray {
+  grid-area: tray;
+  background: var(--glass);
+  border: 1px solid var(--glass-border);
+  border-radius: 0.9rem;
+  padding: 0.75rem 0.85rem;
+  backdrop-filter: blur(12px);
+  max-height: min(42dvh, 360px);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.status {
+  margin: 0;
+  font-family: 'Cormorant Garamond', Georgia, serif;
+  font-size: 1.15rem;
+  font-weight: 600;
+}
+
+.diff-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.72rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  opacity: 0.85;
+}
+
+.diff-field select {
+  min-height: 44px;
+  border-radius: 0.5rem;
+  border: 1px solid var(--glass-border);
+  background: rgba(0, 0, 0, 0.35);
+  color: var(--cream);
+  font: inherit;
+  font-size: 0.85rem;
+  text-transform: none;
+  letter-spacing: 0;
+  padding: 0 0.65rem;
+}
+
+.event-log {
+  margin: 0.25rem 0 0;
+  padding: 0;
+  list-style: none;
+  overflow-y: auto;
+  flex: 1;
+  font-size: 0.75rem;
+  line-height: 1.35;
+  opacity: 0.8;
+}
+
+.event-log li {
+  padding: 0.25rem 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.action-dock {
+  grid-area: actions;
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+}
+
+.sizing {
+  background: var(--glass);
+  border: 1px solid var(--glass-border);
+  border-radius: 0.75rem;
+  padding: 0.65rem 0.75rem;
+}
+
+.sizing-head {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.8rem;
+  margin-bottom: 0.35rem;
+}
+
+.sizing-head strong {
+  color: var(--gold-soft);
+  font-variant-numeric: tabular-nums;
+}
+
+#betSlider {
+  width: 100%;
+  accent-color: var(--gold);
+  min-height: 28px;
+}
+
+.size-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  margin-top: 0.45rem;
+}
+
+.size-chip {
+  min-height: 36px;
+  padding: 0.3rem 0.65rem;
+  border-radius: 999px;
+  border: 1px solid var(--glass-border);
+  background: rgba(255, 255, 255, 0.04);
+  color: inherit;
+  font: inherit;
+  font-size: 0.72rem;
+  cursor: pointer;
+}
+
+.size-chip:hover {
+  border-color: rgba(201, 162, 39, 0.5);
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.act-btn {
+  flex: 1 1 auto;
+  min-height: var(--touch-target, 44px);
+  min-width: min(100%, 5.5rem);
+  padding: 0.55rem 0.9rem;
+  border-radius: 0.65rem;
+  border: 1px solid var(--glass-border);
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--cream);
+  font: inherit;
+  font-weight: 560;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: transform 0.15s, background 0.2s, border-color 0.2s;
+}
+
+.act-btn:hover {
+  transform: translateY(-1px);
+  border-color: rgba(201, 162, 39, 0.4);
+}
+
+.act-btn--fold {
+  background: rgba(196, 92, 74, 0.2);
+  border-color: rgba(196, 92, 74, 0.4);
+}
+
+.act-btn--check,
+.act-btn--call {
+  background: rgba(61, 154, 106, 0.18);
+  border-color: rgba(61, 154, 106, 0.4);
+}
+
+.act-btn--bet,
+.act-btn--raise,
+.act-btn--accent,
+.act-btn--allin {
+  background: linear-gradient(145deg, rgba(201, 162, 39, 0.35), rgba(201, 162, 39, 0.15));
+  border-color: rgba(201, 162, 39, 0.55);
+}
+
+.dock {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.dock-btn {
+  min-height: var(--touch-target, 44px);
+  padding: 0.45rem 0.85rem;
+  border-radius: 0.55rem;
+  border: 1px solid var(--glass-border);
+  background: rgba(255, 255, 255, 0.05);
+  color: inherit;
+  font: inherit;
+  font-size: 0.82rem;
+  cursor: pointer;
+  transition: background 0.2s, border-color 0.2s;
+}
+
+.dock-btn:hover,
+.dock-btn.is-active {
+  border-color: rgba(201, 162, 39, 0.45);
+  background: rgba(201, 162, 39, 0.12);
+}
+
+.dock-btn.accent {
+  background: linear-gradient(145deg, rgba(201, 162, 39, 0.4), rgba(201, 162, 39, 0.18));
+  border-color: rgba(201, 162, 39, 0.55);
+  font-weight: 600;
+}
+
+.dock-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+/* Overlays */
+.overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 40;
+  display: grid;
+  place-items: center;
+  padding:
+    max(1rem, var(--safe-top))
+    max(1rem, var(--safe-right))
+    max(1rem, var(--safe-bottom))
+    max(1rem, var(--safe-left));
+  background:
+    radial-gradient(ellipse at 50% 30%, rgba(15, 61, 40, 0.55), transparent 55%),
+    rgba(4, 8, 6, 0.82);
+  backdrop-filter: blur(8px);
+}
+
+.overlay[hidden] {
+  display: none !important;
+}
+
+.overlay-card {
+  width: min(420px, 100%);
+  max-height: min(92dvh, 640px);
+  overflow-y: auto;
+  padding: 1.5rem 1.35rem 1.35rem;
+  border-radius: 1rem;
+  background:
+    linear-gradient(160deg, rgba(20, 36, 26, 0.95), rgba(10, 18, 14, 0.98));
+  border: 1px solid var(--glass-border);
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.5);
+  animation: fadeUp 0.5s ease;
+}
+
+.overlay-card h1,
+.overlay-card h2 {
+  margin: 0.35rem 0 0.65rem;
+  font-family: 'Cormorant Garamond', Georgia, serif;
+  font-weight: 600;
+  font-size: clamp(1.8rem, 6vw, 2.4rem);
+  letter-spacing: 0.02em;
+}
+
+.lede {
+  margin: 0 0 1.1rem;
+  font-size: 0.95rem;
+  line-height: 1.5;
+  opacity: 0.88;
+}
+
+.intro-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.intro-note {
+  margin: 1rem 0 0;
+  font-size: 0.75rem;
+  opacity: 0.55;
+}
+
+.ranks-card {
+  width: min(440px, 100%);
+}
+
+.rank-list {
+  margin: 0 0 1rem;
+  padding: 0;
+  list-style: none;
+}
+
+.rank-list li {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.45rem 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  font-size: 0.85rem;
+}
+
+.rank-list span {
+  opacity: 0.7;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.lab-footer {
+  display: flex;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.35rem 1rem calc(0.5rem + var(--safe-bottom));
+  font-size: 0.75rem;
+  opacity: 0.55;
+}
+
+.lab-footer a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.lab-footer a:hover {
+  color: var(--gold-soft);
+}
+
+/* Shared header tweaks inside shell */
+.poker-shell .lab-header,
+.poker-shell header[data-lab-header] {
+  width: 100%;
+}
+
+/* —— Responsivo —— */
+@media (max-width: 768px) {
+  .poker-shell {
+    padding-top: calc(0.35rem + var(--safe-top));
+    gap: 0.55rem;
+  }
+
+  .table-stage {
+    min-height: min(46dvh, 360px);
+    padding: 0.65rem 0.5rem 0.85rem;
+    border-radius: 1rem;
+  }
+
+  .felt-rail {
+    box-shadow:
+      inset 0 0 0 10px var(--rail),
+      inset 0 0 0 12px var(--rail-hi),
+      inset 0 0 20px rgba(0, 0, 0, 0.5);
+  }
+
+  .hud {
+    grid-template-columns: 1fr;
+    grid-template-areas:
+      'actions'
+      'coach'
+      'tray';
+  }
+
+  .coach,
+  .tray {
+    max-height: min(36dvh, 280px);
+  }
+
+  .tray {
+    order: 3;
+  }
+
+  .hand-name {
+    max-width: 70vw;
+  }
+
+  .act-btn {
+    min-width: calc(50% - 0.3rem);
+  }
+}
+
+@media (max-height: 520px) and (orientation: landscape) {
+  .table-stage {
+    min-height: min(58dvh, 280px);
+    grid-template-columns: 1fr 1.4fr 1fr;
+    grid-template-rows: auto;
+    align-items: center;
+    padding: 0.4rem 0.5rem;
+  }
+
+  .table-hud {
+    position: absolute;
+    top: 0.35rem;
+    left: 0.5rem;
+    right: 0.5rem;
+  }
+
+  .seat--ai { grid-column: 1; }
+  .board-wrap { grid-column: 2; }
+  .seat--hero { grid-column: 3; }
+
+  .hud {
+    grid-template-columns: 1fr 1fr;
+    grid-template-areas:
+      'actions actions'
+      'coach tray';
+  }
+
+  .coach,
+  .tray {
+    max-height: min(28dvh, 160px);
+  }
+
+  --card-w: clamp(40px, 9vw, 58px);
+
+  .lab-footer {
+    display: none;
+  }
+}
+
+@media (pointer: coarse) {
+  .size-chip {
+    min-height: 44px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    transition-duration: 0.01ms !important;
+  }
+}

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -325,6 +325,12 @@
     <priority>0.7</priority>
   </url>
   <url>
+    <loc>https://diogopaulino.com.br/labs/poker/</loc>
+    <lastmod>2026-09-06</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
     <loc>https://diogopaulino.com.br/labs/xadrez/</loc>
     <lastmod>2026-08-14</lastmod>
     <changefreq>monthly</changefreq>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 🎯 Objetivo

Novo lab de Texas Hold'em heads-up hiper-realista contra IA, com modo academia para quem ainda não sabe jogar poker.

## ✨ O que mudou

- Lab `/labs/poker/`: mesa de feltro, cartas CSS, blinds, pot, fold/check/call/bet/raise/all-in
- Dealer IA em 3 níveis (iniciante / intermediária / agressiva) com pot odds e força de mão
- Modo Aprender: 10 lições com quiz (ranking, blinds, ruas, pot odds, posição, etc.) + ranking visual
- Mestre com dicas ao vivo (pot odds, força pré-flop, mão feita)
- Catálogo 56: card na galeria, linha no README, entrada no `sitemap.xml`, SEO/JSON-LD

## 🧪 Como testar

1. Na raiz do repo: `python3 -m http.server 8000`
2. Abrir [http://localhost:8000/](http://localhost:8000/) (home) e [http://localhost:8000/labs/](http://localhost:8000/labs/) (galeria)
3. Abrir [http://localhost:8000/labs/poker/](http://localhost:8000/labs/poker/) — Sentar à mesa, jogar uma mão, usar Dica / Aprender / Ranking
4. Responsivo: DevTools em **375×667**, **390×844** e landscape curto (~667×375) — sem overflow horizontal, HUD/controles utilizáveis, alvos ≥ 44px
5. Conferir pasta ↔ card da galeria ↔ README ↔ `sitemap.xml` ↔ canonical/OG

## ✅ Checklist

- [x] Links conferidos: pasta do lab ↔ card da galeria ↔ README ↔ sitemap
- [x] README atualizado (linha na tabela + URL + contagem no badge/texto)
- [x] SEO consistente: title, description, canonical, author, robots, OG, Twitter, JSON-LD (e contagem nos metas da galeria)
- [x] Testado via HTTP na raiz, não via `file://`
- [ ] Responsivo: 375px / 390px / landscape — overflow, HUD, toque, safe-area (`viewport-fit=cover`)
- [x] Nada fora do escopo foi quebrado

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a077b0-db9f-7743-bca4-4faeddd6d55a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a077b0-db9f-7743-bca4-4faeddd6d55a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

