### PR TITLE
🎨 Poker hiper-realista — mesa 3D, texturas, fichas e UI renovada

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Cada pasta em `/labs/<slug>/` é o mesmo slug do card da galeria, da linha abaix
 
 | Projeto | O que é? |
 | :--- | :--- |
-| ♠ **[Poker](https://diogopaulino.com.br/labs/poker/)** | Texas Hold'em heads-up — feltro, cartas realistas, Dealer IA e academia (ranking, blinds, pot odds) |
+| ♠ **[Poker](https://diogopaulino.com.br/labs/poker/)** | Texas Hold'em heads-up 3D — feltro texturizado, fichas, cartas com flip, Dealer IA e academia |
 | 🤖 **[Claude Bros](https://diogopaulino.com.br/labs/claude-bros/)** | Plataforma 2D em canvas puro: colete estrelas Gemini, pule nos rivais ChatGPT e chegue à bandeira |
 | 🐒 **[Kong Kong](https://diogopaulino.com.br/labs/kong-kong/)** | Platformer estilo SNES — o macaquinho do lenço vermelho, canhões-barril e o Rei Croco |
 | 🎈 **[Ravi 1·2·3](https://diogopaulino.com.br/labs/ravi-123/)** | Festa surpresa com heróis — conte 1 a 9 estilo Mickey's 123 |

--- a/labs/index.html
+++ b/labs/index.html
@@ -518,7 +518,7 @@
         </div>
         <div class="project-content">
           <h2>Poker</h2>
-          <p>Texas Hold'em heads-up no feltro: cartas realistas, Dealer IA e um mestre que ensina ranking, blinds e pot odds</p>
+          <p>Texas Hold'em heads-up 3D: feltro texturizado, fichas, cartas com flip e IA que ensina ranking, blinds e pot odds</p>
           <div class="project-tags">
             <span class="tag">Poker</span>
             <span class="tag">IA</span>

--- a/labs/poker/assets/CREDITS.md
+++ b/labs/poker/assets/CREDITS.md
@@ -1,3 +1,3 @@
 # Poker lab assets
 
-Cartas e mesa renderizadas em CSS puro — sem sprites externos.
+Mesa, cartas e fichas em CSS puro (texturas SVG noise, flip 3D, pilhas de chips) — sem sprites externos.

--- a/labs/poker/index.html
+++ b/labs/poker/index.html
@@ -4,10 +4,10 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover, maximum-scale=1, user-scalable=no">
-  <meta name="theme-color" content="#0c1a12">
+  <meta name="theme-color" content="#060a08">
   <title>Poker — Texas Hold'em vs IA que ensina | Diogo Paulino</title>
   <meta name="description"
-    content="Texas Hold'em heads-up hiper-realista: mesa de feltro, cartas, IA e academia que ensina ranking, blinds, pot odds e estratégia. Um lab de Diogo Paulino.">
+    content="Texas Hold'em heads-up hiper-realista: mesa 3D com feltro texturizado, cartas, fichas e IA que ensina ranking, blinds e pot odds. Um lab de Diogo Paulino.">
   <link rel="canonical" href="https://diogopaulino.com.br/labs/poker/">
   <meta name="author" content="Diogo Paulino">
   <meta name="robots" content="index, follow">
@@ -17,14 +17,14 @@
   <meta property="og:url" content="https://diogopaulino.com.br/labs/poker/">
   <meta property="og:title" content="Poker — Texas Hold'em vs IA que ensina | Diogo Paulino">
   <meta property="og:description"
-    content="Mesa heads-up com feltro, cartas realistas, Dealer IA e lições de ranking, blinds e pot odds.">
+    content="Mesa heads-up 3D com feltro, cartas, fichas, Dealer IA e lições de ranking, blinds e pot odds.">
   <meta property="og:image" content="https://diogopaulino.com.br/assets/img/diogo.jpeg">
   <meta property="og:image:alt" content="Diogo Paulino">
   <meta property="og:locale" content="pt_BR">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Poker — Texas Hold'em vs IA que ensina | Diogo Paulino">
   <meta name="twitter:description"
-    content="Mesa heads-up com feltro, cartas realistas, Dealer IA e lições de ranking, blinds e pot odds.">
+    content="Mesa heads-up 3D com feltro, cartas, fichas, Dealer IA e lições de ranking, blinds e pot odds.">
   <meta name="twitter:image" content="https://diogopaulino.com.br/assets/img/diogo.jpeg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -39,7 +39,7 @@
         "@type": "WebApplication",
         "name": "Poker",
         "url": "https://diogopaulino.com.br/labs/poker/",
-        "description": "Texas Hold'em heads-up hiper-realista com IA e academia que ensina ranking, blinds, pot odds e estratégia.",
+        "description": "Texas Hold'em heads-up hiper-realista com mesa 3D, fichas, IA e academia que ensina ranking, blinds, pot odds e estratégia.",
         "applicationCategory": "GameApplication",
         "operatingSystem": "Any",
         "inLanguage": "pt-BR",
@@ -91,48 +91,91 @@
     </header>
 
     <section class="table-stage" aria-label="Mesa de Texas Hold'em">
-      <div class="felt" aria-hidden="true">
-        <div class="felt-glow"></div>
-        <div class="felt-rail"></div>
+      <div class="room" aria-hidden="true">
+        <div class="room-vignette"></div>
+        <div class="room-spot room-spot--key"></div>
+        <div class="room-spot room-spot--fill"></div>
+        <div class="room-dust"></div>
       </div>
 
-      <div class="table-hud">
-        <p class="meta-line"><span id="handNumber">—</span> · <span id="diffLabel">IA · intermediária</span></p>
-        <p id="streetLabel" class="street-pill">—</p>
-      </div>
-
-      <article class="seat seat--ai" aria-label="Dealer IA">
-        <div class="seat-info">
-          <span id="aiDealer" class="dealer-btn" hidden title="Botão">D</span>
-          <span id="aiBlind" class="blind-tag"></span>
-          <h2 class="seat-name">Dealer IA</h2>
-          <p class="seat-stack"><span id="aiStack">1.000</span> <small>fichas</small></p>
+      <div class="table-scene">
+        <div class="table-cast" aria-hidden="true"></div>
+        <div class="table-body">
+          <div class="rail">
+            <div class="rail-grain"></div>
+            <div class="rail-edge"></div>
+            <div class="rail-shine"></div>
+          </div>
+          <div class="felt">
+            <div class="felt-nap"></div>
+            <div class="felt-weave"></div>
+            <div class="felt-rim"></div>
+            <div class="felt-glow"></div>
+            <div class="felt-crest" aria-hidden="true">♠</div>
+          </div>
         </div>
-        <div id="aiCards" class="hole-cards" aria-label="Cartas da IA"></div>
-        <p class="seat-bet">Aposta <strong id="aiBet">0</strong></p>
-      </article>
 
-      <div class="board-wrap">
-        <p class="pot-line">Pote <strong id="potValue">0</strong></p>
-        <div id="board" class="board" aria-label="Cartas comunitárias"></div>
-        <p id="resultBanner" class="result-banner" hidden></p>
+        <div class="deck-pile" aria-hidden="true">
+          <span></span><span></span><span></span>
+        </div>
+
+        <div class="table-hud">
+          <p class="meta-line"><span id="handNumber">—</span> · <span id="diffLabel">IA · intermediária</span></p>
+          <p id="streetLabel" class="street-pill">—</p>
+        </div>
+
+        <article class="seat seat--ai" aria-label="Dealer IA">
+          <div class="avatar avatar--ai" aria-hidden="true">
+            <span class="avatar-ring"></span>
+            <span class="avatar-face">♠</span>
+          </div>
+          <div class="seat-info">
+            <span id="aiDealer" class="dealer-btn" hidden title="Botão">D</span>
+            <span id="aiBlind" class="blind-tag"></span>
+            <h2 class="seat-name">Dealer IA</h2>
+            <p class="seat-stack"><span id="aiStack">1.000</span> <small>fichas</small></p>
+          </div>
+          <div id="aiCards" class="hole-cards" aria-label="Cartas da IA"></div>
+          <div class="bet-zone">
+            <div id="aiChipStack" class="chip-stack" aria-hidden="true"></div>
+            <p class="seat-bet">Aposta <strong id="aiBet">0</strong></p>
+          </div>
+        </article>
+
+        <div class="board-wrap">
+          <div class="pot-cluster">
+            <div id="potChips" class="chip-stack chip-stack--pot" aria-hidden="true"></div>
+            <p class="pot-line">Pote <strong id="potValue">0</strong></p>
+          </div>
+          <div id="board" class="board" aria-label="Cartas comunitárias"></div>
+          <p id="resultBanner" class="result-banner" hidden></p>
+        </div>
+
+        <article class="seat seat--hero" aria-label="Você">
+          <div id="heroCards" class="hole-cards" aria-label="Suas cartas"></div>
+          <div class="bet-zone">
+            <div id="heroChipStack" class="chip-stack" aria-hidden="true"></div>
+            <p class="seat-bet">Aposta <strong id="heroBet">0</strong></p>
+          </div>
+          <div class="seat-info">
+            <span id="heroDealer" class="dealer-btn" hidden title="Botão">D</span>
+            <span id="heroBlind" class="blind-tag"></span>
+            <div class="avatar avatar--hero" aria-hidden="true">
+              <span class="avatar-ring"></span>
+              <span class="avatar-face">♥</span>
+            </div>
+            <h2 class="seat-name">Você</h2>
+            <p class="seat-stack"><span id="heroStack">1.000</span> <small>fichas</small></p>
+            <p id="heroHandName" class="hand-name">—</p>
+          </div>
+        </article>
       </div>
 
-      <article class="seat seat--hero" aria-label="Você">
-        <div id="heroCards" class="hole-cards" aria-label="Suas cartas"></div>
-        <div class="seat-info">
-          <span id="heroDealer" class="dealer-btn" hidden title="Botão">D</span>
-          <span id="heroBlind" class="blind-tag"></span>
-          <h2 class="seat-name">Você</h2>
-          <p class="seat-stack"><span id="heroStack">1.000</span> <small>fichas</small></p>
-          <p id="heroHandName" class="hand-name">—</p>
-        </div>
-        <p class="seat-bet">Aposta <strong id="heroBet">0</strong></p>
-      </article>
+      <div id="fxLayer" class="fx-layer" aria-hidden="true"></div>
     </section>
 
     <div class="hud">
-      <aside id="coach" class="coach" aria-label="Mestre de poker">
+      <aside id="coach" class="panel coach" aria-label="Mestre de poker">
         <button id="coachToggle" class="coach-toggle" type="button" aria-expanded="true">
           <span class="eyebrow"><i></i> Mestre</span>
           <span id="coachTitle">Mesa</span>
@@ -156,7 +199,7 @@
         </div>
       </aside>
 
-      <aside class="tray" aria-label="Partida">
+      <aside class="panel tray" aria-label="Partida">
         <p class="eyebrow">PARTIDA</p>
         <p id="statusLine" class="status" aria-live="polite">Pronto</p>
         <label class="diff-field">
@@ -171,7 +214,7 @@
       </aside>
 
       <div class="action-dock">
-        <div id="sizing" class="sizing" hidden>
+        <div id="sizing" class="sizing panel" hidden>
           <div class="sizing-head">
             <span id="betLabel">Aposta</span>
             <strong id="betValue">0</strong>
@@ -198,9 +241,14 @@
 
     <div id="intro" class="overlay">
       <div class="overlay-card">
+        <div class="intro-fan" aria-hidden="true">
+          <span class="fan-card fan-card--a"></span>
+          <span class="fan-card fan-card--b"></span>
+          <span class="fan-card fan-card--c"></span>
+        </div>
         <p class="eyebrow"><i></i> Texas Hold'em</p>
         <h1>Poker</h1>
-        <p class="lede">Mesa heads-up contra a Dealer IA — e um mestre que ensina ranking, blinds e pot odds enquanto você joga.</p>
+        <p class="lede">Mesa heads-up em 3D contra a Dealer IA — feltro, fichas e um mestre que ensina ranking, blinds e pot odds enquanto você joga.</p>
         <div class="intro-actions">
           <button id="btnStart" class="dock-btn accent" type="button">Sentar à mesa</button>
           <button id="btnAcademyIntro" class="dock-btn" type="button">Começar aprendendo</button>

--- a/labs/poker/src/cards.js
+++ b/labs/poker/src/cards.js
@@ -1,38 +1,85 @@
 /**
- * Renderização de cartas — HTML/CSS hiper-realista.
+ * Cartas hiper-realistas — faces duplas (flip 3D), textura e pip pattern.
  */
 
 import { RANK_LABEL, SUIT_SYMBOL, SUIT_COLOR, parseCard } from './engine.js';
 
-export function cardElement(cardId, { faceDown = false, small = false, dealDelay = 0 } = {}) {
-    const el = document.createElement('div');
-    el.className = `card${faceDown ? ' is-back' : ''}${small ? ' is-small' : ''}`;
-    el.style.setProperty('--deal-delay', `${dealDelay}ms`);
-    el.dataset.card = cardId || '';
-
-    if (faceDown || !cardId) {
-        el.innerHTML = `<div class="card-face card-back" aria-hidden="true"><i></i></div>`;
-        el.setAttribute('aria-label', 'Carta fechada');
-        return el;
-    }
-
-    const { rank, suit } = parseCard(cardId);
-    const color = SUIT_COLOR[suit];
-    const sym = SUIT_SYMBOL[suit];
-    const label = RANK_LABEL[rank];
-    el.classList.add(color === 'red' ? 'is-red' : 'is-black');
-    el.setAttribute('aria-label', `${label} de ${suitName(suit)}`);
-    el.innerHTML = `
-      <div class="card-face card-front">
-        <span class="corner tl"><b>${label}</b><i>${sym}</i></span>
-        <span class="pip">${sym}</span>
-        <span class="corner br"><b>${label}</b><i>${sym}</i></span>
-      </div>`;
-    return el;
-}
+const PIP_LAYOUTS = {
+    '2': [1, 0, 0, 0, 1],
+    '3': [1, 0, 1, 0, 1],
+    '4': [2, 0, 0, 0, 2],
+    '5': [2, 0, 1, 0, 2],
+    '6': [2, 0, 2, 0, 2],
+    '7': [2, 1, 2, 0, 2],
+    '8': [2, 1, 2, 1, 2],
+    '9': [2, 2, 1, 2, 2],
+    T: [2, 2, 2, 2, 2]
+};
 
 function suitName(s) {
     return { s: 'espadas', h: 'copas', d: 'ouros', c: 'paus' }[s] || s;
+}
+
+function centerPip(rank, sym) {
+    if (['J', 'Q', 'K', 'A'].includes(rank)) {
+        return `<span class="pip">${sym}</span>`;
+    }
+    const layout = PIP_LAYOUTS[rank];
+    if (!layout) return `<span class="pip">${sym}</span>`;
+    const rows = layout
+        .map((n) => {
+            if (!n) return '<span>&nbsp;</span>';
+            return `<span>${sym.repeat(n).split('').join(' ')}</span>`;
+        })
+        .join('');
+    return `<div class="pip-grid" aria-hidden="true">${rows}</div>`;
+}
+
+export function cardElement(cardId, { faceDown = false, dealDelay = 0, flip = false } = {}) {
+    const el = document.createElement('div');
+    el.className = `card${faceDown ? ' is-back' : ''}`;
+    el.style.setProperty('--deal-delay', `${dealDelay}ms`);
+    el.style.setProperty('--deal-x', `${40 + Math.random() * 30}px`);
+    el.style.setProperty('--deal-y', `${-50 - Math.random() * 40}px`);
+    el.style.setProperty('--deal-rot', `${-22 + Math.random() * 18}deg`);
+    el.dataset.card = cardId || '';
+
+    let frontHtml = '';
+    if (cardId && cardId !== '?') {
+        const { rank, suit } = parseCard(cardId);
+        const color = SUIT_COLOR[suit];
+        const sym = SUIT_SYMBOL[suit];
+        const label = RANK_LABEL[rank];
+        el.classList.add(color === 'red' ? 'is-red' : 'is-black');
+        el.setAttribute('aria-label', faceDown ? 'Carta fechada' : `${label} de ${suitName(suit)}`);
+        frontHtml = `
+      <div class="card-face card-front">
+        <span class="corner tl"><b>${label}</b><i>${sym}</i></span>
+        ${centerPip(rank, sym)}
+        <span class="corner br"><b>${label}</b><i>${sym}</i></span>
+      </div>`;
+    } else {
+        el.setAttribute('aria-label', 'Carta fechada');
+        frontHtml = `<div class="card-face card-front"></div>`;
+    }
+
+    el.innerHTML = `
+    <div class="card-inner">
+      ${frontHtml}
+      <div class="card-face card-back" aria-hidden="true"><i></i></div>
+    </div>`;
+
+    if (flip && !faceDown) {
+        el.classList.add('is-back', 'is-flipping');
+        requestAnimationFrame(() => {
+            requestAnimationFrame(() => {
+                el.classList.remove('is-back');
+            });
+        });
+        setTimeout(() => el.classList.remove('is-flipping'), 750);
+    }
+
+    return el;
 }
 
 export function clearChildren(node) {
@@ -42,6 +89,26 @@ export function clearChildren(node) {
 export function renderCards(container, ids, opts = {}) {
     clearChildren(container);
     (ids || []).forEach((id, i) => {
-        container.appendChild(cardElement(id, { ...opts, dealDelay: (opts.baseDelay || 0) + i * 70 }));
+        container.appendChild(
+            cardElement(id, {
+                ...opts,
+                dealDelay: (opts.baseDelay || 0) + i * 80,
+                faceDown: opts.faceDown || id === '?'
+            })
+        );
+    });
+}
+
+/** Revela cartas viradas (flip 3D) sem re-deal. */
+export function revealCards(container, ids) {
+    clearChildren(container);
+    (ids || []).forEach((id, i) => {
+        container.appendChild(
+            cardElement(id, {
+                faceDown: false,
+                flip: true,
+                dealDelay: i * 90
+            })
+        );
     });
 }

--- a/labs/poker/src/chips.js
+++ b/labs/poker/src/chips.js
@@ -1,0 +1,98 @@
+/**
+ * Fichas 3D em CSS — decomposição visual do stack/pote.
+ * Denominações clássicas: 1, 5, 10, 25, 100, 500, 1000.
+ */
+
+export const CHIP_DENOMS = [1000, 500, 100, 25, 10, 5, 1];
+
+/** Máximo de discos visíveis numa pilha (performance + leitura). */
+const MAX_VISIBLE = 10;
+
+/**
+ * Decompõe amount em fichas (guloso), limitado a MAX_VISIBLE.
+ * @returns {{ denom: number, count: number }[]}
+ */
+export function decomposeChips(amount) {
+    let left = Math.max(0, Math.floor(amount || 0));
+    if (left <= 0) return [];
+
+    const piles = [];
+    let total = 0;
+    for (const d of CHIP_DENOMS) {
+        const n = Math.floor(left / d);
+        if (n > 0) {
+            piles.push({ denom: d, count: n });
+            left -= n * d;
+            total += n;
+        }
+    }
+
+    // Colapsa se demais: mantém as de maior valor
+    if (total <= MAX_VISIBLE) return expandChips(piles);
+
+    const flat = expandChips(piles);
+    return flat.slice(0, MAX_VISIBLE);
+}
+
+function expandChips(piles) {
+    const out = [];
+    for (const { denom, count } of piles) {
+        for (let i = 0; i < count; i++) out.push(denom);
+    }
+    return out;
+}
+
+export function renderChipStack(container, amount) {
+    if (!container) return;
+    const denoms = decomposeChips(amount);
+    container.innerHTML = denoms
+        .map((d) => `<span class="chip chip--${d}" title="${d}"></span>`)
+        .join('');
+    container.dataset.amount = String(amount || 0);
+}
+
+/**
+ * Anima fichas voando de um elemento origem até o pote.
+ */
+export function flyChips(fromEl, toEl, amount, { count = 4 } = {}) {
+    if (!fromEl || !toEl || amount <= 0) return Promise.resolve();
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+        return Promise.resolve();
+    }
+
+    const from = fromEl.getBoundingClientRect();
+    const to = toEl.getBoundingClientRect();
+    const denoms = decomposeChips(amount).slice(0, count);
+    if (!denoms.length) denoms.push(25);
+
+    const layer = document.body;
+
+    const promises = denoms.map((d, i) => {
+        return new Promise((resolve) => {
+            const el = document.createElement('span');
+            el.className = `chip chip-fly chip--${d}`;
+            const x0 = from.left + from.width / 2 - 10;
+            const y0 = from.top + from.height / 2;
+            const x1 = to.left + to.width / 2 - 10 + (Math.random() - 0.5) * 16;
+            const y1 = to.top + to.height / 2 + (Math.random() - 0.5) * 10;
+            el.style.left = `${x0}px`;
+            el.style.top = `${y0}px`;
+            el.style.transform = 'translate(0,0) scale(1)';
+            layer.appendChild(el);
+
+            requestAnimationFrame(() => {
+                const delay = i * 45;
+                el.style.transitionDelay = `${delay}ms`;
+                el.style.transform = `translate(${x1 - x0}px, ${y1 - y0}px) scale(0.85)`;
+                el.style.opacity = '0.15';
+            });
+
+            setTimeout(() => {
+                el.remove();
+                resolve();
+            }, 620 + i * 45);
+        });
+    });
+
+    return Promise.all(promises);
+}

--- a/labs/poker/src/main.js
+++ b/labs/poker/src/main.js
@@ -1,5 +1,6 @@
 /**
  * Poker Lab — Texas Hold'em heads-up vs IA + academia.
+ * UI hiper-realista: mesa 3D, fichas, flip de cartas.
  */
 
 import {
@@ -18,7 +19,8 @@ import {
 } from './engine.js';
 import { aiThinkDelay, chooseAction } from './ai.js';
 import { HAND_RANK_CHART, LESSONS, liveTip } from './coach.js';
-import { renderCards } from './cards.js';
+import { cardElement, renderCards, revealCards } from './cards.js';
+import { flyChips, renderChipStack } from './chips.js';
 import { isMuted, setMuted, sfxChip, sfxClick, sfxDeal, sfxFold, sfxWin } from './audio.js';
 
 const $ = (sel, root = document) => root.querySelector(sel);
@@ -31,7 +33,10 @@ const state = {
     busy: false,
     lessonIndex: 0,
     betAmount: 0,
-    showAiCards: false
+    showAiCards: false,
+    prevBets: [0, 0],
+    prevPot: 0,
+    aiRevealed: false
 };
 
 function init() {
@@ -78,6 +83,7 @@ function bindUi() {
 
     $('#difficulty')?.addEventListener('change', (e) => {
         state.difficulty = e.target.value;
+        renderBadges();
     });
 
     $('#coachToggle')?.addEventListener('click', () => {
@@ -116,6 +122,25 @@ function bindUi() {
         if (e.key === 'm' || e.key === 'M') $('#muteBtn')?.click();
         if (e.key === 'n' || e.key === 'N') $('#btnNewHand')?.click();
     });
+
+    // Micro parallax leve na mesa (desktop)
+    const stage = $('.table-stage');
+    if (stage && matchMedia('(pointer: fine)').matches) {
+        stage.addEventListener('pointermove', (e) => {
+            if (matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+            const r = stage.getBoundingClientRect();
+            const x = ((e.clientX - r.left) / r.width - 0.5) * 4;
+            const y = ((e.clientY - r.top) / r.height - 0.5) * 3;
+            const scene = $('.table-scene');
+            if (scene) {
+                scene.style.transform = `rotateX(${8 - y}deg) rotateY(${x}deg) scale(0.985)`;
+            }
+        });
+        stage.addEventListener('pointerleave', () => {
+            const scene = $('.table-scene');
+            if (scene) scene.style.transform = '';
+        });
+    }
 }
 
 function showIntro(show) {
@@ -161,9 +186,12 @@ function dealNewHand() {
     }
     startHand(state.match);
     state.showAiCards = false;
+    state.aiRevealed = false;
     state.busy = false;
+    state.prevBets = [0, 0];
+    state.prevPot = state.match.hand?.pot || 0;
     sfxDeal();
-    renderAll();
+    renderAll({ animateChips: true });
     maybeAiTurn();
 }
 
@@ -188,8 +216,15 @@ async function onActionClick(e) {
     if (type === 'fold') sfxFold();
     else sfxChip();
 
+    const beforeBet = state.match.hand?.streetContrib[0] || 0;
     const result = applyAction(state.match, { type, amount });
     if (!result.ok) return;
+
+    const afterBet = state.match.hand?.streetContrib[0] || 0;
+    const delta = Math.max(0, afterBet - beforeBet);
+    if (delta > 0 && type !== 'fold') {
+        await animateBetFlight(0, delta);
+    }
 
     renderAll();
     if (result.handOver) {
@@ -204,16 +239,12 @@ async function maybeAiTurn() {
     const h = match.hand;
     if (!h || h.street === STREET.DONE) return;
     if (h.toAct === match.heroSeat) return;
-    if (h.folded[h.toAct] || (h.allIn[h.toAct] && h.streetContrib[h.toAct] >= h.currentBet)) {
-        // shouldn't happen often
-    }
 
     state.busy = true;
     renderActions();
     setStatus('Dealer IA pensa…');
     await sleep(aiThinkDelay(state.difficulty));
 
-    // Loop while AI to act (e.g. after street advance if somehow)
     while (
         match.hand &&
         match.hand.street !== STREET.DONE &&
@@ -224,7 +255,16 @@ async function maybeAiTurn() {
         if (!action) break;
         if (action.type === 'fold') sfxFold();
         else sfxChip();
+
+        const seat = match.hand.toAct;
+        const beforeBet = match.hand.streetContrib[seat] || 0;
         const result = applyAction(match, action);
+        const afterBet = match.hand?.streetContrib[seat] || 0;
+        const delta = Math.max(0, afterBet - beforeBet);
+        if (delta > 0 && action.type !== 'fold') {
+            await animateBetFlight(seat, delta);
+        }
+
         renderAll();
         if (result.handOver) {
             state.busy = false;
@@ -233,7 +273,6 @@ async function maybeAiTurn() {
         }
         if (match.hand.toAct === match.heroSeat) break;
         if (match.hand.allIn[0] || match.hand.allIn[1]) {
-            // runout handled inside engine
             if (match.hand.street === STREET.DONE) {
                 state.busy = false;
                 onHandOver();
@@ -247,11 +286,19 @@ async function maybeAiTurn() {
     renderAll();
 }
 
+async function animateBetFlight(seat, amount) {
+    const from = seat === 0 ? $('#heroChipStack') : $('#aiChipStack');
+    const to = $('#potChips');
+    // Garante stack visual na origem antes do voo
+    renderChipStack(from, Math.max(amount, 1));
+    await flyChips(from, to, amount, { count: Math.min(5, Math.max(2, Math.ceil(amount / 40))) });
+}
+
 function onHandOver() {
     state.showAiCards = true;
     const r = state.match.lastResult;
     if (r?.winners?.includes(0)) sfxWin();
-    renderAll();
+    renderAll({ revealAi: true });
 
     if (!canContinue(state.match)) {
         const heroWins = state.match.stacks[0] > 0;
@@ -301,11 +348,12 @@ function onHint() {
     sfxClick();
 }
 
-function renderAll() {
+function renderAll(opts = {}) {
     renderStacks();
     renderBoard();
-    renderHoles();
+    renderHoles(opts);
     renderPot();
+    renderChipPiles();
     renderActions();
     renderLog();
     renderBadges();
@@ -340,12 +388,21 @@ function renderStacks() {
     $('#aiBlind').textContent = aiBlind;
 }
 
+function renderChipPiles() {
+    const h = state.match.hand;
+    const heroBet = h?.streetContrib[0] || 0;
+    const aiBet = h?.streetContrib[1] || 0;
+    const pot = h?.pot || 0;
+    renderChipStack($('#heroChipStack'), heroBet);
+    renderChipStack($('#aiChipStack'), aiBet);
+    renderChipStack($('#potChips'), pot);
+}
+
 function renderBoard() {
     const board = $('#board');
     const h = state.match.hand;
     const cards = h?.board || [];
     renderCards(board, cards, { baseDelay: 40 });
-    // Placeholders até 5
     for (let i = cards.length; i < 5; i++) {
         const ph = document.createElement('div');
         ph.className = 'card card-slot';
@@ -366,7 +423,7 @@ function streetName(s) {
     }[s] || '—';
 }
 
-function renderHoles() {
+function renderHoles(opts = {}) {
     const h = state.match.hand;
     const hero = h?.holes[0] || [];
     const ai = h?.holes[1] || [];
@@ -374,19 +431,21 @@ function renderHoles() {
 
     const reveal = state.showAiCards || (h && h.showdown) || (h && h.street === STREET.DONE && h.winners);
     if (reveal && ai.length) {
-        renderCards($('#aiCards'), ai, { baseDelay: 80 });
+        if (opts.revealAi && !state.aiRevealed) {
+            state.aiRevealed = true;
+            revealCards($('#aiCards'), ai);
+        } else {
+            renderCards($('#aiCards'), ai, { baseDelay: 80 });
+        }
     } else if (ai.length) {
-        renderCards($('#aiCards'), ['?', '?'], { faceDown: true });
-        // faceDown with fake ids
         const box = $('#aiCards');
         box.innerHTML = '';
-        box.appendChild(cardBack(0));
-        box.appendChild(cardBack(70));
+        box.appendChild(cardElement('?', { faceDown: true, dealDelay: 0 }));
+        box.appendChild(cardElement('?', { faceDown: true, dealDelay: 70 }));
     } else {
         $('#aiCards').innerHTML = '';
     }
 
-    // Hand label
     if (h && hero.length === 2) {
         if (h.board.length >= 3) {
             $('#heroHandName').textContent = describeHand(evaluateHand([...hero, ...h.board]));
@@ -397,15 +456,6 @@ function renderHoles() {
     } else {
         $('#heroHandName').textContent = '—';
     }
-}
-
-function cardBack(delay) {
-    const el = document.createElement('div');
-    el.className = 'card is-back';
-    el.style.setProperty('--deal-delay', `${delay}ms`);
-    el.innerHTML = '<div class="card-face card-back" aria-hidden="true"><i></i></div>';
-    el.setAttribute('aria-label', 'Carta fechada');
-    return el;
 }
 
 function renderPot() {
@@ -442,7 +492,7 @@ function renderActions() {
     let betOrRaise = legal.find((a) => a.type === 'bet' || a.type === 'raise');
 
     legal.forEach((a) => {
-        if (a.type === 'bet' || a.type === 'raise') return; // handled via confirm
+        if (a.type === 'bet' || a.type === 'raise') return;
         const btn = document.createElement('button');
         btn.type = 'button';
         btn.className = `act-btn act-btn--${a.type}`;
@@ -473,7 +523,6 @@ function renderActions() {
         confirm.textContent = betOrRaise.type === 'bet' ? 'Apostar' : 'Aumentar';
         box.appendChild(confirm);
 
-        // Quick sizes
         const pot = h.pot;
         $$('.size-chip').forEach((chip) => {
             const frac = Number(chip.dataset.frac);

--- a/labs/poker/style.css
+++ b/labs/poker/style.css
@@ -1,25 +1,32 @@
-/* Poker — mesa heads-up hiper-realista */
+/* Poker — mesa heads-up hiper-realista 3D */
 
 :root {
-  --felt-deep: #0a1f14;
-  --felt: #0f3d28;
-  --felt-lit: #1a5c3a;
-  --rail: #3a2416;
-  --rail-hi: #6b4428;
-  --cream: #f4efe6;
-  --ink: #1a1410;
-  --gold: #c9a227;
-  --gold-soft: #e8d5a3;
+  --felt-deep: #062416;
+  --felt: #0c3a26;
+  --felt-mid: #145538;
+  --felt-lit: #1f6b45;
+  --felt-hi: #2a8456;
+  --rail: #2a1810;
+  --rail-mid: #4a2e1c;
+  --rail-hi: #7a4e2e;
+  --rail-shine: #c49a6c;
+  --cream: #f5f0e6;
+  --ink: #16120e;
+  --gold: #d4af37;
+  --gold-soft: #ebdcad;
   --danger: #c45c4a;
   --ok: #3d9a6a;
-  --glass: rgba(12, 22, 16, 0.72);
-  --glass-border: rgba(232, 213, 163, 0.14);
-  --card-w: clamp(52px, 14vw, 78px);
-  --card-h: calc(var(--card-w) * 1.4);
+  --glass: rgba(8, 16, 12, 0.78);
+  --glass-border: rgba(235, 220, 173, 0.16);
+  --card-w: clamp(54px, 13.5vw, 82px);
+  --card-h: calc(var(--card-w) * 1.42);
+  --chip: clamp(18px, 4.2vw, 26px);
   --safe-top: env(safe-area-inset-top, 0px);
   --safe-right: env(safe-area-inset-right, 0px);
   --safe-bottom: env(safe-area-inset-bottom, 0px);
   --safe-left: env(safe-area-inset-left, 0px);
+  --ease-out: cubic-bezier(0.22, 1, 0.36, 1);
+  --ease-spring: cubic-bezier(0.34, 1.4, 0.64, 1);
 }
 
 html,
@@ -33,9 +40,10 @@ body {
   min-height: 100dvh;
   padding: 0;
   background:
-    radial-gradient(ellipse 80% 50% at 50% -10%, rgba(201, 162, 39, 0.12), transparent 50%),
-    radial-gradient(ellipse at 20% 80%, rgba(15, 61, 40, 0.5), transparent 40%),
-    linear-gradient(165deg, #070b09 0%, #0c1510 45%, #0a100e 100%);
+    radial-gradient(ellipse 90% 55% at 50% -8%, rgba(212, 175, 55, 0.1), transparent 48%),
+    radial-gradient(ellipse 50% 40% at 12% 88%, rgba(12, 58, 38, 0.45), transparent 45%),
+    radial-gradient(ellipse 40% 35% at 88% 70%, rgba(42, 24, 16, 0.35), transparent 40%),
+    linear-gradient(168deg, #040706 0%, #0a110e 42%, #070c0a 100%);
   color: var(--cream);
   font-family: 'Outfit', system-ui, sans-serif;
   display: flex;
@@ -47,7 +55,7 @@ body {
   flex: 1;
   display: flex;
   flex-direction: column;
-  width: min(1100px, 100%);
+  width: min(1120px, 100%);
   margin: 0 auto;
   padding:
     calc(0.5rem + var(--safe-top))
@@ -71,93 +79,304 @@ body {
 .brand-mark {
   color: var(--gold);
   font-size: 1.25rem;
+  filter: drop-shadow(0 0 8px rgba(212, 175, 55, 0.45));
 }
 
-/* —— Mesa —— */
+/* —— Scene / Room —— */
 .table-stage {
   position: relative;
   isolation: isolate;
+  min-height: min(54dvh, 460px);
+  padding: 0.5rem 0.35rem 0.75rem;
+  border-radius: 1.35rem;
+  overflow: hidden;
+  perspective: 1400px;
+}
+
+.room {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  border-radius: inherit;
+  background:
+    radial-gradient(ellipse 80% 60% at 50% 40%, #0d1a14 0%, #060a08 70%),
+    #050807;
+}
+
+.room-vignette {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  box-shadow: inset 0 0 80px 24px rgba(0, 0, 0, 0.55);
+  background: radial-gradient(ellipse at 50% 45%, transparent 35%, rgba(0, 0, 0, 0.5) 100%);
+}
+
+.room-spot {
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(28px);
+  mix-blend-mode: screen;
+  animation: spotPulse 7s ease-in-out infinite;
+}
+
+.room-spot--key {
+  width: 55%;
+  height: 45%;
+  left: 22%;
+  top: 12%;
+  background: radial-gradient(circle, rgba(255, 240, 200, 0.18), transparent 70%);
+}
+
+.room-spot--fill {
+  width: 40%;
+  height: 35%;
+  right: 8%;
+  bottom: 18%;
+  background: radial-gradient(circle, rgba(45, 140, 90, 0.12), transparent 70%);
+  animation-delay: -3s;
+}
+
+.room-dust {
+  position: absolute;
+  inset: 0;
+  opacity: 0.35;
+  background-image:
+    radial-gradient(1px 1px at 20% 30%, rgba(255, 255, 255, 0.35), transparent),
+    radial-gradient(1px 1px at 70% 55%, rgba(255, 255, 255, 0.25), transparent),
+    radial-gradient(1.5px 1.5px at 40% 75%, rgba(255, 240, 200, 0.3), transparent),
+    radial-gradient(1px 1px at 85% 20%, rgba(255, 255, 255, 0.2), transparent),
+    radial-gradient(1px 1px at 55% 15%, rgba(255, 255, 255, 0.22), transparent);
+  animation: dustDrift 18s linear infinite;
+}
+
+@keyframes spotPulse {
+  0%, 100% { opacity: 0.75; transform: scale(1); }
+  50% { opacity: 1; transform: scale(1.06); }
+}
+
+@keyframes dustDrift {
+  from { transform: translateY(0); }
+  to { transform: translateY(-12px); }
+}
+
+/* —— Table 3D —— */
+.table-scene {
+  position: relative;
+  z-index: 1;
   display: grid;
   grid-template-rows: auto 1fr auto;
-  gap: 0.35rem;
-  min-height: min(52dvh, 420px);
-  padding: 0.85rem 0.75rem 1rem;
-  border-radius: 1.25rem;
+  gap: 0.3rem;
+  min-height: min(50dvh, 420px);
+  padding: 0.85rem 0.9rem 1.1rem;
+  transform-style: preserve-3d;
+  transform: rotateX(8deg) scale(0.985);
+  transform-origin: 50% 60%;
+}
+
+.table-cast {
+  position: absolute;
+  left: 6%;
+  right: 6%;
+  bottom: -2%;
+  height: 18%;
+  border-radius: 50%;
+  background: radial-gradient(ellipse, rgba(0, 0, 0, 0.55), transparent 70%);
+  filter: blur(8px);
+  z-index: -1;
+  transform: translateZ(-40px);
+}
+
+.table-body {
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  border-radius: 48% / 40%;
+  transform-style: preserve-3d;
+}
+
+.rail {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background:
+    radial-gradient(ellipse 70% 55% at 50% 40%, var(--rail-mid), var(--rail) 70%);
+  box-shadow:
+    0 18px 40px rgba(0, 0, 0, 0.55),
+    inset 0 1px 0 rgba(196, 154, 108, 0.25),
+    inset 0 -8px 20px rgba(0, 0, 0, 0.45);
   overflow: hidden;
+}
+
+.rail-grain {
+  position: absolute;
+  inset: 0;
+  opacity: 0.4;
+  background:
+    repeating-linear-gradient(
+      92deg,
+      transparent 0 3px,
+      rgba(0, 0, 0, 0.08) 3px 4px,
+      transparent 4px 9px,
+      rgba(255, 220, 180, 0.04) 9px 10px
+    ),
+    repeating-linear-gradient(
+      0deg,
+      transparent 0 14px,
+      rgba(0, 0, 0, 0.06) 14px 15px
+    );
+  mix-blend-mode: multiply;
+}
+
+.rail-edge {
+  position: absolute;
+  inset: 10px;
+  border-radius: inherit;
+  border: 2px solid rgba(196, 154, 108, 0.22);
+  box-shadow:
+    inset 0 0 0 1px rgba(0, 0, 0, 0.35),
+    0 0 0 1px rgba(0, 0, 0, 0.4);
+  pointer-events: none;
+}
+
+.rail-shine {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(
+    125deg,
+    rgba(255, 230, 190, 0.12) 0%,
+    transparent 28%,
+    transparent 62%,
+    rgba(255, 220, 170, 0.06) 100%
+  );
+  pointer-events: none;
 }
 
 .felt {
   position: absolute;
-  inset: 0;
-  z-index: -1;
+  inset: 14px;
   border-radius: inherit;
+  overflow: hidden;
   background:
-    radial-gradient(ellipse 70% 55% at 50% 45%, var(--felt-lit), var(--felt) 55%, var(--felt-deep) 100%);
+    radial-gradient(ellipse 65% 55% at 50% 42%, var(--felt-hi), var(--felt-mid) 42%, var(--felt) 72%, var(--felt-deep) 100%);
   box-shadow:
-    inset 0 0 0 3px rgba(201, 162, 39, 0.18),
-    inset 0 0 60px rgba(0, 0, 0, 0.45),
-    0 20px 50px rgba(0, 0, 0, 0.45);
+    inset 0 0 50px rgba(0, 0, 0, 0.45),
+    inset 0 2px 8px rgba(255, 255, 255, 0.05);
 }
 
-.felt::before {
-  content: '';
+.felt-nap {
   position: absolute;
-  inset: 10px;
-  border-radius: 48% / 42%;
-  border: 1px solid rgba(232, 213, 163, 0.08);
+  inset: 0;
+  opacity: 0.55;
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3CfeColorMatrix values='0 0 0 0 0.05 0 0 0 0 0.25 0 0 0 0 0.12 0 0 0 0.55 0'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+  background-size: 180px 180px;
+  mix-blend-mode: soft-light;
+  pointer-events: none;
+}
+
+.felt-weave {
+  position: absolute;
+  inset: 0;
+  opacity: 0.18;
+  background:
+    repeating-linear-gradient(0deg, transparent 0 2px, rgba(0, 0, 0, 0.15) 2px 3px),
+    repeating-linear-gradient(90deg, transparent 0 2px, rgba(255, 255, 255, 0.04) 2px 3px);
+  pointer-events: none;
+}
+
+.felt-rim {
+  position: absolute;
+  inset: 8%;
+  border-radius: 46% / 40%;
+  border: 1.5px solid rgba(235, 220, 173, 0.12);
+  box-shadow: inset 0 0 30px rgba(0, 0, 0, 0.2);
   pointer-events: none;
 }
 
 .felt-glow {
   position: absolute;
-  inset: 20% 15%;
-  background: radial-gradient(circle, rgba(255, 255, 255, 0.06), transparent 65%);
+  inset: 18% 14%;
+  background: radial-gradient(circle, rgba(255, 250, 230, 0.1), transparent 65%);
   pointer-events: none;
-  animation: breathe 6s ease-in-out infinite;
+  animation: breathe 6.5s ease-in-out infinite;
 }
 
-.felt-rail {
+.felt-crest {
   position: absolute;
-  inset: 0;
-  border-radius: inherit;
-  box-shadow:
-    inset 0 0 0 14px var(--rail),
-    inset 0 0 0 16px var(--rail-hi),
-    inset 0 0 28px rgba(0, 0, 0, 0.55);
+  left: 50%;
+  top: 48%;
+  transform: translate(-50%, -50%);
+  font-size: clamp(2.5rem, 8vw, 4.5rem);
+  color: rgba(235, 220, 173, 0.07);
+  text-shadow: 0 2px 0 rgba(0, 0, 0, 0.2);
   pointer-events: none;
-  opacity: 0.92;
+  font-family: 'Cormorant Garamond', Georgia, serif;
+  user-select: none;
 }
 
 @keyframes breathe {
-  0%, 100% { opacity: 0.7; transform: scale(1); }
-  50% { opacity: 1; transform: scale(1.03); }
+  0%, 100% { opacity: 0.65; transform: scale(1); }
+  50% { opacity: 1; transform: scale(1.04); }
 }
 
+/* Deck */
+.deck-pile {
+  position: absolute;
+  right: clamp(1.2rem, 5vw, 2.5rem);
+  top: 42%;
+  width: calc(var(--card-w) * 0.72);
+  height: calc(var(--card-h) * 0.72);
+  z-index: 2;
+  transform: rotate(-8deg) translateZ(12px);
+  pointer-events: none;
+  opacity: 0.9;
+}
+
+.deck-pile span {
+  position: absolute;
+  inset: 0;
+  border-radius: calc(var(--card-w) * 0.06);
+  background:
+    linear-gradient(145deg, rgba(255, 255, 255, 0.1), transparent 40%),
+    repeating-linear-gradient(45deg, #14304c 0 3px, #0e2438 3px 6px);
+  border: 1.5px solid rgba(212, 175, 55, 0.4);
+  box-shadow: 0 3px 8px rgba(0, 0, 0, 0.4);
+}
+
+.deck-pile span:nth-child(1) { transform: translate(0, 0); }
+.deck-pile span:nth-child(2) { transform: translate(2px, -2px); }
+.deck-pile span:nth-child(3) { transform: translate(4px, -4px); }
+
+/* HUD on table */
 .table-hud {
   display: flex;
   justify-content: space-between;
   align-items: center;
   gap: 0.5rem;
-  padding: 0 0.35rem;
-  z-index: 1;
+  padding: 0 0.5rem;
+  z-index: 3;
 }
 
 .meta-line {
   font-size: 0.75rem;
-  opacity: 0.75;
+  opacity: 0.78;
   margin: 0;
+  text-shadow: 0 1px 4px rgba(0, 0, 0, 0.6);
 }
 
 .street-pill {
   margin: 0;
-  padding: 0.25rem 0.7rem;
+  padding: 0.28rem 0.75rem;
   border-radius: 999px;
-  background: rgba(0, 0, 0, 0.35);
+  background: linear-gradient(180deg, rgba(20, 30, 24, 0.75), rgba(0, 0, 0, 0.55));
   border: 1px solid var(--glass-border);
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.35), inset 0 1px 0 rgba(255, 255, 255, 0.06);
   font-size: 0.72rem;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.1em;
   text-transform: uppercase;
   color: var(--gold-soft);
+  backdrop-filter: blur(6px);
 }
 
 /* Seats */
@@ -165,30 +384,28 @@ body {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 0.35rem;
-  transition: opacity 0.3s, filter 0.3s;
-  z-index: 1;
+  gap: 0.4rem;
+  transition: opacity 0.35s, filter 0.35s, transform 0.35s;
+  z-index: 3;
+  transform: translateZ(20px);
 }
 
 .seat.is-folded {
-  opacity: 0.45;
-  filter: grayscale(0.4);
+  opacity: 0.42;
+  filter: grayscale(0.45) brightness(0.85);
 }
 
-.seat.is-turn .seat-name::after {
-  content: '';
-  display: inline-block;
-  width: 0.45rem;
-  height: 0.45rem;
-  margin-left: 0.4rem;
-  border-radius: 50%;
-  background: var(--gold);
-  box-shadow: 0 0 10px var(--gold);
-  animation: pulse 1.2s ease-in-out infinite;
+.seat.is-turn .avatar-ring {
+  animation: ringPulse 1.3s ease-in-out infinite;
+  box-shadow: 0 0 0 2px var(--gold), 0 0 18px rgba(212, 175, 55, 0.55);
 }
 
 .seat.is-winner {
-  animation: winPulse 1.2s ease;
+  animation: winPulse 1.3s ease;
+}
+
+.seat.is-winner .avatar-ring {
+  box-shadow: 0 0 0 2px var(--gold), 0 0 28px rgba(212, 175, 55, 0.75);
 }
 
 @keyframes pulse {
@@ -196,9 +413,49 @@ body {
   50% { opacity: 0.35; }
 }
 
+@keyframes ringPulse {
+  0%, 100% { transform: scale(1); opacity: 1; }
+  50% { transform: scale(1.06); opacity: 0.85; }
+}
+
 @keyframes winPulse {
   0%, 100% { filter: brightness(1); }
-  40% { filter: brightness(1.25); }
+  40% { filter: brightness(1.28); }
+}
+
+.avatar {
+  position: relative;
+  width: 2.4rem;
+  height: 2.4rem;
+  margin: 0 auto 0.15rem;
+}
+
+.avatar-ring {
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  background:
+    conic-gradient(from 200deg, var(--gold), #8a6a20, var(--gold-soft), var(--gold));
+  padding: 2px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+}
+
+.avatar-face {
+  position: absolute;
+  inset: 3px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  background:
+    radial-gradient(circle at 35% 30%, #2a4236, #101a15 70%);
+  border: 1px solid rgba(0, 0, 0, 0.4);
+  font-size: 1rem;
+  color: var(--gold-soft);
+}
+
+.avatar--hero .avatar-face {
+  background: radial-gradient(circle at 35% 30%, #3a2a28, #16100f 70%);
+  color: #e8a0a0;
 }
 
 .seat-info {
@@ -209,15 +466,17 @@ body {
 .seat-name {
   margin: 0;
   font-family: 'Cormorant Garamond', Georgia, serif;
-  font-size: clamp(1rem, 3vw, 1.25rem);
+  font-size: clamp(1rem, 3vw, 1.28rem);
   font-weight: 600;
   letter-spacing: 0.03em;
+  text-shadow: 0 2px 8px rgba(0, 0, 0, 0.55);
 }
 
 .seat-stack {
   margin: 0.1rem 0 0;
   font-size: 0.85rem;
   font-variant-numeric: tabular-nums;
+  text-shadow: 0 1px 4px rgba(0, 0, 0, 0.5);
 }
 
 .seat-stack small {
@@ -226,44 +485,62 @@ body {
 }
 
 .hand-name {
-  margin: 0.15rem 0 0;
+  margin: 0.2rem 0 0;
   font-size: 0.72rem;
   color: var(--gold-soft);
   max-width: 16rem;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  text-shadow: 0 1px 4px rgba(0, 0, 0, 0.5);
 }
 
 .seat-bet {
   margin: 0;
   font-size: 0.72rem;
-  opacity: 0.8;
+  opacity: 0.85;
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.5);
+}
+
+.bet-zone {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.2rem;
+  min-height: calc(var(--chip) + 0.5rem);
 }
 
 .dealer-btn {
   position: absolute;
-  left: -1.6rem;
-  top: 0.1rem;
-  width: 1.35rem;
-  height: 1.35rem;
+  left: -1.75rem;
+  top: 0.15rem;
+  width: 1.45rem;
+  height: 1.45rem;
   border-radius: 50%;
-  background: linear-gradient(145deg, #f5f5f0, #c8c4b8);
+  background:
+    radial-gradient(circle at 35% 30%, #fffef8, #e8e2d4 45%, #b8b0a0 100%);
   color: #222;
   font-size: 0.65rem;
   font-weight: 700;
   display: grid;
   place-items: center;
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.35);
+  box-shadow:
+    0 2px 6px rgba(0, 0, 0, 0.4),
+    inset 0 1px 0 rgba(255, 255, 255, 0.8),
+    inset 0 -2px 3px rgba(0, 0, 0, 0.15);
+  border: 1px solid rgba(0, 0, 0, 0.15);
+  z-index: 2;
 }
 
 .blind-tag {
   display: inline-block;
   min-height: 1rem;
   font-size: 0.65rem;
-  letter-spacing: 0.06em;
+  letter-spacing: 0.08em;
   color: var(--gold);
-  opacity: 0.9;
+  opacity: 0.95;
+  font-weight: 600;
+  text-shadow: 0 0 8px rgba(212, 175, 55, 0.35);
 }
 
 .board-wrap {
@@ -271,19 +548,29 @@ body {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 0.45rem;
+  gap: 0.5rem;
   min-height: 0;
-  z-index: 1;
+  z-index: 3;
+  transform: translateZ(24px);
+}
+
+.pot-cluster {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.25rem;
 }
 
 .pot-line {
   margin: 0;
-  padding: 0.3rem 0.85rem;
+  padding: 0.32rem 0.95rem;
   border-radius: 999px;
-  background: rgba(0, 0, 0, 0.4);
-  border: 1px solid rgba(201, 162, 39, 0.35);
-  font-size: 0.8rem;
+  background: linear-gradient(180deg, rgba(20, 28, 22, 0.8), rgba(0, 0, 0, 0.55));
+  border: 1px solid rgba(212, 175, 55, 0.4);
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.4), inset 0 1px 0 rgba(255, 255, 255, 0.08);
+  font-size: 0.82rem;
   letter-spacing: 0.04em;
+  backdrop-filter: blur(6px);
 }
 
 .pot-line strong {
@@ -294,58 +581,107 @@ body {
 .board,
 .hole-cards {
   display: flex;
-  gap: clamp(0.25rem, 1.5vw, 0.5rem);
+  gap: clamp(0.28rem, 1.5vw, 0.55rem);
   justify-content: center;
   flex-wrap: nowrap;
+  perspective: 800px;
 }
 
 .result-banner {
   margin: 0;
   max-width: min(92%, 28rem);
-  padding: 0.4rem 0.85rem;
-  border-radius: 0.5rem;
-  background: rgba(0, 0, 0, 0.55);
-  border: 1px solid rgba(201, 162, 39, 0.4);
+  padding: 0.45rem 0.9rem;
+  border-radius: 0.55rem;
+  background: linear-gradient(160deg, rgba(20, 36, 26, 0.92), rgba(8, 14, 10, 0.95));
+  border: 1px solid rgba(212, 175, 55, 0.45);
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.45);
   font-size: clamp(0.78rem, 2.5vw, 0.92rem);
   text-align: center;
-  animation: fadeUp 0.45s ease;
+  animation: fadeUp 0.45s var(--ease-out);
 }
 
 @keyframes fadeUp {
-  from { opacity: 0; transform: translateY(6px); }
+  from { opacity: 0; transform: translateY(8px); }
   to { opacity: 1; transform: translateY(0); }
 }
 
-/* —— Cartas —— */
+/* —— Cartas 3D —— */
 .card {
   --deal-delay: 0ms;
+  --tilt: 0deg;
   width: var(--card-w);
   height: var(--card-h);
-  border-radius: calc(var(--card-w) * 0.08);
+  border-radius: calc(var(--card-w) * 0.085);
   position: relative;
   transform-style: preserve-3d;
-  animation: dealIn 0.45s cubic-bezier(0.22, 1, 0.36, 1) both;
+  perspective: 900px;
+  animation: dealIn 0.55s var(--ease-out) both;
   animation-delay: var(--deal-delay);
+  cursor: default;
+}
+
+.card-inner {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  transform-style: preserve-3d;
+  transition: transform 0.55s var(--ease-out);
+  transform: rotateY(0deg) rotateZ(var(--tilt));
   box-shadow:
-    0 4px 10px rgba(0, 0, 0, 0.4),
-    0 1px 0 rgba(255, 255, 255, 0.35) inset;
+    0 8px 18px rgba(0, 0, 0, 0.45),
+    0 2px 4px rgba(0, 0, 0, 0.25);
+}
+
+.card.is-back .card-inner {
+  transform: rotateY(180deg) rotateZ(var(--tilt));
+}
+
+.card.is-flipping .card-inner {
+  transition: transform 0.7s var(--ease-spring);
+}
+
+.card:nth-child(1) { --tilt: -2.5deg; }
+.card:nth-child(2) { --tilt: 1.5deg; }
+.card:nth-child(3) { --tilt: -1deg; }
+.card:nth-child(4) { --tilt: 2deg; }
+.card:nth-child(5) { --tilt: -0.5deg; }
+
+.hole-cards .card:nth-child(1) { --tilt: -4deg; }
+.hole-cards .card:nth-child(2) { --tilt: 4deg; }
+
+.seat--hero .hole-cards .card:hover .card-inner,
+.board .card:hover .card-inner {
+  transform: translateY(-6px) rotateY(0deg) rotateZ(var(--tilt)) scale(1.04);
+  box-shadow:
+    0 14px 28px rgba(0, 0, 0, 0.5),
+    0 2px 4px rgba(0, 0, 0, 0.25);
+}
+
+.seat--hero .hole-cards .card.is-back:hover .card-inner {
+  transform: translateY(-6px) rotateY(180deg) rotateZ(var(--tilt)) scale(1.04);
 }
 
 .card-slot {
-  background: rgba(0, 0, 0, 0.18);
-  border: 1px dashed rgba(232, 213, 163, 0.18);
-  box-shadow: none;
+  background: rgba(0, 0, 0, 0.2);
+  border: 1.5px dashed rgba(235, 220, 173, 0.2);
+  box-shadow: inset 0 2px 8px rgba(0, 0, 0, 0.25);
   animation: none;
+  border-radius: calc(var(--card-w) * 0.085);
+}
+
+.card-slot .card-inner {
+  display: none;
 }
 
 @keyframes dealIn {
   from {
     opacity: 0;
-    transform: translateY(-18px) rotateX(12deg) scale(0.92);
+    transform: translate3d(var(--deal-x, 40px), var(--deal-y, -60px), 40px)
+      rotateZ(var(--deal-rot, -18deg)) scale(0.85);
   }
   to {
     opacity: 1;
-    transform: translateY(0) rotateX(0) scale(1);
+    transform: translate3d(0, 0, 0) rotateZ(0) scale(1);
   }
 }
 
@@ -354,33 +690,60 @@ body {
   inset: 0;
   border-radius: inherit;
   overflow: hidden;
+  backface-visibility: hidden;
+  -webkit-backface-visibility: hidden;
 }
 
 .card-front {
   background:
-    linear-gradient(145deg, #fffef9 0%, #f3eee4 48%, #ebe4d6 100%);
+    linear-gradient(145deg, rgba(255, 255, 255, 0.55) 0%, transparent 42%),
+    linear-gradient(165deg, #fffef8 0%, #f4eee4 45%, #e8dfd0 100%);
   color: var(--ink);
   display: grid;
   grid-template-rows: auto 1fr auto;
-  padding: 0.28em 0.32em;
+  padding: 0.26em 0.3em;
   font-family: 'Cormorant Garamond', Georgia, serif;
+  transform: rotateY(0deg);
+  border: 1px solid rgba(0, 0, 0, 0.08);
 }
 
-.card.is-red .card-front { color: #b42318; }
-.card.is-black .card-front { color: #1a1a1a; }
+.card-front::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  opacity: 0.35;
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 120 120' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='p'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3' stitchTiles='stitch'/%3E%3CfeColorMatrix values='0 0 0 0 0.85 0 0 0 0 0.82 0 0 0 0 0.75 0 0 0 0.12 0'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23p)'/%3E%3C/svg%3E");
+  background-size: 80px;
+  pointer-events: none;
+  mix-blend-mode: multiply;
+}
+
+.card-front::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7), inset 0 -1px 2px rgba(0, 0, 0, 0.08);
+  pointer-events: none;
+}
+
+.card.is-red .card-front { color: #b51f18; }
+.card.is-black .card-front { color: #141414; }
 
 .corner {
+  position: relative;
+  z-index: 1;
   display: flex;
   flex-direction: column;
   align-items: center;
   line-height: 1;
-  font-size: calc(var(--card-w) * 0.22);
+  font-size: calc(var(--card-w) * 0.2);
   font-weight: 700;
 }
 
 .corner i {
   font-style: normal;
-  font-size: 0.85em;
+  font-size: 0.88em;
 }
 
 .corner.br {
@@ -389,32 +752,68 @@ body {
 }
 
 .pip {
+  position: relative;
+  z-index: 1;
   display: grid;
   place-items: center;
-  font-size: calc(var(--card-w) * 0.42);
-  opacity: 0.92;
-  text-shadow: 0 1px 0 rgba(255, 255, 255, 0.4);
+  font-size: calc(var(--card-w) * 0.4);
+  opacity: 0.95;
+  text-shadow: 0 1px 0 rgba(255, 255, 255, 0.45), 0 2px 3px rgba(0, 0, 0, 0.08);
+  filter: drop-shadow(0 1px 0 rgba(255, 255, 255, 0.3));
+}
+
+.pip-grid {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  place-items: center;
+  gap: 0;
+  font-size: calc(var(--card-w) * 0.16);
+  line-height: 1;
+  text-align: center;
+  padding: 0.1em;
+}
+
+.pip-grid span {
+  display: block;
 }
 
 .card-back {
   background:
-    linear-gradient(135deg, rgba(255, 255, 255, 0.08), transparent 40%),
-    repeating-linear-gradient(
-      45deg,
-      #1a3a5c 0 4px,
-      #152f4a 4px 8px
-    );
-  border: 2px solid #c9a22755;
+    linear-gradient(135deg, rgba(255, 255, 255, 0.12), transparent 38%),
+    radial-gradient(circle at 50% 50%, #1a4568, #0c2438 70%);
+  border: 2px solid rgba(212, 175, 55, 0.45);
+  transform: rotateY(180deg);
 }
 
 .card-back i {
   position: absolute;
-  inset: 8%;
-  border: 1px solid rgba(201, 162, 39, 0.45);
-  border-radius: 4px;
+  inset: 7%;
+  border: 1.5px solid rgba(212, 175, 55, 0.5);
+  border-radius: 5px;
   background:
-    radial-gradient(circle at 50% 50%, rgba(201, 162, 39, 0.25), transparent 55%),
+    radial-gradient(circle at 50% 50%, rgba(212, 175, 55, 0.22), transparent 55%),
+    repeating-linear-gradient(
+      45deg,
+      #153652 0 3px,
+      #0f2a40 3px 6px
+    ),
     linear-gradient(160deg, #0e2438, #1a3a5c);
+  box-shadow: inset 0 0 12px rgba(0, 0, 0, 0.35);
+}
+
+.card-back i::before {
+  content: '';
+  position: absolute;
+  inset: 10%;
+  border: 1px solid rgba(212, 175, 55, 0.28);
+  border-radius: 3px;
+  background:
+    repeating-conic-gradient(
+      from 0deg at 50% 50%,
+      rgba(212, 175, 55, 0.08) 0deg 12deg,
+      transparent 12deg 24deg
+    );
 }
 
 .card-back i::after {
@@ -423,11 +822,87 @@ body {
   inset: 0;
   display: grid;
   place-items: center;
-  color: rgba(201, 162, 39, 0.55);
-  font-size: calc(var(--card-w) * 0.35);
+  color: rgba(212, 175, 55, 0.62);
+  font-size: calc(var(--card-w) * 0.32);
+  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.4);
 }
 
-/* —— HUD —— */
+/* —— Fichas —— */
+.chip-stack {
+  display: flex;
+  flex-direction: column-reverse;
+  align-items: center;
+  height: calc(var(--chip) * 0.55);
+  min-width: var(--chip);
+  position: relative;
+}
+
+.chip-stack--pot {
+  height: calc(var(--chip) * 0.9);
+  margin-bottom: 0.1rem;
+}
+
+.chip {
+  width: var(--chip);
+  height: calc(var(--chip) * 0.28);
+  border-radius: 50%;
+  position: relative;
+  margin-top: calc(var(--chip) * -0.18);
+  box-shadow:
+    0 2px 3px rgba(0, 0, 0, 0.45),
+    inset 0 1px 0 rgba(255, 255, 255, 0.35),
+    inset 0 -1px 2px rgba(0, 0, 0, 0.35);
+  border: 1px solid rgba(0, 0, 0, 0.25);
+  transform: translateZ(0);
+}
+
+.chip::before {
+  content: '';
+  position: absolute;
+  inset: 18% 14%;
+  border-radius: 50%;
+  border: 1.5px dashed rgba(255, 255, 255, 0.45);
+  opacity: 0.7;
+}
+
+.chip::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.28), transparent 45%, rgba(0, 0, 0, 0.2));
+  pointer-events: none;
+}
+
+.chip--1 { background: linear-gradient(180deg, #f5f5f0, #c8c4b8); }
+.chip--5 { background: linear-gradient(180deg, #e85a4a, #9a2e24); }
+.chip--10 { background: linear-gradient(180deg, #4a8fd4, #1e4f8a); }
+.chip--25 { background: linear-gradient(180deg, #3d9a6a, #1e5a3c); }
+.chip--100 { background: linear-gradient(180deg, #3a3a3a, #111); color: #eee; }
+.chip--500 { background: linear-gradient(180deg, #8b5cf6, #4c1d95); }
+.chip--1000 { background: linear-gradient(180deg, #f0c14b, #a67c00); }
+
+.chip-fly {
+  position: fixed;
+  width: var(--chip);
+  height: calc(var(--chip) * 0.28);
+  border-radius: 50%;
+  z-index: 50;
+  pointer-events: none;
+  box-shadow: 0 3px 8px rgba(0, 0, 0, 0.45);
+  transition: transform 0.55s var(--ease-out), opacity 0.55s ease;
+  will-change: transform, opacity;
+}
+
+.fx-layer {
+  position: absolute;
+  inset: 0;
+  z-index: 20;
+  pointer-events: none;
+  overflow: visible;
+}
+
+/* —— HUD panels —— */
 .hud {
   display: grid;
   grid-template-columns: minmax(0, 1.1fr) minmax(0, 0.85fr);
@@ -438,12 +913,19 @@ body {
   align-items: start;
 }
 
+.panel {
+  background:
+    linear-gradient(165deg, rgba(18, 32, 24, 0.88), rgba(8, 14, 11, 0.92));
+  border: 1px solid var(--glass-border);
+  border-radius: 0.95rem;
+  backdrop-filter: blur(14px);
+  box-shadow:
+    0 12px 32px rgba(0, 0, 0, 0.35),
+    inset 0 1px 0 rgba(255, 255, 255, 0.05);
+}
+
 .coach {
   grid-area: coach;
-  background: var(--glass);
-  border: 1px solid var(--glass-border);
-  border-radius: 0.9rem;
-  backdrop-filter: blur(12px);
   overflow: hidden;
   max-height: min(42dvh, 360px);
   display: flex;
@@ -502,14 +984,14 @@ body {
   margin: 0;
   font-size: 0.9rem;
   line-height: 1.45;
-  color: rgba(244, 239, 230, 0.9);
+  color: rgba(245, 240, 230, 0.9);
 }
 
 .coach-tip {
   margin: 0.65rem 0 0;
   padding: 0.55rem 0.65rem;
   border-left: 2px solid var(--gold);
-  background: rgba(201, 162, 39, 0.08);
+  background: rgba(212, 175, 55, 0.08);
   font-size: 0.82rem;
   line-height: 1.4;
   color: var(--gold-soft);
@@ -567,11 +1049,12 @@ body {
   font-size: 0.85rem;
   text-align: left;
   cursor: pointer;
-  transition: border-color 0.2s, background 0.2s;
+  transition: border-color 0.2s, background 0.2s, transform 0.15s;
 }
 
 .quiz-btn:hover {
-  border-color: rgba(201, 162, 39, 0.45);
+  border-color: rgba(212, 175, 55, 0.45);
+  transform: translateY(-1px);
 }
 
 .quiz-btn.is-correct {
@@ -586,11 +1069,7 @@ body {
 
 .tray {
   grid-area: tray;
-  background: var(--glass);
-  border: 1px solid var(--glass-border);
-  border-radius: 0.9rem;
   padding: 0.75rem 0.85rem;
-  backdrop-filter: blur(12px);
   max-height: min(42dvh, 360px);
   overflow: hidden;
   display: flex;
@@ -619,7 +1098,7 @@ body {
   min-height: 44px;
   border-radius: 0.5rem;
   border: 1px solid var(--glass-border);
-  background: rgba(0, 0, 0, 0.35);
+  background: rgba(0, 0, 0, 0.4);
   color: var(--cream);
   font: inherit;
   font-size: 0.85rem;
@@ -642,6 +1121,7 @@ body {
 .event-log li {
   padding: 0.25rem 0;
   border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+  animation: fadeUp 0.3s var(--ease-out);
 }
 
 .action-dock {
@@ -652,9 +1132,6 @@ body {
 }
 
 .sizing {
-  background: var(--glass);
-  border: 1px solid var(--glass-border);
-  border-radius: 0.75rem;
   padding: 0.65rem 0.75rem;
 }
 
@@ -693,10 +1170,13 @@ body {
   font: inherit;
   font-size: 0.72rem;
   cursor: pointer;
+  transition: border-color 0.2s, transform 0.15s, background 0.2s;
 }
 
 .size-chip:hover {
-  border-color: rgba(201, 162, 39, 0.5);
+  border-color: rgba(212, 175, 55, 0.5);
+  background: rgba(212, 175, 55, 0.1);
+  transform: translateY(-1px);
 }
 
 .actions {
@@ -710,39 +1190,46 @@ body {
   min-height: var(--touch-target, 44px);
   min-width: min(100%, 5.5rem);
   padding: 0.55rem 0.9rem;
-  border-radius: 0.65rem;
+  border-radius: 0.7rem;
   border: 1px solid var(--glass-border);
-  background: rgba(255, 255, 255, 0.06);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0.03));
   color: var(--cream);
   font: inherit;
   font-weight: 560;
   font-size: 0.9rem;
   cursor: pointer;
-  transition: transform 0.15s, background 0.2s, border-color 0.2s;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25), inset 0 1px 0 rgba(255, 255, 255, 0.06);
+  transition: transform 0.15s, background 0.2s, border-color 0.2s, box-shadow 0.2s;
 }
 
 .act-btn:hover {
-  transform: translateY(-1px);
-  border-color: rgba(201, 162, 39, 0.4);
+  transform: translateY(-2px);
+  border-color: rgba(212, 175, 55, 0.45);
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.3), inset 0 1px 0 rgba(255, 255, 255, 0.08);
+}
+
+.act-btn:active {
+  transform: translateY(0);
 }
 
 .act-btn--fold {
-  background: rgba(196, 92, 74, 0.2);
-  border-color: rgba(196, 92, 74, 0.4);
+  background: linear-gradient(180deg, rgba(196, 92, 74, 0.35), rgba(196, 92, 74, 0.15));
+  border-color: rgba(196, 92, 74, 0.45);
 }
 
 .act-btn--check,
 .act-btn--call {
-  background: rgba(61, 154, 106, 0.18);
-  border-color: rgba(61, 154, 106, 0.4);
+  background: linear-gradient(180deg, rgba(61, 154, 106, 0.32), rgba(61, 154, 106, 0.12));
+  border-color: rgba(61, 154, 106, 0.45);
 }
 
 .act-btn--bet,
 .act-btn--raise,
 .act-btn--accent,
 .act-btn--allin {
-  background: linear-gradient(145deg, rgba(201, 162, 39, 0.35), rgba(201, 162, 39, 0.15));
-  border-color: rgba(201, 162, 39, 0.55);
+  background: linear-gradient(180deg, rgba(212, 175, 55, 0.42), rgba(212, 175, 55, 0.14));
+  border-color: rgba(212, 175, 55, 0.58);
 }
 
 .dock {
@@ -754,31 +1241,34 @@ body {
 .dock-btn {
   min-height: var(--touch-target, 44px);
   padding: 0.45rem 0.85rem;
-  border-radius: 0.55rem;
+  border-radius: 0.6rem;
   border: 1px solid var(--glass-border);
   background: rgba(255, 255, 255, 0.05);
   color: inherit;
   font: inherit;
   font-size: 0.82rem;
   cursor: pointer;
-  transition: background 0.2s, border-color 0.2s;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  transition: background 0.2s, border-color 0.2s, transform 0.15s;
 }
 
 .dock-btn:hover,
 .dock-btn.is-active {
-  border-color: rgba(201, 162, 39, 0.45);
-  background: rgba(201, 162, 39, 0.12);
+  border-color: rgba(212, 175, 55, 0.45);
+  background: rgba(212, 175, 55, 0.14);
+  transform: translateY(-1px);
 }
 
 .dock-btn.accent {
-  background: linear-gradient(145deg, rgba(201, 162, 39, 0.4), rgba(201, 162, 39, 0.18));
-  border-color: rgba(201, 162, 39, 0.55);
+  background: linear-gradient(180deg, rgba(212, 175, 55, 0.45), rgba(212, 175, 55, 0.18));
+  border-color: rgba(212, 175, 55, 0.55);
   font-weight: 600;
 }
 
 .dock-btn:disabled {
   opacity: 0.4;
   cursor: not-allowed;
+  transform: none;
 }
 
 /* Overlays */
@@ -794,9 +1284,9 @@ body {
     max(1rem, var(--safe-bottom))
     max(1rem, var(--safe-left));
   background:
-    radial-gradient(ellipse at 50% 30%, rgba(15, 61, 40, 0.55), transparent 55%),
-    rgba(4, 8, 6, 0.82);
-  backdrop-filter: blur(8px);
+    radial-gradient(ellipse at 50% 28%, rgba(15, 61, 40, 0.5), transparent 55%),
+    rgba(3, 6, 5, 0.86);
+  backdrop-filter: blur(10px);
 }
 
 .overlay[hidden] {
@@ -804,16 +1294,69 @@ body {
 }
 
 .overlay-card {
+  position: relative;
   width: min(420px, 100%);
   max-height: min(92dvh, 640px);
   overflow-y: auto;
   padding: 1.5rem 1.35rem 1.35rem;
-  border-radius: 1rem;
+  border-radius: 1.1rem;
   background:
-    linear-gradient(160deg, rgba(20, 36, 26, 0.95), rgba(10, 18, 14, 0.98));
+    linear-gradient(160deg, rgba(22, 40, 30, 0.96), rgba(8, 14, 11, 0.98));
   border: 1px solid var(--glass-border);
-  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.5);
-  animation: fadeUp 0.5s ease;
+  box-shadow:
+    0 28px 70px rgba(0, 0, 0, 0.55),
+    inset 0 1px 0 rgba(255, 255, 255, 0.06);
+  animation: fadeUp 0.5s var(--ease-out);
+}
+
+.intro-fan {
+  position: relative;
+  height: 3.2rem;
+  margin-bottom: 0.5rem;
+}
+
+.fan-card {
+  position: absolute;
+  left: 50%;
+  top: 0;
+  width: 2.4rem;
+  height: 3.3rem;
+  border-radius: 0.35rem;
+  background:
+    linear-gradient(145deg, rgba(255, 255, 255, 0.1), transparent 40%),
+    repeating-linear-gradient(45deg, #14304c 0 3px, #0e2438 3px 6px);
+  border: 1.5px solid rgba(212, 175, 55, 0.45);
+  box-shadow: 0 6px 14px rgba(0, 0, 0, 0.4);
+  transform-origin: 50% 100%;
+  animation: fanIn 0.7s var(--ease-spring) both;
+}
+
+.fan-card--a {
+  --fan-rot: -18deg;
+  transform: translateX(-50%) rotate(var(--fan-rot));
+  animation-delay: 0.05s;
+}
+.fan-card--b {
+  --fan-rot: 0deg;
+  transform: translateX(-50%) rotate(var(--fan-rot));
+  animation-delay: 0.12s;
+  z-index: 1;
+}
+.fan-card--c {
+  --fan-rot: 18deg;
+  transform: translateX(-50%) rotate(var(--fan-rot));
+  animation-delay: 0.2s;
+}
+
+@keyframes fanIn {
+  from {
+    opacity: 0;
+    transform: translateX(-50%) rotate(0deg) translateY(12px) scale(0.9);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(-50%) rotate(var(--fan-rot, 0deg)) translateY(0) scale(1);
+  }
 }
 
 .overlay-card h1,
@@ -887,7 +1430,6 @@ body {
   color: var(--gold-soft);
 }
 
-/* Shared header tweaks inside shell */
 .poker-shell .lab-header,
 .poker-shell header[data-lab-header] {
   width: 100%;
@@ -901,16 +1443,33 @@ body {
   }
 
   .table-stage {
-    min-height: min(46dvh, 360px);
-    padding: 0.65rem 0.5rem 0.85rem;
-    border-radius: 1rem;
+    min-height: min(48dvh, 380px);
+    padding: 0.35rem 0.2rem 0.55rem;
+    border-radius: 1.1rem;
   }
 
-  .felt-rail {
-    box-shadow:
-      inset 0 0 0 10px var(--rail),
-      inset 0 0 0 12px var(--rail-hi),
-      inset 0 0 20px rgba(0, 0, 0, 0.5);
+  .table-scene {
+    min-height: min(44dvh, 340px);
+    padding: 0.65rem 0.55rem 0.9rem;
+    transform: rotateX(5deg) scale(0.99);
+  }
+
+  .felt,
+  .table-body {
+    border-radius: 42% / 38%;
+  }
+
+  .rail {
+    border-radius: inherit;
+  }
+
+  .deck-pile {
+    display: none;
+  }
+
+  .avatar {
+    width: 2.1rem;
+    height: 2.1rem;
   }
 
   .hud {
@@ -941,11 +1500,16 @@ body {
 
 @media (max-height: 520px) and (orientation: landscape) {
   .table-stage {
-    min-height: min(58dvh, 280px);
+    min-height: min(60dvh, 290px);
+  }
+
+  .table-scene {
+    min-height: min(56dvh, 260px);
     grid-template-columns: 1fr 1.4fr 1fr;
     grid-template-rows: auto;
     align-items: center;
     padding: 0.4rem 0.5rem;
+    transform: rotateX(3deg);
   }
 
   .table-hud {
@@ -958,6 +1522,15 @@ body {
   .seat--ai { grid-column: 1; }
   .board-wrap { grid-column: 2; }
   .seat--hero { grid-column: 3; }
+
+  .avatar {
+    width: 1.8rem;
+    height: 1.8rem;
+  }
+
+  .deck-pile {
+    display: none;
+  }
 
   .hud {
     grid-template-columns: 1fr 1fr;
@@ -982,6 +1555,11 @@ body {
   .size-chip {
     min-height: 44px;
   }
+
+  .seat--hero .hole-cards .card:hover .card-inner,
+  .board .card:hover .card-inner {
+    transform: none;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -990,5 +1568,9 @@ body {
   *::after {
     animation-duration: 0.01ms !important;
     transition-duration: 0.01ms !important;
+  }
+
+  .table-scene {
+    transform: none;
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 🎯 Objetivo

Elevar o lab Poker a uma mesa heads-up hiper-realista em CSS 3D, com texturas, movimento de cartas/fichas e UI renovada — sem libs externas.

## ✨ O que mudou

- Mesa em perspectiva com feltro (noise SVG), rail de madeira, spots e pó ambient
- Cartas com faces duplas, flip 3D no showdown, deal em arco e tilt
- Pilhas de fichas por denominação + animação de voo até o pote
- Avatares, baralho, HUD glass e overlay de intro com leque de cartas
- Parallax leve da mesa no desktop; media queries mobile/landscape mantidas
- Descrições na galeria e README alinhadas ao visual 3D

## 🧪 Como testar

1. Na raiz do repo: `python3 -m http.server 8000`
2. Abrir [http://localhost:8000/labs/poker/](http://localhost:8000/labs/poker/)
3. Sentar à mesa, jogar uma mão (fold/call/raise) e ver fichas voando + flip da IA no showdown
4. Responsivo: DevTools em **375×667**, **390×844** e landscape curto (~667×375)
5. Conferir galeria `/labs/` e link do README

## ✅ Checklist

- [x] Links conferidos: pasta do lab ↔ card da galeria ↔ README ↔ sitemap
- [x] README atualizado (descrição do Poker)
- [x] SEO consistente (title, description, canonical, OG, JSON-LD)
- [ ] Testado via HTTP na raiz
- [ ] Responsivo: 375px / 390px / landscape
- [x] Nada fora do escopo foi quebrado

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a077f4-df98-7ef3-b7e8-679eb3cc21f6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a077f4-df98-7ef3-b7e8-679eb3cc21f6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

