### PR TITLE
🎨 Poker — polimento 3D, texturas e faces das cartas

### DIFF
--- a/labs/poker/src/cards.js
+++ b/labs/poker/src/cards.js
@@ -35,42 +35,60 @@ function centerPip(rank, sym) {
     return `<div class="pip-grid" aria-hidden="true">${rows}</div>`;
 }
 
-export function cardElement(cardId, { faceDown = false, dealDelay = 0, flip = false } = {}) {
-    const el = document.createElement('div');
-    el.className = `card${faceDown ? ' is-back' : ''}`;
-    el.style.setProperty('--deal-delay', `${dealDelay}ms`);
-    el.style.setProperty('--deal-x', `${40 + Math.random() * 30}px`);
-    el.style.setProperty('--deal-y', `${-50 - Math.random() * 40}px`);
-    el.style.setProperty('--deal-rot', `${-22 + Math.random() * 18}deg`);
-    el.dataset.card = cardId || '';
-
-    let frontHtml = '';
-    if (cardId && cardId !== '?') {
-        const { rank, suit } = parseCard(cardId);
-        const color = SUIT_COLOR[suit];
-        const sym = SUIT_SYMBOL[suit];
-        const label = RANK_LABEL[rank];
-        el.classList.add(color === 'red' ? 'is-red' : 'is-black');
-        el.setAttribute('aria-label', faceDown ? 'Carta fechada' : `${label} de ${suitName(suit)}`);
-        frontHtml = `
+function frontMarkup(cardId) {
+    const { rank, suit } = parseCard(cardId);
+    const sym = SUIT_SYMBOL[suit];
+    const label = RANK_LABEL[rank];
+    return `
       <div class="card-face card-front">
         <span class="corner tl"><b>${label}</b><i>${sym}</i></span>
         ${centerPip(rank, sym)}
         <span class="corner br"><b>${label}</b><i>${sym}</i></span>
       </div>`;
+}
+
+function backMarkup() {
+    return `<div class="card-face card-back" aria-hidden="true"><i></i></div>`;
+}
+
+export function cardElement(cardId, { faceDown = false, dealDelay = 0, flip = false } = {}) {
+    const el = document.createElement('div');
+    el.className = 'card';
+    el.style.setProperty('--deal-delay', `${dealDelay}ms`);
+    el.style.setProperty('--deal-x', `${36 + Math.random() * 28}px`);
+    el.style.setProperty('--deal-y', `${-48 - Math.random() * 36}px`);
+    el.style.setProperty('--deal-rot', `${-20 + Math.random() * 16}deg`);
+    el.dataset.card = cardId || '';
+
+    const valid = cardId && cardId !== '?' && cardId.length >= 2;
+
+    if (valid) {
+        const { suit } = parseCard(cardId);
+        el.classList.add(SUIT_COLOR[suit] === 'red' ? 'is-red' : 'is-black');
+        const { rank } = parseCard(cardId);
+        el.setAttribute(
+            'aria-label',
+            faceDown && !flip ? 'Carta fechada' : `${RANK_LABEL[rank]} de ${suitName(suit)}`
+        );
     } else {
         el.setAttribute('aria-label', 'Carta fechada');
-        frontHtml = `<div class="card-face card-front"></div>`;
     }
 
-    el.innerHTML = `
-    <div class="card-inner">
-      ${frontHtml}
-      <div class="card-face card-back" aria-hidden="true"><i></i></div>
-    </div>`;
+    // Flip: ambas as faces. Face-up: só frente. Face-down: só verso.
+    let inner;
+    if (flip && valid) {
+        el.classList.add('is-back', 'is-flipping', 'has-flip');
+        inner = `${frontMarkup(cardId)}${backMarkup()}`;
+    } else if (faceDown || !valid) {
+        el.classList.add('is-back');
+        inner = backMarkup();
+    } else {
+        inner = frontMarkup(cardId);
+    }
 
-    if (flip && !faceDown) {
-        el.classList.add('is-back', 'is-flipping');
+    el.innerHTML = `<div class="card-inner">${inner}</div>`;
+
+    if (flip && valid) {
         requestAnimationFrame(() => {
             requestAnimationFrame(() => {
                 el.classList.remove('is-back');
@@ -93,7 +111,8 @@ export function renderCards(container, ids, opts = {}) {
             cardElement(id, {
                 ...opts,
                 dealDelay: (opts.baseDelay || 0) + i * 80,
-                faceDown: opts.faceDown || id === '?'
+                faceDown: opts.faceDown || id === '?',
+                flip: false
             })
         );
     });

--- a/labs/poker/src/main.js
+++ b/labs/poker/src/main.js
@@ -133,7 +133,7 @@ function bindUi() {
             const y = ((e.clientY - r.top) / r.height - 0.5) * 4;
             const scene = $('.table-scene');
             if (scene) {
-                scene.style.transform = `rotateX(${14 - y}deg) rotateY(${x}deg) scale(0.97)`;
+                scene.style.transform = `rotateX(${18 - y}deg) rotateY(${x}deg) scale(0.96)`;
             }
         });
         stage.addEventListener('pointerleave', () => {

--- a/labs/poker/src/main.js
+++ b/labs/poker/src/main.js
@@ -129,11 +129,11 @@ function bindUi() {
         stage.addEventListener('pointermove', (e) => {
             if (matchMedia('(prefers-reduced-motion: reduce)').matches) return;
             const r = stage.getBoundingClientRect();
-            const x = ((e.clientX - r.left) / r.width - 0.5) * 4;
-            const y = ((e.clientY - r.top) / r.height - 0.5) * 3;
+            const x = ((e.clientX - r.left) / r.width - 0.5) * 6;
+            const y = ((e.clientY - r.top) / r.height - 0.5) * 4;
             const scene = $('.table-scene');
             if (scene) {
-                scene.style.transform = `rotateX(${8 - y}deg) rotateY(${x}deg) scale(0.985)`;
+                scene.style.transform = `rotateX(${14 - y}deg) rotateY(${x}deg) scale(0.97)`;
             }
         });
         stage.addEventListener('pointerleave', () => {

--- a/labs/poker/style.css
+++ b/labs/poker/style.css
@@ -170,8 +170,9 @@ body {
   min-height: min(50dvh, 420px);
   padding: 0.85rem 0.9rem 1.1rem;
   transform-style: preserve-3d;
-  transform: rotateX(8deg) scale(0.985);
-  transform-origin: 50% 60%;
+  transform: rotateX(14deg) scale(0.97);
+  transform-origin: 50% 58%;
+  transition: transform 0.35s var(--ease-out);
 }
 
 .table-cast {
@@ -200,30 +201,33 @@ body {
   inset: 0;
   border-radius: inherit;
   background:
-    radial-gradient(ellipse 70% 55% at 50% 40%, var(--rail-mid), var(--rail) 70%);
+    radial-gradient(ellipse 70% 55% at 50% 40%, var(--rail-mid), var(--rail) 70%),
+    linear-gradient(180deg, var(--rail-hi), var(--rail));
   box-shadow:
-    0 18px 40px rgba(0, 0, 0, 0.55),
-    inset 0 1px 0 rgba(196, 154, 108, 0.25),
-    inset 0 -8px 20px rgba(0, 0, 0, 0.45);
+    0 22px 48px rgba(0, 0, 0, 0.6),
+    0 8px 16px rgba(0, 0, 0, 0.4),
+    inset 0 2px 0 rgba(220, 180, 130, 0.28),
+    inset 0 -10px 24px rgba(0, 0, 0, 0.5),
+    inset 0 0 0 1px rgba(0, 0, 0, 0.35);
   overflow: hidden;
 }
 
 .rail-grain {
   position: absolute;
   inset: 0;
-  opacity: 0.4;
+  opacity: 0.55;
   background:
     repeating-linear-gradient(
       92deg,
       transparent 0 3px,
-      rgba(0, 0, 0, 0.08) 3px 4px,
+      rgba(0, 0, 0, 0.1) 3px 4px,
       transparent 4px 9px,
-      rgba(255, 220, 180, 0.04) 9px 10px
+      rgba(255, 220, 180, 0.06) 9px 10px
     ),
     repeating-linear-gradient(
       0deg,
       transparent 0 14px,
-      rgba(0, 0, 0, 0.06) 14px 15px
+      rgba(0, 0, 0, 0.08) 14px 15px
     );
   mix-blend-mode: multiply;
 }
@@ -268,9 +272,9 @@ body {
 .felt-nap {
   position: absolute;
   inset: 0;
-  opacity: 0.55;
+  opacity: 0.72;
   background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3CfeColorMatrix values='0 0 0 0 0.05 0 0 0 0 0.25 0 0 0 0 0.12 0 0 0 0.55 0'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
-  background-size: 180px 180px;
+  background-size: 140px 140px;
   mix-blend-mode: soft-light;
   pointer-events: none;
 }
@@ -278,10 +282,10 @@ body {
 .felt-weave {
   position: absolute;
   inset: 0;
-  opacity: 0.18;
+  opacity: 0.28;
   background:
-    repeating-linear-gradient(0deg, transparent 0 2px, rgba(0, 0, 0, 0.15) 2px 3px),
-    repeating-linear-gradient(90deg, transparent 0 2px, rgba(255, 255, 255, 0.04) 2px 3px);
+    repeating-linear-gradient(0deg, transparent 0 2px, rgba(0, 0, 0, 0.18) 2px 3px),
+    repeating-linear-gradient(90deg, transparent 0 2px, rgba(255, 255, 255, 0.05) 2px 3px);
   pointer-events: none;
 }
 
@@ -628,8 +632,11 @@ body {
   transition: transform 0.55s var(--ease-out);
   transform: rotateY(0deg) rotateZ(var(--tilt));
   box-shadow:
-    0 8px 18px rgba(0, 0, 0, 0.45),
-    0 2px 4px rgba(0, 0, 0, 0.25);
+    0 10px 22px rgba(0, 0, 0, 0.5),
+    0 3px 6px rgba(0, 0, 0, 0.3),
+    1px 0 0 rgba(0, 0, 0, 0.15),
+    2px 1px 0 rgba(40, 30, 20, 0.35),
+    3px 2px 0 rgba(30, 22, 14, 0.25);
 }
 
 .card.is-back .card-inner {
@@ -832,22 +839,23 @@ body {
   display: flex;
   flex-direction: column-reverse;
   align-items: center;
-  height: calc(var(--chip) * 0.55);
+  height: calc(var(--chip) * 0.85);
   min-width: var(--chip);
   position: relative;
+  filter: drop-shadow(0 4px 6px rgba(0, 0, 0, 0.45));
 }
 
 .chip-stack--pot {
-  height: calc(var(--chip) * 0.9);
-  margin-bottom: 0.1rem;
+  height: calc(var(--chip) * 1.25);
+  margin-bottom: 0.15rem;
 }
 
 .chip {
   width: var(--chip);
-  height: calc(var(--chip) * 0.28);
+  height: calc(var(--chip) * 0.32);
   border-radius: 50%;
   position: relative;
-  margin-top: calc(var(--chip) * -0.18);
+  margin-top: calc(var(--chip) * -0.16);
   box-shadow:
     0 2px 3px rgba(0, 0, 0, 0.45),
     inset 0 1px 0 rgba(255, 255, 255, 0.35),
@@ -1451,7 +1459,7 @@ body {
   .table-scene {
     min-height: min(44dvh, 340px);
     padding: 0.65rem 0.55rem 0.9rem;
-    transform: rotateX(5deg) scale(0.99);
+    transform: rotateX(8deg) scale(0.98);
   }
 
   .felt,
@@ -1509,7 +1517,7 @@ body {
     grid-template-rows: auto;
     align-items: center;
     padding: 0.4rem 0.5rem;
-    transform: rotateX(3deg);
+    transform: rotateX(5deg);
   }
 
   .table-hud {

--- a/labs/poker/style.css
+++ b/labs/poker/style.css
@@ -90,7 +90,8 @@ body {
   padding: 0.5rem 0.35rem 0.75rem;
   border-radius: 1.35rem;
   overflow: hidden;
-  perspective: 1400px;
+  perspective: 1100px;
+  perspective-origin: 50% 45%;
 }
 
 .room {
@@ -170,8 +171,8 @@ body {
   min-height: min(50dvh, 420px);
   padding: 0.85rem 0.9rem 1.1rem;
   transform-style: preserve-3d;
-  transform: rotateX(14deg) scale(0.97);
-  transform-origin: 50% 58%;
+  transform: rotateX(18deg) scale(0.96);
+  transform-origin: 50% 55%;
   transition: transform 0.35s var(--ease-out);
 }
 
@@ -630,17 +631,13 @@ body {
   border-radius: inherit;
   transform-style: preserve-3d;
   transition: transform 0.55s var(--ease-out);
-  transform: rotateY(0deg) rotateZ(var(--tilt));
+  transform: rotateZ(var(--tilt));
   box-shadow:
     0 10px 22px rgba(0, 0, 0, 0.5),
     0 3px 6px rgba(0, 0, 0, 0.3),
     1px 0 0 rgba(0, 0, 0, 0.15),
     2px 1px 0 rgba(40, 30, 20, 0.35),
     3px 2px 0 rgba(30, 22, 14, 0.25);
-}
-
-.card.is-back .card-inner {
-  transform: rotateY(180deg) rotateZ(var(--tilt));
 }
 
 .card.is-flipping .card-inner {
@@ -656,16 +653,12 @@ body {
 .hole-cards .card:nth-child(1) { --tilt: -4deg; }
 .hole-cards .card:nth-child(2) { --tilt: 4deg; }
 
-.seat--hero .hole-cards .card:hover .card-inner,
+.seat--hero .hole-cards .card:not(.is-back):hover .card-inner,
 .board .card:hover .card-inner {
-  transform: translateY(-6px) rotateY(0deg) rotateZ(var(--tilt)) scale(1.04);
+  transform: translateY(-6px) rotateZ(var(--tilt)) scale(1.04);
   box-shadow:
     0 14px 28px rgba(0, 0, 0, 0.5),
     0 2px 4px rgba(0, 0, 0, 0.25);
-}
-
-.seat--hero .hole-cards .card.is-back:hover .card-inner {
-  transform: translateY(-6px) rotateY(180deg) rotateZ(var(--tilt)) scale(1.04);
 }
 
 .card-slot {
@@ -701,6 +694,22 @@ body {
   -webkit-backface-visibility: hidden;
 }
 
+/* Carta só com frente (sem flip): face em fluxo normal */
+.card:not(.has-flip) .card-front {
+  position: absolute;
+  transform: none;
+  backface-visibility: visible;
+}
+
+.card:not(.has-flip) .card-back {
+  position: absolute;
+  transform: none;
+}
+
+.card:not(.has-flip).is-back .card-inner {
+  transform: rotateZ(var(--tilt));
+}
+
 .card-front {
   background:
     linear-gradient(145deg, rgba(255, 255, 255, 0.55) 0%, transparent 42%),
@@ -710,7 +719,7 @@ body {
   grid-template-rows: auto 1fr auto;
   padding: 0.26em 0.3em;
   font-family: 'Cormorant Garamond', Georgia, serif;
-  transform: rotateY(0deg);
+  transform: rotateY(0deg) translateZ(1px);
   border: 1px solid rgba(0, 0, 0, 0.08);
 }
 
@@ -790,7 +799,15 @@ body {
     linear-gradient(135deg, rgba(255, 255, 255, 0.12), transparent 38%),
     radial-gradient(circle at 50% 50%, #1a4568, #0c2438 70%);
   border: 2px solid rgba(212, 175, 55, 0.45);
-  transform: rotateY(180deg);
+  transform: rotateY(180deg) translateZ(1px);
+}
+
+.card.has-flip.is-back .card-inner {
+  transform: rotateY(180deg) rotateZ(var(--tilt));
+}
+
+.card.has-flip:not(.is-back) .card-inner {
+  transform: rotateY(0deg) rotateZ(var(--tilt));
 }
 
 .card-back i {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 🎯 Objetivo

Polir a mesa hiper-realista do Poker após o merge do #188: perspectiva mais forte, feltro/rail mais presentes e correção das faces das cartas.

## ✨ O que mudou

- Perspectiva da mesa ~18° e `perspective` mais curta (efeito 3D mais legível)
- Feltro com nap/weave mais visíveis; rail com bevel e sombra
- Cartas face-up renderizam só a frente (evita verso fantasma); flip 3D só no showdown
- Pilhas de fichas um pouco mais altas; parallax alinhado ao novo ângulo

## 🧪 Como testar

1. `python3 -m http.server 8000` na raiz
2. Abrir [http://localhost:8000/labs/poker/](http://localhost:8000/labs/poker/)
3. Sentar à mesa: ambas as hole cards do herói visíveis; mesa com inclinação perceptível
4. Jogar até showdown e ver flip das cartas da IA
5. Responsivo: 375×667, 390×844 e landscape curto

## ✅ Checklist

- [x] Links conferidos (sem mudança de slug)
- [x] README/SEO já ok no #188
- [x] Testado via HTTP (sem overflow em 375px)
- [x] Responsivo ok
- [x] Nada fora do escopo

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a077f4-df98-7ef3-b7e8-679eb3cc21f6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a077f4-df98-7ef3-b7e8-679eb3cc21f6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

