### PR TITLE
⚡️ Labs — UI, performance, jogabilidade e responsivo (56 experimentos)

### DIFF
--- a/labs/aurora-flow/script.js
+++ b/labs/aurora-flow/script.js
@@ -43,7 +43,7 @@ let turbulence = 0.0038;
 let interactionMode = 'attract';
 let interactionForce = 3.5;
 let particleSize = 1.35;
-let trailLength = 0.93;
+let trailLength = 0.965;
 let blendMode = 'lighter';
 let auroraIntensity = 80;
 let auroraAltitude = 0.7;
@@ -67,7 +67,7 @@ let ripples = [];
 let wakes = [];
 let iceSpark = [];
 
-const TRAIL = isMobile ? 4 : 8;
+const TRAIL = isMobile ? 6 : 12;
 
 const scenes = {
     boreal: {
@@ -462,7 +462,7 @@ class Particle {
         this.size = (Math.random() * 1.2 + 0.55) * particleSize;
         this.life = Math.random() * 240 + 80;
         this.maxLife = this.life;
-        this.glow = !isMobile && Math.random() < 0.08;
+        this.glow = !isMobile && Math.random() < 0.14;
         this.ti = 0;
         this.tn = 0;
         for (let i = 0; i < this.trail.length; i += 2) {
@@ -716,8 +716,8 @@ function drawAurora() {
     const hzn = horizonY();
     const skyH = Math.max(90, hzn);
     const short = height < 520;
-    const sheets = short || isMobile ? Math.min(current.sheets, 3) : current.sheets;
-    const step = short ? 6 : isMobile ? 4 : 2;
+    const sheets = short || isMobile ? Math.min(current.sheets, 4) : current.sheets;
+    const step = short ? 4 : isMobile ? 3 : 1.5;
 
     curtainT += 0.002 * flowSpeed;
     kpBreath = 0.82 + Math.sin(curtainT * 1.3) * 0.18;
@@ -732,19 +732,20 @@ function drawAurora() {
         const botC = current.colors[s % current.colors.length];
         const grad = skyCtx.createLinearGradient(0, 0, 0, hzn);
         grad.addColorStop(0, hexAlpha(topC, 0.92));
-        grad.addColorStop(0.35, hexAlpha(current.colors[1], 0.7));
-        grad.addColorStop(0.78, hexAlpha(botC, 0.38));
+        grad.addColorStop(0.28, hexAlpha(current.colors[1], 0.78));
+        grad.addColorStop(0.62, hexAlpha(botC, 0.42));
+        grad.addColorStop(0.88, hexAlpha(botC, 0.12));
         grad.addColorStop(1, hexAlpha(botC, 0));
         skyCtx.strokeStyle = grad;
-        skyCtx.lineWidth = (isMobile ? 2.2 : 3.1) + s * 0.35;
-        skyCtx.globalAlpha = intensity * (0.9 - s * 0.14) * kpBreath;
+        skyCtx.lineWidth = (isMobile ? 2.4 : 3.4) + s * 0.4;
+        skyCtx.globalAlpha = intensity * (0.92 - s * 0.12) * kpBreath;
         skyCtx.beginPath();
 
         for (let x = 0; x < width; x += step) {
             const env = fbm(x * 0.0016 + phase, curtainT * 0.5 + s, s * 0.4);
             const fold = Math.pow(clamp(Math.sin(x * 0.007 + curtainT + phase) * 0.5 + 0.5, 0, 1), 1.6);
             const envelope = Math.pow(clamp(env * 0.5 + 0.5, 0, 1), 1.25) * (0.28 + fold * 0.85);
-            if (envelope < 0.16) continue;
+            if (envelope < 0.14) continue;
             const flicker = 0.62 + noise3D(x * 0.02, curtainT * 1.6, s) * 0.38;
             const h = envelope * skyH * auroraAltitude * (0.55 + s * 0.1) * flicker;
             const wobble = noise3D(x * 0.028, curtainT * 0.8, s + 2) * 14;
@@ -802,16 +803,22 @@ function drawParticles() {
 
     for (const [color, group] of groups) {
         skyCtx.strokeStyle = color;
-        skyCtx.globalAlpha = 0.48;
+        skyCtx.globalAlpha = 0.22;
+        skyCtx.lineWidth = particleSize * 2.4;
+        skyCtx.beginPath();
+        for (const p of group) p.trace(skyCtx);
+        skyCtx.stroke();
+        skyCtx.globalAlpha = 0.58;
+        skyCtx.lineWidth = particleSize;
         skyCtx.beginPath();
         for (const p of group) p.trace(skyCtx);
         skyCtx.stroke();
     }
 
-    skyCtx.globalAlpha = 0.55;
+    skyCtx.globalAlpha = 0.62;
     for (const p of particles) {
         if (!p.glow) continue;
-        const r = p.size * 4.2;
+        const r = p.size * 5.2;
         const g = skyCtx.createRadialGradient(p.x, p.y, 0, p.x, p.y, r);
         g.addColorStop(0, p.color);
         g.addColorStop(1, 'transparent');

--- a/labs/beige-box/index.html
+++ b/labs/beige-box/index.html
@@ -34,7 +34,7 @@
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=Outfit:wght@300;400;500;600;700&display=swap"
         rel="stylesheet">
     <link rel="stylesheet" href="/labs/shared.css?v=13">
-    <link rel="stylesheet" href="style.css?v=1">
+    <link rel="stylesheet" href="style.css?v=2">
 
     <script type="importmap">
     {
@@ -147,7 +147,7 @@
     </main>
 
     <script src="/labs/shared.js?v=13" defer></script>
-    <script type="module" src="src/main.js?v=3"></script>
+    <script type="module" src="src/main.js?v=4"></script>
 </body>
 
 </html>

--- a/labs/beige-box/src/main.js
+++ b/labs/beige-box/src/main.js
@@ -24,18 +24,22 @@ function detectQuality() {
     const mobile = isMobile();
     const soft = (() => {
         try {
-            const gl = document.createElement('canvas').getContext('webgl2');
+            const gl = document.createElement('canvas').getContext('webgl2')
+                || document.createElement('canvas').getContext('webgl');
             const info = gl && gl.getExtension('WEBGL_debug_renderer_info');
             const r = info ? gl.getParameter(info.UNMASKED_RENDERER_WEBGL) : '';
-            return /SwiftShader|llvmpipe|Soft/i.test(r);
+            return /SwiftShader|llvmpipe|Soft|microsoft basic render|\bcpu\b/i.test(r);
         } catch {
             return false;
         }
     })();
-    if (mobile || soft) {
-        return { pixelRatio: Math.min(window.devicePixelRatio || 1, 1.25), shadow: 1024, bloom: false, aniso: 4, dust: 70 };
+    if (soft) {
+        return { pixelRatio: 1, shadow: 0, bloom: false, aniso: 1, dust: 40, antialias: false, shadows: false };
     }
-    return { pixelRatio: Math.min(window.devicePixelRatio || 1, 2), shadow: 2048, bloom: true, aniso: 8, dust: 240 };
+    if (mobile) {
+        return { pixelRatio: Math.min(window.devicePixelRatio || 1, 1.25), shadow: 512, bloom: false, aniso: 2, dust: 70, antialias: false, shadows: true };
+    }
+    return { pixelRatio: Math.min(window.devicePixelRatio || 1, 2), shadow: 2048, bloom: true, aniso: 8, dust: 240, antialias: true, shadows: true };
 }
 
 class BeigeBox {
@@ -91,8 +95,8 @@ class BeigeBox {
         try {
             this.renderer = new THREE.WebGLRenderer({
                 canvas: this.canvas,
-                antialias: !isMobile(),
-                powerPreference: 'high-performance',
+                antialias: !!quality.antialias,
+                powerPreference: quality.antialias ? 'high-performance' : 'low-power',
                 stencil: false
             });
         } catch {
@@ -104,7 +108,7 @@ class BeigeBox {
         this.renderer.setSize(window.innerWidth, window.innerHeight, false);
         this.renderer.toneMapping = THREE.ACESFilmicToneMapping;
         this.renderer.toneMappingExposure = 1.05;
-        this.renderer.shadowMap.enabled = true;
+        this.renderer.shadowMap.enabled = quality.shadows !== false && quality.shadow > 0;
         this.renderer.shadowMap.type = THREE.PCFSoftShadowMap;
         this.renderer.outputColorSpace = THREE.SRGBColorSpace;
 

--- a/labs/beige-box/style.css
+++ b/labs/beige-box/style.css
@@ -450,3 +450,8 @@ button {
     .hud-left { max-width: 14rem; }
     .hint-bar { display: none; }
 }
+
+/* agent-responsive-768 */
+@media (max-width: 768px) {
+  html, body { overflow-x: clip; }
+}

--- a/labs/calculator/index.html
+++ b/labs/calculator/index.html
@@ -25,7 +25,7 @@
     <meta name="twitter:title" content="Calculator — cálculo científico e câmbio ao vivo | Diogo Paulino">
     <meta name="twitter:description" content="Calculadora online com modos simples, científico e conversor de moedas em tempo real.">
     <link rel="stylesheet" href="/labs/shared.css?v=13">
-    <link rel="stylesheet" href="style.css?v=6">
+    <link rel="stylesheet" href="style.css?v=7">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;500;700&display=swap" rel="stylesheet">

--- a/labs/calculator/style.css
+++ b/labs/calculator/style.css
@@ -140,10 +140,11 @@ body {
     border-radius: 20px;
     padding: 20px 0;
     cursor: pointer;
-    transition: all 0.2s ease;
+    transition: transform 0.12s ease, box-shadow 0.18s ease, background 0.18s ease, border-color 0.18s ease, filter 0.12s ease;
     box-shadow: 0 4px 6px var(--shadow-sm);
     user-select: none;
     border: 1px solid var(--border-subtle);
+    -webkit-tap-highlight-color: transparent;
 }
 
 .btn:hover {
@@ -154,7 +155,9 @@ body {
 }
 
 .btn:active {
-    transform: translateY(0);
+    transform: translateY(1px) scale(0.94);
+    box-shadow: inset 0 3px 10px rgba(0, 0, 0, 0.22), 0 1px 2px var(--shadow-sm);
+    filter: brightness(0.92);
 }
 
 .btn.function {

--- a/labs/castelo-estelar/index.html
+++ b/labs/castelo-estelar/index.html
@@ -35,7 +35,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;600;700&family=Outfit:wght@300;400;500;600;700&display=swap"
         rel="stylesheet">
     <link rel="stylesheet" href="/labs/shared.css?v=13">
-    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="style.css?v=2">
 
     <script type="importmap">
     {
@@ -205,7 +205,7 @@
             }
         })();
     </script>
-    <script type="module" src="src/main.js"></script>
+    <script type="module" src="src/main.js?v=2"></script>
 </body>
 
 </html>

--- a/labs/castelo-estelar/src/main.js
+++ b/labs/castelo-estelar/src/main.js
@@ -35,8 +35,9 @@ const QUALITY = {
 };
 
 function pickQuality(mode, renderer) {
+    if (detectSoftwareGL(renderer)) return QUALITY.low;
     if (QUALITY[mode]) return QUALITY[mode];
-    if (detectSoftwareGL(renderer) || detectMobile()) return QUALITY.medium; // Use medium as default for mobile to preserve sharpness
+    if (detectMobile()) return QUALITY.low;
     if (devicePixelRatio >= 2) return QUALITY.high;
     return QUALITY.medium;
 }
@@ -101,9 +102,11 @@ class CasteloEstelar {
 
     boot() {
         try {
+            // Qualidade ainda não resolvida: assume low até o SoftGL probe no renderer.
+            const softProbe = detectSoftwareGL();
             this.renderer = new THREE.WebGLRenderer({
                 canvas: this.canvas,
-                antialias: true,
+                antialias: !softProbe,
                 alpha: false,
                 powerPreference: 'high-performance'
             });

--- a/labs/castelo-estelar/style.css
+++ b/labs/castelo-estelar/style.css
@@ -512,6 +512,40 @@ body[data-state="intro"] .hint {
     }
 }
 
+@media (max-height: 520px) and (orientation: landscape) {
+    .hint {
+        bottom: calc(4.2rem + var(--safe-bottom));
+        font-size: 0.68rem;
+        max-width: min(420px, 70vw);
+    }
+
+    .dock {
+        bottom: calc(0.45rem + var(--safe-bottom));
+        gap: 0.3rem;
+        padding: 0.35rem;
+    }
+
+    .dock-btn {
+        padding: 0.4rem 0.7rem;
+        min-height: 36px;
+        font-size: 0.72rem;
+    }
+
+    .title-card {
+        bottom: calc(5.2rem + var(--safe-bottom));
+    }
+
+    .overlay {
+        padding: calc(3rem + var(--safe-top)) 0.85rem calc(0.75rem + var(--safe-bottom));
+    }
+
+    .overlay-card {
+        max-height: min(92dvh, 32rem);
+        overflow-y: auto;
+        padding: 0.9rem 1.1rem;
+    }
+}
+
 /* agent-responsive-768 */
 @media (max-width: 768px) {
   html, body { overflow-x: clip; }

--- a/labs/castelo-estelar/style.css
+++ b/labs/castelo-estelar/style.css
@@ -511,3 +511,11 @@ body[data-state="intro"] .hint {
         transform: none;
     }
 }
+
+/* agent-responsive-768 */
+@media (max-width: 768px) {
+  html, body { overflow-x: clip; }
+  .hud, .overlay, .menu-overlay, .overlay-card {
+    max-width: 100%;
+  }
+}

--- a/labs/claude-bros/index.html
+++ b/labs/claude-bros/index.html
@@ -66,7 +66,7 @@
   </script>
 
   <link rel="stylesheet" href="/labs/shared.css?v=13">
-  <link rel="stylesheet" href="style.css?v=3">
+  <link rel="stylesheet" href="style.css?v=4">
 </head>
 
 <body>
@@ -118,7 +118,7 @@
   </main>
 
   <script src="/labs/shared.js?v=13" defer></script>
-  <script src="main.js?v=3" defer></script>
+  <script src="main.js?v=4" defer></script>
 </body>
 
 </html>

--- a/labs/claude-bros/index.html
+++ b/labs/claude-bros/index.html
@@ -66,7 +66,7 @@
   </script>
 
   <link rel="stylesheet" href="/labs/shared.css?v=13">
-  <link rel="stylesheet" href="style.css?v=2">
+  <link rel="stylesheet" href="style.css?v=3">
 </head>
 
 <body>
@@ -118,7 +118,7 @@
   </main>
 
   <script src="/labs/shared.js?v=13" defer></script>
-  <script src="main.js?v=2" defer></script>
+  <script src="main.js?v=3" defer></script>
 </body>
 
 </html>

--- a/labs/claude-bros/main.js
+++ b/labs/claude-bros/main.js
@@ -1059,8 +1059,9 @@ function mountAudioToggle() {
 }
 mountAudioToggle();
 
-// Mostra os controles de toque só onde eles servem.
-if (touchLayer && !window.matchMedia('(pointer: fine)').matches) touchLayer.hidden = false;
+// Mostra os controles de toque só em ponteiro grosso (celular/tablet).
+// Em VMs/desktop sem `(pointer: fine)` o teste antigo `!fine` exibia pads à toa.
+if (touchLayer) touchLayer.hidden = !window.matchMedia('(pointer: coarse)').matches;
 
 resetGame();
 resize();

--- a/labs/claude-bros/main.js
+++ b/labs/claude-bros/main.js
@@ -1060,8 +1060,14 @@ function mountAudioToggle() {
 mountAudioToggle();
 
 // Mostra os controles de toque só em ponteiro grosso (celular/tablet).
-// Em VMs/desktop sem `(pointer: fine)` o teste antigo `!fine` exibia pads à toa.
-if (touchLayer) touchLayer.hidden = !window.matchMedia('(pointer: coarse)').matches;
+// Default CSS já esconde; isto sincroniza o atributo `hidden` e reage a mudanças.
+function syncTouchPads() {
+    if (!touchLayer) return;
+    const coarse = window.matchMedia('(pointer: coarse)').matches;
+    touchLayer.hidden = !coarse;
+}
+syncTouchPads();
+window.matchMedia('(pointer: coarse)').addEventListener?.('change', syncTouchPads);
 
 resetGame();
 resize();

--- a/labs/claude-bros/style.css
+++ b/labs/claude-bros/style.css
@@ -292,6 +292,12 @@ body {
 /* Com mouse/teclado os botões de toque só atrapalham a vista. */
 @media (pointer: fine) {
     .touch-controls {
-        display: none;
+        display: none !important;
+    }
+}
+
+@media (pointer: coarse) {
+    .touch-controls:not([hidden]) {
+        display: flex;
     }
 }

--- a/labs/claude-bros/style.css
+++ b/labs/claude-bros/style.css
@@ -185,7 +185,8 @@ body {
     left: 0;
     right: 0;
     bottom: 0;
-    display: flex;
+    /* Default oculto: só aparece com pointer:coarse (evita pads em VMs/desktop híbrido). */
+    display: none;
     align-items: flex-end;
     justify-content: space-between;
     gap: 1rem;
@@ -196,7 +197,7 @@ body {
 }
 
 .touch-controls[hidden] {
-    display: none;
+    display: none !important;
 }
 
 .touch-move {

--- a/labs/cupola-64/index.html
+++ b/labs/cupola-64/index.html
@@ -34,7 +34,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600;700;800&family=Press+Start+2P&display=swap"
         rel="stylesheet">
     <link rel="stylesheet" href="/labs/shared.css?v=13">
-    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="style.css?v=2">
 
     <script type="importmap">
     {
@@ -290,7 +290,7 @@
             }
         })();
     </script>
-    <script type="module" src="src/main.js"></script>
+    <script type="module" src="src/main.js?v=2"></script>
 </body>
 
 </html>

--- a/labs/cupola-64/src/main.js
+++ b/labs/cupola-64/src/main.js
@@ -49,9 +49,11 @@ class Game {
     }
 
     qualityPreset() {
+        // SoftGL/SwiftShader: sempre low, mesmo com preset salvo em "high".
+        if (detectSoftwareGL()) return QUALITY.low;
         let key = this.settings.quality;
         if (key === 'auto') {
-            key = (this.mobile || detectSoftwareGL()) ? 'low' : (innerWidth >= 1400 ? 'high' : 'medium');
+            key = this.mobile ? 'low' : (innerWidth >= 1400 ? 'high' : 'medium');
         }
         return QUALITY[key] || QUALITY.medium;
     }
@@ -79,6 +81,16 @@ class Game {
         h.qualitySelect.addEventListener('change', () => {
             this.settings.quality = h.qualitySelect.value;
             this.saveSettings();
+            this.quality = this.qualityPreset();
+            this.resize?.();
+            if (this.renderer) {
+                this.renderer.shadowMap.enabled = !!this.quality.shadows;
+                const pr = Math.min(window.devicePixelRatio || 1, this.quality.pixelRatio || 1);
+                this.renderer.setPixelRatio(pr);
+            }
+            for (const m of n64Materials) {
+                if (m.userData.n64) m.userData.snap = this.quality.snap;
+            }
         });
         h.volumeSlider.addEventListener('input', () => {
             this.settings.volume = Number(h.volumeSlider.value);
@@ -168,6 +180,7 @@ class Game {
     }
 
     start() {
+        if (this.state === 'boot' || !this.player || !this.world) return;
         this.audio.init();
         this.audio.setEnabled(!this.settings.muted);
         this.audio.setVolume(this.settings.volume / 100);
@@ -178,7 +191,8 @@ class Game {
         this.entities.reset();
         this.state = 'play';
         this.hud.showPlay();
-        this.hud.setTouchVisible(this.mobile);
+        const coarse = window.matchMedia('(pointer: coarse)').matches;
+        this.hud.setTouchVisible(coarse || this.mobile);
         this.hud.setStats({
             stars: 0,
             coins: 0,

--- a/labs/cupola-64/style.css
+++ b/labs/cupola-64/style.css
@@ -918,3 +918,11 @@ kbd {
         margin: 0.7rem 0 0.85rem;
     }
 }
+
+/* agent-responsive-768 */
+@media (max-width: 768px) {
+  html, body { overflow-x: clip; }
+  .hud, .overlay, .menu-overlay, .overlay-card {
+    max-width: 100%;
+  }
+}

--- a/labs/cyberos/index.html
+++ b/labs/cyberos/index.html
@@ -30,7 +30,7 @@
   <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=VT323&display=swap"
     rel="stylesheet">
   <link rel="stylesheet" href="/labs/shared.css?v=13">
-  <link rel="stylesheet" href="style.css?v=3">
+  <link rel="stylesheet" href="style.css?v=4">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",

--- a/labs/cyberos/style.css
+++ b/labs/cyberos/style.css
@@ -999,3 +999,8 @@ select {
     padding-block: 0.25rem;
   }
 }
+
+/* agent-responsive-768 */
+@media (max-width: 768px) {
+  html, body { overflow-x: clip; }
+}

--- a/labs/english-duo/style.css
+++ b/labs/english-duo/style.css
@@ -1104,6 +1104,7 @@ body {
     border: 2px solid var(--border-subtle);
     border-radius: 1rem;
     padding: 1rem 1.25rem;
+    min-height: 52px;
     cursor: pointer;
     font-size: 1.1rem;
     font-weight: 600;
@@ -1114,6 +1115,14 @@ body {
     color: var(--text-primary);
     position: relative;
     overflow: hidden;
+    -webkit-tap-highlight-color: transparent;
+}
+
+.option-card:focus-visible {
+    outline: 2px solid var(--talk-primary, var(--accent));
+    outline-offset: 3px;
+    border-color: var(--talk-primary, var(--accent));
+    box-shadow: 0 0 0 4px color-mix(in srgb, var(--talk-primary, var(--accent)) 28%, transparent);
 }
 
 .option-card::before {
@@ -1288,6 +1297,7 @@ body {
     align-items: center;
     gap: 0.5rem;
     padding: 0.75rem 1.5rem;
+    min-height: 48px;
     border: none;
     border-radius: 2rem;
     font-weight: 700;
@@ -1295,6 +1305,17 @@ body {
     cursor: pointer;
     transition: all 0.2s;
     white-space: nowrap;
+}
+
+.btn-next:focus-visible,
+.btn-submit:focus-visible,
+.btn-restart:focus-visible,
+.btn-continue:focus-visible,
+.btn-speak:focus-visible,
+.btn-listen-large:focus-visible {
+    outline: 2px solid var(--talk-primary, var(--accent));
+    outline-offset: 3px;
+    box-shadow: 0 0 0 4px color-mix(in srgb, var(--talk-primary, var(--accent)) 28%, transparent);
 }
 
 .feedback-area.correct .btn-next {
@@ -1529,6 +1550,7 @@ body {
     align-items: center;
     gap: 0.5rem;
     padding: 1rem 1.5rem;
+    min-height: 48px;
     background: var(--avatar-bg);
     color: white;
     border: none;

--- a/labs/eyra/index.html
+++ b/labs/eyra/index.html
@@ -34,7 +34,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;600;700;800&family=Outfit:wght@400;500;600;700;800&display=swap"
         rel="stylesheet">
     <link rel="stylesheet" href="/labs/shared.css?v=13">
-    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="style.css?v=2">
 
     <script type="importmap">
     {
@@ -280,7 +280,7 @@
             }
         })();
     </script>
-    <script type="module" src="src/main.js"></script>
+    <script type="module" src="src/main.js?v=2"></script>
 </body>
 
 </html>

--- a/labs/eyra/src/main.js
+++ b/labs/eyra/src/main.js
@@ -16,9 +16,10 @@ import {
 import { detectMobile, detectSoftwareGL, zoneAt, clamp } from './utils.js';
 
 function pickQuality(mode, renderer) {
+    if (detectSoftwareGL(renderer)) return QUALITY.low;
     if (QUALITY[mode]) return QUALITY[mode];
     const mobile = detectMobile() || innerWidth < 800;
-    if (detectSoftwareGL(renderer) || mobile) return QUALITY.low;
+    if (mobile) return QUALITY.low;
     if (devicePixelRatio >= 2 && innerWidth >= 1400) return QUALITY.high;
     return QUALITY.medium;
 }

--- a/labs/eyra/style.css
+++ b/labs/eyra/style.css
@@ -703,6 +703,93 @@ kbd {
     }
 }
 
+@media (max-height: 520px) and (orientation: landscape) {
+    .hud-top {
+        gap: 0.45rem;
+        grid-template-columns: auto minmax(0, 1fr) auto;
+    }
+
+    .hud-actions {
+        top: calc(0.55rem + var(--safe-top));
+        right: calc(0.7rem + var(--safe-right));
+        gap: 0.35rem;
+    }
+
+    .icon-button {
+        width: 2.1rem;
+        height: 2.1rem;
+        font-size: 0.85rem;
+    }
+
+    .panel {
+        padding: 0.4rem 0.6rem;
+    }
+
+    .hud-label {
+        font-size: 0.6rem;
+    }
+
+    .message {
+        bottom: calc(6.2rem + var(--safe-bottom));
+        max-width: min(20rem, 46vw);
+        font-size: 0.78rem;
+        line-height: 1.25;
+    }
+
+    .touch-controls {
+        inset: auto calc(0.7rem + var(--safe-right)) calc(0.5rem + var(--safe-bottom)) calc(0.7rem + var(--safe-left));
+    }
+
+    .stick {
+        width: 4.8rem;
+        height: 4.8rem;
+    }
+
+    .stick i {
+        width: 1.8rem;
+        height: 1.8rem;
+        margin: -0.9rem 0 0 -0.9rem;
+    }
+
+    .stick span {
+        bottom: -1.1rem;
+        font-size: 0.6rem;
+    }
+
+    .pad {
+        width: 2.5rem;
+        height: 2.5rem;
+        font-size: 0.65rem;
+    }
+
+    .pad-magic {
+        width: 3.1rem;
+        height: 3.1rem;
+    }
+
+    .overlay {
+        padding: calc(3.4rem + var(--safe-top)) 1rem calc(1rem + var(--safe-bottom));
+    }
+
+    .overlay-card,
+    .loading-card {
+        max-height: min(92dvh, 34rem);
+        overflow-y: auto;
+    }
+
+    .menu-grid {
+        grid-template-columns: 1fr 1fr;
+        gap: 0.9rem;
+        margin: 0.9rem 0 0.8rem;
+    }
+
+    .loading-card h1,
+    .menu-head h1,
+    .compact-card h2 {
+        font-size: clamp(1.6rem, 4vw, 2.2rem);
+    }
+}
+
 /* agent-responsive-768 */
 @media (max-width: 768px) {
   html, body { overflow-x: clip; }

--- a/labs/eyra/style.css
+++ b/labs/eyra/style.css
@@ -702,3 +702,11 @@ kbd {
         display: none !important;
     }
 }
+
+/* agent-responsive-768 */
+@media (max-width: 768px) {
+  html, body { overflow-x: clip; }
+  .hud, .overlay, .menu-overlay, .overlay-card {
+    max-width: 100%;
+  }
+}

--- a/labs/f1-racing/index.html
+++ b/labs/f1-racing/index.html
@@ -181,7 +181,7 @@
     <script src="https://cdn.babylonjs.com/v9.25.0/babylon.js"></script>
     <script src="https://cdn.babylonjs.com/v9.25.0/loaders/babylonjs.loaders.min.js"></script>
     <script src="/labs/shared.js?v=13" defer></script>
-    <script type="module" src="src/main.js?v=2"></script>
+    <script type="module" src="src/main.js?v=3"></script>
 </body>
 
 </html>

--- a/labs/f1-racing/index.html
+++ b/labs/f1-racing/index.html
@@ -181,7 +181,7 @@
     <script src="https://cdn.babylonjs.com/v9.25.0/babylon.js"></script>
     <script src="https://cdn.babylonjs.com/v9.25.0/loaders/babylonjs.loaders.min.js"></script>
     <script src="/labs/shared.js?v=13" defer></script>
-    <script type="module" src="src/main.js"></script>
+    <script type="module" src="src/main.js?v=2"></script>
 </body>
 
 </html>

--- a/labs/f1-racing/src/main.js
+++ b/labs/f1-racing/src/main.js
@@ -74,71 +74,103 @@ class F1GrandPrix {
 
     async boot() {
         const BABYLON = window.BABYLON;
-        if (!BABYLON) return;
+        if (!BABYLON) {
+            this.failBoot('Babylon.js não carregou. Recarregue a página.');
+            return;
+        }
 
         try {
             this.engine = new BABYLON.Engine(this.canvas, true, {
                 preserveDrawingBuffer: false,
                 stencil: true,
-                adaptToDeviceRatio: true
+                adaptToDeviceRatio: false,
+                powerPreference: 'high-performance',
+                failIfMajorPerformanceCaveat: false
             });
             this.scene = new BABYLON.Scene(this.engine);
             this.scene.clearColor = new BABYLON.Color4(0.05, 0.06, 0.08, 1.0);
+
+            // Cap de DPR: adaptToDeviceRatio sozinho derrete GPU em telas 2x/3x.
+            const pr = Math.min(window.devicePixelRatio || 1, matchMedia('(pointer: coarse)').matches ? 1.1 : 1.5);
+            this.engine.setHardwareScalingLevel(1 / pr);
+
+            // Carregar Circuito
+            this.loadCircuit(this.selectedCircuitKey);
+
+            // Carro do Jogador
+            this.playerCar = buildF1Car(BABYLON, this.scene, '#e10600');
+            this.vehicle = new Vehicle({
+                circuit: this.circuit,
+                team: TEAMS[0],
+                isPlayer: true
+            });
+
+            // Efeitos
+            this.effects = new RaceEffects(BABYLON, this.scene);
+
+            // Câmera de perseguição F1
+            this.camera = new BABYLON.FreeCamera('f1_cam', new BABYLON.Vector3(0, 3, -6), this.scene);
+            this.camera.minZ = 0.1;
+            this.camera.maxZ = 1200;
+
+            // Pipeline PBR — mais leve no ponteiro grosso
+            const pipe = new BABYLON.DefaultRenderingPipeline('pipeline', true, this.scene, [this.camera]);
+            const lite = matchMedia('(pointer: coarse)').matches;
+            pipe.fxaaEnabled = !lite;
+            pipe.bloomEnabled = !lite;
+            pipe.bloomThreshold = 0.78;
+            pipe.bloomWeight = 0.28;
+            pipe.imageProcessing.toneMappingEnabled = true;
+            pipe.imageProcessing.toneMappingType = BABYLON.ImageProcessingConfiguration.TONEMAPPING_ACES;
+            pipe.imageProcessing.contrast = 1.16;
+
+            document.getElementById('loadingOverlay').classList.remove('is-visible');
+            document.getElementById('loadingOverlay').hidden = true;
+            const menu = document.getElementById('menuOverlay');
+            if (menu) menu.classList.add('is-visible');
+            // state interno precisa bater com o Enter do menu (dataset sozinho não basta).
+            this.state = 'menu';
+            document.body.dataset.state = 'menu';
+
+            this._renderLoop = () => {
+                this.frame();
+                this.scene.render();
+            };
+            if (window.LabRuntime) LabRuntime.bindBabylonLoop(this.engine, this._renderLoop);
+            else this.engine.runRenderLoop(this._renderLoop);
+
+            if (window.LabRuntime) LabRuntime.debounceResize(() => this.engine.resize());
+            else window.addEventListener('resize', () => this.engine.resize());
         } catch (err) {
             console.error(err);
-            return;
+            this.failBoot(err?.message || 'Não foi possível iniciar o WebGL neste navegador.');
         }
+    }
 
-        // Carregar Circuito
-        this.loadCircuit(this.selectedCircuitKey);
-
-        // Carro do Jogador
-        this.playerCar = buildF1Car(BABYLON, this.scene, '#e10600');
-        this.vehicle = new Vehicle({
-            circuit: this.circuit,
-            team: TEAMS[0],
-            isPlayer: true
-        });
-
-        // Efeitos
-        this.effects = new RaceEffects(BABYLON, this.scene);
-
-        // Câmera de perseguição F1
-        this.camera = new BABYLON.FreeCamera('f1_cam', new BABYLON.Vector3(0, 3, -6), this.scene);
-        this.camera.minZ = 0.1;
-        this.camera.maxZ = 1200;
-
-        // Pipeline PBR
-        const pipe = new BABYLON.DefaultRenderingPipeline('pipeline', true, this.scene, [this.camera]);
-        pipe.fxaaEnabled = true;
-        pipe.bloomEnabled = true;
-        pipe.bloomThreshold = 0.78;
-        pipe.bloomWeight = 0.28;
-        pipe.imageProcessing.toneMappingEnabled = true;
-        pipe.imageProcessing.toneMappingType = BABYLON.ImageProcessingConfiguration.TONEMAPPING_ACES;
-        pipe.imageProcessing.contrast = 1.16;
-
-        document.getElementById('loadingOverlay').classList.remove('is-visible');
-        document.getElementById('loadingOverlay').hidden = true;
+    failBoot(message) {
+        const loading = document.getElementById('loadingOverlay');
+        if (loading) {
+            loading.classList.remove('is-visible');
+            loading.hidden = true;
+        }
         const menu = document.getElementById('menuOverlay');
         if (menu) menu.classList.add('is-visible');
-        // state interno precisa bater com o Enter do menu (dataset sozinho não basta).
-        this.state = 'menu';
-        document.body.dataset.state = 'menu';
-
-        // Cap de DPR: adaptToDeviceRatio sozinho derrete GPU em telas 2x/3x.
-        const pr = Math.min(window.devicePixelRatio || 1, matchMedia('(pointer: coarse)').matches ? 1.1 : 1.5);
-        this.engine.setHardwareScalingLevel(1 / pr);
-
-        this._renderLoop = () => {
-            this.frame();
-            this.scene.render();
-        };
-        if (window.LabRuntime) LabRuntime.bindBabylonLoop(this.engine, this._renderLoop);
-        else this.engine.runRenderLoop(this._renderLoop);
-
-        if (window.LabRuntime) LabRuntime.debounceResize(() => this.engine.resize());
-        else window.addEventListener('resize', () => this.engine.resize());
+        this.state = 'error';
+        document.body.dataset.state = 'error';
+        const card = menu?.querySelector('.overlay-card, .menu-card') || menu;
+        if (card && !card.querySelector('.boot-error')) {
+            const p = document.createElement('p');
+            p.className = 'boot-error';
+            p.style.cssText = 'color:#ff6b6b;margin:1rem 0 0;font-size:.9rem;max-width:36ch';
+            p.textContent = message;
+            card.appendChild(p);
+        }
+        const btn = document.getElementById('startButton');
+        if (btn) {
+            btn.disabled = true;
+            btn.setAttribute('aria-disabled', 'true');
+            btn.title = message;
+        }
     }
 
     loadCircuit(key) {
@@ -155,7 +187,7 @@ class F1GrandPrix {
     }
 
     startRace() {
-        if (this.state === 'boot' || !this.vehicle) return;
+        if (!this.vehicle || !this.engine || this.state === 'error' || this.state === 'boot') return;
         this.state = 'racing';
         const menu = document.getElementById('menuOverlay');
         if (menu) menu.classList.remove('is-visible');

--- a/labs/f1-racing/src/main.js
+++ b/labs/f1-racing/src/main.js
@@ -122,7 +122,13 @@ class F1GrandPrix {
         document.getElementById('loadingOverlay').hidden = true;
         const menu = document.getElementById('menuOverlay');
         if (menu) menu.classList.add('is-visible');
+        // state interno precisa bater com o Enter do menu (dataset sozinho não basta).
+        this.state = 'menu';
         document.body.dataset.state = 'menu';
+
+        // Cap de DPR: adaptToDeviceRatio sozinho derrete GPU em telas 2x/3x.
+        const pr = Math.min(window.devicePixelRatio || 1, matchMedia('(pointer: coarse)').matches ? 1.1 : 1.5);
+        this.engine.setHardwareScalingLevel(1 / pr);
 
         this._renderLoop = () => {
             this.frame();
@@ -149,11 +155,13 @@ class F1GrandPrix {
     }
 
     startRace() {
+        if (this.state === 'boot' || !this.vehicle) return;
         this.state = 'racing';
         const menu = document.getElementById('menuOverlay');
         if (menu) menu.classList.remove('is-visible');
         document.getElementById('hud').hidden = false;
-        document.getElementById('touchControls').hidden = !('ontouchstart' in window);
+        const coarse = window.matchMedia('(pointer: coarse)').matches;
+        document.getElementById('touchControls').hidden = !coarse;
         document.body.dataset.state = 'racing';
 
         this.vehicle.reset();

--- a/labs/f1-racing/style.css
+++ b/labs/f1-racing/style.css
@@ -1058,3 +1058,11 @@ kbd {
         height: min(42%, 38dvh);
     }
 }
+
+/* agent-responsive-768 */
+@media (max-width: 768px) {
+  html, body { overflow-x: clip; }
+  .hud, .overlay, .menu-overlay, .overlay-card {
+    max-width: 100%;
+  }
+}

--- a/labs/forrest-run/index.html
+++ b/labs/forrest-run/index.html
@@ -261,7 +261,7 @@
     <script src="https://cdn.babylonjs.com/v9.25.0/babylon.js"></script>
     <script src="https://cdn.babylonjs.com/v9.25.0/loaders/babylonjs.loaders.min.js"></script>
     <script src="/labs/shared.js?v=13" defer></script>
-    <script type="module" src="src/main.js"></script>
+    <script type="module" src="src/main.js?v=2"></script>
 </body>
 
 </html>

--- a/labs/forrest-run/src/main.js
+++ b/labs/forrest-run/src/main.js
@@ -417,19 +417,24 @@ class Game {
     }
     updateCamera(dt, instant) {
         const rig = CAMERAS[this.cameraMode];
-        const targetPos = new BABYLON.Vector3(
+        if (!this._camTargetPos) {
+            this._camTargetPos = new BABYLON.Vector3();
+            this._camTargetLook = new BABYLON.Vector3();
+            this._camFinalLook = new BABYLON.Vector3();
+        }
+        this._camTargetPos.copyFromFloats(
             this.player.x + rig.offset.x,
             this.player.y + rig.offset.y,
             this.player.z + rig.offset.z
         );
-        const targetLook = new BABYLON.Vector3(
+        this._camTargetLook.copyFromFloats(
             this.player.x + rig.look.x,
             this.player.y + rig.look.y,
             this.player.z + rig.look.z
         );
         const k = instant ? 1.0 : 1.0 - Math.exp(-dt * (this.cameraMode === 2 ? 12 : 6.5));
-        this.camPos = BABYLON.Vector3.Lerp(this.camPos, targetPos, k);
-        this.camLook = BABYLON.Vector3.Lerp(this.camLook, targetLook, k);
+        this.camPos = BABYLON.Vector3.Lerp(this.camPos, this._camTargetPos, k);
+        this.camLook = BABYLON.Vector3.Lerp(this.camLook, this._camTargetLook, k);
 
         this.cameraShake = Math.max(0, this.cameraShake - dt * 2.5);
         const shakeX = (Math.random() - 0.5) * this.cameraShake * 0.5;
@@ -439,10 +444,10 @@ class Game {
         this.camera.position.x += shakeX;
         this.camera.position.y += shakeY;
 
-        const finalLook = this.camLook.clone();
-        finalLook.x += shakeX;
-        finalLook.y += shakeY;
-        this.camera.setTarget(finalLook);
+        this._camFinalLook.copyFrom(this.camLook);
+        this._camFinalLook.x += shakeX;
+        this._camFinalLook.y += shakeY;
+        this.camera.setTarget(this._camFinalLook);
 
         const targetFov = 0.88 + (this.player.speed / 30) * 0.12;
         this.camera.fov = damp(this.camera.fov, targetFov, 4.0, dt);

--- a/labs/forrest-run/style.css
+++ b/labs/forrest-run/style.css
@@ -733,3 +733,11 @@ kbd {
         height: 44px;
     }
 }
+
+/* agent-responsive-768 */
+@media (max-width: 768px) {
+  html, body { overflow-x: clip; }
+  .hud, .overlay, .menu-overlay, .overlay-card {
+    max-width: 100%;
+  }
+}

--- a/labs/grao/script.js
+++ b/labs/grao/script.js
@@ -404,7 +404,7 @@ const chart = {
     points: [],
     width: 0,
     height: 0,
-    pad: { t: 22, r: 16, b: 28, l: 40 }
+    pad: { t: 24, r: 18, b: 32, l: 48 }
 };
 
 function cssVar(name, fallback) {
@@ -471,7 +471,7 @@ function drawChart(now) {
     ctx.strokeStyle = track;
     ctx.lineWidth = 1;
     const ticks = 4;
-    ctx.font = '11px Outfit, system-ui, sans-serif';
+    ctx.font = '600 11.5px Outfit, system-ui, sans-serif';
     ctx.fillStyle = text;
     ctx.textAlign = 'right';
     ctx.textBaseline = 'middle';
@@ -482,16 +482,17 @@ function drawChart(now) {
         ctx.moveTo(pad.l, y);
         ctx.lineTo(width - pad.r, y);
         ctx.stroke();
-        ctx.fillText(`${Math.round(mg)}`, pad.l - 8, y);
+        ctx.fillText(i === ticks ? `${Math.round(mg)} mg` : `${Math.round(mg)}`, pad.l - 8, y);
     }
 
     ctx.textAlign = 'center';
     ctx.textBaseline = 'top';
+    ctx.font = '500 11px Outfit, system-ui, sans-serif';
     for (let h = 0; h < 24; h += 4) {
         const t = chart.start + h * 36e5;
         const x = xOf(t);
         const labelDate = new Date(t);
-        ctx.fillText(formatTime(labelDate), x, height - pad.b + 8);
+        ctx.fillText(formatTime(labelDate), x, height - pad.b + 10);
     }
 
     const threshold = state.settings.sleepThresholdMg;
@@ -504,6 +505,13 @@ function drawChart(now) {
     ctx.moveTo(pad.l, ty);
     ctx.lineTo(width - pad.r, ty);
     ctx.stroke();
+    ctx.setLineDash([]);
+    ctx.globalAlpha = 0.85;
+    ctx.font = '600 10px Outfit, system-ui, sans-serif';
+    ctx.fillStyle = bean;
+    ctx.textAlign = 'left';
+    ctx.textBaseline = 'bottom';
+    ctx.fillText('limite sono', pad.l + 4, ty - 3);
     ctx.restore();
 
     const bed = nextBedtime(now).getTime();
@@ -516,6 +524,12 @@ function drawChart(now) {
         ctx.moveTo(bx, pad.t);
         ctx.lineTo(bx, height - pad.b);
         ctx.stroke();
+        ctx.globalAlpha = 0.8;
+        ctx.font = '600 10px Outfit, system-ui, sans-serif';
+        ctx.fillStyle = text;
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'top';
+        ctx.fillText('cama', bx, pad.t + 2);
         ctx.restore();
     }
 
@@ -532,7 +546,7 @@ function drawChart(now) {
     const fill = ctx.createLinearGradient(0, pad.t, 0, height - pad.b);
     fill.addColorStop(0, crema);
     fill.addColorStop(1, 'rgba(0,0,0,0)');
-    ctx.globalAlpha = 0.35;
+    ctx.globalAlpha = 0.38;
     ctx.fillStyle = fill;
     ctx.fill();
     ctx.globalAlpha = 1;
@@ -545,13 +559,20 @@ function drawChart(now) {
         else ctx.lineTo(x, y);
     });
     ctx.strokeStyle = bean;
-    ctx.lineWidth = 2.4;
+    ctx.lineWidth = 2.8;
     ctx.lineJoin = 'round';
+    ctx.lineCap = 'round';
     ctx.stroke();
 
     const nx = xOf(now.getTime());
     const ny = yOf(totalAt(now.getTime()));
     if (now.getTime() >= chart.start && now.getTime() <= chart.end) {
+        ctx.beginPath();
+        ctx.arc(nx, ny, 9, 0, Math.PI * 2);
+        ctx.fillStyle = cssVar('--crema', '#d9a36a');
+        ctx.globalAlpha = 0.28;
+        ctx.fill();
+        ctx.globalAlpha = 1;
         ctx.beginPath();
         ctx.arc(nx, ny, 5.5, 0, Math.PI * 2);
         ctx.fillStyle = bean;

--- a/labs/grao/style.css
+++ b/labs/grao/style.css
@@ -166,7 +166,9 @@ header .app-logo .logo-mark {
     position: relative;
     height: 220px;
     border-radius: 16px;
-    background: var(--ring-track);
+    background:
+        radial-gradient(120% 90% at 50% 0%, color-mix(in srgb, var(--crema, #d9a36a) 16%, transparent), transparent 60%),
+        var(--ring-track);
     overflow: hidden;
 }
 

--- a/labs/gravity/script.js
+++ b/labs/gravity/script.js
@@ -432,17 +432,19 @@
         drawTrail() {
             if (!enableOrbits || this.trail.length < 4) return;
             const n = this.trail.length / 2;
-            ctx.beginPath();
-            let prev = null;
-            for (let i = 0; i < n; i++) {
-                const s = toScreen(this.trail[i * 2], this.trail[i * 2 + 1]);
-                if (!prev || Math.hypot(s.x - prev.x, s.y - prev.y) > 48) ctx.moveTo(s.x, s.y);
-                else ctx.lineTo(s.x, s.y);
-                prev = s;
+            for (let i = 1; i < n; i++) {
+                const s0 = toScreen(this.trail[(i - 1) * 2], this.trail[(i - 1) * 2 + 1]);
+                const s1 = toScreen(this.trail[i * 2], this.trail[i * 2 + 1]);
+                if (Math.hypot(s1.x - s0.x, s1.y - s0.y) > 48) continue;
+                const t = i / (n - 1);
+                ctx.beginPath();
+                ctx.moveTo(s0.x, s0.y);
+                ctx.lineTo(s1.x, s1.y);
+                ctx.strokeStyle = this.colorAlpha(0.08 + t * 0.42);
+                ctx.lineWidth = Math.max(0.7, (0.7 + t * 1.6) * cam.zoom);
+                ctx.lineCap = 'round';
+                ctx.stroke();
             }
-            ctx.strokeStyle = this.colorAlpha(0.28);
-            ctx.lineWidth = Math.max(0.8, 1.2 * cam.zoom);
-            ctx.stroke();
         }
 
         draw() {
@@ -482,13 +484,17 @@
 
     function drawGlow(s, r, color, mul) {
         if (!enableGlow) return;
-        const g = ctx.createRadialGradient(s.x, s.y, r * 0.2, s.x, s.y, r * mul);
+        const outer = r * mul * 1.2;
+        const g = ctx.createRadialGradient(s.x, s.y, r * 0.12, s.x, s.y, outer);
         g.addColorStop(0, color);
+        g.addColorStop(0.4, color);
         g.addColorStop(1, 'rgba(0,0,0,0)');
+        ctx.globalAlpha = 0.85;
         ctx.fillStyle = g;
         ctx.beginPath();
-        ctx.arc(s.x, s.y, r * mul, 0, TAU);
+        ctx.arc(s.x, s.y, outer, 0, TAU);
         ctx.fill();
+        ctx.globalAlpha = 1;
     }
 
     function drawSun(s, r, b) {
@@ -579,7 +585,7 @@
     }
 
     function drawPlanet(s, r, b) {
-        drawGlow(s, r, b.colorAlpha(0.55), 2.1 + b.pulse * 0.4);
+        drawGlow(s, r, b.colorAlpha(0.62), 2.45 + b.pulse * 0.5);
         const g = ctx.createRadialGradient(s.x - r * 0.3, s.y - r * 0.35, r * 0.1, s.x, s.y, r);
         g.addColorStop(0, 'rgba(255,255,255,0.55)');
         g.addColorStop(0.35, b.color);

--- a/labs/guerreiro-castelo/css/style.css
+++ b/labs/guerreiro-castelo/css/style.css
@@ -703,3 +703,11 @@ kbd {
         }
     }
 }
+
+/* agent-responsive-768 */
+@media (max-width: 768px) {
+  html, body { overflow-x: clip; }
+  .hud, .overlay, .menu-overlay, .overlay-card {
+    max-width: 100%;
+  }
+}

--- a/labs/guerreiro-castelo/index.html
+++ b/labs/guerreiro-castelo/index.html
@@ -257,7 +257,7 @@
     <script src="https://cdn.babylonjs.com/v9.25.0/loaders/babylonjs.loaders.min.js"></script>
     <script src="https://cdn.babylonjs.com/v9.25.0/materialsLibrary/babylonjs.materials.min.js"></script>
     <script src="/labs/shared.js?v=13" defer></script>
-    <script type="module" src="js/main.js"></script>
+    <script type="module" src="js/main.js?v=2"></script>
 </body>
 
 </html>

--- a/labs/guerreiro-castelo/js/core/Game.js
+++ b/labs/guerreiro-castelo/js/core/Game.js
@@ -52,8 +52,11 @@ export class Game {
         this.engine = new BABYLON.Engine(this.canvas, antialias, {
             preserveDrawingBuffer: true,
             stencil: true,
-            adaptToDeviceRatio: true
+            adaptToDeviceRatio: false,
+            powerPreference: 'high-performance'
         });
+        const pr = Math.min(window.devicePixelRatio || 1, this.quality.pixelRatio || 1.5);
+        this.engine.setHardwareScalingLevel(1 / pr);
 
         this.scene = new BABYLON.Scene(this.engine);
         this.scene.clearColor = new BABYLON.Color4(0.02, 0.03, 0.05, 1);

--- a/labs/guerreiro-castelo/js/ui/Menu.js
+++ b/labs/guerreiro-castelo/js/ui/Menu.js
@@ -37,6 +37,9 @@ export class Menu {
                 const q = QUALITY[e.target.value];
                 if (q) {
                     game.quality = q;
+                    const pr = Math.min(window.devicePixelRatio || 1, q.pixelRatio || 1.5);
+                    game.engine?.setHardwareScalingLevel(1 / pr);
+                    if (game.camera) game.camera.maxZ = q.far || 500;
                     this._saveSettings();
                 }
             });

--- a/labs/honor-front/index.html
+++ b/labs/honor-front/index.html
@@ -217,7 +217,7 @@
     <script src="https://cdn.babylonjs.com/v9.25.0/babylon.js"></script>
     <script src="https://cdn.babylonjs.com/v9.25.0/loaders/babylonjs.loaders.min.js"></script>
     <script src="/labs/shared.js?v=13" defer></script>
-    <script type="module" src="src/main.js?v=2"></script>
+    <script type="module" src="src/main.js?v=3"></script>
 </body>
 
 </html>

--- a/labs/honor-front/src/main.js
+++ b/labs/honor-front/src/main.js
@@ -12,6 +12,16 @@ import { heightAt, buildCombatWorld } from './world.js';
 import { setupAtmosphere } from './sky.js';
 import { clamp } from './utils.js';
 import { loadAssets } from './models.js?v=2';
+import { QUALITY } from './config.js';
+
+function pickQuality() {
+    const coarse = typeof matchMedia === 'function' && matchMedia('(pointer: coarse)').matches;
+    const narrow = Math.min(window.innerWidth, window.innerHeight) < 760;
+    if (coarse || narrow) return QUALITY.low;
+    const dpr = window.devicePixelRatio || 1;
+    if (dpr >= 2 || Math.min(window.innerWidth, window.innerHeight) < 900) return QUALITY.medium;
+    return QUALITY.high;
+}
 
 class HonorFront {
     constructor() {
@@ -149,12 +159,17 @@ class HonorFront {
         const BABYLON = window.BABYLON;
         if (!BABYLON) return;
 
+        this.quality = pickQuality();
+
         try {
-            this.engine = new BABYLON.Engine(this.canvas, true, {
+            this.engine = new BABYLON.Engine(this.canvas, this.quality.antialias, {
                 preserveDrawingBuffer: false,
                 stencil: true,
-                adaptToDeviceRatio: true
+                adaptToDeviceRatio: false,
+                powerPreference: 'high-performance'
             });
+            const pr = Math.min(window.devicePixelRatio || 1, this.quality.pixelRatio);
+            this.engine.setHardwareScalingLevel(1 / pr);
             this.scene = new BABYLON.Scene(this.engine);
             this.scene.clearColor = new BABYLON.Color4(0.45, 0.52, 0.6, 1.0);
         } catch (err) {
@@ -166,7 +181,7 @@ class HonorFront {
         this.assets = await loadAssets(BABYLON, this.scene);
 
         // Iluminação & Atmosfera
-        this.lights = setupAtmosphere(BABYLON, this.scene);
+        this.lights = setupAtmosphere(BABYLON, this.scene, this.quality);
 
         // Cenário da Praia e Bunkers
         this.world = buildCombatWorld(BABYLON, this.scene, this.assets);
@@ -174,7 +189,7 @@ class HonorFront {
         // Câmera do Jogador
         this.camera = new BABYLON.FreeCamera('fpsCam', new BABYLON.Vector3(0, 1.6, -70), this.scene);
         this.camera.minZ = 0.05;
-        this.camera.maxZ = 800;
+        this.camera.maxZ = this.quality.far || 800;
 
         // Armas
         this.loadout = new Loadout(BABYLON, this.camera, this.scene, this.assets);
@@ -187,8 +202,8 @@ class HonorFront {
 
         // Pipeline PBR
         const pipe = new BABYLON.DefaultRenderingPipeline('pipeline', true, this.scene, [this.camera]);
-        pipe.fxaaEnabled = true;
-        pipe.bloomEnabled = true;
+        pipe.fxaaEnabled = this.quality.antialias;
+        pipe.bloomEnabled = this.quality.id !== 'low';
         pipe.bloomThreshold = 0.82;
         pipe.bloomWeight = 0.22;
         pipe.imageProcessing.toneMappingEnabled = true;
@@ -198,6 +213,7 @@ class HonorFront {
         document.getElementById('loadingOverlay').hidden = true;
         document.getElementById('menuOverlay').hidden = false;
         document.body.dataset.state = 'intro';
+        this.state = 'menu';
 
         this._renderLoop = () => {
             this.frame();
@@ -215,7 +231,8 @@ class HonorFront {
         document.getElementById('menuOverlay').hidden = true;
         document.getElementById('hud').hidden = false;
         document.getElementById('crosshair').hidden = false;
-        document.getElementById('touchControls').hidden = !('ontouchstart' in window);
+        const coarse = window.matchMedia('(pointer: coarse)').matches;
+        document.getElementById('touchControls').hidden = !coarse;
         document.body.dataset.state = 'play';
 
         this.player.spawn(0, -60, Math.PI, heightAt);
@@ -239,14 +256,15 @@ class HonorFront {
         const dt = Math.min(0.05, this.engine.getDeltaTime() / 1000);
 
         if (this.state === 'play') {
-            // Teclado
+            // Teclado — sempre limpa eixos no keyup (híbridos com ontouchstart
+            // não podem deixar WASD “preso”).
             if (this.keys['KeyW'] || this.keys['ArrowUp']) this.input.move.z = 1;
             else if (this.keys['KeyS'] || this.keys['ArrowDown']) this.input.move.z = -1;
-            else if (!('ontouchstart' in window)) this.input.move.z = 0;
+            else this.input.move.z = 0;
 
             if (this.keys['KeyA'] || this.keys['ArrowLeft']) this.input.move.x = -1;
             else if (this.keys['KeyD'] || this.keys['ArrowRight']) this.input.move.x = 1;
-            else if (!('ontouchstart' in window)) this.input.move.x = 0;
+            else this.input.move.x = 0;
 
             this.input.move.sprint = !!(this.keys['ShiftLeft'] || this.keys['ShiftRight']);
 

--- a/labs/honor-front/src/sky.js
+++ b/labs/honor-front/src/sky.js
@@ -2,10 +2,12 @@
  * Céu costeiro de amanhecer nublado e iluminação para Honor Front em Babylon.js.
  */
 
-export function setupAtmosphere(BABYLON, scene) {
+export function setupAtmosphere(BABYLON, scene, quality = null) {
+    const q = quality || { shadows: true, shadowSize: 2048, fog: 0.0075 };
+
     // Neblina de praia e fumaça
     scene.fogMode = BABYLON.Scene.FOGMODE_EXP2;
-    scene.fogDensity = 0.0075;
+    scene.fogDensity = q.fog ?? 0.0075;
     scene.fogColor = new BABYLON.Color3(0.55, 0.60, 0.65);
 
     // Domo do céu
@@ -29,8 +31,11 @@ export function setupAtmosphere(BABYLON, scene) {
     sun.diffuse = new BABYLON.Color3(1.0, 0.88, 0.72);
     sun.intensity = 1.4;
 
-    const shadowGen = new BABYLON.ShadowGenerator(2048, sun);
-    shadowGen.usePoissonSampling = true;
+    let shadowGen = null;
+    if (q.shadows !== false) {
+        shadowGen = new BABYLON.ShadowGenerator(q.shadowSize || 1024, sun);
+        shadowGen.usePoissonSampling = true;
+    }
 
     return { hemi, sun, shadowGen };
 }

--- a/labs/honor-front/style.css
+++ b/labs/honor-front/style.css
@@ -1055,3 +1055,11 @@ kbd {
         right: calc(11rem + var(--safe-right, 0px));
     }
 }
+
+/* agent-responsive-768 */
+@media (max-width: 768px) {
+  html, body { overflow-x: clip; }
+  .hud, .overlay, .menu-overlay, .overlay-card {
+    max-width: 100%;
+  }
+}

--- a/labs/image-editor/style.css
+++ b/labs/image-editor/style.css
@@ -38,14 +38,24 @@
     padding: 2.5rem 2rem;
     border: 2px dashed var(--border-subtle);
     border-radius: 1rem;
-    transition: all 0.3s ease;
+    transition: border-color 0.3s ease, color 0.3s ease, background 0.3s ease, box-shadow 0.3s ease, transform 0.3s ease;
     max-width: 420px;
+    background: color-mix(in srgb, var(--bg-card) 70%, transparent);
 }
 
 .upload-placeholder:hover {
     border-color: var(--accent);
     color: var(--accent);
-    background: var(--shadow-sm);
+    background: color-mix(in srgb, var(--accent) 8%, var(--bg-card));
+    box-shadow: 0 0 0 4px color-mix(in srgb, var(--accent) 16%, transparent);
+}
+
+.upload-placeholder svg {
+    transition: transform 0.35s ease;
+}
+
+.upload-placeholder:hover svg {
+    transform: translateY(-4px);
 }
 
 .upload-placeholder p {
@@ -63,6 +73,18 @@
     border-color: var(--accent);
     outline: 2px dashed var(--accent);
     outline-offset: 4px;
+    animation: dropPulse 1.1s ease-in-out infinite;
+}
+
+.preview-area.drag-active .upload-placeholder {
+    color: var(--accent);
+    background: color-mix(in srgb, var(--accent) 12%, var(--bg-card));
+    box-shadow: 0 0 0 6px color-mix(in srgb, var(--accent) 18%, transparent);
+}
+
+@keyframes dropPulse {
+    0%, 100% { transform: scale(1); }
+    50% { transform: scale(1.02); }
 }
 
 .sample-gallery {

--- a/labs/image-optimizer/script.js
+++ b/labs/image-optimizer/script.js
@@ -112,7 +112,18 @@ document.addEventListener('DOMContentLoaded', () => {
         processBtn.textContent = 'Processando...';
 
         for (const file of currentFiles) {
+            const cardId = `card-${file.name.replace(/[^a-zA-Z0-9]/g, '')}`;
+            const card = document.getElementById(cardId);
+            if (card) {
+                const status = card.querySelector('.status');
+                if (status) {
+                    status.classList.add('processing');
+                    status.innerHTML = 'Processando<span class="progress-pulse"></span>';
+                }
+                card.classList.add('is-processing');
+            }
             await processSingleFile(file);
+            if (card) card.classList.remove('is-processing');
         }
 
         processBtn.disabled = false;

--- a/labs/image-optimizer/style.css
+++ b/labs/image-optimizer/style.css
@@ -36,19 +36,38 @@ body {
     padding: 4rem 2rem;
     text-align: center;
     cursor: pointer;
-    transition: all 0.3s ease;
+    transition: border-color 0.3s ease, background 0.3s ease, box-shadow 0.3s ease, transform 0.25s ease;
     background: var(--bg-card);
+    position: relative;
 }
 
 .upload-zone:hover,
 .upload-zone.dragover {
     border-color: var(--accent);
-    background: rgba(59, 130, 246, 0.1);
+    background: color-mix(in srgb, var(--accent) 10%, var(--bg-card));
+    box-shadow: 0 0 0 6px color-mix(in srgb, var(--accent) 16%, transparent);
+}
+
+.upload-zone.dragover {
+    transform: scale(1.01);
+    animation: optDropPulse 1s ease-in-out infinite;
+}
+
+@keyframes optDropPulse {
+    0%, 100% { box-shadow: 0 0 0 4px color-mix(in srgb, var(--accent) 14%, transparent); }
+    50% { box-shadow: 0 0 0 10px color-mix(in srgb, var(--accent) 22%, transparent); }
 }
 
 .upload-icon {
     color: var(--text-secondary);
     margin-bottom: 1rem;
+    transition: transform 0.3s ease, color 0.3s ease;
+}
+
+.upload-zone:hover .upload-icon,
+.upload-zone.dragover .upload-icon {
+    color: var(--accent);
+    transform: translateY(-6px);
 }
 
 .upload-content h3 {
@@ -239,6 +258,48 @@ input[type="number"] {
     font-size: 0.875rem;
     color: var(--text-secondary);
     margin-bottom: 1rem;
+}
+
+.status.processing {
+    color: var(--accent);
+    font-weight: 600;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+}
+
+.progress-pulse {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--accent);
+    animation: statusPulse 0.9s ease-in-out infinite;
+}
+
+@keyframes statusPulse {
+    0%, 100% { opacity: 0.35; transform: scale(0.85); }
+    50% { opacity: 1; transform: scale(1.15); }
+}
+
+.image-card.is-processing {
+    outline: 1px solid color-mix(in srgb, var(--accent) 45%, transparent);
+    box-shadow: 0 0 0 4px color-mix(in srgb, var(--accent) 12%, transparent);
+}
+
+.image-card.is-processing .image-preview::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    bottom: 0;
+    height: 3px;
+    width: 40%;
+    background: linear-gradient(90deg, transparent, var(--accent), transparent);
+    animation: barSweep 1.2s linear infinite;
+}
+
+@keyframes barSweep {
+    0% { transform: translateX(-100%); width: 35%; }
+    100% { transform: translateX(320%); width: 45%; }
 }
 
 .savings {

--- a/labs/joao-e-o-pe-de-feijao/index.html
+++ b/labs/joao-e-o-pe-de-feijao/index.html
@@ -36,7 +36,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;600;700;800&family=Nunito:wght@400;600;700;800&display=swap"
         rel="stylesheet">
     <link rel="stylesheet" href="/labs/shared.css?v=13">
-    <link rel="stylesheet" href="style.css?v=2">
+    <link rel="stylesheet" href="style.css?v=3">
 
     <script type="application/ld+json">
     {
@@ -318,7 +318,7 @@
             }
         })();
     </script>
-    <script type="module" src="src/main.js?v=2"></script>
+    <script type="module" src="src/main.js?v=3"></script>
 </body>
 
 </html>

--- a/labs/joao-e-o-pe-de-feijao/src/main.js
+++ b/labs/joao-e-o-pe-de-feijao/src/main.js
@@ -63,9 +63,10 @@ class Game {
     }
 
     resolveQuality() {
+        if (detectSoftwareGL()) return QUALITY.low;
         const choice = this.settings.quality;
         if (choice !== 'auto' && QUALITY[choice]) return QUALITY[choice];
-        if (detectMobile() || detectSoftwareGL()) return QUALITY.low;
+        if (detectMobile()) return QUALITY.low;
         const big = Math.min(window.innerWidth, window.innerHeight) >= 900;
         return big ? QUALITY.high : QUALITY.medium;
     }
@@ -77,7 +78,7 @@ class Game {
         setModelQuality(this.quality.id);
 
         try {
-            this.engine = new B.Engine(this.canvas, true, {
+            this.engine = new B.Engine(this.canvas, !!this.quality.antialias, {
                 preserveDrawingBuffer: false,
                 stencil: true,
                 powerPreference: 'high-performance',
@@ -354,7 +355,7 @@ class Game {
         this.introT = 0;
         this.player.setVisible(true);
         this.hud.showHud(true);
-        this.hud.setTouchVisible(this.mobile);
+        this.hud.setTouchVisible(matchMedia('(pointer: coarse)').matches || this.mobile);
         this.hud.setChapter(this.chapter);
         this.hud.setHearts(this.player.health, this.player.maxHealth);
         this._syncRelics();

--- a/labs/joao-e-o-pe-de-feijao/style.css
+++ b/labs/joao-e-o-pe-de-feijao/style.css
@@ -793,3 +793,7 @@ kbd {
     .dialogue-text { font-size: 0.92rem; margin-bottom: 0.5rem; }
 }
 
+/* agent-responsive-768 */
+@media (max-width: 768px) {
+  html, body { overflow-x: clip; }
+}

--- a/labs/jornada-do-anel/index.html
+++ b/labs/jornada-do-anel/index.html
@@ -34,7 +34,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;600;700;800&family=Outfit:wght@300;400;500;600;700&display=swap"
         rel="stylesheet">
     <link rel="stylesheet" href="/labs/shared.css?v=13">
-    <link rel="stylesheet" href="style.css?v=1">
+    <link rel="stylesheet" href="style.css?v=2">
 
     <script type="importmap">
     {
@@ -313,7 +313,7 @@
             }
         })();
     </script>
-    <script type="module" src="src/main.js?v=3"></script>
+    <script type="module" src="src/main.js?v=4"></script>
 </body>
 
 </html>

--- a/labs/jornada-do-anel/src/main.js
+++ b/labs/jornada-do-anel/src/main.js
@@ -65,9 +65,10 @@ class Game {
     }
 
     resolveQuality() {
+        if (detectSoftwareGL()) return QUALITY.low;
         const choice = this.settings.quality;
         if (choice !== 'auto' && QUALITY[choice]) return QUALITY[choice];
-        if (detectMobile() || detectSoftwareGL()) return QUALITY.low;
+        if (detectMobile()) return QUALITY.low;
         const big = Math.min(window.innerWidth, window.innerHeight) >= 900;
         return big ? QUALITY.high : QUALITY.medium;
     }
@@ -348,7 +349,7 @@ class Game {
         this.introT = 0;
         this.player.root.visible = true;
         this.hud.showHud(true);
-        this.hud.setTouchVisible(this.mobile);
+        this.hud.setTouchVisible(matchMedia('(pointer: coarse)').matches || this.mobile);
         this.hud.setChapter(this.chapter);
         this.hud.setHearts(this.player.health, this.player.maxHealth);
         this.hud.setRing(this.player.hasRing);

--- a/labs/jornada-do-anel/style.css
+++ b/labs/jornada-do-anel/style.css
@@ -863,3 +863,8 @@ kbd {
         top: -1.1rem;
     }
 }
+
+/* agent-responsive-768 */
+@media (max-width: 768px) {
+  html, body { overflow-x: clip; }
+}

--- a/labs/jungle-run/index.html
+++ b/labs/jungle-run/index.html
@@ -29,7 +29,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@600;900&family=Plus+Jakarta+Sans:wght@400;500;700;800&display=swap" rel="stylesheet">
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link rel="stylesheet" href="/labs/shared.css?v=13">
-    <link rel="stylesheet" href="style.css?v=4">
+    <link rel="stylesheet" href="style.css?v=5">
     <script src="https://cdn.jsdelivr.net/npm/pixi.js@8.6.6/dist/pixi.min.js" defer></script>
     <script type="application/ld+json">
     {
@@ -306,7 +306,7 @@
     </div>
 
     <script src="/labs/shared.js?v=13" defer></script>
-    <script src="script.js?v=6" defer></script>
+    <script src="script.js?v=7" defer></script>
 </body>
 
 </html>

--- a/labs/jungle-run/index.html
+++ b/labs/jungle-run/index.html
@@ -29,7 +29,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@600;900&family=Plus+Jakarta+Sans:wght@400;500;700;800&display=swap" rel="stylesheet">
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
     <link rel="stylesheet" href="/labs/shared.css?v=13">
-    <link rel="stylesheet" href="style.css?v=3">
+    <link rel="stylesheet" href="style.css?v=4">
     <script src="https://cdn.jsdelivr.net/npm/pixi.js@8.6.6/dist/pixi.min.js" defer></script>
     <script type="application/ld+json">
     {

--- a/labs/jungle-run/script.js
+++ b/labs/jungle-run/script.js
@@ -1223,7 +1223,7 @@ class JungleRun {
     updatePlayerTrails(speed, delta) {
         const show = !this.reducedMotion && (!this.player.onGround || speed > CONFIG.BASE_SCROLL_SPEED + 2.5);
         this.playerTrails.forEach((trail, idx) => {
-            const targetAlpha = show ? 0.08 - idx * 0.03 : 0;
+            const targetAlpha = show ? 0.22 - idx * 0.07 : 0;
             trail.alpha += (targetAlpha - trail.alpha) * 0.20 * delta;
             trail.texture = this.player.sprite.texture;
             trail.x = this.player.x - this.player.facing * (10 + idx * 10);
@@ -1456,7 +1456,7 @@ class JungleRun {
         const container = new PIXI.Container();
         for (let i = 0; i < amount; i++) {
             const p = new PIXI.Graphics();
-            p.circle(0, 0, 2 + Math.random() * 2.5).fill({ color: 0x486b45, alpha: 0.4 });
+            p.circle(0, 0, 3 + Math.random() * 3.5).fill({ color: Math.random() > 0.5 ? 0x6a8f52 : 0xc4b07a, alpha: 0.65 });
             p.x = x + (Math.random() - 0.5) * 20;
             p.y = y + Math.random() * 4;
             p.vx = -1.0 - Math.random() * 2.0;

--- a/labs/jungle-run/style.css
+++ b/labs/jungle-run/style.css
@@ -681,6 +681,16 @@ kbd {
     pointer-events: none;
 }
 
+.mobile-hint {
+    display: none;
+}
+
+@media (pointer: coarse) {
+    .mobile-hint {
+        display: inline;
+    }
+}
+
 .control-left,
 .control-climb {
     display: flex;

--- a/labs/jurassic/index.html
+++ b/labs/jurassic/index.html
@@ -34,7 +34,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,500;0,600;0,700;1,500&family=Barlow:wght@400;500;600;700&display=swap"
         rel="stylesheet">
     <link rel="stylesheet" href="/labs/shared.css?v=13">
-    <link rel="stylesheet" href="style.css?v=1">
+    <link rel="stylesheet" href="style.css?v=2">
 
     <script type="importmap">
     {
@@ -304,7 +304,7 @@
             }
         })();
     </script>
-    <script type="module" src="src/main.js?v=1"></script>
+    <script type="module" src="src/main.js?v=2"></script>
 </body>
 
 </html>

--- a/labs/jurassic/src/main.js
+++ b/labs/jurassic/src/main.js
@@ -73,9 +73,10 @@ class Game {
     }
 
     resolveQuality() {
+        if (detectSoftwareGL()) return QUALITY.low;
         const choice = this.settings.quality;
         if (choice !== 'auto' && QUALITY[choice]) return QUALITY[choice];
-        if (detectMobile() || detectSoftwareGL()) return QUALITY.medium;
+        if (detectMobile()) return QUALITY.low;
         const big = Math.min(window.innerWidth, window.innerHeight) >= 900;
         return big ? QUALITY.ultra : QUALITY.high;
     }
@@ -295,7 +296,7 @@ class Game {
         this.hud.showMenu(false);
         this.hud.showPause(false);
         this.hud.showHud(true);
-        this.hud.showTouch(this.mobile);
+        this.hud.showTouch(matchMedia('(pointer: coarse)').matches || this.mobile);
         this.hud.setRain(this.rain);
         this.hud.setTod(todLabel(this.tod));
         this.hud.randomRadio();

--- a/labs/jurassic/style.css
+++ b/labs/jurassic/style.css
@@ -792,3 +792,8 @@ body[data-state="pause"] [data-lab-footer] {
         display: none;
     }
 }
+
+/* agent-responsive-768 */
+@media (max-width: 768px) {
+  html, body { overflow-x: clip; }
+}

--- a/labs/kong-kong/index.html
+++ b/labs/kong-kong/index.html
@@ -30,7 +30,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@500;700;800&family=Titan+One&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/labs/shared.css?v=13">
-  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="style.css?v=2">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -148,7 +148,7 @@
 
   <p class="sr-only" id="announcer" aria-live="assertive"></p>
   <script src="/labs/shared.js?v=13" defer></script>
-  <script type="module" src="src/main.js"></script>
+  <script type="module" src="src/main.js?v=2"></script>
 </body>
 
 </html>

--- a/labs/kong-kong/style.css
+++ b/labs/kong-kong/style.css
@@ -129,10 +129,13 @@ body.kong-lab {
 
 .rail-bottom p {
     margin: 0;
-    max-width: 70ch;
+    max-width: min(70ch, 100%);
     overflow: hidden;
     text-overflow: ellipsis;
-    white-space: nowrap;
+    white-space: normal;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
 }
 
 .rail-bottom strong {

--- a/labs/lander/index.html
+++ b/labs/lander/index.html
@@ -26,7 +26,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="stylesheet" href="/labs/shared.css?v=13">
-    <link rel="stylesheet" href="style.css?v=5">
+    <link rel="stylesheet" href="style.css?v=6">
     <link href="https://fonts.googleapis.com/css2?family=VT323&display=swap" rel="stylesheet">
     <script type="application/ld+json">
     {
@@ -188,7 +188,7 @@
     </div>
 
     <script src="/labs/shared.js?v=13" defer></script>
-    <script src="script.js?v=4" defer></script>
+    <script src="script.js?v=5" defer></script>
 </body>
 
 </html>

--- a/labs/lander/index.html
+++ b/labs/lander/index.html
@@ -26,7 +26,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="stylesheet" href="/labs/shared.css?v=13">
-    <link rel="stylesheet" href="style.css?v=4">
+    <link rel="stylesheet" href="style.css?v=5">
     <link href="https://fonts.googleapis.com/css2?family=VT323&display=swap" rel="stylesheet">
     <script type="application/ld+json">
     {

--- a/labs/lander/script.js
+++ b/labs/lander/script.js
@@ -268,6 +268,25 @@ const lander = {
 
         target.fillStyle = '#888';
         target.fillRect(-3, 3, 6, 3);
+
+        // Chama do motor — o lander “dispara” visualmente, não só com partículas.
+        if (this.engineOn) {
+            const h = 6 + Math.random() * 4;
+            target.fillStyle = '#ff0';
+            target.beginPath();
+            target.moveTo(-4, 6);
+            target.lineTo(0, 6 + h);
+            target.lineTo(4, 6);
+            target.closePath();
+            target.fill();
+            target.fillStyle = '#f30';
+            target.beginPath();
+            target.moveTo(-2, 6);
+            target.lineTo(0, 6 + h * 0.65);
+            target.lineTo(2, 6);
+            target.closePath();
+            target.fill();
+        }
         target.restore();
     }
 };
@@ -500,7 +519,7 @@ function checkLowFuel() {
 }
 
 function emitEngineParticles(dt) {
-    engineParticleBudget += 70 * dt;
+    engineParticleBudget += 110 * dt;
     const count = Math.floor(engineParticleBudget);
     engineParticleBudget -= count;
     if (count === 0) return;
@@ -513,9 +532,9 @@ function emitEngineParticles(dt) {
         particles.push({
             x: lander.x + exhaustX * 9 + (Math.random() - 0.5) * 4,
             y: lander.y + 5 + exhaustY * 8,
-            vx: exhaustX * speed + lander.vx * 0.15,
+            vx: exhaustX * speed + lander.vx * 0.15 + (Math.random() - 0.5) * 18,
             vy: exhaustY * speed + lander.vy * 0.15,
-            life: 0.2 + Math.random() * 0.18,
+            life: 0.28 + Math.random() * 0.25,
             color: Math.random() > 0.3 ? '#ff0' : '#f30',
             debris: false
         });

--- a/labs/lander/style.css
+++ b/labs/lander/style.css
@@ -379,6 +379,10 @@ canvas {
 }
 
 @media (max-width: 768px) {
+    html, body {
+        overflow-x: clip;
+    }
+
     .game-area {
         padding: 0;
     }

--- a/labs/lander/style.css
+++ b/labs/lander/style.css
@@ -224,16 +224,24 @@ canvas {
     white-space: nowrap;
 }
 
-/* On-Screen Controls - Strictly matching image */
+/* On-Screen Controls — só em ponteiro grosso; no desktop o teclado basta. */
 .onscreen-controls {
     position: absolute;
-    top: 220px;
-    right: 74px;
-    display: flex;
+    top: auto;
+    bottom: max(8px, env(safe-area-inset-bottom, 0px));
+    right: max(12px, env(safe-area-inset-right, 0px));
+    display: none;
     flex-direction: column;
     align-items: center;
     gap: 5px;
     pointer-events: auto;
+    z-index: 4;
+}
+
+@media (pointer: coarse) {
+    .onscreen-controls {
+        display: flex;
+    }
 }
 
 .onscreen-controls .row {
@@ -242,8 +250,10 @@ canvas {
 }
 
 .control-btn {
-    width: 42px;
-    height: 42px;
+    width: 44px;
+    height: 44px;
+    min-width: 44px;
+    min-height: 44px;
     background-color: #c0c0c0;
     border-top: 2px solid #fff;
     border-left: 2px solid #fff;
@@ -366,6 +376,69 @@ canvas {
 
 .hidden {
     display: none;
+}
+
+@media (max-width: 768px) {
+    .game-area {
+        padding: 0;
+    }
+
+    .win31-window {
+        width: 100%;
+        max-width: 100%;
+    }
+
+    .hud-stats {
+        font-size: 14px;
+        min-width: 168px;
+        right: 8px;
+        top: 8px;
+    }
+
+    .stat-row.meta {
+        font-size: 13px;
+    }
+
+    .flight-status {
+        font-size: 11px;
+    }
+
+    .safe-readout {
+        display: none;
+    }
+
+    .onscreen-controls {
+        top: auto;
+        bottom: max(2px, env(safe-area-inset-bottom, 0px));
+        right: max(14px, env(safe-area-inset-right, 0px));
+    }
+
+    .control-btn {
+        height: 48px;
+        width: 48px;
+    }
+
+    .center-msg {
+        font-size: 20px;
+    }
+
+    .center-msg > strong {
+        font-size: 30px;
+    }
+
+    .center-msg small {
+        font-size: 13px;
+    }
+
+    .start-button {
+        font-size: 18px;
+    }
+
+    .game-viewport {
+        width: 100%;
+        height: auto;
+        aspect-ratio: 4 / 3;
+    }
 }
 
 @media (max-width: 600px) {

--- a/labs/lavandula/index.html
+++ b/labs/lavandula/index.html
@@ -34,7 +34,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;600;700;800&family=Outfit:wght@300;400;500;600;700&display=swap"
         rel="stylesheet">
     <link rel="stylesheet" href="/labs/shared.css?v=13">
-    <link rel="stylesheet" href="style.css?v=1">
+    <link rel="stylesheet" href="style.css?v=2">
 
     <script type="importmap">
     {
@@ -283,7 +283,7 @@
             }
         })();
     </script>
-    <script type="module" src="src/main.js?v=3"></script>
+    <script type="module" src="src/main.js?v=4"></script>
 </body>
 
 </html>

--- a/labs/lavandula/src/main.js
+++ b/labs/lavandula/src/main.js
@@ -51,9 +51,10 @@ class Game {
     }
 
     resolveQuality() {
+        if (detectSoftwareGL()) return QUALITY.low;
         const choice = this.settings.quality;
         if (choice !== 'auto' && QUALITY[choice]) return QUALITY[choice];
-        if (detectMobile() || detectSoftwareGL()) return QUALITY.low;
+        if (detectMobile()) return QUALITY.low;
         const big = Math.min(window.innerWidth, window.innerHeight) >= 900;
         return big ? QUALITY.high : QUALITY.medium;
     }
@@ -278,7 +279,7 @@ class Game {
         this.hud.setTime(0);
         this.hud.setObjective('Ande pela estrada. Os campos não pedem nada.');
         this.hud.showHud(true);
-        this.hud.setTouchVisible(this.mobile);
+        this.hud.setTouchVisible(matchMedia('(pointer: coarse)').matches || this.mobile);
         this.hud.say('O vento nas fileiras. Anda quando quiser.', 5);
         this.state = 'intro';
         this.hud.setState('intro');

--- a/labs/lavandula/style.css
+++ b/labs/lavandula/style.css
@@ -635,3 +635,8 @@ kbd {
     .menu-head h1 { font-size: 1.7rem; }
     .hud-actions { bottom: calc(7.5rem + var(--safe-bottom)); }
 }
+
+/* agent-responsive-768 */
+@media (max-width: 768px) {
+  html, body { overflow-x: clip; }
+}

--- a/labs/lavandula/style.css
+++ b/labs/lavandula/style.css
@@ -636,6 +636,80 @@ kbd {
     .hud-actions { bottom: calc(7.5rem + var(--safe-bottom)); }
 }
 
+@media (max-height: 520px) and (orientation: landscape) {
+    .hud {
+        padding: calc(3.6rem + var(--safe-top)) calc(0.7rem + var(--safe-right)) calc(0.6rem + var(--safe-bottom))
+            calc(0.7rem + var(--safe-left));
+    }
+
+    .hud-top {
+        grid-template-columns: minmax(0, 1fr) auto;
+        gap: 0.45rem;
+    }
+
+    .panel {
+        padding: 0.4rem 0.6rem;
+    }
+
+    .hud-label {
+        font-size: 0.58rem;
+    }
+
+    .objective {
+        font-size: 0.78rem;
+        line-height: 1.25;
+        display: -webkit-box;
+        -webkit-line-clamp: 1;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+    }
+
+    .message {
+        bottom: calc(5.4rem + var(--safe-bottom));
+        font-size: 0.82rem;
+    }
+
+    .prompt {
+        bottom: calc(7.2rem + var(--safe-bottom));
+        font-size: 0.75rem;
+    }
+
+    .hud-actions {
+        bottom: calc(0.55rem + var(--safe-bottom));
+        right: calc(0.7rem + var(--safe-right));
+    }
+
+    .touch-controls {
+        inset: auto calc(0.6rem + var(--safe-right)) calc(0.4rem + var(--safe-bottom)) calc(0.6rem + var(--safe-left));
+    }
+
+    .stick {
+        width: 4.6rem;
+        height: 4.6rem;
+    }
+
+    .pad {
+        width: 2.5rem;
+        height: 2.5rem;
+    }
+
+    .overlay-card,
+    .loading-card {
+        max-height: min(92dvh, 32rem);
+        overflow-y: auto;
+        padding: 0.85rem 1rem;
+    }
+
+    .menu-head h1 {
+        font-size: clamp(1.45rem, 4vw, 1.9rem);
+    }
+
+    .menu-grid {
+        grid-template-columns: 1fr 1fr;
+        gap: 0.75rem;
+    }
+}
+
 /* agent-responsive-768 */
 @media (max-width: 768px) {
   html, body { overflow-x: clip; }

--- a/labs/matrix/index.html
+++ b/labs/matrix/index.html
@@ -28,7 +28,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Share+Tech+Mono&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/labs/shared.css?v=13">
-    <link rel="stylesheet" href="style.css?v=4">
+    <link rel="stylesheet" href="style.css?v=5">
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
@@ -339,7 +339,7 @@
     </main>
 
     <script src="/labs/shared.js?v=13" defer></script>
-    <script src="script.js" defer></script>
+    <script src="script.js?v=2" defer></script>
 </body>
 
 </html>

--- a/labs/matrix/script.js
+++ b/labs/matrix/script.js
@@ -278,7 +278,7 @@
         const unit = Math.max(2, Math.round(2 * dpr));
         line.width = 1;
         line.height = unit * 2;
-        lineCtx.fillStyle = 'rgba(0, 0, 0, 0.38)';
+        lineCtx.fillStyle = 'rgba(0, 0, 0, 0.26)';
         lineCtx.fillRect(0, 0, 1, unit);
         scanPattern = ctx.createPattern(line, 'repeat');
 

--- a/labs/menina-da-lanterna/index.html
+++ b/labs/menina-da-lanterna/index.html
@@ -34,7 +34,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@500;600;700&family=Nunito:wght@400;600;700;800&display=swap"
         rel="stylesheet">
     <link rel="stylesheet" href="/labs/shared.css?v=13">
-    <link rel="stylesheet" href="style.css?v=2">
+    <link rel="stylesheet" href="style.css?v=3">
 
     <script type="importmap">
     {
@@ -331,7 +331,7 @@
             }
         })();
     </script>
-    <script type="module" src="src/main.js?v=2"></script>
+    <script type="module" src="src/main.js?v=3"></script>
 </body>
 
 </html>

--- a/labs/menina-da-lanterna/src/main.js
+++ b/labs/menina-da-lanterna/src/main.js
@@ -67,9 +67,10 @@ class Game {
     }
 
     resolveQuality() {
+        if (detectSoftwareGL()) return QUALITY.low;
         const choice = this.settings.quality;
         if (choice !== 'auto' && QUALITY[choice]) return QUALITY[choice];
-        if (detectMobile() || detectSoftwareGL()) return QUALITY.low;
+        if (detectMobile()) return QUALITY.low;
         const big = Math.min(window.innerWidth, window.innerHeight) >= 900;
         return big ? QUALITY.high : QUALITY.medium;
     }

--- a/labs/mimo/index.html
+++ b/labs/mimo/index.html
@@ -278,7 +278,7 @@
     <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
 
     <script src="/labs/shared.js?v=13"></script>
-    <script type="module" src="src/main.js"></script>
+    <script type="module" src="src/main.js?v=2"></script>
 </body>
 
 </html>

--- a/labs/mimo/src/main.js
+++ b/labs/mimo/src/main.js
@@ -25,8 +25,9 @@ const HOME_TARGET = new THREE.Vector3(0, 0.42, 0.1);
 const TMP = new THREE.Vector3();
 
 function resolveQuality(choice) {
+    if (detectSoftwareGL()) return QUALITY.low;
     if (choice && choice !== 'auto' && QUALITY[choice]) return QUALITY[choice];
-    if (detectMobile() || detectSoftwareGL()) return QUALITY.low;
+    if (detectMobile()) return QUALITY.low;
     const big = Math.min(window.innerWidth, window.innerHeight) >= 900;
     return big ? QUALITY.high : QUALITY.medium;
 }
@@ -73,7 +74,7 @@ class Mimo {
         try {
             this.renderer = new THREE.WebGLRenderer({
                 canvas: this.canvas,
-                antialias: this.quality.id !== 'low',
+                antialias: this.quality.antialias !== false && this.quality.id !== 'low',
                 powerPreference: 'high-performance',
                 alpha: false
             });

--- a/labs/minesweeper/index.html
+++ b/labs/minesweeper/index.html
@@ -24,7 +24,7 @@
     <meta name="twitter:title" content="Campo Minado 95 — clássico do Windows | Diogo Paulino">
     <meta name="twitter:description" content="Campo Minado com visual autêntico do Windows 95, três níveis, cronômetro e recordes salvos direto no navegador.">
     <link rel="stylesheet" href="/labs/shared.css?v=13">
-    <link rel="stylesheet" href="style.css?v=2">
+    <link rel="stylesheet" href="style.css?v=3">
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",

--- a/labs/minesweeper/style.css
+++ b/labs/minesweeper/style.css
@@ -32,7 +32,7 @@ body {
     box-shadow: 4px 4px 10px rgba(0, 0, 0, 0.5);
     min-width: 200px;
     max-width: min(100%, 100vw - 1.5rem);
-    overflow-x: auto;
+    overflow-x: clip;
     -webkit-overflow-scrolling: touch;
 }
 
@@ -357,4 +357,24 @@ body {
 @media (max-width: 480px) {
     .window { max-width: 100%; overflow-x: auto; }
     .board { max-width: 100%; }
+}
+
+
+/* agent-responsive */
+@media (max-width: 768px) {
+    :root { --cell-size: clamp(14px, 5.2vw, 22px); }
+    .window {
+        width: min(100%, 100vw);
+        max-width: 100%;
+        overflow-x: clip;
+    }
+    .face-btn {
+        width: 32px;
+        height: 32px;
+    }
+}
+
+@media (max-height: 520px) and (orientation: landscape) {
+    .title-bar .title { font-size: 12px; }
+    .window { margin: 0 auto; }
 }

--- a/labs/neon-rider/index.html
+++ b/labs/neon-rider/index.html
@@ -34,7 +34,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Audiowide&family=Outfit:wght@400;500;600;700&family=Share+Tech+Mono&display=swap"
         rel="stylesheet">
     <link rel="stylesheet" href="/labs/shared.css?v=13">
-    <link rel="stylesheet" href="style.css?v=2">
+    <link rel="stylesheet" href="style.css?v=3">
 
     <script type="importmap">
     {
@@ -269,7 +269,7 @@
     </main>
 
     <script src="/labs/shared.js?v=13" defer></script>
-    <script type="module" src="src/main.js?v=5"></script>
+    <script type="module" src="src/main.js?v=6"></script>
 </body>
 
 </html>

--- a/labs/neon-rider/index.html
+++ b/labs/neon-rider/index.html
@@ -269,7 +269,7 @@
     </main>
 
     <script src="/labs/shared.js?v=13" defer></script>
-    <script type="module" src="src/main.js?v=4"></script>
+    <script type="module" src="src/main.js?v=5"></script>
 </body>
 
 </html>

--- a/labs/neon-rider/index.html
+++ b/labs/neon-rider/index.html
@@ -34,7 +34,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Audiowide&family=Outfit:wght@400;500;600;700&family=Share+Tech+Mono&display=swap"
         rel="stylesheet">
     <link rel="stylesheet" href="/labs/shared.css?v=13">
-    <link rel="stylesheet" href="style.css?v=4">
+    <link rel="stylesheet" href="style.css?v=5">
 
     <script type="importmap">
     {
@@ -269,7 +269,7 @@
     </main>
 
     <script src="/labs/shared.js?v=13" defer></script>
-    <script type="module" src="src/main.js?v=6"></script>
+    <script type="module" src="src/main.js?v=7"></script>
 </body>
 
 </html>

--- a/labs/neon-rider/index.html
+++ b/labs/neon-rider/index.html
@@ -34,7 +34,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Audiowide&family=Outfit:wght@400;500;600;700&family=Share+Tech+Mono&display=swap"
         rel="stylesheet">
     <link rel="stylesheet" href="/labs/shared.css?v=13">
-    <link rel="stylesheet" href="style.css?v=3">
+    <link rel="stylesheet" href="style.css?v=4">
 
     <script type="importmap">
     {

--- a/labs/neon-rider/src/config.js
+++ b/labs/neon-rider/src/config.js
@@ -129,21 +129,21 @@ export const QUALITY = {
         bloom: false,
         shadows: false,
         lamps: 0,
-        drawDistance: 180,
-        fogDensity: 0.014,
-        chunkProps: 0.4,
-        particles: 40
+        drawDistance: 140,
+        fogDensity: 0.018,
+        chunkProps: 0.28,
+        particles: 20
     },
     medium: {
-        antialias: true,
-        pixelRatio: 1.25,
+        antialias: false,
+        pixelRatio: 1.15,
         bloom: false,
         shadows: false,
-        lamps: 3,
-        drawDistance: 280,
-        fogDensity: 0.01,
-        chunkProps: 0.7,
-        particles: 120
+        lamps: 2,
+        drawDistance: 240,
+        fogDensity: 0.012,
+        chunkProps: 0.55,
+        particles: 80
     },
     high: {
         antialias: true,

--- a/labs/neon-rider/src/config.js
+++ b/labs/neon-rider/src/config.js
@@ -129,32 +129,32 @@ export const QUALITY = {
         bloom: false,
         shadows: false,
         lamps: 0,
-        drawDistance: 220,
-        fogDensity: 0.012,
-        chunkProps: 0.55,
-        particles: 80
+        drawDistance: 180,
+        fogDensity: 0.014,
+        chunkProps: 0.4,
+        particles: 40
     },
     medium: {
         antialias: true,
-        pixelRatio: 1.5,
-        bloom: true,
+        pixelRatio: 1.25,
+        bloom: false,
         shadows: false,
-        lamps: 4,
-        drawDistance: 320,
-        fogDensity: 0.0085,
-        chunkProps: 0.85,
-        particles: 180
+        lamps: 3,
+        drawDistance: 280,
+        fogDensity: 0.01,
+        chunkProps: 0.7,
+        particles: 120
     },
     high: {
         antialias: true,
-        pixelRatio: 2,
+        pixelRatio: 1.5,
         bloom: true,
         shadows: true,
-        lamps: 8,
-        drawDistance: 420,
-        fogDensity: 0.0064,
+        lamps: 6,
+        drawDistance: 380,
+        fogDensity: 0.0068,
         chunkProps: 1,
-        particles: 280
+        particles: 200
     }
 };
 

--- a/labs/neon-rider/src/main.js
+++ b/labs/neon-rider/src/main.js
@@ -70,7 +70,7 @@ class Game {
             this.renderer = new THREE.WebGLRenderer({
                 canvas: this.canvas,
                 antialias: this.quality.antialias,
-                powerPreference: 'high-performance',
+                powerPreference: detectSoftwareGL() ? 'low-power' : 'high-performance',
                 stencil: false
             });
         } catch (err) {

--- a/labs/neon-rider/src/main.js
+++ b/labs/neon-rider/src/main.js
@@ -47,9 +47,12 @@ class Game {
     }
 
     resolveQuality() {
+        // SoftGL/SwiftShader derrete com high — sempre capar, mesmo se o usuário
+        // salvou “high” numa sessão anterior com GPU real.
+        if (detectSoftwareGL()) return QUALITY.low;
         const choice = this.settings.quality;
         if (choice !== 'auto' && QUALITY[choice]) return QUALITY[choice];
-        if (detectMobile() || detectSoftwareGL()) return QUALITY.low;
+        if (detectMobile()) return QUALITY.low;
         const big = Math.min(window.innerWidth, window.innerHeight) >= 900;
         return big ? QUALITY.high : QUALITY.medium;
     }

--- a/labs/neon-rider/src/main.js
+++ b/labs/neon-rider/src/main.js
@@ -527,7 +527,7 @@ class Game {
         if (!this._look) this._look = LOOK.clone();
         this._look.lerp(LOOK, k);
         this.camera.lookAt(this._look);
-        this.camera.fov = damp(this.camera.fov, 56 + this.player.speed * 0.18, 4, dt);
+        this.camera.fov = damp(this.camera.fov, 60 + this.player.speed * 0.32, 5.5, dt);
         this.camera.updateProjectionMatrix();
     }
 

--- a/labs/neon-rider/style.css
+++ b/labs/neon-rider/style.css
@@ -124,9 +124,9 @@ button {
     position: absolute;
     inset: 0;
     background:
-        radial-gradient(120% 90% at 50% 45%, transparent 50%, rgba(0, 0, 0, 0.55) 100%),
+        radial-gradient(120% 90% at 50% 45%, transparent 40%, rgba(0, 0, 0, 0.72) 100%),
         linear-gradient(90deg, rgba(255, 43, 214, 0.06), transparent 18%, transparent 82%, rgba(0, 240, 255, 0.06));
-    box-shadow: inset 0 0 80px rgba(0, 0, 0, 0.45);
+    box-shadow: inset 0 0 110px rgba(0, 0, 0, 0.6);
 }
 
 .glitch-layer {
@@ -798,4 +798,12 @@ kbd {
     .touch-controls {
         height: min(42%, 38dvh);
     }
+}
+
+/* agent-responsive-768 */
+@media (max-width: 768px) {
+  html, body { overflow-x: clip; }
+  .hud, .overlay, .menu-overlay, .overlay-card {
+    max-width: 100%;
+  }
 }

--- a/labs/nereida/index.html
+++ b/labs/nereida/index.html
@@ -34,7 +34,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,500;0,600;0,700;1,500&family=Figtree:wght@400;600;700;800&display=swap"
         rel="stylesheet">
     <link rel="stylesheet" href="/labs/shared.css?v=13">
-    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="style.css?v=2">
 
     <script type="importmap">
     {
@@ -267,7 +267,7 @@
             }
         })();
     </script>
-    <script type="module" src="src/main.js"></script>
+    <script type="module" src="src/main.js?v=2"></script>
 </body>
 
 </html>

--- a/labs/nereida/src/main.js
+++ b/labs/nereida/src/main.js
@@ -29,9 +29,10 @@ function detectSoftwareGL(renderer) {
 }
 
 function pickQuality(mode, renderer) {
+    if (detectSoftwareGL(renderer)) return QUALITY.low;
     if (QUALITY[mode]) return QUALITY[mode];
     const mobile = matchMedia('(pointer: coarse)').matches || innerWidth < 800;
-    if (detectSoftwareGL(renderer) || mobile) return QUALITY.low;
+    if (mobile) return QUALITY.low;
     if (devicePixelRatio >= 2 && innerWidth >= 1400) return QUALITY.high;
     return QUALITY.medium;
 }

--- a/labs/nereida/style.css
+++ b/labs/nereida/style.css
@@ -652,3 +652,11 @@ kbd {
         display: none !important;
     }
 }
+
+/* agent-responsive-768 */
+@media (max-width: 768px) {
+  html, body { overflow-x: clip; }
+  .hud, .overlay, .menu-overlay, .overlay-card {
+    max-width: 100%;
+  }
+}

--- a/labs/nereida/style.css
+++ b/labs/nereida/style.css
@@ -653,6 +653,93 @@ kbd {
     }
 }
 
+@media (max-height: 520px) and (orientation: landscape) {
+    .hud-top {
+        gap: 0.45rem;
+        grid-template-columns: auto minmax(0, 1fr) auto;
+    }
+
+    .hud-actions {
+        top: calc(0.55rem + var(--safe-top));
+        right: calc(0.7rem + var(--safe-right));
+        gap: 0.35rem;
+    }
+
+    .icon-button {
+        width: 2.1rem;
+        height: 2.1rem;
+        font-size: 0.85rem;
+    }
+
+    .panel {
+        padding: 0.4rem 0.6rem;
+    }
+
+    .hud-label {
+        font-size: 0.6rem;
+    }
+
+    .message {
+        bottom: calc(6.2rem + var(--safe-bottom));
+        max-width: min(20rem, 46vw);
+        font-size: 0.78rem;
+        line-height: 1.25;
+    }
+
+    .touch-controls {
+        inset: auto calc(0.7rem + var(--safe-right)) calc(0.5rem + var(--safe-bottom)) calc(0.7rem + var(--safe-left));
+    }
+
+    .stick {
+        width: 4.8rem;
+        height: 4.8rem;
+    }
+
+    .stick i {
+        width: 1.8rem;
+        height: 1.8rem;
+        margin: -0.9rem 0 0 -0.9rem;
+    }
+
+    .stick span {
+        bottom: -1.1rem;
+        font-size: 0.6rem;
+    }
+
+    .pad {
+        width: 2.5rem;
+        height: 2.5rem;
+        font-size: 0.95rem;
+    }
+
+    .pad-magic {
+        width: 3.1rem;
+        height: 3.1rem;
+    }
+
+    .overlay {
+        padding: calc(3.4rem + var(--safe-top)) 1rem calc(1rem + var(--safe-bottom));
+    }
+
+    .overlay-card,
+    .loading-card {
+        max-height: min(92dvh, 34rem);
+        overflow-y: auto;
+    }
+
+    .menu-grid {
+        grid-template-columns: 1fr 1fr;
+        gap: 0.9rem;
+        margin: 0.9rem 0 0.8rem;
+    }
+
+    .loading-card h1,
+    .menu-head h1,
+    .compact-card h2 {
+        font-size: clamp(1.6rem, 4vw, 2.2rem);
+    }
+}
+
 /* agent-responsive-768 */
 @media (max-width: 768px) {
   html, body { overflow-x: clip; }

--- a/labs/nina/index.html
+++ b/labs/nina/index.html
@@ -34,7 +34,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Fredoka:wght@500;600;700&family=Nunito:wght@400;600;700;800&display=swap"
         rel="stylesheet">
     <link rel="stylesheet" href="/labs/shared.css?v=13">
-    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="style.css?v=2">
 
     <script type="importmap">
     {
@@ -267,7 +267,7 @@
             }
         })();
     </script>
-    <script type="module" src="src/main.js"></script>
+    <script type="module" src="src/main.js?v=2"></script>
 </body>
 
 </html>

--- a/labs/nina/src/main.js
+++ b/labs/nina/src/main.js
@@ -35,9 +35,10 @@ function detectSoftwareGL(renderer) {
 }
 
 function pickQuality(mode, renderer) {
+    if (detectSoftwareGL(renderer)) return QUALITY.low;
     if (QUALITY[mode]) return QUALITY[mode];
     const mobile = matchMedia('(pointer: coarse)').matches || innerWidth < 800;
-    if (detectSoftwareGL(renderer) || mobile) return QUALITY.low;
+    if (mobile) return QUALITY.low;
     if (devicePixelRatio >= 2 && innerWidth >= 1400) return QUALITY.high;
     return QUALITY.medium;
 }

--- a/labs/nina/style.css
+++ b/labs/nina/style.css
@@ -810,3 +810,11 @@ kbd {
         font-size: clamp(1.6rem, 4vw, 2.2rem);
     }
 }
+
+/* agent-responsive-768 */
+@media (max-width: 768px) {
+  html, body { overflow-x: clip; }
+  .hud, .overlay, .menu-overlay, .overlay-card {
+    max-width: 100%;
+  }
+}

--- a/labs/orbis/index.html
+++ b/labs/orbis/index.html
@@ -35,7 +35,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;600;700&family=Syne:wght@400;500;600;700;800&display=swap"
         rel="stylesheet">
     <link rel="stylesheet" href="/labs/shared.css?v=13">
-    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="style.css?v=3">
 
     <script type="importmap">
     {
@@ -178,7 +178,7 @@
     <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
 
     <script src="/labs/shared.js?v=13" defer></script>
-    <script type="module" src="./src/main.js"></script>
+    <script type="module" src="./src/main.js?v=3"></script>
 </body>
 
 </html>

--- a/labs/orbis/src/main.js
+++ b/labs/orbis/src/main.js
@@ -9,9 +9,9 @@ import { StarSystem } from './system.js';
 import { clamp, damp, hashString } from './rng.js';
 
 const QUALITY = {
-    high: { planetSeg: 96, starSeg: 64, stars: 7000, asteroids: 1400, bloom: true, pr: 2 },
-    medium: { planetSeg: 72, starSeg: 48, stars: 4200, asteroids: 800, bloom: true, pr: 1.5 },
-    low: { planetSeg: 48, starSeg: 32, stars: 2200, asteroids: 400, bloom: false, pr: 1 }
+    high: { planetSeg: 96, starSeg: 64, stars: 7000, asteroids: 1400, bloom: true, pr: 2, antialias: true },
+    medium: { planetSeg: 72, starSeg: 48, stars: 4200, asteroids: 800, bloom: true, pr: 1.5, antialias: true },
+    low: { planetSeg: 48, starSeg: 32, stars: 2200, asteroids: 400, bloom: false, pr: 1, antialias: false }
 };
 
 function detectSoftwareGL() {
@@ -65,7 +65,7 @@ class Orbis {
 
         this.renderer = new THREE.WebGLRenderer({
             canvas: this.canvas,
-            antialias: this.qualityId !== 'low',
+            antialias: !!this.quality.antialias,
             alpha: false,
             powerPreference: 'high-performance'
         });

--- a/labs/orbis/style.css
+++ b/labs/orbis/style.css
@@ -686,3 +686,8 @@ body[data-view="system"] #backSystem {
         height: min(42%, 38dvh);
     }
 }
+
+/* agent-responsive-768 */
+@media (max-width: 768px) {
+  html, body { overflow-x: clip; }
+}

--- a/labs/paint/index.html
+++ b/labs/paint/index.html
@@ -29,7 +29,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@100..900&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/labs/shared.css?v=13">
-    <link rel="stylesheet" href="style.css?v=5">
+    <link rel="stylesheet" href="style.css?v=6">
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
@@ -306,7 +306,7 @@
         <footer data-lab-footer data-home-href="/"></footer>
     </div>
     <script src="/labs/shared.js?v=13" defer></script>
-    <script src="script.js?v=3" defer></script>
+    <script src="script.js?v=4" defer></script>
 </body>
 
 </html>

--- a/labs/paint/script.js
+++ b/labs/paint/script.js
@@ -25,6 +25,50 @@ const fillShapesInput = document.getElementById('fillShapes');
 const activeToolName = document.getElementById('activeToolName');
 const swatches = document.querySelectorAll('.color-swatch');
 
+// Brush cursor preview (desktop)
+const brushCursor = document.createElement('div');
+brushCursor.className = 'brush-cursor';
+brushCursor.setAttribute('aria-hidden', 'true');
+container.appendChild(brushCursor);
+
+const syncBrushCursor = () => {
+    const rect = canvas.getBoundingClientRect();
+    const scale = rect.width / canvas.width || 1;
+    const size = Math.max(4, brushSize * scale);
+    brushCursor.style.width = `${size}px`;
+    brushCursor.style.height = `${size}px`;
+    brushCursor.classList.toggle('is-eraser', currentTool === 'eraser');
+    const showPreview = currentTool === 'brush' || currentTool === 'eraser';
+    if (!showPreview) brushCursor.classList.remove('is-visible');
+    if (showPreview) {
+        const alphaHex = Math.round(currentOpacity * 55).toString(16).padStart(2, '0');
+        brushCursor.style.backgroundColor = currentTool === 'eraser'
+            ? 'rgba(255,255,255,0.35)'
+            : `${currentColor}${alphaHex}`;
+    }
+};
+
+const moveBrushCursor = (clientX, clientY) => {
+    const showPreview = currentTool === 'brush' || currentTool === 'eraser';
+    if (!showPreview) {
+        brushCursor.classList.remove('is-visible');
+        return;
+    }
+    const crect = container.getBoundingClientRect();
+    brushCursor.style.left = `${clientX - crect.left + container.scrollLeft}px`;
+    brushCursor.style.top = `${clientY - crect.top + container.scrollTop}px`;
+    syncBrushCursor();
+    brushCursor.classList.add('is-visible');
+};
+
+canvas.addEventListener('pointermove', (e) => {
+    if (e.pointerType === 'mouse') moveBrushCursor(e.clientX, e.clientY);
+});
+canvas.addEventListener('pointerenter', (e) => {
+    if (e.pointerType === 'mouse') moveBrushCursor(e.clientX, e.clientY);
+});
+canvas.addEventListener('pointerleave', () => brushCursor.classList.remove('is-visible'));
+
 // Actions Elements
 const undoBtn = document.getElementById('undoBtn');
 const redoBtn = document.getElementById('redoBtn');
@@ -357,6 +401,7 @@ toolBtns.forEach(btn => {
         if (activeToolName) {
             activeToolName.textContent = btn.dataset.name || currentTool;
         }
+        syncBrushCursor();
     });
 });
 
@@ -372,6 +417,7 @@ const setColor = (color) => {
         sw.classList.toggle('is-active', sw.dataset.color?.toLowerCase() === color.toLowerCase());
         sw.setAttribute('aria-pressed', String(sw.classList.contains('is-active')));
     });
+    syncBrushCursor();
 };
 
 colorPicker.addEventListener('input', (e) => setColor(e.target.value));
@@ -383,11 +429,13 @@ swatches.forEach(swatch => {
 brushSizeInput.addEventListener('input', (e) => {
     brushSize = e.target.value;
     brushSizeVal.textContent = `${brushSize}px`;
+    syncBrushCursor();
 });
 
 opacityInput.addEventListener('input', (e) => {
     currentOpacity = e.target.value / 100;
     opacityVal.textContent = `${e.target.value}%`;
+    syncBrushCursor();
 });
 
 if (fillShapesInput) {

--- a/labs/paint/style.css
+++ b/labs/paint/style.css
@@ -282,6 +282,7 @@ footer[data-lab-footer] {
     flex: 1;
     min-width: 0;
     min-height: 0;
+    position: relative;
     background-color: var(--checker-2);
     background-image:
         linear-gradient(45deg, var(--checker-1) 25%, transparent 25%),
@@ -308,6 +309,35 @@ canvas {
     object-fit: contain;
     border-radius: 8px;
     touch-action: none;
+}
+
+@media (pointer: fine) {
+    canvas {
+        cursor: none;
+    }
+}
+
+.brush-cursor {
+    position: absolute;
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    border: 1.5px solid rgba(15, 23, 42, 0.75);
+    box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.7), 0 2px 8px rgba(0, 0, 0, 0.18);
+    pointer-events: none;
+    transform: translate(-50%, -50%);
+    z-index: 5;
+    opacity: 0;
+    transition: opacity 0.12s ease, background-color 0.12s ease;
+}
+
+.brush-cursor.is-visible {
+    opacity: 1;
+}
+
+.brush-cursor.is-eraser {
+    border-color: rgba(239, 68, 68, 0.85);
+    background: rgba(255, 255, 255, 0.35);
 }
 
 .property-group {

--- a/labs/partitura/script.js
+++ b/labs/partitura/script.js
@@ -819,11 +819,21 @@ function updateFeedback(msg, type = 'normal') {
   const text = document.getElementById('feedback-text');
   if (!banner) return;
 
-  banner.className = `feedback-banner ${type}`;
-  if (type === 'success') icon.textContent = '🌟';
-  else if (type === 'error') icon.textContent = '❌';
-  else icon.textContent = '💡';
+  banner.className = `feedback-bar-integrated ${type === 'normal' ? '' : type}`.trim();
+  if (type === 'success') {
+    icon.textContent = '🌟';
+    banner.classList.add('feedback-pop');
+  } else if (type === 'error') {
+    icon.textContent = '❌';
+    banner.classList.add('feedback-pop');
+  } else {
+    icon.textContent = '💡';
+  }
   text.innerHTML = msg;
+  if (type === 'success' || type === 'error') {
+    clearTimeout(updateFeedback._popTimer);
+    updateFeedback._popTimer = setTimeout(() => banner.classList.remove('feedback-pop'), 420);
+  }
 }
 
 function setTargetClefAndPitch() {
@@ -1196,6 +1206,10 @@ function setupControlBars() {
   noteBtns.forEach(btn => {
     btn.addEventListener('click', (e) => {
       const note = btn.dataset.note;
+      btn.classList.remove('active-hit');
+      void btn.offsetWidth;
+      btn.classList.add('active-hit');
+      setTimeout(() => btn.classList.remove('active-hit'), 320);
       handleNoteInput(note, e);
     });
   });

--- a/labs/partitura/style.css
+++ b/labs/partitura/style.css
@@ -359,6 +359,12 @@ body {
 
 .feedback-bar-integrated.success { background: rgba(16, 185, 129, 0.18); color: #34d399; border-color: rgba(16,185,129,0.5); }
 .feedback-bar-integrated.error { background: rgba(244, 63, 94, 0.18); color: #fb7185; border-color: rgba(244,63,94,0.5); }
+.feedback-bar-integrated.feedback-pop { animation: feedbackPop 0.42s ease; }
+@keyframes feedbackPop {
+  0% { transform: scale(0.96); filter: brightness(1.2); }
+  55% { transform: scale(1.03); }
+  100% { transform: scale(1); filter: brightness(1); }
+}
 
 /* Brilho estático na pauta — sem scale/translate (confunde leitura de linha/espaço) */
 .clef-mark { filter: drop-shadow(0 0 8px var(--neon-cyan)); }
@@ -368,10 +374,11 @@ body {
 .mode-bass-clef .note-glow { filter: drop-shadow(0 0 12px var(--neon-amethyst)); }
 
 /* Feedback de acerto: só intensifica o glow, sem mexer a posição da nota */
-.note-hit-anim { animation: noteHitFlash 0.45s ease; }
+.note-hit-anim { animation: noteHitFlash 0.55s ease; }
 @keyframes noteHitFlash {
-  0%, 100% { filter: drop-shadow(0 0 10px var(--neon-cyan)); }
-  50% { filter: drop-shadow(0 0 22px var(--neon-emerald)); }
+  0%, 100% { filter: drop-shadow(0 0 10px var(--neon-cyan)); opacity: 1; }
+  35% { filter: drop-shadow(0 0 28px var(--neon-emerald)) drop-shadow(0 0 12px #fff); opacity: 1; }
+  70% { filter: drop-shadow(0 0 18px var(--neon-emerald)); }
 }
 
 .staff-shake { animation: staffShake 0.4s ease; }
@@ -418,6 +425,14 @@ body {
   border-color: var(--neon-cyan);
   box-shadow: 0 0 16px var(--neon-cyan);
   background: rgba(34, 211, 238, 0.2);
+}
+
+.trigger-pad.active-hit {
+  animation: padHitFlash 0.35s ease;
+}
+@keyframes padHitFlash {
+  0% { transform: scale(0.94) translateY(0); filter: brightness(1.35); }
+  100% { transform: translateY(-2px); filter: brightness(1); }
 }
 
 .virtual-keyboard-deck {

--- a/labs/piano/script.js
+++ b/labs/piano/script.js
@@ -242,6 +242,10 @@ function playNote(noteName, velocity = 0.7) {
   const keyElement = document.querySelector(`[data-note="${noteName}"]`);
   if (keyElement) {
     keyElement.classList.add('active');
+    keyElement.style.setProperty('--key-velocity', velocity.toFixed(3));
+    keyElement.classList.remove('key-strike');
+    void keyElement.offsetWidth;
+    keyElement.classList.add('key-strike');
   }
 }
 

--- a/labs/piano/style.css
+++ b/labs/piano/style.css
@@ -74,44 +74,64 @@ body {
 .key {
   position: relative;
   cursor: pointer;
-  transition: all 0.05s cubic-bezier(0.4, 0, 0.2, 1);
+  transition: background 0.05s cubic-bezier(0.4, 0, 0.2, 1), box-shadow 0.05s ease, transform 0.05s ease;
   border: none;
   outline: none;
+  --key-velocity: 0.7;
 }
 
 .key.white {
   width: 48px;
   height: 100%;
-  background: var(--piano-white);
+  background: linear-gradient(180deg, #ffffff 0%, #f8fafc 70%, #e2e8f0 100%);
   border: 1px solid var(--border-subtle);
   border-radius: 0 0 4px 4px;
   z-index: 1;
-  box-shadow: inset 0 -2px 3px rgba(0, 0, 0, 0.08);
+  box-shadow: inset 0 -2px 3px rgba(0, 0, 0, 0.08), 0 1px 0 rgba(255,255,255,0.6);
 }
 
 .key.black {
   position: absolute;
   width: 32px;
   height: 58%;
-  background: var(--piano-black);
+  background: linear-gradient(180deg, #334155 0%, var(--piano-black) 55%, #020617 100%);
   border: 1px solid var(--border-subtle);
   border-radius: 0 0 3px 3px;
   z-index: 2;
-  box-shadow: 0 3px 6px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 3px 6px rgba(0, 0, 0, 0.2), inset 0 1px 0 rgba(255,255,255,0.12);
 }
 
 .key.white:active,
 .key.white.active {
-  background: var(--piano-white-active);
-  box-shadow: inset 0 3px 10px rgba(0, 0, 0, 0.1);
-  transform: translateY(1px);
+  background: linear-gradient(180deg, #e2e8f0 0%, var(--piano-white-active) 100%);
+  box-shadow:
+    inset 0 calc(2px + var(--key-velocity) * 6px) calc(8px + var(--key-velocity) * 8px) rgba(0, 0, 0, 0.16),
+    0 0 calc(8px + var(--key-velocity) * 14px) rgba(148, 163, 184, calc(0.15 + var(--key-velocity) * 0.35));
+  transform: translateY(calc(1px + var(--key-velocity) * 2px));
 }
 
 .key.black:active,
 .key.black.active {
-  background: var(--piano-black-active);
-  box-shadow: inset 0 3px 8px rgba(0, 0, 0, 0.3);
-  transform: translateY(1px);
+  background: linear-gradient(180deg, #0f172a 0%, var(--piano-black-active) 100%);
+  box-shadow:
+    inset 0 calc(2px + var(--key-velocity) * 5px) 10px rgba(0, 0, 0, 0.45),
+    0 0 calc(6px + var(--key-velocity) * 12px) rgba(96, 165, 250, calc(0.12 + var(--key-velocity) * 0.35));
+  transform: translateY(calc(1px + var(--key-velocity) * 1.5px));
+}
+
+.key.key-strike::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  background: radial-gradient(circle at 50% 20%, rgba(255,255,255,calc(0.15 + var(--key-velocity) * 0.35)), transparent 65%);
+  animation: keyStrikeFlash 0.28s ease-out;
+}
+
+@keyframes keyStrikeFlash {
+  from { opacity: 1; }
+  to { opacity: 0; }
 }
 
 .key-note {

--- a/labs/poker/index.html
+++ b/labs/poker/index.html
@@ -274,7 +274,7 @@
   </footer>
 
   <script src="/labs/shared.js?v=7" defer></script>
-  <script type="module" src="src/main.js"></script>
+  <script type="module" src="src/main.js?v=2"></script>
 </body>
 
 </html>

--- a/labs/poker/index.html
+++ b/labs/poker/index.html
@@ -274,7 +274,7 @@
   </footer>
 
   <script src="/labs/shared.js?v=7" defer></script>
-  <script type="module" src="src/main.js?v=2"></script>
+  <script type="module" src="src/main.js?v=3"></script>
 </body>
 
 </html>

--- a/labs/poker/src/audio.js
+++ b/labs/poker/src/audio.js
@@ -2,8 +2,26 @@
  * Sons leves via Web Audio API — sem arquivos externos.
  */
 
+const MUTE_KEY = 'poker:muted';
+
 let ctx = null;
-let muted = false;
+let muted = readMuted();
+
+function readMuted() {
+    try {
+        return localStorage.getItem(MUTE_KEY) === '1';
+    } catch (err) {
+        return false;
+    }
+}
+
+function persistMuted(value) {
+    try {
+        localStorage.setItem(MUTE_KEY, value ? '1' : '0');
+    } catch (err) {
+        /* Storage pode falhar em modo privado. */
+    }
+}
 
 function ac() {
     if (!ctx) ctx = new (window.AudioContext || window.webkitAudioContext)();
@@ -13,6 +31,7 @@ function ac() {
 
 export function setMuted(v) {
     muted = !!v;
+    persistMuted(muted);
 }
 
 export function isMuted() {

--- a/labs/poker/src/main.js
+++ b/labs/poker/src/main.js
@@ -42,6 +42,11 @@ const state = {
 function init() {
     state.match = createMatch({ startingStack: 1000, smallBlind: 5, bigBlind: 10 });
     bindUi();
+    const mute = $('#muteBtn');
+    if (mute) {
+        mute.setAttribute('aria-pressed', String(isMuted()));
+        mute.textContent = isMuted() ? 'Mudo' : 'Som';
+    }
     renderAll();
     showIntro(true);
 }

--- a/labs/poker/style.css
+++ b/labs/poker/style.css
@@ -1599,3 +1599,25 @@ body {
     transform: none;
   }
 }
+
+/* agent-overflow-pass */
+@media (max-width: 768px) {
+  html, body {
+    overflow-x: clip;
+  }
+
+  .app, .shell, .layout, main {
+    max-width: 100%;
+    min-width: 0;
+  }
+
+  .table-stage,
+  .table-scene,
+  .felt {
+    max-width: 100%;
+  }
+
+  .action-bar, .actions, .bet-row {
+    flex-wrap: wrap;
+  }
+}

--- a/labs/pomodoro/index.html
+++ b/labs/pomodoro/index.html
@@ -28,7 +28,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/labs/shared.css?v=13">
-    <link rel="stylesheet" href="style.css?v=4">
+    <link rel="stylesheet" href="style.css?v=5">
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",

--- a/labs/pomodoro/style.css
+++ b/labs/pomodoro/style.css
@@ -1065,3 +1065,8 @@ input[type="range"] {
     .task-check { width: 22px; height: 22px; }
     .task-form { grid-template-columns: minmax(0, 1fr) 72px 44px; }
 }
+
+/* agent-responsive-768 */
+@media (max-width: 768px) {
+  html, body { overflow-x: clip; }
+}

--- a/labs/ps5-controller/index.html
+++ b/labs/ps5-controller/index.html
@@ -37,7 +37,7 @@
     <link rel="preload" href="/labs/ps5-controller/assets/draco/gltf/draco_decoder.wasm" as="fetch" crossorigin>
     <link rel="preload" href="/labs/ps5-controller/assets/models/first-light-controller.glb" as="fetch" crossorigin>
     <link rel="stylesheet" href="/labs/shared.css?v=13">
-    <link rel="stylesheet" href="style.css?v=1">
+    <link rel="stylesheet" href="style.css?v=2">
 
     <script type="importmap">
     {
@@ -103,7 +103,7 @@
     <footer class="lab-foot" data-lab-footer data-home-href="/"></footer>
 
     <script src="/labs/shared.js?v=13" defer></script>
-    <script type="module" src="src/main.js?v=2"></script>
+    <script type="module" src="src/main.js?v=3"></script>
 </body>
 
 </html>

--- a/labs/ps5-controller/src/main.js
+++ b/labs/ps5-controller/src/main.js
@@ -1046,7 +1046,18 @@ var init_ProductScene = __esm({
       /** Resolves once the renderer, environment and first model are ready. */
       async init(container, onProgress) {
         const rendererOptions = {
-          antialias: true,
+          antialias: (() => {
+            try {
+              const c = document.createElement('canvas');
+              const gl = c.getContext('webgl2') || c.getContext('webgl');
+              if (!gl) return false;
+              const info = gl.getExtension('WEBGL_debug_renderer_info');
+              const name = info ? String(gl.getParameter(info.UNMASKED_RENDERER_WEBGL) || '') : '';
+              return !/swiftshader|llvmpipe|softpipe|microsoft basic render|\bcpu\b/i.test(name);
+            } catch {
+              return false;
+            }
+          })(),
           alpha: false,
           powerPreference: "high-performance"
         };

--- a/labs/ps5-controller/styles/responsive.css
+++ b/labs/ps5-controller/styles/responsive.css
@@ -332,3 +332,8 @@
     transform: none;
   }
 }
+
+/* agent-responsive-768 */
+@media (max-width: 768px) {
+  html, body { overflow-x: clip; }
+}

--- a/labs/pulsar/script.js
+++ b/labs/pulsar/script.js
@@ -608,9 +608,16 @@
             }
             ctx.beginPath();
             ctx.arc(rp.x, rp.y, r, 0, Math.PI * 2);
-            ctx.lineWidth = 2.2 - (r / rp.maxR) * 1.4;
-            ctx.strokeStyle = rgba(rp.color, alpha);
+            ctx.lineWidth = 2.8 - (r / rp.maxR) * 1.6;
+            ctx.strokeStyle = rgba(rp.color, alpha * 1.15);
             ctx.stroke();
+            if (alpha > 0.2) {
+                ctx.beginPath();
+                ctx.arc(rp.x, rp.y, r * 0.72, 0, Math.PI * 2);
+                ctx.lineWidth = 1.2;
+                ctx.strokeStyle = rgba(rp.color, alpha * 0.45);
+                ctx.stroke();
+            }
         }
         ctx.globalCompositeOperation = 'source-over';
     }
@@ -622,18 +629,28 @@
         const local = ((beats % o.period) + o.period) % o.period;
         const until = (o.phase - local + o.period) % o.period;
         const approach = until < 0.55 ? 1 - until / 0.55 : 0;
-        const burst = clamp(1 - (t - o.lastTrigger) / 0.42, 0, 1);
-        const r = o.r + approach * 2.2 + burst * 6;
-        const glowR = r + 14 + burst * 22;
+        const burst = clamp(1 - (t - o.lastTrigger) / 0.55, 0, 1);
+        const breath = 0.5 + 0.5 * Math.sin(beats * Math.PI * 2 / Math.max(1, o.period) + o.phase);
+        const r = o.r + approach * 2.6 + burst * 7.5 + breath * 0.8;
+        const glowR = r + 16 + burst * 34 + approach * 8;
         ctx.globalAlpha = ghosted ? 0.38 : 1;
 
-        const bloom = ctx.createRadialGradient(o.x, o.y, r * 0.2, o.x, o.y, glowR);
-        bloom.addColorStop(0, rgba(o.color, (dark ? 0.55 : 0.4) + burst * 0.3));
+        const bloom = ctx.createRadialGradient(o.x, o.y, r * 0.15, o.x, o.y, glowR);
+        bloom.addColorStop(0, rgba(o.color, (dark ? 0.7 : 0.5) + burst * 0.4));
+        bloom.addColorStop(0.45, rgba(o.color, (dark ? 0.28 : 0.18) + burst * 0.2));
         bloom.addColorStop(1, rgba(o.color, 0));
         ctx.fillStyle = bloom;
         ctx.beginPath();
         ctx.arc(o.x, o.y, glowR, 0, Math.PI * 2);
         ctx.fill();
+
+        if (burst > 0.05 && !ghosted) {
+            ctx.strokeStyle = rgba(o.color, burst * 0.55);
+            ctx.lineWidth = 2 + burst * 2;
+            ctx.beginPath();
+            ctx.arc(o.x, o.y, r + 10 + (1 - burst) * 28, 0, Math.PI * 2);
+            ctx.stroke();
+        }
 
         const body = ctx.createRadialGradient(o.x - r * 0.25, o.y - r * 0.3, r * 0.1, o.x, o.y, r);
         body.addColorStop(0, dark ? '#fff' : 'rgba(255,255,255,0.95)');
@@ -645,7 +662,7 @@
         ctx.fill();
 
         if (approach > 0.05 && !ghosted) {
-            ctx.strokeStyle = rgba(o.color, approach * 0.55);
+            ctx.strokeStyle = rgba(o.color, approach * 0.6);
             ctx.lineWidth = 1.5;
             ctx.beginPath();
             ctx.arc(o.x, o.y, r + 6 + (1 - approach) * 8, 0, Math.PI * 2);

--- a/labs/quimera/index.html
+++ b/labs/quimera/index.html
@@ -35,7 +35,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,500;0,9..144,650;1,9..144,500&family=Outfit:wght@300;400;500;600;700&display=swap"
         rel="stylesheet">
     <link rel="stylesheet" href="/labs/shared.css?v=13">
-    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="style.css?v=3">
 
     <script type="importmap">
     {
@@ -195,7 +195,7 @@
     </main>
 
     <script src="/labs/shared.js?v=13" defer></script>
-    <script type="module" src="./src/main.js"></script>
+    <script type="module" src="./src/main.js?v=3"></script>
 </body>
 
 </html>

--- a/labs/quimera/src/main.js
+++ b/labs/quimera/src/main.js
@@ -89,6 +89,7 @@ class Quimera {
         this.renderer = new THREE.WebGLRenderer({
             canvas: this.canvas,
             antialias: this.quality !== 'low',
+            powerPreference: this.quality === 'low' ? 'low-power' : 'high-performance',
             powerPreference: 'high-performance'
         });
         this.renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, pr));

--- a/labs/quimera/style.css
+++ b/labs/quimera/style.css
@@ -469,3 +469,8 @@ footer[data-lab-footer] a {
         grid-template-columns: 1fr;
     }
 }
+
+/* agent-responsive-768 */
+@media (max-width: 768px) {
+  html, body { overflow-x: clip; }
+}

--- a/labs/quimera/style.css
+++ b/labs/quimera/style.css
@@ -470,6 +470,50 @@ footer[data-lab-footer] a {
     }
 }
 
+@media (max-height: 520px) and (orientation: landscape) {
+    .hud-left {
+        top: max(3.6rem, calc(var(--safe-top) + 2.8rem));
+        left: max(0.7rem, var(--safe-left));
+        width: min(18rem, calc(100vw - 1.4rem));
+        padding: 0.55rem 0.75rem;
+    }
+
+    .hud-left h2 {
+        font-size: 1.05rem;
+    }
+
+    .meta-line {
+        margin: 0.25rem 0 0.45rem;
+        font-size: 0.75rem;
+    }
+
+    .readout {
+        gap: 0.75rem;
+    }
+
+    .dock {
+        bottom: max(0.35rem, var(--safe-bottom));
+        width: min(100vw - 0.8rem, 56rem);
+        padding: 0.45rem;
+        gap: 0.4rem;
+        grid-template-columns: repeat(3, minmax(0, 1fr)) auto;
+    }
+
+    .slot-name {
+        margin-bottom: 0.2rem;
+        font-size: 0.55rem;
+    }
+
+    .step {
+        height: max(2.2rem, 40px);
+        font-size: 1.15rem;
+    }
+
+    .hint {
+        display: none;
+    }
+}
+
 /* agent-responsive-768 */
 @media (max-width: 768px) {
   html, body { overflow-x: clip; }

--- a/labs/rastro-vermelho/index.html
+++ b/labs/rastro-vermelho/index.html
@@ -34,7 +34,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;600;700;800&family=Outfit:wght@300;400;500;600;700&display=swap"
         rel="stylesheet">
     <link rel="stylesheet" href="/labs/shared.css?v=13">
-    <link rel="stylesheet" href="style.css?v=3">
+    <link rel="stylesheet" href="style.css?v=4">
 
     <script type="application/ld+json">
     {
@@ -185,6 +185,6 @@
     <script src="https://cdn.babylonjs.com/v9.25.0/babylon.js" onerror="rastroLoadError()"></script>
     <script src="https://cdn.babylonjs.com/v9.25.0/loaders/babylonjs.loaders.min.js" onerror="rastroLoadError()"></script>
     <script src="https://cdn.babylonjs.com/v9.25.0/materialsLibrary/babylonjs.materials.min.js" onerror="rastroLoadError()"></script>
-    <script type="module" src="src/main.js?v=3" onerror="rastroLoadError()"></script>
+    <script type="module" src="src/main.js?v=4" onerror="rastroLoadError()"></script>
 </body>
 </html>

--- a/labs/rastro-vermelho/src/main.js
+++ b/labs/rastro-vermelho/src/main.js
@@ -31,7 +31,23 @@ class RastroVermelho {
         this.cameraPosition = new B.Vector3(); this.cameraTarget = new B.Vector3(); this.sunsetFog = B.Color3.FromHexString('#a68a75'); this.dayFog = B.Color3.FromHexString('#a4b6ba'); this.nightFog = B.Color3.FromHexString('#26313e');
         this.init().catch(error => { this.state = 'error'; this.audio.pause(); this.engine.stopRenderLoop(); showError(error); });
     }
-    pickQuality() { return PROFILES[this.settings.quality] || (matchMedia('(pointer: coarse)').matches ? PROFILES.low : PROFILES.medium); }
+    pickQuality() {
+        try {
+            const c = document.createElement('canvas');
+            const gl = c.getContext('webgl2') || c.getContext('webgl');
+            if (gl) {
+                const info = gl.getExtension('WEBGL_debug_renderer_info');
+                const name = info ? String(gl.getParameter(info.UNMASKED_RENDERER_WEBGL) || '') : '';
+                if (/swiftshader|llvmpipe|softpipe|microsoft basic render|\bcpu\b/i.test(name)) {
+                    return PROFILES.low;
+                }
+            } else {
+                return PROFILES.low;
+            }
+        } catch { /* ignore */ }
+        return PROFILES[this.settings.quality]
+            || (matchMedia('(pointer: coarse)').matches ? PROFILES.low : PROFILES.medium);
+    }
     async init() {
         const scene = this.scene;
         this.camera = new B.UniversalCamera('câmera', new B.Vector3(0, 14, -12), scene);

--- a/labs/rastro-vermelho/style.css
+++ b/labs/rastro-vermelho/style.css
@@ -207,3 +207,11 @@ body[data-state="play"] .lab-foot { display: none; }
 @media (prefers-reduced-motion: reduce) {
     *, *::before, *::after { animation-duration: .01ms !important; animation-iteration-count: 1 !important; transition-duration: .01ms !important; }
 }
+
+/* agent-responsive-768 */
+@media (max-width: 768px) {
+  html, body { overflow-x: clip; }
+  .hud, .overlay, .menu-overlay, .overlay-card {
+    max-width: 100%;
+  }
+}

--- a/labs/ravi-123/style.css
+++ b/labs/ravi-123/style.css
@@ -226,3 +226,11 @@ header[data-lab-header] .subtitle {
 }
 /* --- lab-responsive-pass --- */
 #hud { z-index: 30; }
+
+/* agent-responsive-768 */
+@media (max-width: 768px) {
+  html, body { overflow-x: clip; }
+  .hud, .overlay, .menu-overlay, .overlay-card {
+    max-width: 100%;
+  }
+}

--- a/labs/riftball/index.html
+++ b/labs/riftball/index.html
@@ -34,7 +34,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600;700;800&family=Syne:wght@700;800&display=swap"
         rel="stylesheet">
     <link rel="stylesheet" href="/labs/shared.css?v=13">
-    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="style.css?v=2">
 
     <script type="importmap">
     {
@@ -285,7 +285,7 @@
 
     <script src="https://cdn.jsdelivr.net/npm/peerjs@1.5.4/dist/peerjs.min.js" defer></script>
     <script src="/labs/shared.js?v=13" defer></script>
-    <script type="module" src="src/main.js"></script>
+    <script type="module" src="src/main.js?v=2"></script>
 </body>
 
 </html>

--- a/labs/riftball/src/main.js
+++ b/labs/riftball/src/main.js
@@ -11,7 +11,7 @@ import { OutputPass } from 'three/addons/postprocessing/OutputPass.js';
 import {
     STORAGE_KEY, QUALITY, DT, MAX_STEPS, NET, TEAMS
 } from './config.js';
-import { clamp, lerp, wrapPi, detectMobile, detectSoftwareGL } from './utils.js';
+import { clamp, lerp, wrapPi, detectMobile, detectTouch, detectSoftwareGL } from './utils.js';
 import { Input } from './input.js';
 import { GameAudio } from './audio.js';
 import { Hud } from './hud.js';
@@ -304,7 +304,7 @@ class Game {
         this.guestInput = blankInput();
         this.localSlot = mode === 'online-guest' ? 1 : 0;
         this.hud.showHud();
-        this.hud.setTouch(this.mobile && mode !== 'local');
+        this.hud.setTouch(detectTouch() && mode !== 'local');
         this.hud.setNames(TEAMS[0].name, TEAMS[1].name);
         this.hud.setScore(this.match.score, this.match.clock, false);
         this.hud.announce('Riftball', 1.1);

--- a/labs/riftball/src/utils.js
+++ b/labs/riftball/src/utils.js
@@ -27,6 +27,12 @@ export function detectMobile() {
     return Boolean(coarse && narrow) || /Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
 }
 
+export function detectTouch() {
+    if (typeof navigator === 'undefined') return false;
+    return Boolean(window.matchMedia?.('(pointer: coarse)')?.matches)
+        || /Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
+}
+
 export function detectSoftwareGL() {
     try {
         const canvas = document.createElement('canvas');

--- a/labs/riftball/style.css
+++ b/labs/riftball/style.css
@@ -796,3 +796,11 @@ kbd {
         bottom: calc(7.2rem + var(--safe-bottom));
     }
 }
+
+/* agent-responsive-768 */
+@media (max-width: 768px) {
+  html, body { overflow-x: clip; }
+  .hud, .overlay, .menu-overlay, .overlay-card {
+    max-width: 100%;
+  }
+}

--- a/labs/river-knight/index.html
+++ b/labs/river-knight/index.html
@@ -34,7 +34,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;600;700;800&family=Outfit:wght@300;400;500;600;700&display=swap"
         rel="stylesheet">
     <link rel="stylesheet" href="/labs/shared.css?v=13">
-    <link rel="stylesheet" href="style.css?v=5">
+    <link rel="stylesheet" href="style.css?v=6">
 
     <script type="importmap">
     {
@@ -301,7 +301,7 @@
     </main>
 
     <script src="/labs/shared.js?v=13" defer></script>
-    <script type="module" src="src/main.js?v=16"></script>
+    <script type="module" src="src/main.js?v=17"></script>
 </body>
 
 </html>

--- a/labs/river-knight/src/main.js
+++ b/labs/river-knight/src/main.js
@@ -29,7 +29,7 @@ import { Input } from './input.js';
 import { GameAudio } from './audio.js?v=14';
 import { updateCloth } from './models.js?v=14';
 import { centerX, halfWidth } from './river.js';
-import { clamp, damp, detectMobile, detectSoftwareGL, formatTime, randRange } from './utils.js?v=15';
+import { clamp, damp, detectMobile, detectTouch, detectSoftwareGL, formatTime, randRange } from './utils.js?v=16';
 
 const WHITE = new THREE.Color(1, 1, 1);
 
@@ -208,7 +208,7 @@ class Game {
         this.input = new Input(this.canvas);
         this.bindUi();
 
-        this.isTouch = detectMobile();
+        this.isTouch = detectTouch();
         this.hud.setTouchVisible(false);
 
         await this.setupPostProcessing(quality);

--- a/labs/river-knight/src/utils.js
+++ b/labs/river-knight/src/utils.js
@@ -121,6 +121,13 @@ export function detectMobile() {
     return Boolean(coarse && narrow) || /Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
 }
 
+/** Pads de toque — qualquer ponteiro grosso (tablet landscape incluso). */
+export function detectTouch() {
+    if (typeof navigator === 'undefined') return false;
+    return Boolean(window.matchMedia?.('(pointer: coarse)')?.matches)
+        || /Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
+}
+
 /** SwiftShader / llvmpipe / etc. — auto quality must not pick "Cinemática". */
 export function detectSoftwareGL() {
     try {

--- a/labs/river-knight/style.css
+++ b/labs/river-knight/style.css
@@ -1311,3 +1311,11 @@ input[type="range"]::-moz-range-thumb {
         right: calc(0.7rem + var(--safe-right));
     }
 }
+
+/* agent-responsive-768 */
+@media (max-width: 768px) {
+  html, body { overflow-x: clip; }
+  .hud, .overlay, .menu-overlay, .overlay-card {
+    max-width: 100%;
+  }
+}

--- a/labs/rock-kombat/constants.js
+++ b/labs/rock-kombat/constants.js
@@ -6,8 +6,10 @@
 export const W = 1280;
 export const H = 720;
 export const GROUND = 620;
-export const LEFT_WALL = 160;
-export const RIGHT_WALL = 1120;
+/* Sprites têm ~405px de largura visual: paredes internas evitam o corpo
+   sumir pela beirada quando a câmera acompanha o duelo. */
+export const LEFT_WALL = 210;
+export const RIGHT_WALL = 1070;
 
 export const STEP = 1000 / 60;
 export const INPUT_BUFFER = 10;

--- a/labs/rock-kombat/index.html
+++ b/labs/rock-kombat/index.html
@@ -23,7 +23,7 @@
   <meta property="og:description" content="Escolha sua lenda. Leia a distância. Domine o palco.">
   <meta property="og:url" content="https://diogopaulino.com.br/labs/rock-kombat/">
   <link rel="stylesheet" href="/labs/shared.css?v=13">
-  <link rel="stylesheet" href="style.css?v=7">
+  <link rel="stylesheet" href="style.css?v=8">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -265,6 +265,6 @@
   <footer data-lab-footer data-home-href="/"></footer>
 
   <script src="/labs/shared.js?v=13" defer></script>
-  <script type="module" src="main.js?v=4"></script>
+  <script type="module" src="main.js?v=5"></script>
 </body>
 </html>

--- a/labs/rock-kombat/renderer.js
+++ b/labs/rock-kombat/renderer.js
@@ -55,8 +55,8 @@ export function render(ctx, match, frameNumber, images, renderState) {
   ctx.save();
 
   const mid = (match.p1.x + match.p2.x) / 2;
-  const camX = clamp(mid - W / 2, -48, 48);
-  ctx.translate(-camX * 0.35, 0);
+  const camX = clamp(mid - W / 2, -28, 28);
+  ctx.translate(-camX * 0.28, 0);
 
   if (match.shake) {
     ctx.translate(random(-match.shake, match.shake), random(-match.shake * 0.45, match.shake * 0.45));

--- a/labs/rock-kombat/style.css
+++ b/labs/rock-kombat/style.css
@@ -1011,10 +1011,12 @@ legend {
 .pause-button {
   position: absolute;
   z-index: 6;
-  right: 10px;
+  right: max(10px, env(safe-area-inset-right, 0px));
   top: 86px;
-  width: 38px;
-  height: 38px;
+  width: 44px;
+  height: 44px;
+  min-width: 44px;
+  min-height: 44px;
   border: 1px solid #ffffff33;
   background: #08090b99;
 }
@@ -1358,6 +1360,32 @@ dialog h2 {
   }
 }
 
+@media (max-width: 768px) {
+  .fighter-card {
+    min-height: min(380px, 70dvh);
+  }
+
+  .fighter-visual {
+    height: min(260px, 42dvh);
+  }
+
+  .roster {
+    grid-template-columns: 1fr;
+    gap: 10px;
+  }
+
+  .pause-button {
+    top: max(64px, calc(env(safe-area-inset-top, 0px) + 52px));
+    width: 44px;
+    height: 44px;
+  }
+
+  .arena {
+    padding-left: max(4px, env(safe-area-inset-left, 0px));
+    padding-right: max(4px, env(safe-area-inset-right, 0px));
+  }
+}
+
 
 /* ==========================================================================
    16. Responsive — Mobile (≤ 650px)
@@ -1519,8 +1547,8 @@ dialog h2 {
 
   .pause-button {
     top: 70px;
-    width: 34px;
-    height: 34px;
+    width: 44px;
+    height: 44px;
   }
 
   .versus-duel {

--- a/labs/safari-dourado/index.html
+++ b/labs/safari-dourado/index.html
@@ -207,7 +207,7 @@
     <script src="https://cdn.babylonjs.com/v9.25.0/babylon.js"></script>
     <script src="https://cdn.babylonjs.com/v9.25.0/loaders/babylonjs.loaders.min.js"></script>
     <script src="/labs/shared.js?v=13" defer></script>
-    <script type="module" src="src/main.js?v=2"></script>
+    <script type="module" src="src/main.js?v=3"></script>
 </body>
 
 </html>

--- a/labs/safari-dourado/src/main.js
+++ b/labs/safari-dourado/src/main.js
@@ -6,6 +6,16 @@
 import { buildSavannaWorld } from './world.js?v=2';
 import { buildJeep } from './models.js?v=2';
 import { clamp, lerp } from './utils.js';
+import { QUALITY } from './config.js';
+
+function pickQuality() {
+    const coarse = typeof matchMedia === 'function' && matchMedia('(pointer: coarse)').matches;
+    const narrow = Math.min(window.innerWidth, window.innerHeight) < 760;
+    if (coarse || narrow) return QUALITY.low;
+    const dpr = window.devicePixelRatio || 1;
+    if (dpr >= 2 || Math.min(window.innerWidth, window.innerHeight) < 900) return QUALITY.medium;
+    return QUALITY.high;
+}
 
 class SafariDourado {
     constructor() {
@@ -88,12 +98,17 @@ class SafariDourado {
         const BABYLON = window.BABYLON;
         if (!BABYLON) return;
 
+        this.quality = pickQuality();
+
         try {
-            this.engine = new BABYLON.Engine(this.canvas, true, {
+            this.engine = new BABYLON.Engine(this.canvas, this.quality.antialias, {
                 preserveDrawingBuffer: false,
                 stencil: true,
-                adaptToDeviceRatio: true
+                adaptToDeviceRatio: false,
+                powerPreference: 'high-performance'
             });
+            const pr = Math.min(window.devicePixelRatio || 1, this.quality.pixelRatio);
+            this.engine.setHardwareScalingLevel(1 / pr);
             this.scene = new BABYLON.Scene(this.engine);
             this.scene.clearColor = new BABYLON.Color4(0.12, 0.08, 0.05, 1.0);
         } catch (err) {
@@ -114,8 +129,8 @@ class SafariDourado {
 
         // Pipeline PBR de cinema
         const pipe = new BABYLON.DefaultRenderingPipeline('pipeline', true, this.scene, [this.camera]);
-        pipe.fxaaEnabled = true;
-        pipe.bloomEnabled = true;
+        pipe.fxaaEnabled = this.quality.antialias;
+        pipe.bloomEnabled = this.quality.bloom !== false;
         pipe.bloomThreshold = 0.78;
         pipe.bloomWeight = 0.32;
         pipe.imageProcessing.toneMappingEnabled = true;
@@ -125,6 +140,7 @@ class SafariDourado {
         document.getElementById('loadingOverlay').hidden = true;
         document.getElementById('menuOverlay').hidden = false;
         document.body.dataset.state = 'menu';
+        this.state = 'menu';
 
         this._renderLoop = () => {
             this.frame();
@@ -141,7 +157,8 @@ class SafariDourado {
         this.state = 'drive';
         document.getElementById('menuOverlay').hidden = true;
         document.getElementById('hud').hidden = false;
-        document.getElementById('touchControls').hidden = !('ontouchstart' in window);
+        const coarse = window.matchMedia('(pointer: coarse)').matches;
+        document.getElementById('touchControls').hidden = !coarse;
         document.body.dataset.state = 'drive';
     }
 

--- a/labs/safari-dourado/style.css
+++ b/labs/safari-dourado/style.css
@@ -841,3 +841,11 @@ kbd {
         bottom: calc(0.8rem + var(--safe-bottom, 0px));
     }
 }
+
+/* agent-responsive-768 */
+@media (max-width: 768px) {
+  html, body { overflow-x: clip; }
+  .hud, .overlay, .menu-overlay, .overlay-card {
+    max-width: 100%;
+  }
+}

--- a/labs/snake/index.html
+++ b/labs/snake/index.html
@@ -180,7 +180,7 @@
     </div>
 
     <script src="/labs/shared.js?v=13" defer></script>
-    <script src="script.js?v=4" defer></script>
+    <script src="script.js?v=5" defer></script>
 </body>
 
 </html>

--- a/labs/snake/index.html
+++ b/labs/snake/index.html
@@ -180,7 +180,7 @@
     </div>
 
     <script src="/labs/shared.js?v=13" defer></script>
-    <script src="script.js?v=5" defer></script>
+    <script src="script.js?v=6" defer></script>
 </body>
 
 </html>

--- a/labs/snake/index.html
+++ b/labs/snake/index.html
@@ -26,7 +26,7 @@
         content="Snake retrô em um console portátil 8-bit: colete frutas, ganhe velocidade e bata o seu recorde.">
     <meta property="og:url" content="https://diogopaulino.com.br/labs/snake/">
     <link rel="stylesheet" href="/labs/shared.css?v=13">
-    <link rel="stylesheet" href="style.css?v=2">
+    <link rel="stylesheet" href="style.css?v=3">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
@@ -180,7 +180,7 @@
     </div>
 
     <script src="/labs/shared.js?v=13" defer></script>
-    <script src="script.js?v=3" defer></script>
+    <script src="script.js?v=4" defer></script>
 </body>
 
 </html>

--- a/labs/snake/script.js
+++ b/labs/snake/script.js
@@ -36,6 +36,9 @@ let lastFrame = 0;
 let rafId = null;
 let isGameRunning = false;
 let isPaused = false;
+// A cobra só anda depois do primeiro comando — senão, no meio do tabuleiro
+// indo para a direita, morre na parede em ~1s sem o jogador ter jogado.
+let awaitingFirstMove = false;
 
 // Colors are pulled from the CSS custom properties so the LCD follows the theme.
 const COLORS = { bg: '#9bbc0f', snake: '#0f380f', food: '#0f380f' };
@@ -166,14 +169,16 @@ function announce(message) {
 // Initialize Game
 function initGame() {
     const startY = Math.floor(TILE_COUNT_Y / 2);
+    // Começa mais à esquerda para dar margem quando o primeiro comando for “direita”.
     snake = [
-        { x: 10, y: startY },
-        { x: 9, y: startY },
-        { x: 8, y: startY }
+        { x: 6, y: startY },
+        { x: 5, y: startY },
+        { x: 4, y: startY }
     ];
     dx = 1;
     dy = 0;
     queuedDirection = null;
+    awaitingFirstMove = true;
     score = 0;
     stepInterval = BASE_SPEED;
     accumulator = 0;
@@ -188,7 +193,7 @@ function initGame() {
     eatPulse = 0;
     deathFlash = 0;
     updateHud();
-    announce('Partida iniciada.');
+    announce('Partida iniciada. Escolha uma direção.');
     sfxStart();
 
     startLoop();
@@ -234,7 +239,7 @@ function gameLoop(timestamp) {
     eatPulse = Math.max(0, eatPulse - delta / 220);
     deathFlash = Math.max(0, deathFlash - delta / 420);
 
-    if (isGameRunning && !isPaused) {
+    if (isGameRunning && !isPaused && !awaitingFirstMove) {
         accumulator += delta;
         while (accumulator >= stepInterval) {
             accumulator -= stepInterval;
@@ -518,6 +523,15 @@ function queueDirection(nextDx, nextDy) {
     if (nextDx === -currentDx && nextDy === -currentDy) return;
     if (nextDx === currentDx && nextDy === currentDy) return;
     queuedDirection = { dx: nextDx, dy: nextDy };
+    if (awaitingFirstMove) {
+        // Aplica já e libera o passo fixo — o jogador pediu para andar.
+        dx = nextDx;
+        dy = nextDy;
+        queuedDirection = null;
+        awaitingFirstMove = false;
+        accumulator = 0;
+        announce('Partida em andamento.');
+    }
     sfxTurn();
 }
 

--- a/labs/snake/script.js
+++ b/labs/snake/script.js
@@ -402,19 +402,21 @@ function drawFood() {
     const r = (GRID_SIZE / 2 - 2) * scale;
 
     ctx.fillStyle = COLORS.food;
+    // Duas lobos: silhueta de maçã, ainda 2-tone Game Boy.
     ctx.beginPath();
-    ctx.arc(cx, cy + 1, r, 0, Math.PI * 2);
+    ctx.arc(cx - r * 0.28, cy + 1, r * 0.82, 0, Math.PI * 2);
+    ctx.arc(cx + r * 0.28, cy + 1, r * 0.82, 0, Math.PI * 2);
     ctx.fill();
 
     // Talo e folha.
     ctx.strokeStyle = COLORS.food;
-    ctx.lineWidth = 2;
+    ctx.lineWidth = 2.5;
     ctx.beginPath();
-    ctx.moveTo(cx, cy - r);
+    ctx.moveTo(cx, cy - r * 0.85);
     ctx.lineTo(cx, cy - r - 3);
     ctx.stroke();
     ctx.beginPath();
-    ctx.ellipse(cx + 3, cy - r - 3, 3, 1.6, -0.5, 0, Math.PI * 2);
+    ctx.ellipse(cx + 4, cy - r - 3, 4, 2.2, -0.5, 0, Math.PI * 2);
     ctx.fill();
 
     // Brilho: um furinho na cor do fundo, do jeito que um sprite 8-bit faria.

--- a/labs/snake/script.js
+++ b/labs/snake/script.js
@@ -520,8 +520,12 @@ function queueDirection(nextDx, nextDy) {
     // Compare against the direction that will actually be applied next step.
     const currentDx = queuedDirection ? queuedDirection.dx : dx;
     const currentDy = queuedDirection ? queuedDirection.dy : dy;
-    if (nextDx === -currentDx && nextDy === -currentDy) return;
-    if (nextDx === currentDx && nextDy === currentDy) return;
+    // Antes do primeiro passo, qualquer direção é válida (ainda não há "reverso"
+    // perigoso — a cobra está parada).
+    if (!awaitingFirstMove) {
+        if (nextDx === -currentDx && nextDy === -currentDy) return;
+        if (nextDx === currentDx && nextDy === currentDy) return;
+    }
     queuedDirection = { dx: nextDx, dy: nextDy };
     if (awaitingFirstMove) {
         // Aplica já e libera o passo fixo — o jogador pediu para andar.

--- a/labs/snake/style.css
+++ b/labs/snake/style.css
@@ -552,3 +552,27 @@ canvas {
         padding: 0.5rem 0;
     }
 }
+
+@media (max-width: 768px) {
+    body {
+        overflow-x: clip;
+        padding-left: max(0.5rem, env(safe-area-inset-left, 0px));
+        padding-right: max(0.5rem, env(safe-area-inset-right, 0px));
+    }
+
+    .instructions {
+        font-size: 0.85rem;
+        padding-inline: 0.75rem;
+    }
+
+    .handheld-device {
+        width: min(320px, 100%);
+    }
+}
+
+@media (max-height: 500px) and (orientation: landscape) {
+    .handheld-device {
+        width: min(560px, 100%);
+        max-width: 100%;
+    }
+}

--- a/labs/space-shooter/index.html
+++ b/labs/space-shooter/index.html
@@ -26,7 +26,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="stylesheet" href="/labs/shared.css?v=13">
-    <link rel="stylesheet" href="style.css?v=3">
+    <link rel="stylesheet" href="style.css?v=4">
     <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
     <script type="application/ld+json">
     {

--- a/labs/space-shooter/index.html
+++ b/labs/space-shooter/index.html
@@ -26,7 +26,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="stylesheet" href="/labs/shared.css?v=13">
-    <link rel="stylesheet" href="style.css?v=4">
+    <link rel="stylesheet" href="style.css?v=5">
     <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
     <script type="application/ld+json">
     {
@@ -196,7 +196,7 @@
     </div>
 
     <script src="/labs/shared.js?v=13" defer></script>
-    <script src="script.js?v=4" defer></script>
+    <script src="script.js?v=5" defer></script>
 </body>
 
 </html>

--- a/labs/space-shooter/script.js
+++ b/labs/space-shooter/script.js
@@ -421,27 +421,30 @@ function draw() {
 
     // Draw Player — sem shadowBlur (caro em mobile); brilho via alpha no fill
     ctx.shadowBlur = 0;
-    // Pluma do motor (feedback de movimento)
-    const thrusting = keys.Space; // tiro acende a pluma
-    if (thrusting || bullets.length) {
+    // Pluma do motor: sempre um sopro baixo; no tiro fica mais forte.
+    const fireOn = keys.Space;
+    {
         const cx = player.x + player.width / 2;
         const by = player.y + player.height;
-        const flick = 0.55 + 0.35 * (0.5 + 0.5 * Math.sin(starT * 28));
+        const flick = (fireOn ? 0.7 : 0.35) + 0.25 * (0.5 + 0.5 * Math.sin(starT * 28));
+        const reach = fireOn ? 10 : 5;
         ctx.globalAlpha = flick;
         ctx.fillStyle = '#ff9f1c';
         ctx.beginPath();
         ctx.moveTo(cx - 5, by - 4);
-        ctx.lineTo(cx, by + 10 + Math.sin(starT * 40) * 2);
+        ctx.lineTo(cx, by + reach + Math.sin(starT * 40) * 2);
         ctx.lineTo(cx + 5, by - 4);
         ctx.closePath();
         ctx.fill();
-        ctx.fillStyle = '#ff4fd8';
-        ctx.beginPath();
-        ctx.moveTo(cx - 3, by - 2);
-        ctx.lineTo(cx, by + 6);
-        ctx.lineTo(cx + 3, by - 2);
-        ctx.closePath();
-        ctx.fill();
+        if (fireOn) {
+            ctx.fillStyle = '#ff4fd8';
+            ctx.beginPath();
+            ctx.moveTo(cx - 3, by - 2);
+            ctx.lineTo(cx, by + 6);
+            ctx.lineTo(cx + 3, by - 2);
+            ctx.closePath();
+            ctx.fill();
+        }
         ctx.globalAlpha = 1;
     }
     ctx.fillStyle = player.color;

--- a/labs/space-shooter/script.js
+++ b/labs/space-shooter/script.js
@@ -422,7 +422,7 @@ function draw() {
     // Draw Player — sem shadowBlur (caro em mobile); brilho via alpha no fill
     ctx.shadowBlur = 0;
     // Pluma do motor (feedback de movimento)
-    const thrusting = keys['ArrowUp'] || keys['KeyW'] || keys['Space'];
+    const thrusting = keys.Space; // tiro acende a pluma
     if (thrusting || bullets.length) {
         const cx = player.x + player.width / 2;
         const by = player.y + player.height;

--- a/labs/space-shooter/script.js
+++ b/labs/space-shooter/script.js
@@ -128,7 +128,9 @@ function initStars() {
             x: Math.random() * gameWidth,
             y: Math.random() * gameHeight,
             size: Math.random() * 2,
-            speed: Math.random() * 0.5 + 0.1
+            speed: Math.random() * 0.5 + 0.1,
+            phase: Math.random() * Math.PI * 2,
+            twinkle: 0.8 + Math.random() * 1.4
         });
     }
 }
@@ -405,10 +407,12 @@ function draw() {
         ctx.stroke();
     }
 
-    // Draw Stars
+    // Draw Stars — twinkle estável (seno), não noise por frame
+    const starT = performance.now() / 1000;
     ctx.fillStyle = '#ffffff';
     stars.forEach(star => {
-        ctx.globalAlpha = Math.random() * 0.5 + 0.3;
+        const tw = 0.35 + 0.55 * (0.5 + 0.5 * Math.sin(starT * star.twinkle + star.phase));
+        ctx.globalAlpha = tw;
         ctx.beginPath();
         ctx.arc(star.x, star.y, star.size, 0, Math.PI * 2);
         ctx.fill();
@@ -417,6 +421,29 @@ function draw() {
 
     // Draw Player — sem shadowBlur (caro em mobile); brilho via alpha no fill
     ctx.shadowBlur = 0;
+    // Pluma do motor (feedback de movimento)
+    const thrusting = keys['ArrowUp'] || keys['KeyW'] || keys['Space'];
+    if (thrusting || bullets.length) {
+        const cx = player.x + player.width / 2;
+        const by = player.y + player.height;
+        const flick = 0.55 + 0.35 * (0.5 + 0.5 * Math.sin(starT * 28));
+        ctx.globalAlpha = flick;
+        ctx.fillStyle = '#ff9f1c';
+        ctx.beginPath();
+        ctx.moveTo(cx - 5, by - 4);
+        ctx.lineTo(cx, by + 10 + Math.sin(starT * 40) * 2);
+        ctx.lineTo(cx + 5, by - 4);
+        ctx.closePath();
+        ctx.fill();
+        ctx.fillStyle = '#ff4fd8';
+        ctx.beginPath();
+        ctx.moveTo(cx - 3, by - 2);
+        ctx.lineTo(cx, by + 6);
+        ctx.lineTo(cx + 3, by - 2);
+        ctx.closePath();
+        ctx.fill();
+        ctx.globalAlpha = 1;
+    }
     ctx.fillStyle = player.color;
     // Simple ship shape
     ctx.beginPath();

--- a/labs/space-shooter/style.css
+++ b/labs/space-shooter/style.css
@@ -681,3 +681,49 @@ footer a {
         right: max(14px, env(safe-area-inset-right, 0px));
     }
 }
+
+/* Pads só em toque real — em desktop estreito o teclado basta. */
+@media (pointer: fine) {
+    .touch-controls {
+        display: none !important;
+    }
+}
+
+@media (pointer: coarse) {
+    .touch-controls {
+        position: absolute;
+        z-index: 3;
+        left: max(14px, env(safe-area-inset-left, 0px));
+        right: max(14px, env(safe-area-inset-right, 0px));
+        bottom: max(14px, env(safe-area-inset-bottom, 0px));
+        display: flex;
+        align-items: flex-end;
+        justify-content: space-between;
+        pointer-events: none;
+    }
+
+    .touch-controls button {
+        pointer-events: auto;
+        touch-action: none;
+        min-width: 44px;
+        min-height: 44px;
+    }
+}
+
+@media (max-width: 768px) {
+    body {
+        padding: max(8px, env(safe-area-inset-top, 0px)) max(8px, env(safe-area-inset-right, 0px))
+            max(8px, env(safe-area-inset-bottom, 0px)) max(8px, env(safe-area-inset-left, 0px));
+        overflow-x: clip;
+    }
+
+    .game-panel {
+        width: 100%;
+        max-width: 100%;
+    }
+
+    .mission-panel,
+    .quick-controls {
+        display: none;
+    }
+}

--- a/labs/spider-swing/index.html
+++ b/labs/spider-swing/index.html
@@ -272,7 +272,7 @@
     </main>
 
     <script src="/labs/shared.js?v=13" defer></script>
-    <script type="module" src="src/main.js?v=2"></script>
+    <script type="module" src="src/main.js?v=3"></script>
 </body>
 
 </html>

--- a/labs/spider-swing/src/main.js
+++ b/labs/spider-swing/src/main.js
@@ -9,7 +9,7 @@ import * as THREE from 'three';
 import {
     QUALITY, DIFFICULTY, CAMERA, PALETTE, loadSettings, saveSettings
 } from './config.js';
-import { clamp, damp, detectMobile, detectSoftwareGL, hexToArr } from './utils.js';
+import { clamp, damp, detectMobile, detectTouch, detectSoftwareGL, hexToArr } from './utils.js';
 import { City } from './city.js';
 import { Player } from './player.js?v=2';
 import { Effects } from './effects.js';
@@ -43,9 +43,10 @@ class Game {
     }
 
     resolveQuality() {
+        if (detectSoftwareGL()) return QUALITY.low;
         const choice = this.settings.quality;
         if (choice !== 'auto' && QUALITY[choice]) return QUALITY[choice];
-        if (detectMobile() || detectSoftwareGL()) return QUALITY.low;
+        if (detectMobile()) return QUALITY.low;
         const cores = navigator.hardwareConcurrency || 8;
         if (cores <= 4) return QUALITY.low;
         const big = Math.min(window.innerWidth, window.innerHeight) >= 900;
@@ -123,7 +124,7 @@ class Game {
             await this.setupPostProcessing();
 
             this.bindUi();
-            this.isTouch = detectMobile();
+            this.isTouch = detectTouch();
 
             this.enterAttract();
             this.renderer.compile(this.scene, this.camera);

--- a/labs/spider-swing/src/utils.js
+++ b/labs/spider-swing/src/utils.js
@@ -43,6 +43,13 @@ export function detectMobile() {
     return Boolean(coarse && narrow) || /Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
 }
 
+/** Pads/HUD de toque: qualquer ponteiro grosso (inclui tablet landscape). */
+export function detectTouch() {
+    if (typeof navigator === 'undefined') return false;
+    return Boolean(window.matchMedia?.('(pointer: coarse)')?.matches)
+        || /Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
+}
+
 export function detectSoftwareGL() {
     try {
         const canvas = document.createElement('canvas');

--- a/labs/spider-swing/style.css
+++ b/labs/spider-swing/style.css
@@ -798,3 +798,11 @@ kbd {
         height: min(42%, 38dvh);
     }
 }
+
+/* agent-responsive-768 */
+@media (max-width: 768px) {
+  html, body { overflow-x: clip; }
+  .hud, .overlay, .menu-overlay, .overlay-card {
+    max-width: 100%;
+  }
+}

--- a/labs/spider-swing/style.css
+++ b/labs/spider-swing/style.css
@@ -225,9 +225,15 @@ button {
     pointer-events: auto;
 }
 
-body[data-state="playing"] .lab-foot,
-body[data-state="playing"] .game-shell > header .app-logo {
+body[data-state="playing"] .lab-foot {
     opacity: 0;
+    transition: opacity 0.5s var(--ease);
+}
+
+/* Menu já traz o título — o logo do chrome colidia com o lede em 375px. */
+.game-shell > header .app-logo {
+    opacity: 0;
+    pointer-events: none;
     transition: opacity 0.5s var(--ease);
 }
 
@@ -771,15 +777,29 @@ kbd {
 }
 
 @media (max-width: 560px) {
+    .overlay {
+        place-items: start center;
+        padding-top: calc(3.8rem + var(--safe-top));
+        padding-left: max(0.75rem, var(--safe-left));
+        padding-right: max(0.75rem, var(--safe-right));
+    }
+
     .overlay,
     .overlay-card,
     .menu-card {
         max-height: min(92dvh, 900px);
     }
+
     .overlay-card,
     .menu-card {
+        max-height: min(calc(92dvh - 3.2rem), 900px);
         overflow-y: auto;
         -webkit-overflow-scrolling: touch;
+    }
+
+    .menu-head .lede {
+        font-size: 0.88rem;
+        line-height: 1.4;
     }
 }
 

--- a/labs/tamagotchi/index.html
+++ b/labs/tamagotchi/index.html
@@ -25,7 +25,7 @@
     <meta name="twitter:title" content="RakuRaku Dinokun — pet virtual retrô | Diogo Paulino">
     <meta name="twitter:description" content="Recriação pesquisada do RakuRaku Dinokun / Dinkie Dino: carcaça, LCD, controles e ciclo de cuidado em tempo real.">
   <link rel="stylesheet" href="/labs/shared.css?v=13">
-  <link rel="stylesheet" href="style.css?v=14">
+  <link rel="stylesheet" href="style.css?v=15">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",

--- a/labs/tamagotchi/style.css
+++ b/labs/tamagotchi/style.css
@@ -828,3 +828,8 @@ header {
     display: none;
   }
 }
+
+/* agent-responsive-768 */
+@media (max-width: 768px) {
+  html, body { overflow-x: clip; }
+}

--- a/labs/tatu-bola/index.html
+++ b/labs/tatu-bola/index.html
@@ -34,7 +34,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Press+Start+2P&display=swap"
         rel="stylesheet">
     <link rel="stylesheet" href="/labs/shared.css?v=13">
-    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="style.css?v=2">
 
     <script type="importmap">
     {
@@ -277,7 +277,7 @@
     </main>
 
     <script src="/labs/shared.js?v=13" defer></script>
-    <script type="module" src="src/main.js"></script>
+    <script type="module" src="src/main.js?v=2"></script>
 </body>
 
 </html>

--- a/labs/tatu-bola/src/main.js
+++ b/labs/tatu-bola/src/main.js
@@ -62,19 +62,22 @@ class Game {
     }
 
     qualityPreset() {
+        if (detectSoftwareGL()) return QUALITY.low;
         let key = this.settings.quality;
         if (key === 'auto') {
-            key = (this.mobile || detectSoftwareGL()) ? 'low' : 'high';
+            key = this.mobile ? 'low' : 'high';
         }
         return QUALITY[key] || QUALITY.medium;
     }
 
     async boot() {
         this.hud.setLoading(0.12, 'Inserindo o CD…');
+        const soft = detectSoftwareGL();
+        const preset = this.qualityPreset();
         try {
             this.renderer = new THREE.WebGLRenderer({
                 canvas: this.canvas,
-                antialias: true,
+                antialias: !soft && preset.pixel > 1,
                 powerPreference: 'high-performance'
             });
         } catch {
@@ -83,7 +86,7 @@ class Game {
         }
 
         this.renderer.outputColorSpace = THREE.SRGBColorSpace;
-        this.renderer.shadowMap.enabled = true;
+        this.renderer.shadowMap.enabled = !!preset.shadows && !soft;
         this.renderer.shadowMap.type = THREE.PCFSoftShadowMap;
         this.renderer.setClearColor(0xff9a72, 1);
         this.renderer.toneMapping = THREE.ACESFilmicToneMapping;

--- a/labs/tetris/index.html
+++ b/labs/tetris/index.html
@@ -24,7 +24,7 @@
     <meta name="twitter:title" content="Tetris 90s — clássico estilo Game Boy | Diogo Paulino">
     <meta name="twitter:description" content="Tetris clássico com visual de Game Boy, controles por teclado e toque, próxima peça, pontuação e recorde salvo no navegador.">
     <link rel="stylesheet" href="/labs/shared.css?v=13">
-    <link rel="stylesheet" href="style.css?v=3">
+    <link rel="stylesheet" href="style.css?v=4">
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
@@ -174,7 +174,7 @@
     </div>
 
     <script src="/labs/shared.js?v=13" defer></script>
-    <script src="script.js?v=2" defer></script>
+    <script src="script.js?v=3" defer></script>
 </body>
 
 </html>

--- a/labs/tetris/index.html
+++ b/labs/tetris/index.html
@@ -24,7 +24,7 @@
     <meta name="twitter:title" content="Tetris 90s — clássico estilo Game Boy | Diogo Paulino">
     <meta name="twitter:description" content="Tetris clássico com visual de Game Boy, controles por teclado e toque, próxima peça, pontuação e recorde salvo no navegador.">
     <link rel="stylesheet" href="/labs/shared.css?v=13">
-    <link rel="stylesheet" href="style.css?v=2">
+    <link rel="stylesheet" href="style.css?v=3">
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",

--- a/labs/tetris/script.js
+++ b/labs/tetris/script.js
@@ -226,14 +226,28 @@ function drawGhost() {
 
     if (ghostY === startY) return;
 
+    // Ghost oco: contorno legível no LCD verde (os pontos 0.3 eram quase invisíveis).
+    context.save();
+    context.globalAlpha = 0.22;
     context.fillStyle = colors[2];
     player.matrix.forEach((row, y) => {
         row.forEach((value, x) => {
             if (value !== 0) {
-                context.fillRect(x + player.pos.x + 0.35, y + ghostY + 0.35, 0.3, 0.3);
+                context.fillRect(x + player.pos.x + 0.08, y + ghostY + 0.08, 0.84, 0.84);
             }
         });
     });
+    context.globalAlpha = 1;
+    context.strokeStyle = colors[2];
+    context.lineWidth = 0.08;
+    player.matrix.forEach((row, y) => {
+        row.forEach((value, x) => {
+            if (value !== 0) {
+                context.strokeRect(x + player.pos.x + 0.12, y + ghostY + 0.12, 0.76, 0.76);
+            }
+        });
+    });
+    context.restore();
 }
 
 function drawNext() {

--- a/labs/tetris/style.css
+++ b/labs/tetris/style.css
@@ -543,3 +543,28 @@ body {
         display: none;
     }
 }
+
+@media (max-width: 768px) {
+    body {
+        overflow-x: clip;
+        padding-left: max(0.5rem, env(safe-area-inset-left, 0px));
+        padding-right: max(0.5rem, env(safe-area-inset-right, 0px));
+    }
+
+    .instructions {
+        margin-top: 0.75rem;
+        font-size: 0.85rem;
+        padding-inline: 0.75rem;
+    }
+
+    .game-boy {
+        width: min(320px, 100%);
+    }
+}
+
+@media (max-height: 520px) and (orientation: landscape) {
+    .game-boy {
+        width: min(560px, 100%);
+        max-width: 100%;
+    }
+}

--- a/labs/ultimo-bastiao/index.html
+++ b/labs/ultimo-bastiao/index.html
@@ -29,7 +29,7 @@
   <link rel="preconnect" href="https://cdn.babylonjs.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;600;700;800&family=Manrope:wght@400;500;600;700&family=Outfit:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/labs/shared.css?v=13">
-  <link rel="stylesheet" href="style.css?v=6">
+  <link rel="stylesheet" href="style.css?v=7">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",

--- a/labs/ultimo-bastiao/src/game.js
+++ b/labs/ultimo-bastiao/src/game.js
@@ -471,6 +471,16 @@ class Game {
   }
 
   resolveQuality(choice = this.settings.quality) {
+    try {
+      const c = document.createElement('canvas');
+      const gl = c.getContext('webgl2') || c.getContext('webgl');
+      if (!gl) return QUALITY.performance;
+      const info = gl.getExtension('WEBGL_debug_renderer_info');
+      const name = info ? String(gl.getParameter(info.UNMASKED_RENDERER_WEBGL) || '') : '';
+      if (/swiftshader|llvmpipe|softpipe|microsoft basic render|\bcpu\b/i.test(name)) {
+        return QUALITY.performance;
+      }
+    } catch { /* ignore */ }
     if (choice !== 'auto' && QUALITY[choice]) return QUALITY[choice];
     const mobile = matchMedia('(pointer: coarse)').matches || innerWidth < 800;
     if (mobile || (navigator.hardwareConcurrency || 4) <= 4) return QUALITY.performance;

--- a/labs/videogame/style.css
+++ b/labs/videogame/style.css
@@ -699,3 +699,11 @@ body.game-mode {
 ::-webkit-scrollbar-thumb:hover {
     background: var(--text-tertiary);
 }
+
+/* agent-responsive-768 */
+@media (max-width: 768px) {
+  html, body { overflow-x: clip; }
+  .hud, .overlay, .menu-overlay, .overlay-card {
+    max-width: 100%;
+  }
+}

--- a/labs/winamp/index.html
+++ b/labs/winamp/index.html
@@ -27,7 +27,7 @@
     <meta name="twitter:description" content="Player retrô 100% vanilla: playlist, equalizador, visualizador e músicas chiptune sintetizadas no navegador.">
     <meta name="twitter:image" content="https://diogopaulino.com.br/assets/img/diogo.jpeg">
     <link rel="stylesheet" href="/labs/shared.css?v=13">
-    <link rel="stylesheet" href="style.css?v=7">
+    <link rel="stylesheet" href="style.css?v=8">
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",

--- a/labs/winamp/style.css
+++ b/labs/winamp/style.css
@@ -1583,3 +1583,8 @@ noscript {
     .task-button { width: auto; flex: 1 1 0; min-width: 0; }
     .system-tray { flex-shrink: 0; }
 }
+
+/* agent-responsive-768 */
+@media (max-width: 768px) {
+  html, body { overflow-x: clip; }
+}

--- a/labs/xadrez/index.html
+++ b/labs/xadrez/index.html
@@ -246,7 +246,7 @@
     <script src="https://cdn.babylonjs.com/v9.25.0/babylon.js"></script>
     
     <script src="/labs/shared.js?v=13" defer></script>
-    <script type="module" src="src/main.js"></script>
+    <script type="module" src="src/main.js?v=2"></script>
 </body>
 
 </html>

--- a/labs/xadrez/src/main.js
+++ b/labs/xadrez/src/main.js
@@ -20,16 +20,30 @@ const GLYPH = {
 };
 
 const QUALITY = {
-    low: { id: 'low', pr: 1, seg: 24, shadows: false, shadowMap: 1024 },
-    medium: { id: 'medium', pr: 1.25, seg: 40, shadows: true, shadowMap: 1536 },
-    high: { id: 'high', pr: 1.75, seg: 64, shadows: true, shadowMap: 2048 }
+    low: { id: 'low', pr: 1, seg: 24, shadows: false, shadowMap: 1024, antialias: false },
+    medium: { id: 'medium', pr: 1.25, seg: 40, shadows: true, shadowMap: 1536, antialias: true },
+    high: { id: 'high', pr: 1.75, seg: 64, shadows: true, shadowMap: 2048, antialias: true }
 };
 
 function isMobile() {
     return /Mobi|Android|iPhone|iPad/i.test(navigator.userAgent) || window.innerWidth < 720;
 }
 
+function detectSoftwareGL() {
+    try {
+        const canvas = document.createElement('canvas');
+        const gl = canvas.getContext('webgl2') || canvas.getContext('webgl');
+        if (!gl) return true;
+        const info = gl.getExtension('WEBGL_debug_renderer_info');
+        const name = info ? String(gl.getParameter(info.UNMASKED_RENDERER_WEBGL) || '') : '';
+        return /swiftshader|llvmpipe|softpipe|microsoft basic render|\bcpu\b/i.test(name);
+    } catch {
+        return true;
+    }
+}
+
 function pickQuality(mode) {
+    if (detectSoftwareGL()) return QUALITY.low;
     if (QUALITY[mode]) return QUALITY[mode];
     if (isMobile()) return navigator.hardwareConcurrency >= 6 ? QUALITY.medium : QUALITY.low;
     if ((window.devicePixelRatio || 1) >= 2 && window.innerWidth >= 1400) return QUALITY.high;
@@ -206,7 +220,7 @@ class Atelier {
         }
 
         try {
-            this.engine = new BABYLON.Engine(this.canvas, true, {
+            this.engine = new BABYLON.Engine(this.canvas, this.quality?.antialias ?? false, {
                 preserveDrawingBuffer: false,
                 stencil: false,
                 // The game controls its own render scale below. Keeping the

--- a/labs/xadrez/style.css
+++ b/labs/xadrez/style.css
@@ -176,3 +176,8 @@ body[data-mode="academy"] .history-panel, body[data-mode="puzzles"] .history-pan
     .camera-help { display: none; }
 }
 @media (prefers-reduced-motion: reduce) { *, *::before, *::after { transition: none !important; scroll-behavior: auto !important; } }
+
+/* agent-responsive-768 */
+@media (max-width: 768px) {
+  html, body { overflow-x: clip; }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 🎯 Objetivo

Auditar e polishar os **56 labs**: SoftGL/DPR, touch pads só em `pointer: coarse`, fixes de jogabilidade, polish visual e responsivo (375 / 390 / landscape curto + safe-area), sem quebrar catálogo/SEO.

## ✨ O que mudou

- SoftGL-first / DPR cap / QUALITY → engine nos labs 3D (Babylon/Three)
- Touch pads ocultos em desktop (`pointer: fine`); pads em `pointer: coarse`
- Jogabilidade: Snake (espera 1º input), F1 (menu + failBoot), Rock Kombat, Claude Bros, Neon Rider, Honor/Safari/Guerreiro
- Polish: Space Shooter (pluma), Lander (chama + overflow-x), tools (aurora, gravity, piano, paint, calculator, …)
- `@media (max-width: 768px)` em todos; landscape `520px` em Eyra/Nereida/Castelo/Lavandula/Quimera
- Spider Swing: logo do chrome oculto no menu (sem overlap do lede em 375px)

## 🧪 Como testar

1. `python3 -m http.server 8000` na raiz
2. Galeria + spot-check 3D/2D/tools
3. DevTools **375×667**, **390×844**, landscape **~667×375**
4. SoftGL/headless: Neon pode ficar ~20 fps; GPU real para FPS honesto

## ✅ Evidência browser (todos os 56)

- `qa-3d-menus` — 12 menus 3D PASS (pads ocultos no desktop)
- `qa-landscape` — 10 labs @667×375 PASS; spider 375 FAIL→PASS
- `qa-2d` — 12 clássicos @390 PASS
- `qa-rest` — 22 restantes @~390 PASS
- `qa-sample` / `qa-games` — tools + games sample

## ✅ Checklist

- [x] Catálogo: 56 pastas ↔ 56 cards ↔ 56 README ↔ 56 sitemap
- [x] SEO preservado (sem rename/slug)
- [x] HTTP na raiz
- [x] Responsivo + safe-area / viewport-fit=cover nos canvas labs
- [x] Nada fora do escopo quebrado

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a078c0-2ec8-7e08-8397-48e3c0c24b03?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a078c0-2ec8-7e08-8397-48e3c0c24b03&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

